### PR TITLE
docs: add embedded Connect tutorial

### DIFF
--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -242,7 +242,7 @@ WITH (kafka_topic='rider_locations', value_format='json', partitions=1, key='dri
 12. Enrich driverLocations stream by joining with PostgreSQL data
 -----------------------------------------------------------------
 
-The ``driverLocations`` stream has a relatively compact schema, and doesn’t contain much data that a human would find particularly useful. We’d therefore like to *enrich* our stream of driver location events by joining them with the human-friendly vehicle information stored in our PostgreSQL database. This enriched data may then be presented by the rider’s mobile application, ultimately helping the rider to safely identify the driver’s vehicle.
+The `driverLocations` stream has a relatively compact schema, and it doesn’t contain much data that a human would find particularly useful. You can *enrich* the stream of driver location events by joining them with the human-friendly vehicle information stored in the PostgreSQL database. This enriched data can be presented by the rider’s mobile application, ultimately helping the rider to safely identify the driver’s vehicle.
 
 We can easily achieve this result using ksqlDB by simply joining the ``driverLocations`` stream with the ``drivers`` table stored in PostgreSQL:
 

--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -96,7 +96,7 @@ unzip confluentinc-kafka-connect-jdbc-5.3.1.zip
 3. Configure Connect
 --------------------
 
-In order to tell ksqlDB to run Connect in embedded mode, we must point ksqlDB to a separate Connect configuration file. In our docker-compose file, this is done via the ``KSQL_KSQL_CONNECT_WORKER_CONFIG`` environment variable. From within your local working directory, run this command to generate the Connect configuration file:
+In order to tell ksqlDB to run Connect in embedded mode, we must point ksqlDB to a separate Connect configuration file. In our docker-compose file, this is done via the `KSQL_KSQL_CONNECT_WORKER_CONFIG` environment variable. From within your local working directory, run this command to generate the Connect configuration file:
 
 ```bash
 cat << EOF > ./connect.properties
@@ -257,10 +257,10 @@ CREATE STREAM enrichedDriverLocations AS
     jdbc.model         AS model,
     jdbc.year          AS year,
     jdbc.license_plate AS license_plate,
-    jdbc.rating AS rating
+    jdbc.rating        AS rating
   FROM driverLocations dl JOIN drivers jdbc
     ON dl.driver_id = jdbc.driver_id
-  EMIT CHANGES; 
+  EMIT CHANGES;
 ```
 
 13. Create the rendezvous stream

--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -201,7 +201,7 @@ SHOW TOPICS;
 10. Create drivers table in ksqlDB
 ----------------------------------
 
-While our driver data is now integrated as a Kafka topic, we’ll want to create a ksqlDB table over this topic in order to begin referencing it from any ksqlDB queries. Streams and tables in ksqlDB essentially associate a schema with a Kafka topic, breaking each message in the topic into strongly typed columns:
+The driver data is now integrated as a {{ site.ak }} topic, but you need to create a ksqlDB table over this topic to begin referencing it from ksqlDB queries. Streams and tables in ksqlDB essentially associate a schema with a {{ site.ak }} topic, breaking each message in the topic into strongly typed columns.
 
 ```sql
 CREATE TABLE drivers (

--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -288,7 +288,7 @@ CREATE STREAM rendezvous AS
 14. Start two ksqlDB CLI sessions
 ---------------------------------
 
-Run this command to twice to open two separate ksqlDB CLI sessions. Will we use both of these sessions in the steps to follow. Note that if you still have a CLI session open from a previous step, you may reuse that session.
+Run the following command twice to open two separate ksqlDB CLI sessions. If you still have a CLI session open from a previous step, you can reuse that session.
 
 ```bash
 docker exec -it ksqldb-cli ksql http://ksqldb-server:8088

--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -324,7 +324,7 @@ INSERT INTO driverLocations (driver_id, latitude, longitude, speed) VALUES (3, 3
 INSERT INTO riderLocations (driver_id, latitude, longitude) VALUES (3, 37.4442, -122.1658);
 ```
 
-As soon as you start writing rows to the input streams, your continuous query from the previous step will begin producing joined output: the rider's location pings are joined with their inbound driver's location pings in real time, providing the rider with driver ETA, rating, as well as additional describing the driver's vehicle.
+As soon as you start writing rows to the input streams, your continuous query from the previous step will begin producing joined output: the rider's location pings are joined with their inbound driver's location pings in real time, providing the rider with driver ETA, rating, as well as additional information describing the driver's vehicle.
 
 Next steps
 -------------

--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -128,7 +128,7 @@ docker-compose up
 5. Connect to PostgreSQL
 ------------------------
 
-Establish an interactive session with PostgreSQL by running this command:
+Run the following command to establish an interactive session with PostgreSQL.
 
 ```bash
 docker exec -it postgres psql -U postgres

--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -17,6 +17,25 @@ of computer-friendly driver and rider location events, we derive an enriched
 output stream that the ride sharing app may use to facilitate a rendezvous in
 real time.
 
+When to use embedded Connect
+------------------------------
+
+ksqlDB natively integrates with {{ site.kconnect }} by either communicating
+with an external {{ site.kconnect }} cluster or by running {{ site.kconnect }}
+embedded within the KSQL server process. Each of these modes is best suited
+for the following environments:
+
+* **Embedded** - Suitable for development, testing, and simpler production
+workloads at lower throughputs when there is no need to scale ksqlDB
+independently of {{ site.kconnect }}.
+* **External** - Suitable for all production workloads.
+
+!!! note
+	The {{ site.kconnect }} integration mode is a deployment configuration
+	option. The {{ site.kconnect }} integration interface is identical for both
+	modes, so your `CREATE SOURCE` and `CREATE SINK` statements are independent
+	of the integration mode.
+
 1. Get ksqlDB
 --------------
 

--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -170,7 +170,7 @@ docker exec -it ksqldb-cli ksql http://ksqldb-server:8088
 8. Create source connector
 --------------------------
 
-Next, we are going to make our PostgreSQL data accessible to ksqlDB by creating a *source* connector. From within the ksqlDB session opened in the previous step, run this command:
+Make your PostgreSQL data accessible to ksqlDB by creating a *source* connector. In the ksqlDB CLI, run the following command.
 
 ```sql
 CREATE SOURCE CONNECTOR jdbc_source WITH (

--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -263,7 +263,7 @@ CREATE STREAM enrichedDriverLocations AS
   EMIT CHANGES; 
 ```
 
-13. Create rendezvous stream
+13. Create the rendezvous stream
 ----------------------------
 
 Putting all of this together, we will now create a final stream that the ride sharing app can use to facilitate a driver-rider rendezvous in real time. This stream is defined by a query that joins together rider and driver location updates, resulting in a contextualized output that the app may use to show the rider their driver’s position as the rider waits to be picked up.

--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -268,7 +268,7 @@ CREATE STREAM enrichedDriverLocations AS
 
 Putting all of this together, we will now create a final stream that the ride sharing app can use to facilitate a driver-rider rendezvous in real time. This stream is defined by a query that joins together rider and driver location updates, resulting in a contextualized output that the app may use to show the rider their driver’s position as the rider waits to be picked up.
 
-Our rendezvous stream also includes human-friendly information describing the driver’s vehicle for the rider, and even computes (albeit naively) the driver’s estimated time of arrival (ETA) at the rider’s location:
+The rendezvous stream includes human-friendly information describing the driver’s vehicle for the rider. Also, the rendezvous stream computes (albeit naively) the driver’s estimated time of arrival (ETA) at the rider’s location.
 
 ```sql
 CREATE STREAM rendezvous AS

--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -299,7 +299,7 @@ docker exec -it ksqldb-cli ksql http://ksqldb-server:8088
 
 In this step, you run a continuous query over the rendezvous stream.
 
-This is the first thing that may feel a bit unfamiliar to you, because the query will never return until it's terminated. It will perpetually push output rows to the client as events are written to the rendezvous stream. Leave the query running in your CLI session for now. It will begin producing output as soon as we write events into ksqlDB:
+This may feel a bit unfamiliar, because the query never returns until you terminate it. The query perpetually pushes output rows to the client as events are written to the rendezvous stream. Leave the query running in your CLI session for now. It will begin producing output as soon as events are written into ksqlDB.
 
 ```sql
 SELECT * FROM rendezvous EMIT CHANGES;

--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -16,7 +16,7 @@ This tutorial will demonstrate how to integrate ksqlDB with an external data sou
 
 Since ksqlDB runs natively on Apache Kafka®, you'll need to have a Kafka installation running that ksqlDB is configured to use. The docker-compose files to the right will run everything for you via Docker, including ksqlDB running [Kafka Connect](https://docs.confluent.io/current/connect/index.html) in embedded mode. Embedded Connect enables you to leverage the power of Connect without having to manage a separate Connect cluster--ksqlDB will manage one for you. Additionally, we will be using PostgreSQL as an external datastore to integrate with ksqlDB.
 
-Copy and paste the below ``docker-compose`` content into a file named ``docker-compose.yml`` in an empty local working directory. We will create and add a number of other files to this directory during this tutorial.
+In an empty local working directory, copy and paste the following `docker-compose` content into a file named `docker-compose.yml`. You will create and add a number of other files to this directory during this tutorial.
 
 ```bash
 ---

--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -315,7 +315,7 @@ INSERT INTO driverLocations (driver_id, latitude, longitude, speed) VALUES (0, 3
 INSERT INTO riderLocations (driver_id, latitude, longitude) VALUES (0, 37.3952, -122.0813);
 
 INSERT INTO driverLocations (driver_id, latitude, longitude, speed) VALUES (1, 37.7850, -122.40270, 12.0);
-INSERT INTO riderLocations (driver_id, latitude, longitude) VALUES (1, 37.7887,-122.4074);
+INSERT INTO riderLocations (driver_id, latitude, longitude) VALUES (1, 37.7887, -122.4074);
 
 INSERT INTO driverLocations (driver_id, latitude, longitude, speed) VALUES (2, 37.7925, -122.4148, 11.2);
 INSERT INTO riderLocations (driver_id, latitude, longitude) VALUES (2, 37.7876,-122.4235);

--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -220,7 +220,7 @@ Tables in ksqlDB support update semantics, where each message in the underlying 
 11. Create streams for driver locations and rider locations
 -----------------------------------------------------
 
-Next we’ll create streams to encapsulate location pings sent every few seconds by drivers’ and riders’ phones. In contrast to tables, ksqlDB streams are append-only collections of events, and therefore suitable for a continuous stream of location updates.
+In this step, you create streams to encapsulate location pings that are sent every few seconds by drivers’ and riders’ phones. In contrast to tables, ksqlDB streams are append-only collections of events, so they're suitable for a continuous stream of location updates.
 
 ```sql
 CREATE STREAM driverLocations (

--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -266,7 +266,7 @@ CREATE STREAM enrichedDriverLocations AS
 13. Create the rendezvous stream
 ----------------------------
 
-Putting all of this together, we will now create a final stream that the ride sharing app can use to facilitate a driver-rider rendezvous in real time. This stream is defined by a query that joins together rider and driver location updates, resulting in a contextualized output that the app may use to show the rider their driver’s position as the rider waits to be picked up.
+To put all of this together, create a final stream that the ridesharing app can use to facilitate a driver-rider rendezvous in real time. This stream is defined by a query that joins together rider and driver location updates, resulting in a contextualized output that the app can use to show the rider their driver’s position as the rider waits to be picked up.
 
 The rendezvous stream includes human-friendly information describing the driver’s vehicle for the rider. Also, the rendezvous stream computes (albeit naively) the driver’s estimated time of arrival (ETA) at the rider’s location.
 

--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -192,7 +192,7 @@ When the source connector is created, it imports any PostgreSQL tables matching 
 9. View imported topic
 ----------------------
 
-From within your ksqlDB CLI session, run this command to verify that the drivers table has been imported. Since we’ve specified ``jdbc_`` as our topic prefix, you should see a ``jdbc_drivers`` topic in the output of this command:
+In the ksqlDB CLI session, run the following command to verify that the `drivers` table has been imported. Because you specified `jdbc_` as the topic prefix, you should see a `jdbc_drivers` topic in the output.
 
 ```bash
 SHOW TOPICS;

--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -244,7 +244,7 @@ WITH (kafka_topic='rider_locations', value_format='json', partitions=1, key='dri
 
 The `driverLocations` stream has a relatively compact schema, and it doesn’t contain much data that a human would find particularly useful. You can *enrich* the stream of driver location events by joining them with the human-friendly vehicle information stored in the PostgreSQL database. This enriched data can be presented by the rider’s mobile application, ultimately helping the rider to safely identify the driver’s vehicle.
 
-We can easily achieve this result using ksqlDB by simply joining the ``driverLocations`` stream with the ``drivers`` table stored in PostgreSQL:
+You can achieve this result easily by joining the `driverLocations` stream with the `drivers` table stored in PostgreSQL.
 
 ```sql
 CREATE STREAM enrichedDriverLocations AS

--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -308,7 +308,7 @@ SELECT * FROM rendezvous EMIT CHANGES;
 16. Write data to input streams
 -------------------------------
 
-Our continuous query is reading from the ``rendezvous`` stream, which takes its input from the ``enrichedDriverLocations`` and ``riderLocations`` streams. Because ``enrichedDriverLocations`` takes its input from the ``driverLocations`` stream, we'll need to write data into ``driverLocations`` and ``riderLocations`` before ``rendezvous`` will produce the joined output that our continuous query will read:
+Your continuous query reads from the `rendezvous` stream, which takes its input from the `enrichedDriverLocations` and `riderLocations` streams. And `enrichedDriverLocations` takes its input from the `driverLocations` stream, so you need to write data into `driverLocations` and `riderLocations` before `rendezvous` produces the joined output that the continuous query reads.
 
 ```sql
 INSERT INTO driverLocations (driver_id, latitude, longitude, speed) VALUES (0, 37.3965, -122.0818, 23.2);
@@ -324,11 +324,11 @@ INSERT INTO driverLocations (driver_id, latitude, longitude, speed) VALUES (3, 3
 INSERT INTO riderLocations (driver_id, latitude, longitude) VALUES (3, 37.4442, -122.1658);
 ```
 
-As soon as you start writing rows to the input streams, your continuous query from the previous step will begin producing joined output: the rider's location pings are joined with their inbound driver's location pings in real time, providing the rider with driver ETA, rating, as well as additional information describing the driver's vehicle.
+As soon as you start writing rows to the input streams, your continuous query from the previous step starts producing joined output. The rider's location pings are joined with their inbound driver's location pings in real time, providing the rider with driver ETA, rating, and additional information describing the driver's vehicle.
 
 Next steps
 -------------
 
-This tutorial demonstrated how to run ksqlDB in embedded Connect mode using Docker. We used the JDBC connector to integrate ksqlDB with PostgreSQL data, but this is just one of many connectors that are available to help you integrate ksqlDB with external systems. Check out [Confluent Hub](https://www.confluent.io/hub/) to learn more about all of the various connectors that enable integration with a wide variety of external systems.
+This tutorial shows how to run ksqlDB in embedded {{ site.kconnect }} mode using Docker. It uses the JDBC connector to integrate ksqlDB with PostgreSQL data, but this is just one of many connectors that are available to help you integrate ksqlDB with external systems. Check out [Confluent Hub](https://www.confluent.io/hub/) to learn more about all of the various connectors that enable integration with a wide variety of external systems.
 
 You may also want to take a look at our [examples](https://ksqldb.io/examples.html) to better understand how you can use ksqlDB for your specific workload.

--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -308,7 +308,7 @@ SELECT * FROM rendezvous EMIT CHANGES;
 16. Write data to input streams
 -------------------------------
 
-Our continuous query is reading from the ``rendezvous`` stream, which takes its input from the ``enrichedDriverLocations`` and ``riderLocations`` streams. And ``enrichedDriverLocations`` takes its input from the ``driverLocations`` stream, so we'll need to write data into ``driverLocations`` and ``riderLocations`` before ``rendezvous`` will produce the joined output that our continuous query will read:
+Our continuous query is reading from the ``rendezvous`` stream, which takes its input from the ``enrichedDriverLocations`` and ``riderLocations`` streams. Because ``enrichedDriverLocations`` takes its input from the ``driverLocations`` stream, we'll need to write data into ``driverLocations`` and ``riderLocations`` before ``rendezvous`` will produce the joined output that our continuous query will read:
 
 ```sql
 INSERT INTO driverLocations (driver_id, latitude, longitude, speed) VALUES (0, 37.3965, -122.0818, 23.2);

--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -137,7 +137,7 @@ docker exec -it postgres psql -U postgres
 6. Populate PostgreSQL with vehicle/driver data
 -----------------------------------------------
 
-From within the session opened in the previous step, run these SQL statements to set up our driver data. We will ultimately join this PostgreSQL data with our event streams in ksqlDB:
+In the PostgreSQL session, run the following SQL statements to set up the driver data. You will join this PostgreSQL data with event streams in ksqlDB.
 
 ```sql
 CREATE TABLE drivers (

--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -14,7 +14,7 @@ This tutorial will demonstrate how to integrate ksqlDB with an external data sou
 1. Get ksqlDB
 --------------
 
-Since ksqlDB runs natively on Apache Kafka®, you'll need to have a Kafka installation running that ksqlDB is configured to use. The docker-compose files to the right will run everything for you via Docker, including ksqlDB running [Kafka Connect](https://docs.confluent.io/current/connect/index.html) in embedded mode. Embedded Connect enables you to leverage the power of Connect without having to manage a separate Connect cluster--ksqlDB will manage one for you. Additionally, we will be using PostgreSQL as an external datastore to integrate with ksqlDB.
+Since ksqlDB runs natively on {{ site.aktm }}, you need a running {{ site.ak }} installation that ksqlDB is configured to use. The following docker-compose files run everything for you via Docker, including ksqlDB running [Kafka Connect](https://docs.confluent.io/current/connect/index.html) in embedded mode. Embedded Connect enables you to leverage the power of {{ site.kconnect }} without having to manage a separate {{ site.kconnect }} cluster, because ksqlDB manages one for you. Also, this tutorial use PostgreSQL as an external datastore to integrate with ksqlDB.
 
 In an empty local working directory, copy and paste the following `docker-compose` content into a file named `docker-compose.yml`. You will create and add a number of other files to this directory during this tutorial.
 

--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -329,6 +329,6 @@ As soon as you start writing rows to the input streams, your continuous query fr
 Next steps
 -------------
 
-This tutorial has demonstrated how to run ksqlDB in embedded Connect mode using Docker. We have used the JDBC connector to integrate ksqlDB with PostgreSQL data, but this is just one of many connectors that are available to help you integrate ksqlDB with external systems. Check out [Confluent Hub](https://www.confluent.io/hub/) to learn more about all of the various connectors that enable integration with a wide variety of external systems.
+This tutorial demonstrated how to run ksqlDB in embedded Connect mode using Docker. We used the JDBC connector to integrate ksqlDB with PostgreSQL data, but this is just one of many connectors that are available to help you integrate ksqlDB with external systems. Check out [Confluent Hub](https://www.confluent.io/hub/) to learn more about all of the various connectors that enable integration with a wide variety of external systems.
 
 You may also want to take a look at our [examples](https://ksqldb.io/examples.html) to better understand how you can use ksqlDB for your specific workload.

--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -64,8 +64,8 @@ services:
       KSQL_KSQL_LOGGING_PROCESSING_TOPIC_AUTO_CREATE: "true"
       KSQL_KSQL_CONNECT_WORKER_CONFIG: "/connect/connect.properties"
     volumes:
-      - ${PWD}/confluentinc-kafka-connect-jdbc-5.3.1:/usr/share/kafka/plugins/jdbc
-      - ${PWD}/connect.properties:/connect/connect.properties
+      - ./confluentinc-kafka-connect-jdbc-5.3.1:/usr/share/kafka/plugins/jdbc
+      - ./connect.properties:/connect/connect.properties
 
   ksqldb-cli:
     image: confluentinc/ksqldb-cli:0.6.0

--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -187,7 +187,7 @@ CREATE SOURCE CONNECTOR jdbc_source WITH (
 
 ```
 
-Once the source connector is created, it will import any PostgreSQL tables matching the specified ``table.whitelist``. Tables are imported via Kafka topics, one topic per imported table. Once these topics are created, we may interact with them just like any other Kafka topic used by ksqlDB.
+When the source connector is created, it imports any PostgreSQL tables matching the specified `table.whitelist`. Tables are imported via {{ site.ak }} topics, with one topic per imported table. Once these topics are created, you can interact with them just like any other {{ site.ak }} topic used by ksqlDB.
 
 9. View imported topic
 ----------------------

--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -1,0 +1,334 @@
+---
+layout: page
+title: ksqlDB with Embedded Connect
+tagline: Run Kafka Connect embedded within ksqlDB
+description: Learn how to use ksqlDB with embedded Connect to integrate with external data sources and sinks
+keywords: ksqlDB, connect, PostgreSQL, jdbc
+---
+
+Overview
+==============
+
+This tutorial will demonstrate how to integrate ksqlDB with an external data source to power a simple ride sharing app. Our external source will be a PostgreSQL database containing relatively static data describing each driver’s vehicle. By combining this human-friendly static data with a continuous stream of computer-friendly driver and rider location events, we derive an enriched output stream that the ride sharing app may use to facilitate a rendezvous in real time.
+
+1. Get ksqlDB
+--------------
+
+Since ksqlDB runs natively on Apache Kafka®, you'll need to have a Kafka installation running that ksqlDB is configured to use. The docker-compose files to the right will run everything for you via Docker, including ksqlDB running [Kafka Connect](https://docs.confluent.io/current/connect/index.html) in embedded mode. Embedded Connect enables you to leverage the power of Connect without having to manage a separate Connect cluster--ksqlDB will manage one for you. Additionally, we will be using PostgreSQL as an external datastore to integrate with ksqlDB.
+
+Copy and paste the below ``docker-compose`` content into a file named ``docker-compose.yml`` in an empty local working directory. We will create and add a number of other files to this directory during this tutorial.
+
+```bash
+---
+version: '2'
+
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:5.3.1
+    hostname: zookeeper
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  broker:
+    image: confluentinc/cp-enterprise-kafka:5.3.1
+    hostname: broker
+    container_name: broker
+    depends_on:
+      - zookeeper
+    ports:
+      - "29092:29092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:9092,PLAINTEXT_HOST://localhost:29092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+
+  ksqldb-server:
+    image: confluentinc/ksqldb-server:0.6.0
+    hostname: ksqldb-server
+    container_name: ksqldb-server
+    depends_on:
+      - broker
+    ports:
+      - "8088:8088"
+    environment:
+      KSQL_LISTENERS: http://0.0.0.0:8088
+      KSQL_BOOTSTRAP_SERVERS: broker:9092
+      KSQL_KSQL_LOGGING_PROCESSING_STREAM_AUTO_CREATE: "true"
+      KSQL_KSQL_LOGGING_PROCESSING_TOPIC_AUTO_CREATE: "true"
+      KSQL_KSQL_CONNECT_WORKER_CONFIG: "/connect/connect.properties"
+    volumes:
+      - ${PWD}/confluentinc-kafka-connect-jdbc-5.3.1:/usr/share/kafka/plugins/jdbc
+      - ${PWD}/connect.properties:/connect/connect.properties
+
+  ksqldb-cli:
+    image: confluentinc/ksqldb-cli:0.6.0
+    container_name: ksqldb-cli
+    depends_on:
+      - broker
+      - ksqldb-server
+    entrypoint: /bin/sh
+    tty: true
+  
+  postgres:
+    image: postgres:12
+    hostname: postgres
+    container_name: postgres
+    ports:
+      - "5432:5432"
+```
+
+2. Get the JDBC connector
+-------------------------
+
+[Download the JDBC connector](https://www.confluent.io/hub/confluentinc/kafka-connect-jdbc) to your local working directory. Next, unzip the downloaded archive:
+
+```bash
+unzip confluentinc-kafka-connect-jdbc-5.3.1.zip
+```
+
+3. Configure Connect
+--------------------
+
+In order to tell ksqlDB to run Connect in embedded mode, we must point ksqlDB to a separate Connect configuration file. In our docker-compose file, this is done via the ``KSQL_KSQL_CONNECT_WORKER_CONFIG`` environment variable. From within your local working directory, run this command to generate the Connect configuration file:
+
+```bash
+cat << EOF > ./connect.properties
+bootstrap.servers=broker:9092
+plugin.path=/usr/share/kafka/plugins
+group.id=ksql-connect-cluster
+key.converter=org.apache.kafka.connect.json.JsonConverter
+value.converter=org.apache.kafka.connect.json.JsonConverter
+value.converter.schemas.enable=false
+internal.key.converter.schemas.enable=false
+config.storage.topic=ksql-connect-configs
+offset.storage.topic=ksql-connect-offsets
+status.storage.topic=ksql-connect-statuses
+config.storage.replication.factor=1
+offset.storage.replication.factor=1
+status.storage.replication.factor=1
+EOF
+```
+
+4. Start ksqlDB and PostgreSQL
+------------------------------
+
+From a directory containing the ``docker-compose.yml`` file created in the first step, run this command in order to start all services in the correct order:
+
+```bash
+docker-compose up
+```
+
+5. Connect to PostgreSQL
+------------------------
+
+Establish an interactive session with PostgreSQL by running this command:
+
+```bash
+docker exec -it postgres psql -U postgres
+```
+
+6. Populate PostgreSQL with vehicle/driver data
+-----------------------------------------------
+
+From within the session opened in the previous step, run these SQL statements to set up our driver data. We will ultimately join this PostgreSQL data with our event streams in ksqlDB:
+
+```sql
+CREATE TABLE drivers (
+  driver_id integer PRIMARY KEY,
+  make text,
+  model text,
+  year integer,
+  license_plate text,
+  rating float
+);
+
+INSERT INTO drivers (driver_id, make, model, year, license_plate, rating) VALUES
+  (0, 'Toyota', 'Prius',   2019, 'KAFKA-1', 5.00),
+  (1, 'Kia',    'Sorento', 2017, 'STREAMS', 4.89),
+  (2, 'Tesla',  'Model S', 2019, 'CNFLNT',  4.92),
+  (3, 'Toyota', 'Camry',   2018, 'ILVKSQL', 4.85);
+```
+
+7. Start ksqlDB's interactive CLI
+---------------------------------
+
+ksqlDB runs as a server which clients connect to in order to issue queries.
+
+Run this command to connect to the ksqlDB server and enter an interactive command-line interface (CLI) session:
+
+```bash
+docker exec -it ksqldb-cli ksql http://ksqldb-server:8088
+```
+
+8. Create source connector
+--------------------------
+
+Next, we are going to make our PostgreSQL data accessible to ksqlDB by creating a *source* connector. From within the ksqlDB session opened in the previous step, run this command:
+
+```sql
+CREATE SOURCE CONNECTOR jdbc_source WITH (
+  'connector.class'          = 'io.confluent.connect.jdbc.JdbcSourceConnector',
+  'connection.url'           = 'jdbc:postgresql://postgres:5432/postgres',
+  'connection.user'          = 'postgres',
+  'topic.prefix'             = 'jdbc_',
+  'table.whitelist'          = 'drivers',
+  'mode'                     = 'incrementing',
+  'numeric.mapping'          = 'best_fit',
+  'incrementing.column.name' = 'driver_id',
+  'key'                      = 'driver_id',
+  'value.converter.schemas.enable' = false);
+
+```
+
+Once the source connector is created, it will import any PostgreSQL tables matching the specified ``table.whitelist``. Tables are imported via Kafka topics, one topic per imported table. Once these topics are created, we may interact with them just like any other Kafka topic used by ksqlDB.
+
+9. View imported topic
+----------------------
+
+From within your ksqlDB CLI session, run this command to verify that the drivers table has been imported. Since we’ve specified ``jdbc_`` as our topic prefix, you should see a ``jdbc_drivers`` topic in the output of this command:
+
+```bash
+SHOW TOPICS;
+```
+
+10. Create drivers table in ksqlDB
+----------------------------------
+
+While our driver data is now integrated as a Kafka topic, we’ll want to create a ksqlDB table over this topic in order to begin referencing it from any ksqlDB queries. Streams and tables in ksqlDB essentially associate a schema with a Kafka topic, breaking each message in the topic into strongly typed columns:
+
+```sql
+CREATE TABLE drivers (
+  driver_id INTEGER,
+  make STRING,
+  model STRING,
+  year INTEGER,
+  license_plate STRING,
+  rating DOUBLE
+)
+WITH (kafka_topic='jdbc_drivers', value_format='json', partitions=1, key='driver_id');
+```
+
+Tables in ksqlDB support update semantics, where each message in the underlying topic represents a row in the table. For messages in the topic with the same key, the latest message associated with a given key represents the latest value for the corresponding row in the table.
+
+11. Create driverLocations and riderLocations streams
+-----------------------------------------------------
+
+Next we’ll create streams to encapsulate location pings sent every few seconds by drivers’ and riders’ phones. In contrast to tables, ksqlDB streams are append-only collections of events, and therefore suitable for a continuous stream of location updates.
+
+```sql
+CREATE STREAM driverLocations (
+  driver_id INTEGER,
+  latitude DOUBLE,
+  longitude DOUBLE,
+  speed DOUBLE
+)
+WITH (kafka_topic='driver_locations', value_format='json', partitions=1, key='driver_id');
+
+CREATE STREAM riderLocations (
+  driver_id INTEGER,
+  latitude DOUBLE,
+  longitude DOUBLE
+)
+WITH (kafka_topic='rider_locations', value_format='json', partitions=1, key='driver_id');
+```
+
+12. Enrich driverLocations stream by joining with PostgreSQL data
+-----------------------------------------------------------------
+
+The ``driverLocations`` stream has a relatively compact schema, and doesn’t contain much data that a human would find particularly useful. We’d therefore like to *enrich* our stream of driver location events by joining them with the human-friendly vehicle information stored in our PostgreSQL database. This enriched data may then be presented by the rider’s mobile application, ultimately helping the rider to safely identify the driver’s vehicle.
+
+We can easily achieve this result using ksqlDB by simply joining the ``driverLocations`` stream with the ``drivers`` table stored in PostgreSQL:
+
+```sql
+CREATE STREAM enrichedDriverLocations AS
+  SELECT
+    dl.driver_id       AS driver_id,
+    dl.latitude        AS latitude,
+    dl.longitude       AS longitude,
+    dl.speed           AS speed,
+    jdbc.make          AS make,
+    jdbc.model         AS model,
+    jdbc.year          AS year,
+    jdbc.license_plate AS license_plate,
+    jdbc.rating AS rating
+  FROM driverLocations dl JOIN drivers jdbc
+    ON dl.driver_id = jdbc.driver_id
+  EMIT CHANGES; 
+```
+
+13. Create rendezvous stream
+----------------------------
+
+Putting all of this together, we will now create a final stream that the ride sharing app can use to facilitate a driver-rider rendezvous in real time. This stream is defined by a query that joins together rider and driver location updates, resulting in a contextualized output that the app may use to show the rider their driver’s position as the rider waits to be picked up.
+
+Our rendezvous stream also includes human-friendly information describing the driver’s vehicle for the rider, and even computes (albeit naively) the driver’s estimated time of arrival (ETA) at the rider’s location:
+
+```sql
+CREATE STREAM rendezvous AS
+  SELECT
+    e.license_plate AS license_plate,
+    e.make          AS make,
+    e.model         AS model,
+    e.year          AS year,
+    e.latitude      AS vehicle_lat,
+    e.longitude     AS vehicle_long,
+    GEO_DISTANCE(e.latitude, e.longitude, r.latitude, r.longitude) / e.speed AS eta
+  FROM enrichedDriverLocations e JOIN riderLocations r WITHIN 1 MINUTE
+    ON e.driver_id = r.driver_id
+  EMIT CHANGES;
+```
+
+14. Start two ksqlDB CLI sessions
+---------------------------------
+
+Run this command to twice to open two separate ksqlDB CLI sessions. Will we use both of these sessions in the steps to follow. Note that if you still have a CLI session open from a previous step, you may reuse that session.
+
+```bash
+docker exec -it ksqldb-cli ksql http://ksqldb-server:8088
+```
+
+15. Run a continuous query
+--------------------------
+
+We’re now going to run a continuous query over the rendezvous stream.
+
+This is the first thing that may feel a bit unfamiliar to you, because the query will never return until it's terminated. It will perpetually push output rows to the client as events are written to the rendezvous stream. Leave the query running in your CLI session for now. It will begin producing output as soon as we write events into ksqlDB:
+
+```sql
+SELECT * FROM rendezvous EMIT CHANGES;
+```
+
+16. Write data to input streams
+-------------------------------
+
+Our continuous query is reading from the ``rendezvous`` stream, which takes its input from the ``enrichedDriverLocations`` and ``riderLocations`` streams. And ``enrichedDriverLocations`` takes its input from the ``driverLocations`` stream, so we'll need to write data into ``driverLocations`` and ``riderLocations`` before ``rendezvous`` will produce the joined output that our continuous query will read:
+
+```sql
+INSERT INTO driverLocations (driver_id, latitude, longitude, speed) VALUES (0, 37.3965, -122.0818, 23.2);
+INSERT INTO riderLocations (driver_id, latitude, longitude) VALUES (0, 37.3952, -122.0813);
+
+INSERT INTO driverLocations (driver_id, latitude, longitude, speed) VALUES (1, 37.7850, -122.40270, 12.0);
+INSERT INTO riderLocations (driver_id, latitude, longitude) VALUES (1, 37.7887,-122.4074);
+
+INSERT INTO driverLocations (driver_id, latitude, longitude, speed) VALUES (2, 37.7925, -122.4148, 11.2);
+INSERT INTO riderLocations (driver_id, latitude, longitude) VALUES (2, 37.7876,-122.4235);
+
+INSERT INTO driverLocations (driver_id, latitude, longitude, speed) VALUES (3, 37.4471, -122.1625, 14.7);
+INSERT INTO riderLocations (driver_id, latitude, longitude) VALUES (3, 37.4442, -122.1658);
+```
+
+As soon as you start writing rows to the input streams, your continuous query from the previous step will begin producing joined output: the rider's location pings are joined with their inbound driver's location pings in real time, providing the rider with driver ETA, rating, as well as additional describing the driver's vehicle.
+
+Next steps
+-------------
+
+This tutorial has demonstrated how to run ksqlDB in embedded Connect mode using Docker. We have used the JDBC connector to integrate ksqlDB with PostgreSQL data, but this is just one of many connectors that are available to help you integrate ksqlDB with external systems. Check out [Confluent Hub](https://www.confluent.io/hub/) to learn more about all of the various connectors that enable integration with a wide variety of external systems.
+
+You may also want to take a look at our [examples](https://ksqldb.io/examples.html) to better understand how you can use ksqlDB for your specific workload.

--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -18,7 +18,7 @@ Since ksqlDB runs natively on {{ site.aktm }}, you need a running {{ site.ak }} 
 
 In an empty local working directory, copy and paste the following `docker-compose` content into a file named `docker-compose.yml`. You will create and add a number of other files to this directory during this tutorial.
 
-```bash
+```yaml
 ---
 version: '2'
 

--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -119,7 +119,7 @@ EOF
 4. Start ksqlDB and PostgreSQL
 ------------------------------
 
-From a directory containing the ``docker-compose.yml`` file created in the first step, run this command in order to start all services in the correct order:
+In the directory containing the `docker-compose.yml` file you created in the first step, run the following command to start all services in the correct order.
 
 ```bash
 docker-compose up

--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -318,7 +318,7 @@ INSERT INTO driverLocations (driver_id, latitude, longitude, speed) VALUES (1, 3
 INSERT INTO riderLocations (driver_id, latitude, longitude) VALUES (1, 37.7887, -122.4074);
 
 INSERT INTO driverLocations (driver_id, latitude, longitude, speed) VALUES (2, 37.7925, -122.4148, 11.2);
-INSERT INTO riderLocations (driver_id, latitude, longitude) VALUES (2, 37.7876,-122.4235);
+INSERT INTO riderLocations (driver_id, latitude, longitude) VALUES (2, 37.7876, -122.4235);
 
 INSERT INTO driverLocations (driver_id, latitude, longitude, speed) VALUES (3, 37.4471, -122.1625, 14.7);
 INSERT INTO riderLocations (driver_id, latitude, longitude) VALUES (3, 37.4442, -122.1658);

--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -297,7 +297,7 @@ docker exec -it ksqldb-cli ksql http://ksqldb-server:8088
 15. Run a continuous query
 --------------------------
 
-We’re now going to run a continuous query over the rendezvous stream.
+In this step, you run a continuous query over the rendezvous stream.
 
 This is the first thing that may feel a bit unfamiliar to you, because the query will never return until it's terminated. It will perpetually push output rows to the client as events are written to the rendezvous stream. Leave the query running in your CLI session for now. It will begin producing output as soon as we write events into ksqlDB:
 

--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -161,7 +161,7 @@ INSERT INTO drivers (driver_id, make, model, year, license_plate, rating) VALUES
 
 ksqlDB runs as a server which clients connect to in order to issue queries.
 
-Run this command to connect to the ksqlDB server and enter an interactive command-line interface (CLI) session:
+Run the following command to connect to the ksqlDB server and start an interactive command-line interface (CLI) session.
 
 ```bash
 docker exec -it ksqldb-cli ksql http://ksqldb-server:8088

--- a/docs-md/tutorials/embedded-connect.md
+++ b/docs-md/tutorials/embedded-connect.md
@@ -217,7 +217,7 @@ WITH (kafka_topic='jdbc_drivers', value_format='json', partitions=1, key='driver
 
 Tables in ksqlDB support update semantics, where each message in the underlying topic represents a row in the table. For messages in the topic with the same key, the latest message associated with a given key represents the latest value for the corresponding row in the table.
 
-11. Create driverLocations and riderLocations streams
+11. Create streams for driver locations and rider locations
 -----------------------------------------------------
 
 Next we’ll create streams to encapsulate location pings sent every few seconds by drivers’ and riders’ phones. In contrast to tables, ksqlDB streams are append-only collections of events, and therefore suitable for a continuous stream of location updates.

--- a/docs-md/tutorials/index.md
+++ b/docs-md/tutorials/index.md
@@ -11,6 +11,7 @@ keywords: ksqldb, query, application, quickstart, tutorial, walkthrough, how to
 - [Write Streaming Queries Against {{ site.aktm }} Using ksqlDB (Local)](basics-local.md)
 - [Write Streaming Queries Against {{ site.aktm }} Using ksqlDB and {{ site.c3 }}](basics-control-center.md)
 - [Clickstream Data Analysis Pipeline Using ksqlDB (Docker)](clickstream-docker.md)
+- [ksqlDB with Embedded Connect](embedded-connect.md)
 - [Integrating with PostgreSQL](connect-integration.md)
 - [ksqlDB Examples](examples.md)
 
@@ -100,6 +101,11 @@ of the Clickstream tutorial designed for local {{ site.cp }}
 installs. Running the Clickstream demo locally without Docker requires
 that you have {{ site.cp }} installed locally, along with
 Elasticsearch and Grafana.
+
+ksqlDB with Embedded Connect
+-------------------------------
+
+ksqlDB has native integration with Kafka Connect. While ksqlDB can integrate with a separate [Kafka Connect](https://docs.confluent.io/current/connect/index.html) cluster, it can also run Connect embedded within the ksqlDB server, making it unnecessary to run a separate Connect cluster. The [embedded Connect tutorial](embedded-connect.md) provides an overview of how ksqlDB may be configured and used to run Connect in embedded mode.
 
 ksqlDB Examples
 ---------------

--- a/docs-md/tutorials/index.md
+++ b/docs-md/tutorials/index.md
@@ -105,7 +105,7 @@ Elasticsearch and Grafana.
 ksqlDB with Embedded Connect
 -------------------------------
 
-ksqlDB has native integration with Kafka Connect. While ksqlDB can integrate with a separate [Kafka Connect](https://docs.confluent.io/current/connect/index.html) cluster, it can also run Connect embedded within the ksqlDB server, making it unnecessary to run a separate Connect cluster. The [embedded Connect tutorial](embedded-connect.md) provides an overview of how ksqlDB may be configured and used to run Connect in embedded mode.
+ksqlDB has native integration with {{ site.kconnect }}. While ksqlDB can integrate with a separate [Kafka Connect](https://docs.confluent.io/current/connect/index.html) cluster, it can also run {{ site.kconnect }} embedded within the ksqlDB server, making it unnecessary to run a separate {{ site.kconnect }} cluster. The [embedded Connect tutorial](embedded-connect.md) shows how you can configure ksqlDB to run {{ site.kconnect }} in embedded mode.
 
 ksqlDB Examples
 ---------------

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -136,6 +136,7 @@ nav:
       - Write Streaming Queries Against Apache Kafka® Using ksqlDB and Confluent Control Center (Docker): tutorials/basics-docker.md # Could be the canonical quickstart
       # - Write Streaming Queries Against Apache Kafka® Using ksqlDB and Confluent Control Center (Local): tutorials/basics-local.md # leave in docs.confluent.io
       - Clickstream Data Analysis Pipeline Using ksqlDB (Docker): tutorials/clickstream-docker.md
+      - ksqlDB with Embedded Connect: tutorials/embedded-connect.md
       - Integrate with PostgreSQL: tutorials/connect-integration.md
   - Troubleshooting: troubleshoot-ksqldb.md
   - Frequently Asked Questions: faq.md


### PR DESCRIPTION
This PR adds a tutorial for running embedded Connect. For the time being, it makes the most sense to leave this tutorial in the docs (rather than the quickstart) since it's somewhat long. Once we iron out some of the kinks around running embedded Connect, we will consider reworking the quickstart to use embedded Connect by default. 