### PR TITLE
chore: add back expected topology tests

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -127,6 +127,10 @@ public class PersistentQueryMetadata extends QueryMetadata {
     return schemas.getSchemasDescription();
   }
 
+  public String getSchemasString() {
+    return schemas.toString();
+  }
+
   public PhysicalSchema getPhysicalSchema() {
     return resultSchema;
   }

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutorUtil.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutorUtil.java
@@ -135,8 +135,9 @@ public final class TestExecutorUtil {
       final StubKafkaService stubKafkaService
   ) {
     initializeTopics(testCase, engine.getServiceContext(), stubKafkaService);
-    if (testCase.getExpectedTopology().isPresent()) {
-      return testCase.getExpectedTopology().get().getPlan()
+    if (testCase.getExpectedTopology().isPresent()
+        && testCase.getExpectedTopology().get().getPlan().isPresent()) {
+      return testCase.getExpectedTopology().get().getPlan().get()
           .stream()
           .map(p -> ConfiguredKsqlPlan.of(p, testCase.properties(), ksqlConfig))
           .collect(Collectors.toList());
@@ -182,6 +183,19 @@ public final class TestExecutorUtil {
       }
     }
     return Optional.empty();
+  }
+
+  public static List<PersistentQueryMetadata> buildQueries(
+      final TestCase testCase,
+      final ServiceContext serviceContext,
+      final KsqlEngine ksqlEngine,
+      final KsqlConfig ksqlConfig,
+      final StubKafkaService stubKafkaService
+  ) {
+    return doBuildQueries(testCase, serviceContext, ksqlEngine, ksqlConfig, stubKafkaService)
+        .stream()
+        .map(PersistentQueryAndSources::getPersistentQueryMetadata)
+        .collect(Collectors.toList());
   }
 
   private static List<PersistentQueryAndSources> doBuildQueries(

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TopologyAndConfigs.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TopologyAndConfigs.java
@@ -19,16 +19,17 @@ import io.confluent.ksql.engine.KsqlPlan;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 public class TopologyAndConfigs {
 
-  private final List<KsqlPlan> plan;
+  private final Optional<List<KsqlPlan>> plan;
   private final String topology;
   private final Map<String, String> schemas;
   private final Map<String, String> configs;
 
   public TopologyAndConfigs(
-      final List<KsqlPlan> plan,
+      final Optional<List<KsqlPlan>> plan,
       final String topology,
       final Map<String, String> schemas,
       final Map<String, String> configs
@@ -51,7 +52,7 @@ public class TopologyAndConfigs {
     return configs;
   }
 
-  public List<KsqlPlan> getPlan() {
+  public Optional<List<KsqlPlan>> getPlan() {
     return plan;
   }
 }

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/QueryTranslationTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/QueryTranslationTest.java
@@ -20,6 +20,8 @@ import static java.util.Objects.requireNonNull;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Streams;
+import io.confluent.ksql.test.loader.ExpectedTopologiesTestLoader;
 import io.confluent.ksql.test.loader.JsonTestLoader;
 import io.confluent.ksql.test.loader.TestFile;
 import io.confluent.ksql.test.model.TestCaseNode;
@@ -50,8 +52,13 @@ public class QueryTranslationTest {
 
   @Parameterized.Parameters(name = "{0}")
   public static Collection<Object[]> data() {
-    return PlannedTestLoader.of(testFileLoader())
-        .load()
+    return
+        Streams.concat(
+            PlannedTestLoader.of(testFileLoader())
+                .load(),
+            ExpectedTopologiesTestLoader.of(testFileLoader(), "expected_topology/")
+                .load()
+        )
         .map(testCase -> new Object[]{testCase.getName(), testCase})
         .collect(Collectors.toCollection(ArrayList::new));
   }

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/TopologyFileGenerator.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/TopologyFileGenerator.java
@@ -237,23 +237,11 @@ public final class TopologyFileGenerator {
                 .getSource(persistentQueryMetadata.getSinkName())
                 .getKafkaTopicName();
 
-            final SerdeSupplier<?> keySerdes = SerdeUtil.getKeySerdeSupplier(
-                persistentQueryMetadata.getResultTopic().getKeyFormat(),
-                queryMetadata::getLogicalSchema
-            );
-
-            final SerdeSupplier<?> valueSerdes = SerdeUtil.getSerdeSupplier(
-                persistentQueryMetadata.getResultTopic().getValueFormat().getFormat(),
-                queryMetadata::getLogicalSchema
-            );
-
             final Topic sinkTopic = new Topic(
                 sinkKafkaTopicName,
-                Optional.empty(),
-                keySerdes,
-                valueSerdes,
                 1,
-                1
+                1,
+                Optional.empty()
             );
 
             stubKafkaService.createTopic(sinkTopic);

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/TopologyFileGenerator.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/TopologyFileGenerator.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.ksql.engine.KsqlEngine;
+import io.confluent.ksql.engine.KsqlEngineTestUtil;
+import io.confluent.ksql.function.TestFunctionRegistry;
+import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.metastore.MetaStoreImpl;
+import io.confluent.ksql.metastore.MutableMetaStore;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.services.TestServiceContext;
+import io.confluent.ksql.test.loader.ExpectedTopologiesTestLoader;
+import io.confluent.ksql.test.serde.SerdeSupplier;
+import io.confluent.ksql.test.tools.TestCase;
+import io.confluent.ksql.test.tools.TestExecutor;
+import io.confluent.ksql.test.tools.TestExecutorUtil;
+import io.confluent.ksql.test.tools.Topic;
+import io.confluent.ksql.test.tools.stubs.StubKafkaService;
+import io.confluent.ksql.test.utils.SerdeUtil;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.PersistentQueryMetadata;
+import io.confluent.ksql.util.QueryMetadata;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
+/**
+ * This class is used to generate the topology files to ensure safe
+ * upgrades of KSQL across releases.
+ *
+ * There are some manual steps in using this class but this should be ok as
+ * we only need to create new topology files at the end of a release cycle.
+ *
+ * The steps to generate topology files:
+ *
+ * 1. Run this class by running the test {@link #manuallyGenerateTopologies} BEFORE you update the
+ * pom with a new version.
+ *
+ * 2. This class will generate expected topology files
+ * for the version specified in the pom file.  The program writes the files to
+ * ksql-engine/src/test/resources/expected_topology/VERSION_NUM directory.  Where
+ * VERSION_NUM is the version defined in ksql-engine/pom.xml &lt;parent&gt;&lt;version&gt; element.
+ *
+ */
+@Ignore
+public final class TopologyFileGenerator {
+
+    /**
+     * This test exists only to be able to generate topologies as part of the release process
+     * It can be run manually from the IDE
+     * It is deliberately excluded from the test suite
+     */
+    @Test
+    public void manuallyGenerateTopologies() throws Exception {
+        generateTopologies();
+    }
+
+    private static final StubKafkaService stubKafkaService = StubKafkaService.create();
+    private static final String BASE_DIRECTORY = "src/test/resources/expected_topology/";
+
+    static Path findBaseDir() {
+        Path path = Paths.get("./ksql-functional-tests");
+        if (Files.exists(path)) {
+            return path.resolve(BASE_DIRECTORY);
+        }
+        path = Paths.get("../ksql-functional-tests");
+        if (Files.exists(path)) {
+            return path.resolve(BASE_DIRECTORY);
+        }
+        throw new RuntimeException("Failed to determine location of expected topologies directory. "
+            + "App should be run with current directory set to either the root of the repo or the "
+            + "root of the ksql-functional-tests module");
+    }
+
+    private static void generateTopologies() throws Exception {
+        generateTopologies(findBaseDir());
+    }
+
+    static void generateTopologies(final Path base) throws Exception {
+        final String formattedVersion = "0_6_0-pre";
+        final Path generatedTopologyPath = base.resolve(formattedVersion);
+
+        System.out.println(String.format("Starting to write topology files to %s", generatedTopologyPath));
+
+        if (!generatedTopologyPath.toFile().exists()) {
+            Files.createDirectory(generatedTopologyPath);
+        } else {
+            System.out.println("Warning: Directory already exists, "
+                + "this will re-generate topology files. dir: " + generatedTopologyPath);
+        }
+
+        writeExpectedTopologyFiles(generatedTopologyPath, getTestCases());
+
+        System.out
+            .println(String.format("Done writing topology files to %s", generatedTopologyPath));
+    }
+
+    static List<TestCase> getTestCases() {
+        return QueryTranslationTest.findTestCases()
+            .filter(q -> !q.expectedException().isPresent())
+            .collect(Collectors.toList());
+    }
+
+    private static String getFormattedVersionFromPomFile() throws Exception {
+        final File pomFile = new File("pom.xml");
+        final DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        final DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+        final Document pomDoc = documentBuilder.parse(pomFile);
+
+        final NodeList versionNodeList = pomDoc.getElementsByTagName("version");
+        final String versionName = versionNodeList.item(0).getTextContent();
+
+        return versionName.replaceAll("-SNAPSHOT?", "").replaceAll("\\.", "_");
+    }
+
+    private static void writeExpectedTopologyFiles(
+        final Path topologyDir,
+        final List<TestCase> testCases
+    ) {
+        testCases.forEach(testCase -> writeExpectedToplogyFile(topologyDir, testCase));
+    }
+
+    private static void writeExpectedToplogyFile(final Path topologyDir, final TestCase testCase) {
+        try {
+            final Path topologyFile = buildExpectedTopologyPath(topologyDir, testCase);
+
+            final String topologyContent = buildExpectedTopologyContent(testCase, Optional.empty());
+
+            Files.write(topologyFile,
+                topologyContent.getBytes(StandardCharsets.UTF_8),
+                StandardOpenOption.CREATE,
+                StandardOpenOption.WRITE,
+                StandardOpenOption.TRUNCATE_EXISTING
+            );
+        } catch (final IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static Path buildExpectedTopologyPath(final Path topologyDir, final TestCase testCase) {
+        return ExpectedTopologiesTestLoader.buildExpectedTopologyPath(
+            testCase.getName(),
+            topologyDir
+        );
+    }
+
+    static String buildExpectedTopologyContent(
+        final TestCase testCase,
+        final Optional<Map<String, ?>> persistedConfigs
+    ) {
+        final KsqlConfig baseConfigs = new KsqlConfig(TestExecutor.baseConfig())
+            .cloneWithPropertyOverwrite(testCase.properties());
+
+        final KsqlConfig ksqlConfig = persistedConfigs
+            .map(baseConfigs::overrideBreakingConfigsWithOriginalValues)
+            .orElse(baseConfigs);
+
+        try (final ServiceContext serviceContext = getServiceContext();
+            final KsqlEngine ksqlEngine = getKsqlEngine(serviceContext)
+        ) {
+            final PersistentQueryMetadata queryMetadata =
+                buildQuery(testCase, serviceContext, ksqlEngine, ksqlConfig);
+
+            final Map<String, String> configsToPersist
+                = new HashMap<>(ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
+
+            // Ignore the KStreams state directory as its different every time:
+            configsToPersist.remove("ksql.streams.state.dir");
+
+            return ExpectedTopologiesTestLoader.buildExpectedTopologyContent(
+                queryMetadata,
+                configsToPersist
+            );
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static ServiceContext getServiceContext() {
+        final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
+        return TestServiceContext.create(() -> schemaRegistryClient);
+    }
+
+    private static KsqlEngine getKsqlEngine(final ServiceContext serviceContext) {
+        final MutableMetaStore metaStore = new MetaStoreImpl(TestFunctionRegistry.INSTANCE.get());
+        return KsqlEngineTestUtil.createKsqlEngine(serviceContext, metaStore);
+    }
+
+    private static PersistentQueryMetadata buildQuery(
+        final TestCase testCase,
+        final ServiceContext serviceContext,
+        final KsqlEngine ksqlEngine,
+        final KsqlConfig ksqlConfig
+    ) {
+        final List<PersistentQueryMetadata> queries = TestExecutorUtil
+            .buildQueries(testCase, serviceContext, ksqlEngine, ksqlConfig, stubKafkaService);
+
+        final MetaStore metaStore = ksqlEngine.getMetaStore();
+        for (QueryMetadata queryMetadata: queries) {
+            final PersistentQueryMetadata persistentQueryMetadata
+                = (PersistentQueryMetadata) queryMetadata;
+            final String sinkKafkaTopicName = metaStore
+                .getSource(persistentQueryMetadata.getSinkName())
+                .getKafkaTopicName();
+
+            final SerdeSupplier<?> keySerdes = SerdeUtil.getKeySerdeSupplier(
+                persistentQueryMetadata.getResultTopic().getKeyFormat(),
+                queryMetadata::getLogicalSchema
+            );
+
+            final SerdeSupplier<?> valueSerdes = SerdeUtil.getSerdeSupplier(
+                persistentQueryMetadata.getResultTopic().getValueFormat().getFormat(),
+                queryMetadata::getLogicalSchema
+            );
+
+            final Topic sinkTopic = new Topic(
+                sinkKafkaTopicName,
+                Optional.empty(),
+                keySerdes,
+                valueSerdes,
+                1,
+                1
+            );
+
+            stubKafkaService.createTopic(sinkTopic);
+        }
+
+        assertThat("test did not generate any queries.", queries.isEmpty(), is(false));
+        return queries.get(queries.size() - 1);
+    }
+}

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/TopologyFileGeneratorTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/TopologyFileGeneratorTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test;
+
+import org.apache.kafka.test.IntegrationTest;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Do not combine this with `TopologyFileGenerator` as mvn will ignore the tests as the class
+ * does not end in `Test`.
+ */
+@Category(IntegrationTest.class)
+public final class TopologyFileGeneratorTest {
+
+    @ClassRule
+    public static final TemporaryFolder TMP = new TemporaryFolder();
+
+    @Test
+    public void shouldGenerateTopologies() throws Exception {
+        TopologyFileGenerator.generateTopologies(TMP.newFolder().toPath());
+    }
+}

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/TopologyFileRewriter.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/TopologyFileRewriter.java
@@ -1,0 +1,424 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test;
+
+import static io.confluent.ksql.test.loader.ExpectedTopologiesTestLoader.CONFIG_END_MARKER;
+import static io.confluent.ksql.test.loader.ExpectedTopologiesTestLoader.SCHEMAS_END_MARKER;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.google.common.collect.ImmutableSet;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.confluent.ksql.test.loader.ExpectedTopologiesTestLoader;
+import io.confluent.ksql.test.tools.TestCase;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Utility to help re-write the expected topology files used by {@link QueryTranslationTest}.
+ *
+ * Occasionally, things change in the way KStreams generates topologies and we need to update the
+ * previously saved topologies to bring them back inline.  Obviously, care should be taken when
+ * doing so to ensure no backwards incompatible changes are being hidden by any changes made. *
+ */
+@Ignore
+public final class TopologyFileRewriter {
+
+  /**
+   * Set {@code REWRITER} to an appropriate rewriter impl.
+   */
+  private static final Rewriter REWRITER = new RewriteTopologyOnly();
+
+  /**
+   * Exclude some versions. Anything version starting with one of these strings is excluded:
+   */
+  private static final Set<String> EXCLUDE_VERSIONS = ImmutableSet.<String>builder()
+      //.add("5_0")
+      //.add("5_1")
+      .build();
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  public TopologyFileRewriter() {
+  }
+
+  @Test
+  public void runMeToRewrite() throws Exception {
+    final Path baseDir = TopologyFileGenerator.findBaseDir();
+    final List<TestCase> testCases = TopologyFileGenerator.getTestCases();
+
+    Files.list(baseDir)
+        .filter(Files::isDirectory)
+        .filter(TopologyFileRewriter::includedVersion)
+        .forEach(dir -> rewriteTopologyDirectory(dir, testCases));
+  }
+
+  private static boolean includedVersion(final Path path) {
+
+    final String version = getVersion(path);
+
+    return EXCLUDE_VERSIONS.stream()
+        .noneMatch(version::startsWith);
+  }
+
+  @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
+  private static String getVersion(final Path versionDir) {
+    try {
+      final Path versionFile = versionDir
+          .resolve(ExpectedTopologiesTestLoader.TOPOLOGY_VERSION_FILE);
+      if (Files.exists(versionFile)) {
+        return new String(Files.readAllBytes(versionFile), UTF_8);
+      }
+
+      return versionDir.getFileName().toString();
+    } catch (final Exception e) {
+      throw new RuntimeException("Failed to determine version in " + versionDir, e);
+    }
+  }
+
+  private static void rewriteTopologyDirectory(
+      final Path versionDir,
+      final List<TestCase> testCases
+  ) {
+    try {
+      System.out.println("Starting to rewrite topology files in " + versionDir);
+
+      for (TestCase testCase : testCases) {
+        rewriteTopologyFile(versionDir, testCase);
+      }
+
+      deleteOrphanedFiles(versionDir, testCases);
+
+      System.out.println("Done rewrite topology files in " + versionDir);
+    } catch (final Exception e) {
+      throw new RuntimeException("Failed processing version dir: " + versionDir, e);
+    }
+  }
+
+  private static void rewriteTopologyFile(
+      final Path topologyDir,
+      final TestCase testCase
+  ) {
+    final Path path = TopologyFileGenerator.buildExpectedTopologyPath(topologyDir, testCase);
+    if (!Files.exists(path)) {
+      System.err.println("WARING: Missing topology file: " + path);
+      return;
+    }
+
+    try {
+      final String rewritten = REWRITER.rewrite(testCase, path);
+
+      Files.write(path, rewritten.getBytes(UTF_8));
+
+      System.out.println("Rewritten topology file: " + path);
+    } catch (final Exception e) {
+      throw new RuntimeException("Failed processing topology file: " + path, e);
+    }
+  }
+
+  private static void deleteOrphanedFiles(
+      final Path versionDir,
+      final List<TestCase> testCases
+  ) throws IOException {
+    final Set<Path> paths = testCases.stream()
+        .map(testCase -> TopologyFileGenerator.buildExpectedTopologyPath(versionDir, testCase))
+        .collect(Collectors.toSet());
+
+    Files.list(versionDir)
+        .filter(Files::isRegularFile)
+        .filter(path -> !path.endsWith(ExpectedTopologiesTestLoader.TOPOLOGY_VERSION_FILE))
+        .filter(path -> !paths.contains(path))
+        .forEach(TopologyFileRewriter::deleteOrphanedFile);
+  }
+
+  private static void deleteOrphanedFile(final Path orphan) {
+    try {
+      System.out.println("WARNING: Deleting orphaned topology file: " + orphan);
+      Files.delete(orphan);
+    } catch (final Exception e) {
+      throw new RuntimeException("Failed to delete orphaned expected topology file", e);
+    }
+  }
+
+  private static String grabContent(
+      final String contents,
+      final Optional<String> startMarker,
+      final Optional<String> endMarker
+  ) {
+    final int start = startMarker
+        .map(marker -> {
+          final int idx = contents.indexOf(marker + System.lineSeparator());
+          return idx < 0 ? idx : idx + marker.length() + 1;
+        })
+        .orElse(0);
+
+    if (start < 0) {
+      throw new RuntimeException("Failed to find marker for start of section: " + startMarker);
+    }
+
+    final int end = endMarker
+        .map(contents::indexOf)
+        .orElse(contents.length());
+
+    if (end < 0) {
+      throw new RuntimeException("Failed to find marker for end of section: " + startMarker);
+    }
+
+    return contents.substring(start, end);
+  }
+
+  private static Map<String, ?> parseConfigs(final String configs) {
+    try {
+      final ObjectReader objectReader = OBJECT_MAPPER.readerFor(Map.class);
+      final Map<String, ?> parsed = objectReader.readValue(configs);
+
+      final Set<String> toRemove = parsed.entrySet().stream()
+          .filter(e -> e.getValue() == null)
+          .map(Entry::getKey)
+          .collect(Collectors.toSet());
+
+      parsed.remove("ksql.streams.state.dir");
+      parsed.keySet().removeAll(toRemove);
+      return parsed;
+    } catch (final Exception e) {
+      throw new RuntimeException("Failed to parse configs: " + configs, e);
+    }
+  }
+
+  private interface Rewriter {
+
+    String rewrite(final TestCase testCase, final Path path) throws Exception;
+  }
+
+  private interface StructuredRewriter extends Rewriter {
+
+    default String rewrite(final TestCase testCase, final Path path) throws Exception {
+      final String contents = new String(Files.readAllBytes(path), UTF_8);
+
+      final String newConfig = rewriteConfig(
+          testCase,
+          path,
+          grabContent(contents, Optional.empty(), Optional.of(CONFIG_END_MARKER))
+      )
+          + CONFIG_END_MARKER
+          + System.lineSeparator();
+
+      final boolean hasSchemas = contents.contains(SCHEMAS_END_MARKER);
+
+      final String newSchemas = hasSchemas
+          ? rewriteSchemas(
+          testCase,
+          path,
+          grabContent(contents, Optional.of(CONFIG_END_MARKER), Optional.of(SCHEMAS_END_MARKER))
+      )
+          + SCHEMAS_END_MARKER
+          + System.lineSeparator()
+          : "";
+
+      final Optional<String> topologyStart = hasSchemas
+          ? Optional.of(SCHEMAS_END_MARKER)
+          : Optional.of(CONFIG_END_MARKER);
+
+      final String newTopologies = rewriteTopologies(
+          testCase,
+          path,
+          grabContent(contents, topologyStart, Optional.empty())
+      );
+
+      return newConfig + newSchemas + newTopologies;
+    }
+
+    // Overwrite below methods as needed:
+    default String rewriteConfig(
+        final TestCase testCase,
+        final Path path,
+        final String configs
+    ) {
+      return configs;
+    }
+
+    default String rewriteSchemas(
+        final TestCase testCase,
+        final Path path,
+        final String schemas
+    ) {
+      return schemas;
+    }
+
+    default String rewriteTopologies(
+        final TestCase testCase,
+        final Path path,
+        final String topologies
+    ) {
+      return topologies;
+    }
+  }
+
+  private static final class RegexRewriter implements StructuredRewriter {
+
+    @Override
+    public String rewriteSchemas(final TestCase testCase, final Path path, final String schemas) {
+
+      int start;
+      String result = schemas;
+
+      while ((start = result.indexOf("optional<")) != -1) {
+        final int end = findCloseTagFor(result, start + "optional".length());
+
+        final String contents = result.substring(start + "optional<".length(), end);
+
+        result = result.substring(0, start)
+            + contents
+            + result.substring(end + 1);
+      }
+
+      return result
+          .replaceAll(",(\\S)", ", $1")
+          .replaceAll("\\n", " NOT NULL" + System.lineSeparator())
+          .replaceAll("struct<", "STRUCT<")
+          .replaceAll("map<", "MAP<")
+          .replaceAll("array<", "ARRAY<")
+          .replaceAll("boolean", "BOOLEAN")
+          .replaceAll("int32", "INT")
+          .replaceAll("int64", "BIGINT")
+          .replaceAll("float64", "DOUBLE")
+          .replaceAll("string", "VARCHAR");
+    }
+
+    private static int findCloseTagFor(final String contents, final int startIdx) {
+      assert (contents.charAt(startIdx) == '<');
+
+      int depth = 1;
+      int idx = startIdx + 1;
+
+      while (depth > 0 && idx < contents.length()) {
+        final char c = contents.charAt(idx++);
+        switch (c) {
+          case '<':
+            depth++;
+            break;
+
+          case '>':
+            depth--;
+            break;
+
+          default:
+            break;
+        }
+      }
+
+      if (depth > 0) {
+        throw new RuntimeException("Reached end of file before finding close tag");
+      }
+
+      return idx - 1;
+    }
+  }
+
+  private static final class CustomRewriter implements StructuredRewriter {
+
+    @Override
+    public String rewriteSchemas(final TestCase testCase, final Path path, final String schemas) {
+      return Arrays.stream(schemas.split(System.lineSeparator()))
+          // Add any steps you need to rewrite the schemas here.
+          // The is generally no need to check such changes in.
+          .collect(Collectors.joining(System.lineSeparator(), "", System.lineSeparator()));
+    }
+  }
+
+  /**
+   * Uses the standard topology generation code to rewrite expected topology, i.e. it updates
+   * the topology to match what the current code would output, taking into account any config
+   */
+  private static final class RewriteTopologyOnly implements StructuredRewriter {
+
+    private Map<String, ?> configs;
+
+    @Override
+    public String rewriteConfig(
+        final TestCase testCase,
+        final Path path,
+        final String configs
+    ) {
+      this.configs = parseConfigs(configs);
+      return configs;
+    }
+
+    @Override
+    public String rewriteTopologies(
+        final TestCase testCase,
+        final Path path,
+        final String existing
+    ) {
+      final String newContent = TopologyFileGenerator
+          .buildExpectedTopologyContent(testCase, Optional.of(configs));
+
+      final boolean hasSchemas = newContent.contains(SCHEMAS_END_MARKER);
+
+      final Optional<String> topologyStart = hasSchemas
+          ? Optional.of(SCHEMAS_END_MARKER)
+          : Optional.of(CONFIG_END_MARKER);
+
+      return grabContent(newContent, topologyStart, Optional.empty());
+    }
+  }
+
+  /**
+   * Uses the standard topology generation code to rewrite expected schemas, i.e. it updates
+   * the schemes to match what the current code would output, taking into account any config
+   */
+  private static final class RewriteSchemasOnly implements StructuredRewriter {
+
+    private Map<String, ?> configs;
+
+    @Override
+    public String rewriteConfig(
+        final TestCase testCase,
+        final Path path,
+        final String configs
+    ) {
+      this.configs = parseConfigs(configs);
+      return configs;
+    }
+
+    @Override
+    public String rewriteSchemas(
+        final TestCase testCase,
+        final Path path,
+        final String schemas
+    ) {
+      final String newContent = TopologyFileGenerator
+          .buildExpectedTopologyContent(testCase, Optional.of(configs));
+
+      return grabContent(
+          newContent,
+          Optional.of(CONFIG_END_MARKER),
+          Optional.of(SCHEMAS_END_MARKER)
+      );
+    }
+  }
+}

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/loader/ExpectedTopologiesTestLoader.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/loader/ExpectedTopologiesTestLoader.java
@@ -1,0 +1,337 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.loader;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.model.SemanticVersion;
+import io.confluent.ksql.test.model.KsqlVersion;
+import io.confluent.ksql.test.tools.TopologyAndConfigs;
+import io.confluent.ksql.test.tools.VersionedTest;
+import io.confluent.ksql.util.PersistentQueryMetadata;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Loads the expected topology files for each test and creates a new test for each expected version
+ * and sets the expected topology of the test.
+ */
+public class ExpectedTopologiesTestLoader<T extends VersionedTest> implements TestLoader<T> {
+
+  public static final String TOPOLOGY_VERSION_FILE = "__version";
+  public static final String CONFIG_END_MARKER = "CONFIGS_END";
+  public static final String SCHEMAS_END_MARKER = "SCHEMAS_END";
+
+  private static final Pattern TOPOLOGY_VERSION_PATTERN = Pattern.compile("(\\d+)_(\\d+)(_\\d+)?");
+  private static final String TOPOLOGY_VERSIONS_DELIMITER = ",";
+  private static final String TOPOLOGY_VERSIONS_PROP = "topology.versions";
+  private static final String TOPOLOGY_VERSION_LATEST = "latest-only";
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final KsqlVersion CURRENT_VERSION = KsqlVersion.current();
+  private static final String INVALID_FILENAME_CHARS_PATTERN = "\\s|/|\\\\|:|\\*|\\?|\"|<|>|\\|";
+
+  private final String topologyChecksDir;
+  private final TestLoader<T> innerLoader;
+
+  public static <T extends VersionedTest> ExpectedTopologiesTestLoader<T> of(
+      final TestLoader<T> innerLoader,
+      final String topologyChecksDir
+  ) {
+    return new ExpectedTopologiesTestLoader<>(innerLoader, topologyChecksDir);
+  }
+
+  private ExpectedTopologiesTestLoader(
+      final TestLoader<T> innerLoader,
+      final String topologyChecksDir
+  ) {
+    this.topologyChecksDir = Objects.requireNonNull(topologyChecksDir, "topologyChecksDir");
+    this.innerLoader = Objects.requireNonNull(innerLoader, "innerLoader");
+  }
+
+  public Stream<T> load() {
+    final List<TopologiesAndVersion> expectedTopologies = loadTopologiesAndVersions();
+
+    return innerLoader.load()
+        .flatMap(q -> buildVersionedTestCases(q, expectedTopologies));
+  }
+
+  public static Path buildExpectedTopologyPath(final String queryName, final Path topologyDir) {
+    final String updatedQueryName = formatQueryName(queryName);
+    return topologyDir.resolve(updatedQueryName);
+  }
+
+  public static String buildExpectedTopologyContent(
+      final PersistentQueryMetadata query,
+      final Map<String, String> configs
+  ) {
+    try {
+      final ObjectWriter objectWriter = OBJECT_MAPPER.writerWithDefaultPrettyPrinter();
+
+      final String configString = objectWriter.writeValueAsString(configs);
+      final String topologyString = query.getTopology().describe().toString();
+      final String schemasString = query.getSchemasString();
+
+      return configString + "\n"
+          + CONFIG_END_MARKER + "\n"
+          + schemasString + "\n"
+          + SCHEMAS_END_MARKER + "\n"
+          + topologyString;
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private List<TopologiesAndVersion> loadTopologiesAndVersions() {
+    return getTopologyVersions().stream()
+        .map(version -> new TopologiesAndVersion(
+            version,
+            loadExpectedTopologies(topologyChecksDir + version.getName())
+        ))
+        .collect(Collectors.toList());
+  }
+
+  private List<KsqlVersion> getTopologyVersions() {
+    final String versionProp = System.getProperty(TOPOLOGY_VERSIONS_PROP, "");
+
+    final Stream<String> versionStrings = versionProp.isEmpty()
+        ? findExpectedTopologyDirectories().stream()
+        : versionProp.equalsIgnoreCase(TOPOLOGY_VERSION_LATEST)
+            ? Stream.of()
+            : Arrays.stream(versionProp.split(TOPOLOGY_VERSIONS_DELIMITER));
+
+    return versionStrings
+        .map(this::getVersion)
+        .collect(Collectors.toList());
+  }
+
+  private List<String> findExpectedTopologyDirectories() {
+    try {
+      return findContentsOfDirectory(topologyChecksDir).stream()
+          .filter(file -> !file.endsWith(".md"))
+          .collect(Collectors.toList());
+    } catch (final Exception e) {
+      throw new RuntimeException("Could not find expected topology directories.", e);
+    }
+  }
+
+  private KsqlVersion getVersion(final String dir) {
+    final Path versionFile = Paths.get(topologyChecksDir, dir, TOPOLOGY_VERSION_FILE);
+
+    try {
+      final String versionString = loadContents(versionFile.toString())
+          .map(content -> String.join("", content))
+          .orElse(dir);
+
+      final Matcher matcher = TOPOLOGY_VERSION_PATTERN.matcher(versionString);
+      if (!matcher.matches()) {
+        throw new RuntimeException("Version does not match required pattern. "
+            + TOPOLOGY_VERSION_PATTERN
+            + ". Correct the directory name, or add a " + TOPOLOGY_VERSION_FILE + ".");
+      }
+
+      final int major = Integer.parseInt(matcher.group(1));
+      final int minor = Integer.parseInt(matcher.group(2));
+      final int patch = matcher.groupCount() == 3
+          ? 0
+          : Integer.parseInt(matcher.group(3).substring(1));
+
+      return KsqlVersion.of(dir, SemanticVersion.of(major, minor, patch));
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to load version file: " + versionFile, e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T extends VersionedTest> Stream<T> buildVersionedTestCases(
+      final T test,
+      final List<TopologiesAndVersion> expectedTopologies
+  ) {
+    Stream.Builder<T> builder = Stream.builder();
+    if (test.getVersionBounds().contains(CURRENT_VERSION)) {
+      builder.add(test);
+    }
+
+    for (final TopologiesAndVersion topologies : expectedTopologies) {
+      if (!test.getVersionBounds().contains(topologies.getVersion())) {
+        continue;
+      }
+
+      final TopologyAndConfigs topologyAndConfigs =
+          topologies.getTopology(formatQueryName(test.getName()));
+      // could be null if the testCase has expected errors, no topology or configs saved
+      if (topologyAndConfigs != null) {
+        final T versionedTest = (T) test.withExpectedTopology(
+            topologies.getVersion(),
+            topologyAndConfigs
+        );
+
+        builder = builder.add(versionedTest);
+      }
+    }
+    return builder.build();
+  }
+
+  private static Map<String, TopologyAndConfigs> loadExpectedTopologies(final String dir) {
+    final HashMap<String, TopologyAndConfigs> expectedTopologyAndConfigs = new HashMap<>();
+    final ObjectReader objectReader = new ObjectMapper().readerFor(Map.class);
+    final List<String> topologyFiles = findExpectedTopologyFiles(dir);
+    topologyFiles.forEach(fileName -> {
+      final TopologyAndConfigs topologyAndConfigs = readTopologyFile(dir + "/" + fileName,
+          objectReader);
+      expectedTopologyAndConfigs.put(fileName, topologyAndConfigs);
+    });
+    return expectedTopologyAndConfigs;
+  }
+
+  private static List<String> findExpectedTopologyFiles(final String dir) {
+    try {
+      return findContentsOfDirectory(dir);
+    } catch (final Exception e) {
+      throw new RuntimeException("Could not find expected topology files. dir: " + dir, e);
+    }
+  }
+
+  private static Map<String, String> parseSchemas(final String asString) {
+    if (asString == null) {
+      return Collections.emptyMap();
+    }
+    final ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+    final List<String> lines = Arrays.asList(asString.split("\n"));
+    for (final String line : lines) {
+      final String[] split = line.split(" *= *");
+      if (split.length != 2) {
+        throw new RuntimeException("Unexpected format for schema string");
+      }
+      builder.put(split[0], split[1]);
+    }
+    return builder.build();
+  }
+
+  private static TopologyAndConfigs readTopologyFile(
+      final String file,
+      final ObjectReader objectReader
+  ) {
+    final InputStream s = ExpectedTopologiesTestLoader.class.getClassLoader()
+        .getResourceAsStream(file);
+    if (s == null) {
+      throw new AssertionError("Resource not found: " + file);
+    }
+
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(s, UTF_8))
+    ) {
+      final StringBuilder topologyFileBuilder = new StringBuilder();
+
+      String schemas = null;
+      String topologyAndConfigLine;
+      Map<String, String> persistedConfigs = Collections.emptyMap();
+
+      while ((topologyAndConfigLine = reader.readLine()) != null) {
+        if (topologyAndConfigLine.contains(CONFIG_END_MARKER)) {
+          persistedConfigs = objectReader.readValue(topologyFileBuilder.toString());
+          topologyFileBuilder.setLength(0);
+        } else if (topologyAndConfigLine.contains(SCHEMAS_END_MARKER)) {
+          schemas = StringUtils.stripEnd(topologyFileBuilder.toString(), "\n");
+          topologyFileBuilder.setLength(0);
+        } else {
+          topologyFileBuilder.append(topologyAndConfigLine).append("\n");
+        }
+      }
+
+      return new TopologyAndConfigs(
+          Optional.empty(),
+          topologyFileBuilder.toString(),
+          parseSchemas(schemas),
+          persistedConfigs
+      );
+
+    } catch (final IOException e) {
+      throw new RuntimeException(String.format("Couldn't read topology file %s %s", file, e));
+    }
+  }
+
+  private static Optional<List<String>> loadContents(final String path) {
+    final InputStream s = ExpectedTopologiesTestLoader.class.getClassLoader()
+        .getResourceAsStream(path);
+
+    if (s == null) {
+      return Optional.empty();
+    }
+
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(s, UTF_8))) {
+      final List<String> contents = new ArrayList<>();
+      String file;
+      while ((file = reader.readLine()) != null) {
+        contents.add(file);
+      }
+      return Optional.of(contents);
+    } catch (final IOException e) {
+      throw new AssertionError("Failed to read path: " + path, e);
+    }
+  }
+
+  private static List<String> findContentsOfDirectory(final String path) {
+    return loadContents(path)
+        .orElseThrow(() -> new AssertionError("Dir not found: " + path));
+  }
+
+  private static String formatQueryName(final String originalQueryName) {
+    return originalQueryName
+        .replaceAll(" - (AVRO|JSON|DELIMITED|KAFKA)$", "")
+        .replaceAll(INVALID_FILENAME_CHARS_PATTERN, "_");
+  }
+
+  private static class TopologiesAndVersion {
+
+    private final KsqlVersion version;
+    private final Map<String, TopologyAndConfigs> topologies;
+
+    TopologiesAndVersion(final KsqlVersion version,
+        final Map<String, TopologyAndConfigs> topologies) {
+      this.version = Objects.requireNonNull(version, "version");
+      this.topologies = Objects.requireNonNull(topologies, "topologies");
+    }
+
+    KsqlVersion getVersion() {
+      return version;
+    }
+
+    TopologyAndConfigs getTopology(final String name) {
+      return topologies.get(name);
+    }
+  }
+}

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestLoader.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestLoader.java
@@ -75,7 +75,7 @@ public class PlannedTestLoader implements TestLoader<VersionedTest> {
     return testCase.withExpectedTopology(
         version,
         new TopologyAndConfigs(
-            planAtVersionNode.getPlan(),
+            Optional.of(planAtVersionNode.getPlan()),
             planAtVersionNode.getTopology(),
             planAtVersionNode.getSchemas(),
             planAtVersionNode.getConfigs()


### PR DESCRIPTION
Temporarily add back expected topology tests, until we make the
full switchover to the new query plan based tests

