### PR TITLE
chore: drop square brackets from string representation of logical schema (MINOR)

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/json/LogicalSchemaSerializer.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/json/LogicalSchemaSerializer.java
@@ -34,11 +34,6 @@ final class LogicalSchemaSerializer extends JsonSerializer<LogicalSchema> {
       final JsonGenerator gen,
       final SerializerProvider serializerProvider
   ) throws IOException {
-    final String text = schema.toString();
-    gen.writeString(trimArrayBrackets(text));
-  }
-
-  private static String trimArrayBrackets(final String text) {
-    return text.substring(1, text.length() - 1);
+    gen.writeString(schema.toString());
   }
 }

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
@@ -219,7 +219,7 @@ public final class LogicalSchema {
     return columns.stream()
         .filter(withNamespace(Namespace.META).negate())
         .map(c -> c.toString(formatOptions))
-        .collect(Collectors.joining(", ", "[", "]"));
+        .collect(Collectors.joining(", "));
   }
 
   private Optional<Column> findColumnMatching(final Predicate<Column> predicate) {

--- a/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
@@ -520,8 +520,7 @@ public class LogicalSchemaTest {
 
     // Then:
     assertThat(s, is(
-        "["
-            + "`k0` BIGINT KEY, "
+        "`k0` BIGINT KEY, "
             + "`k1` DOUBLE KEY, "
             + "`f0` BOOLEAN, "
             + "`f1` INTEGER, "
@@ -531,7 +530,7 @@ public class LogicalSchemaTest {
             + "`f6` STRUCT<`a` BIGINT>, "
             + "`f7` ARRAY<STRING>, "
             + "`f8` MAP<STRING, STRING>"
-            + "]"));
+    ));
   }
 
   @Test
@@ -550,13 +549,12 @@ public class LogicalSchemaTest {
 
     // Then:
     assertThat(s, is(
-        "["
-            + "`f0` BOOLEAN, "
+        "`f0` BOOLEAN, "
             + "`k0` BIGINT KEY, "
             + "`v0` INTEGER, "
             + "`k1` DOUBLE KEY, "
             + "`v1` BOOLEAN"
-            + "]"));
+    ));
   }
 
   @Test
@@ -578,11 +576,10 @@ public class LogicalSchemaTest {
 
     // Then:
     assertThat(s, is(
-        "["
-            + "ROWKEY STRING KEY, "
+        "ROWKEY STRING KEY, "
             + "`f0` BOOLEAN, "
             + "f1 STRUCT<`f0` BIGINT, f1 BIGINT>"
-            + "]"));
+    ));
   }
 
   @Test
