### PR TITLE
docs: remove basic auth section from server-config (DOCS-3140)

### DIFF
--- a/docs/installation/server-config/integrate-ksql-with-confluent-control-center.rst
+++ b/docs/installation/server-config/integrate-ksql-with-confluent-control-center.rst
@@ -25,17 +25,6 @@ properties in the KSQL Server and |c3-short| configuration files.
 * By default, the |c3-short| configuration file is installed at
   ``<path-to-confluent>/etc/confluent-control-center/control-center.properties``.
 
-Secure Communication with KSQL Server
-=====================================
-
-When you use Basic authentication in KSQL, |c3-short| allows passing credentials
-as part of the KSQL Server URL in |c3-short| configuration.
-
-::
-
-    # KSQL cluster URL
-    confluent.controlcenter.ksql.<ksql-cluster-name>.url=http://<username>:<password>@localhost:8088
-
 You can set up KSQL Server to communicate securely with other components in
 |cp|. For more information, see :ref:`ksql-security`.
 


### PR DESCRIPTION
Per field feedback, "Currently, the basic auth is not supported between KSQL and C3 UI ... Can we please remove this from the current doc?"