### PR TITLE
feat: add test topology rewriter

### DIFF
--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/KsqlVersion.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/KsqlVersion.java
@@ -21,6 +21,7 @@ import io.confluent.ksql.testing.EffectivelyImmutable;
 import io.confluent.ksql.util.Version;
 import java.util.Comparator;
 import java.util.Objects;
+import java.util.OptionalLong;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -33,7 +34,7 @@ public final class KsqlVersion implements Comparable<KsqlVersion> {
   @EffectivelyImmutable
   private static final Comparator<KsqlVersion> COMPARATOR =
       Comparator.comparing(KsqlVersion::getVersion)
-      .thenComparingLong(KsqlVersion::getTimestamp);
+      .thenComparingLong(v -> v.timestamp);
 
   private final transient String name;
   private final SemanticVersion version;
@@ -78,8 +79,8 @@ public final class KsqlVersion implements Comparable<KsqlVersion> {
     return version;
   }
 
-  public long getTimestamp() {
-    return timestamp;
+  public OptionalLong getTimestamp() {
+    return timestamp == Long.MAX_VALUE ? OptionalLong.empty() : OptionalLong.of(timestamp);
   }
 
   @Override

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestCase.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestCase.java
@@ -114,7 +114,8 @@ public class TestCase implements VersionedTest {
       throw new IllegalArgumentException("Test does not support supplied version: " + version);
     }
 
-    final String newName = name + "-" + version.getName();
+    final String newName = name + "-" + version.getName()
+        + (version.getTimestamp().isPresent() ? "-" + version.getTimestamp().getAsLong() : "");
     final TestCase copy = new TestCase(
         testPath,
         newName,

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/PlannedTestRewriterTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/PlannedTestRewriterTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test;
+
+import io.confluent.ksql.test.planned.PlannedTestRewriter;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class PlannedTestRewriterTest {
+  @Test
+  @Ignore
+  public void rewritePlans() {
+    new PlannedTestRewriter(PlannedTestRewriter.FULL)
+        .rewriteTestCases(QueryTranslationTest.findTestCases());
+  }
+}

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/PlannedTestsUpToDateTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/PlannedTestsUpToDateTest.java
@@ -15,20 +15,15 @@
 
 package io.confluent.ksql.test;
 
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.ksql.execution.json.PlanJsonMapper;
 import io.confluent.ksql.test.planned.TestCasePlan;
 import io.confluent.ksql.test.planned.TestCasePlanLoader;
-import io.confluent.ksql.test.planned.PlannedTestLoader;
 import io.confluent.ksql.test.planned.PlannedTestUtils;
 import io.confluent.ksql.test.tools.TestCase;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
@@ -69,22 +64,8 @@ public class PlannedTestsUpToDateTest {
 
   @Test
   public void shouldHaveLatestPlans() {
-    final Path testCaseDir = Paths.get(
-        PlannedTestLoader.PLANS_DIR,
-        PlannedTestUtils.formatName(testCase.getName())
-    );
-
-    assertThat(
-        String.format(
-            "Missing test plan directory for: %s. Please re-generate QTT plans."
-                + " See `ksql-functional-tests/README.md` for more info.",
-            testCase.getName()
-        ),
-        Files.isDirectory(PlannedTestUtils.findBaseDir().resolve(testCaseDir)), is(true)
-    );
-
-    final Optional<TestCasePlan> latest = TestCasePlanLoader.fromLatest(testCaseDir);
-    final TestCasePlan current = TestCasePlanLoader.fromTestCase(testCase);
+    final Optional<TestCasePlan> latest = TestCasePlanLoader.latestForTestCase(testCase);
+    final TestCasePlan current = TestCasePlanLoader.currentForTestCase(testCase);
     assertThat(
         String.format(
             "Current query plan differs from latest for: %s. Please re-generate QTT plans."

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestGenerator.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestGenerator.java
@@ -15,15 +15,7 @@
 
 package io.confluent.ksql.test.planned;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Charsets;
-import io.confluent.ksql.execution.json.PlanJsonMapper;
 import io.confluent.ksql.test.tools.TestCase;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -31,7 +23,6 @@ import java.util.stream.Stream;
  * Tool for generating new TestCasePlans and writing them to the local filesystem
  */
 public class PlannedTestGenerator {
-  private static final ObjectMapper MAPPER = PlanJsonMapper.create();
 
   public static void generatePlans(final Stream<TestCase> testCases) {
     testCases
@@ -40,55 +31,11 @@ public class PlannedTestGenerator {
   }
 
   private static void maybeGenerateTestCase(final TestCase testCase) {
-    final String testCaseName = PlannedTestUtils.formatName(testCase.getName());
-    final Path testCaseDir = Paths.get(PlannedTestLoader.PLANS_DIR, testCaseName);
-    createDirectory(testCaseDir);
-    final Optional<TestCasePlan> latest = TestCasePlanLoader.fromLatest(testCaseDir);
-    final TestCasePlan current = TestCasePlanLoader.fromTestCase(testCase);
+    final Optional<TestCasePlan> latest = TestCasePlanLoader.latestForTestCase(testCase);
+    final TestCasePlan current = TestCasePlanLoader.currentForTestCase(testCase);
     if (PlannedTestUtils.isSamePlan(latest, current)) {
       return;
     }
-    dumpTestCase(testCaseDir, current);
-  }
-
-  private static String getTestDirName(final TestCasePlan planAtVersionNode) {
-    return String.format("%s_%s", planAtVersionNode.getVersion(), planAtVersionNode.getTimestamp());
-  }
-
-  private static void dumpTestCase(final Path dir, final TestCasePlan planAtVersion) {
-    final Path parent = PlannedTestUtils.findBaseDir()
-        .resolve(dir)
-        .resolve(getTestDirName(planAtVersion));
-    final Path specPath = parent.resolve(PlannedTestLoader.SPEC_FILE);
-    final Path topologyPath = parent.resolve(PlannedTestLoader.TOPOLOGY_FILE);
-    try {
-      Files.createDirectories(parent);
-      Files.write(
-          specPath,
-          MAPPER.writerWithDefaultPrettyPrinter()
-              .writeValueAsString(planAtVersion.getNode())
-              .getBytes(Charsets.UTF_8),
-          StandardOpenOption.CREATE,
-          StandardOpenOption.WRITE,
-          StandardOpenOption.TRUNCATE_EXISTING
-      );
-      Files.write(
-          topologyPath,
-          planAtVersion.getTopology().getBytes(Charsets.UTF_8),
-          StandardOpenOption.CREATE,
-          StandardOpenOption.WRITE,
-          StandardOpenOption.TRUNCATE_EXISTING
-      );
-    } catch (final IOException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  private static void createDirectory(final Path path) {
-    try {
-      Files.createDirectories(PlannedTestUtils.findBaseDir().resolve(path));
-    } catch (final IOException e) {
-      throw new RuntimeException(e);
-    }
+    TestCasePlanWriter.writeTestCasePlan(testCase, current);
   }
 }

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestLoader.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestLoader.java
@@ -21,9 +21,7 @@ import io.confluent.ksql.test.tools.TestCase;
 import io.confluent.ksql.test.tools.TopologyAndConfigs;
 import io.confluent.ksql.test.tools.VersionedTest;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
@@ -31,9 +29,6 @@ import java.util.stream.Stream;
  * against a saved physical plan (according to {@link PlannedTestUtils#isPlannedTestCase})
  */
 public class PlannedTestLoader implements TestLoader<VersionedTest> {
-  public static final String PLANS_DIR = "historical_plans/";
-  public static final String SPEC_FILE = "spec.json";
-  public static final String TOPOLOGY_FILE = "topology";
 
   private final TestLoader<TestCase> innerLoader;
 
@@ -54,32 +49,12 @@ public class PlannedTestLoader implements TestLoader<VersionedTest> {
 
   private Stream<VersionedTest> buildHistoricalTestCases(final TestCase testCase) {
     if (PlannedTestUtils.isPlannedTestCase(testCase)) {
-      final Path rootforCase
-          = Paths.get(PLANS_DIR, PlannedTestUtils.formatName(testCase.getName()));
-      return PlannedTestUtils.findContentsOfDirectory(rootforCase.toString()).stream()
-            .map(d -> buildHistoricalTestCase(testCase, rootforCase.resolve(d)));
+      return TestCasePlanLoader.allForTestCase(testCase).stream()
+          .map(plan -> PlannedTestUtils.buildPlannedTestCase(testCase, plan));
     } else if (testCase.getVersionBounds().contains(KsqlVersion.current())) {
       return Stream.of(testCase);
     } else {
       return Stream.empty();
     }
-  }
-
-  private VersionedTest buildHistoricalTestCase(
-      final VersionedTest testCase,
-      final Path dir
-  ) {
-    final TestCasePlan planAtVersionNode = TestCasePlanLoader.fromSpecific(dir);
-    final KsqlVersion version = KsqlVersion.parse(planAtVersionNode.getVersion())
-        .withTimestamp(planAtVersionNode.getTimestamp());
-    return testCase.withExpectedTopology(
-        version,
-        new TopologyAndConfigs(
-            Optional.of(planAtVersionNode.getPlan()),
-            planAtVersionNode.getTopology(),
-            planAtVersionNode.getSchemas(),
-            planAtVersionNode.getConfigs()
-        )
-    );
   }
 }

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestPath.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestPath.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.planned;
+
+import io.confluent.ksql.test.tools.TestCase;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+
+public final class PlannedTestPath {
+  private static final String INVALID_FILENAME_CHARS_PATTERN = "\\s|/|\\\\|:|\\*|\\?|\"|<|>|\\|";
+  private static final String BASE_DIRECTORY = "src/test/resources/";
+  private static final String PLANS_DIR = "historical_plans/";
+  public static final String SPEC_FILE = "spec.json";
+  public static final String TOPOLOGY_FILE = "topology";
+
+  private final Path path;
+
+  private PlannedTestPath(final Path path) {
+    this.path = Objects.requireNonNull(path, "path");
+  }
+
+  public static PlannedTestPath forTestCase(final TestCase testCase) {
+    return new PlannedTestPath(Paths.get(PLANS_DIR, formatName(testCase.getName())));
+  }
+
+  public static PlannedTestPath forTestCasePlan(final TestCase testCase, final TestCasePlan plan) {
+    return new PlannedTestPath(
+        forTestCase(testCase).path().resolve(
+            String.format("%s_%s", plan.getVersion(), plan.getTimestamp()))
+    );
+  }
+
+  public PlannedTestPath resolve(final Path path) {
+    return new PlannedTestPath(this.path.resolve(path));
+  }
+
+  public PlannedTestPath resolve(final String path) {
+    return new PlannedTestPath(this.path.resolve(path));
+  }
+
+  public Path path() {
+    return path;
+  }
+
+  public Path relativePath() {
+    return findBaseDir().resolve(path);
+  }
+
+  private static Path findBaseDir() {
+    Path path = Paths.get("./ksql-functional-tests");
+    if (Files.exists(path)) {
+      return path.resolve(BASE_DIRECTORY);
+    }
+    path = Paths.get("../ksql-functional-tests");
+    if (Files.exists(path)) {
+      return path.resolve(BASE_DIRECTORY);
+    }
+    throw new RuntimeException("Failed to determine location of expected topologies directory. "
+        + "App should be run with current directory set to either the root of the repo or the "
+        + "root of the ksql-functional-tests module");
+  }
+
+  private static String formatName(final String originalName) {
+    return originalName
+        .replaceAll(" - (AVRO|JSON|DELIMITED|KAFKA)$", "")
+        .replaceAll(INVALID_FILENAME_CHARS_PATTERN, "_");
+  }
+}
+

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestRewriter.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestRewriter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.planned;
+
+import io.confluent.ksql.test.tools.TestCase;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+
+/**
+ * Tool for rewriting planned test cases
+ */
+public class PlannedTestRewriter {
+  private final BiFunction<TestCase, TestCasePlan, TestCasePlan> rewriter;
+
+  public static final BiFunction<TestCase, TestCasePlan, TestCasePlan> FULL
+      = TestCasePlanLoader::rebuiltForTestCase;
+
+  public PlannedTestRewriter(final BiFunction<TestCase, TestCasePlan, TestCasePlan> rewriter) {
+    this.rewriter = Objects.requireNonNull(rewriter, "rewriter");
+  }
+
+  public void rewriteTestCases(final Stream<TestCase> testCases) {
+    testCases
+        .filter(PlannedTestUtils::isPlannedTestCase)
+        .forEach(this::rewriteTestCase);
+  }
+
+  private void rewriteTestCase(final TestCase testCase) {
+    for (final TestCasePlan testCasePlan : TestCasePlanLoader.allForTestCase(testCase)) {
+      final TestCasePlan rewritten = rewriter.apply(testCase, testCasePlan);
+      TestCasePlanWriter.writeTestCasePlan(testCase, rewritten);
+    }
+  }
+}

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestUtils.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestUtils.java
@@ -84,7 +84,7 @@ public final class PlannedTestUtils {
     return testCase.withExpectedTopology(
         version,
         new TopologyAndConfigs(
-            planAtVersionNode.getPlan(),
+            Optional.of(planAtVersionNode.getPlan()),
             planAtVersionNode.getTopology(),
             planAtVersionNode.getSchemas(),
             planAtVersionNode.getConfigs()

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestUtils.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestUtils.java
@@ -17,8 +17,13 @@ package io.confluent.ksql.test.planned;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.test.model.KsqlVersion;
 import io.confluent.ksql.test.tools.TestCase;
+import io.confluent.ksql.test.tools.TopologyAndConfigs;
+import io.confluent.ksql.test.tools.VersionedTest;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -26,13 +31,12 @@ import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 public final class PlannedTestUtils {
-  private static final String BASE_DIRECTORY = "src/test/resources/";
-  private static final String INVALID_FILENAME_CHARS_PATTERN = "\\s|/|\\\\|:|\\*|\\?|\"|<|>|\\|";
   // this is temporary
   private static final List<String> WHITELIST = ImmutableList.of(
       "average - calculate average in select"
@@ -71,28 +75,20 @@ public final class PlannedTestUtils {
     }
   }
 
-  public static List<String> findContentsOfDirectory(final String path) {
-    return loadContents(path)
-        .orElseThrow(() -> new AssertionError("Dir not found: " + path));
-  }
-
-  public static String formatName(final String originalName) {
-    return originalName
-        .replaceAll(" - (AVRO|JSON|DELIMITED|KAFKA)$", "")
-        .replaceAll(INVALID_FILENAME_CHARS_PATTERN, "_");
-  }
-
-  public static Path findBaseDir() {
-    Path path = Paths.get("./ksql-functional-tests");
-    if (Files.exists(path)) {
-      return path.resolve(BASE_DIRECTORY);
-    }
-    path = Paths.get("../ksql-functional-tests");
-    if (Files.exists(path)) {
-      return path.resolve(BASE_DIRECTORY);
-    }
-    throw new RuntimeException("Failed to determine location of expected topologies directory. "
-        + "App should be run with current directory set to either the root of the repo or the "
-        + "root of the ksql-functional-tests module");
+  public static TestCase buildPlannedTestCase(
+      final TestCase testCase,
+      final TestCasePlan planAtVersionNode
+  ) {
+    final KsqlVersion version = KsqlVersion.parse(planAtVersionNode.getVersion())
+        .withTimestamp(planAtVersionNode.getTimestamp());
+    return testCase.withExpectedTopology(
+        version,
+        new TopologyAndConfigs(
+            planAtVersionNode.getPlan(),
+            planAtVersionNode.getTopology(),
+            planAtVersionNode.getSchemas(),
+            planAtVersionNode.getConfigs()
+        )
+    );
   }
 }

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/planned/TestCasePlanWriter.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/planned/TestCasePlanWriter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.planned;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Charsets;
+import io.confluent.ksql.execution.json.PlanJsonMapper;
+import io.confluent.ksql.test.tools.TestCase;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+public class TestCasePlanWriter {
+  private static final ObjectMapper MAPPER = PlanJsonMapper.create();
+
+  public static void writeTestCasePlan(final TestCase testCase, final TestCasePlan planAtVersion) {
+    final Path parent = PlannedTestPath.forTestCasePlan(testCase, planAtVersion).relativePath();
+    final Path specPath = parent.resolve(PlannedTestPath.SPEC_FILE);
+    final Path topologyPath = parent.resolve(PlannedTestPath.TOPOLOGY_FILE);
+    try {
+      Files.createDirectories(parent);
+      Files.write(
+          specPath,
+          MAPPER.writerWithDefaultPrettyPrinter()
+              .writeValueAsString(planAtVersion.getNode())
+              .getBytes(Charsets.UTF_8),
+          StandardOpenOption.CREATE,
+          StandardOpenOption.WRITE,
+          StandardOpenOption.TRUNCATE_EXISTING
+      );
+      Files.write(
+          topologyPath,
+          planAtVersion.getTopology().getBytes(Charsets.UTF_8),
+          StandardOpenOption.CREATE,
+          StandardOpenOption.WRITE,
+          StandardOpenOption.TRUNCATE_EXISTING
+      );
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
### Description 

This patch adds a rewriter tool for rewriting test topologies
in the event that the streams topology changes in a backwards
compatible way.