@@ -598,10 +595,9 @@ public class LogicalSchemaTest {
 
     // Then:
     assertThat(s, is(
-        "["
-            + "`bob`.`ROWKEY` STRING KEY, "
+        "`bob`.`ROWKEY` STRING KEY, "
             + "`bob`.`f0` BOOLEAN"
-            + "]"));
+    ));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -203,29 +203,29 @@ public class PhysicalPlanBuilderTest {
     final String[] lines = planText.split("\n");
 
     assertThat(lines[0], startsWith(
-        " > [ PROJECT ] | Schema: [ROWKEY BIGINT KEY, COL0 BIGINT, KSQL_COL_1 DOUBLE, "
-            + "KSQL_COL_2 BIGINT] |"));
+        " > [ PROJECT ] | Schema: ROWKEY BIGINT KEY, COL0 BIGINT, KSQL_COL_1 DOUBLE, "
+            + "KSQL_COL_2 BIGINT |"));
     assertThat(lines[1], startsWith(
-        "\t\t > [ AGGREGATE ] | Schema: [ROWKEY BIGINT KEY, KSQL_INTERNAL_COL_0 BIGINT, "
+        "\t\t > [ AGGREGATE ] | Schema: ROWKEY BIGINT KEY, KSQL_INTERNAL_COL_0 BIGINT, "
             + "KSQL_INTERNAL_COL_1 DOUBLE, KSQL_AGG_VARIABLE_0 DOUBLE, "
-            + "KSQL_AGG_VARIABLE_1 BIGINT] |"));
+            + "KSQL_AGG_VARIABLE_1 BIGINT |"));
     assertThat(lines[2], startsWith(
-        "\t\t\t\t > [ GROUP_BY ] | Schema: [ROWKEY BIGINT KEY, KSQL_INTERNAL_COL_0 BIGINT, "
-            + "KSQL_INTERNAL_COL_1 DOUBLE] |"
+        "\t\t\t\t > [ GROUP_BY ] | Schema: ROWKEY BIGINT KEY, KSQL_INTERNAL_COL_0 BIGINT, "
+            + "KSQL_INTERNAL_COL_1 DOUBLE |"
     ));
     assertThat(lines[3], startsWith(
-        "\t\t\t\t\t\t > [ PROJECT ] | Schema: [ROWKEY STRING KEY, KSQL_INTERNAL_COL_0 BIGINT, "
-            + "KSQL_INTERNAL_COL_1 DOUBLE] |"));
+        "\t\t\t\t\t\t > [ PROJECT ] | Schema: ROWKEY STRING KEY, KSQL_INTERNAL_COL_0 BIGINT, "
+            + "KSQL_INTERNAL_COL_1 DOUBLE |"));
     assertThat(lines[4], startsWith(
-        "\t\t\t\t\t\t\t\t > [ FILTER ] | Schema: [TEST1.ROWKEY STRING KEY, TEST1.ROWTIME BIGINT, TEST1.ROWKEY STRING, "
+        "\t\t\t\t\t\t\t\t > [ FILTER ] | Schema: TEST1.ROWKEY STRING KEY, TEST1.ROWTIME BIGINT, TEST1.ROWKEY STRING, "
             + "TEST1.COL0 BIGINT, TEST1.COL1 STRING, TEST1.COL2 STRING, "
             + "TEST1.COL3 DOUBLE, TEST1.COL4 ARRAY<DOUBLE>, "
-            + "TEST1.COL5 MAP<STRING, DOUBLE>] |"));
+            + "TEST1.COL5 MAP<STRING, DOUBLE> |"));
     assertThat(lines[5], startsWith(
-        "\t\t\t\t\t\t\t\t\t\t > [ SOURCE ] | Schema: [TEST1.ROWKEY STRING KEY, TEST1.ROWTIME BIGINT, TEST1.ROWKEY STRING, "
+        "\t\t\t\t\t\t\t\t\t\t > [ SOURCE ] | Schema: TEST1.ROWKEY STRING KEY, TEST1.ROWTIME BIGINT, TEST1.ROWKEY STRING, "
             + "TEST1.COL0 BIGINT, TEST1.COL1 STRING, TEST1.COL2 STRING, "
             + "TEST1.COL3 DOUBLE, TEST1.COL4 ARRAY<DOUBLE>, "
-            + "TEST1.COL5 MAP<STRING, DOUBLE>] |"));
+            + "TEST1.COL5 MAP<STRING, DOUBLE> |"));
   }
 
   @Test
@@ -243,11 +243,11 @@ public class PhysicalPlanBuilderTest {
     final String[] lines = planText.split("\n");
     Assert.assertTrue(lines.length == 3);
     Assert.assertEquals(lines[0],
-        " > [ SINK ] | Schema: [ROWKEY STRING KEY, COL0 BIGINT, COL1 STRING, COL2 DOUBLE] | Logger: InsertQuery_1.S1");
+        " > [ SINK ] | Schema: ROWKEY STRING KEY, COL0 BIGINT, COL1 STRING, COL2 DOUBLE | Logger: InsertQuery_1.S1");
     Assert.assertEquals(lines[1],
-        "\t\t > [ PROJECT ] | Schema: [ROWKEY STRING KEY, COL0 BIGINT, COL1 STRING, COL2 DOUBLE] | Logger: InsertQuery_1.Project");
+        "\t\t > [ PROJECT ] | Schema: ROWKEY STRING KEY, COL0 BIGINT, COL1 STRING, COL2 DOUBLE | Logger: InsertQuery_1.Project");
     Assert.assertEquals(lines[2],
-        "\t\t\t\t > [ SOURCE ] | Schema: [TEST1.ROWKEY STRING KEY, TEST1.ROWTIME BIGINT, TEST1.ROWKEY STRING, TEST1.COL0 BIGINT, TEST1.COL1 STRING, TEST1.COL2 DOUBLE] | Logger: InsertQuery_1.KsqlTopic.Source");
+        "\t\t\t\t > [ SOURCE ] | Schema: TEST1.ROWKEY STRING KEY, TEST1.ROWTIME BIGINT, TEST1.ROWKEY STRING, TEST1.COL0 BIGINT, TEST1.COL1 STRING, TEST1.COL2 DOUBLE | Logger: InsertQuery_1.KsqlTopic.Source");
     assertThat(queryMetadataList.get(1), instanceOf(PersistentQueryMetadata.class));
     final PersistentQueryMetadata persistentQuery = (PersistentQueryMetadata)
         queryMetadataList.get(1);
@@ -273,13 +273,13 @@ public class PhysicalPlanBuilderTest {
     final String[] lines = planText.split("\n");
     assertThat(lines.length, equalTo(3));
     assertThat(lines[0], containsString(
-        "> [ SINK ] | Schema: [ROWKEY STRING KEY, COL0 INTEGER]"));
+        "> [ SINK ] | Schema: ROWKEY STRING KEY, COL0 INTEGER"));
 
     assertThat(lines[1], containsString(
-        "> [ PROJECT ] | Schema: [ROWKEY STRING KEY, COL0 INTEGER]"));
+        "> [ PROJECT ] | Schema: ROWKEY STRING KEY, COL0 INTEGER"));
 
     assertThat(lines[2], containsString(
-        "> [ SOURCE ] | Schema: [TEST1.ROWKEY STRING KEY, TEST1.ROWTIME BIGINT, TEST1.ROWKEY STRING, TEST1.COL0 INTEGER]"));
+        "> [ SOURCE ] | Schema: TEST1.ROWKEY STRING KEY, TEST1.ROWTIME BIGINT, TEST1.ROWKEY STRING, TEST1.COL0 INTEGER"));
   }
 
   @Test
@@ -294,13 +294,13 @@ public class PhysicalPlanBuilderTest {
     final String planText = queryMetadataList.get(1).getExecutionPlan();
     final String[] lines = planText.split("\n");
     assertThat(lines.length, equalTo(4));
-    assertThat(lines[0], equalTo(" > [ SINK ] | Schema: [ROWKEY BIGINT KEY, COL0 BIGINT, COL1 STRING, COL2 "
-        + "DOUBLE] | Logger: InsertQuery_1.S1"));
+    assertThat(lines[0], equalTo(" > [ SINK ] | Schema: ROWKEY BIGINT KEY, COL0 BIGINT, COL1 STRING, COL2 "
+        + "DOUBLE | Logger: InsertQuery_1.S1"));
     assertThat(lines[2],
-        containsString("[ REKEY ] | Schema: [ROWKEY BIGINT KEY, TEST1.ROWTIME BIGINT, TEST1.ROWKEY STRING, TEST1.COL0 BIGINT, TEST1.COL1 STRING, TEST1.COL2 DOUBLE] "
+        containsString("[ REKEY ] | Schema: ROWKEY BIGINT KEY, TEST1.ROWTIME BIGINT, TEST1.ROWKEY STRING, TEST1.COL0 BIGINT, TEST1.COL1 STRING, TEST1.COL2 DOUBLE "
             + "| Logger: InsertQuery_1.PartitionBy"));
-    assertThat(lines[1], containsString("[ PROJECT ] | Schema: [ROWKEY BIGINT KEY, COL0 BIGINT, COL1 STRING"
-        + ", COL2 DOUBLE] | Logger: InsertQuery_1.Project"));
+    assertThat(lines[1], containsString("[ PROJECT ] | Schema: ROWKEY BIGINT KEY, COL0 BIGINT, COL1 STRING"
+        + ", COL2 DOUBLE | Logger: InsertQuery_1.Project"));
   }
 
   @Test
@@ -316,7 +316,7 @@ public class PhysicalPlanBuilderTest {
         .get(0);
 
     // Then:
-    assertThat(result.getExecutionPlan(), containsString("[ REKEY ] | Schema: [ROWKEY BIGINT KEY, TEST2."));
+    assertThat(result.getExecutionPlan(), containsString("[ REKEY ] | Schema: ROWKEY BIGINT KEY, TEST2."));
   }
 
   @Test
@@ -332,7 +332,7 @@ public class PhysicalPlanBuilderTest {
         .get(0);
 
     // Then:
-    assertThat(result.getExecutionPlan(), containsString("[ REKEY ] | Schema: [ROWKEY BIGINT KEY, TEST3."));
+    assertThat(result.getExecutionPlan(), containsString("[ REKEY ] | Schema: ROWKEY BIGINT KEY, TEST3."));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/PlanSummaryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/PlanSummaryTest.java
@@ -50,7 +50,7 @@ public class PlanSummaryTest {
   @Mock
   private StepSchemaResolver schemaResolver;
 
-  private ExecutionStep sourceStep;
+  private ExecutionStep<?> sourceStep;
   private PlanSummary planSummaryBuilder;
 
   @Before
@@ -66,7 +66,7 @@ public class PlanSummaryTest {
 
     // Then:
     assertThat(summary, is(
-        " > [ SOURCE ] | Schema: [ROWKEY STRING KEY, L0 INTEGER] | Logger: QID.src\n"
+        " > [ SOURCE ] | Schema: ROWKEY STRING KEY, L0 INTEGER | Logger: QID.src\n"
     ));
   }
 
@@ -76,15 +76,15 @@ public class PlanSummaryTest {
     final LogicalSchema schema = LogicalSchema.builder()
         .valueColumn(ColumnName.of("L1"), SqlTypes.STRING)
         .build();
-    final ExecutionStep step = givenStep(StreamSelect.class, "child", schema, sourceStep);
+    final ExecutionStep<?> step = givenStep(StreamSelect.class, "child", schema, sourceStep);
 
     // When:
     final String summary = planSummaryBuilder.summarize(step);
 
     // Then:
     assertThat(summary, is(
-        " > [ PROJECT ] | Schema: [ROWKEY STRING KEY, L1 STRING] | Logger: QID.child"
-            + "\n\t\t > [ SOURCE ] | Schema: [ROWKEY STRING KEY, L0 INTEGER] | Logger: QID.src\n"
+        " > [ PROJECT ] | Schema: ROWKEY STRING KEY, L1 STRING | Logger: QID.child"
+            + "\n\t\t > [ SOURCE ] | Schema: ROWKEY STRING KEY, L0 INTEGER | Logger: QID.src\n"
     ));
   }
 
@@ -97,8 +97,8 @@ public class PlanSummaryTest {
     final LogicalSchema schema = LogicalSchema.builder()
         .valueColumn(ColumnName.of("L1"), SqlTypes.STRING)
         .build();
-    final ExecutionStep sourceStep2 = givenStep(StreamSource.class, "src2", sourceSchema2);
-    final ExecutionStep step =
+    final ExecutionStep<?> sourceStep2 = givenStep(StreamSource.class, "src2", sourceSchema2);
+    final ExecutionStep<?> step =
         givenStep(StreamStreamJoin.class, "child", schema, sourceStep, sourceStep2);
 
     // When:
@@ -106,9 +106,9 @@ public class PlanSummaryTest {
 
     // Then:
     assertThat(summary, is(
-        " > [ JOIN ] | Schema: [ROWKEY STRING KEY, L1 STRING] | Logger: QID.child"
-            + "\n\t\t > [ SOURCE ] | Schema: [ROWKEY STRING KEY, L0 INTEGER] | Logger: QID.src"
-            + "\n\t\t > [ SOURCE ] | Schema: [ROWKEY STRING KEY, L0_2 STRING] | Logger: QID.src2\n"
+        " > [ JOIN ] | Schema: ROWKEY STRING KEY, L1 STRING | Logger: QID.child"
+            + "\n\t\t > [ SOURCE ] | Schema: ROWKEY STRING KEY, L0 INTEGER | Logger: QID.src"
+            + "\n\t\t > [ SOURCE ] | Schema: ROWKEY STRING KEY, L0_2 STRING | Logger: QID.src2\n"
     ));
   }
 

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/timestamp/MetadataTimestampExtractionPolicyTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/timestamp/MetadataTimestampExtractionPolicyTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.streams.processor.UsePartitionTimeOnInvalidTimestamp;
 import org.junit.Test;
 
 public class MetadataTimestampExtractionPolicyTest {
+  @SuppressWarnings("UnstableApiUsage")
   @Test
   public void shouldTestEqualityCorrectly() {
     new EqualsTester()


### PR DESCRIPTION
### Description 

They are not needed and stop the string representation being easily used, e.g. to build the schema in a CS/CT statement. Invariably, code has to strip or replace the square brackets, e.g. `LogicalSchemaSerializer`

Example output:

```sql
-- old
[ROWKEY STRING KEY, V0 INTEGER, V1 VARCHAR]

-- new
ROWKEY STRING KEY, V0 INTEGER, V1 VARCHAR
```

### Testing done 

usual.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

