### PR TITLE
perf: Improves pull query performance by making the default schema service a singleton

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactoryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactoryTest.java
@@ -88,14 +88,10 @@ public class KsqlSchemaRegistryClientFactoryTest {
     final Map<String, Object> expectedConfigs = defaultConfigs();
 
     // When:
-    final SchemaRegistryClient client =
-        new KsqlSchemaRegistryClientFactory(config, restServiceSupplier, sslFactory,
-            srClientFactory, Collections.emptyMap()).get();
+    KsqlSchemaRegistryClientFactory.configureSslFactory(config, sslFactory);
 
     // Then:
-    assertThat(client, is(notNullValue()));
     verify(sslFactory).configure(expectedConfigs);
-    verify(restService).setSslSocketFactory(isA(SSL_CONTEXT.getSocketFactory().getClass()));
   }
 
   @Test
@@ -109,14 +105,10 @@ public class KsqlSchemaRegistryClientFactoryTest {
     expectedConfigs.put(SslConfigs.SSL_PROTOCOL_CONFIG, "SSLv3");
 
     // When:
-    final SchemaRegistryClient client =
-        new KsqlSchemaRegistryClientFactory(config, restServiceSupplier, sslFactory,
-            srClientFactory, Collections.emptyMap()).get();
+    KsqlSchemaRegistryClientFactory.configureSslFactory(config, sslFactory);
 
     // Then:
-    assertThat(client, is(notNullValue()));
     verify(sslFactory).configure(expectedConfigs);
-    verify(restService).setSslSocketFactory(isA(SSL_CONTEXT.getSocketFactory().getClass()));
   }
 
   @Test
@@ -130,15 +122,11 @@ public class KsqlSchemaRegistryClientFactoryTest {
     expectedConfigs.put(SslConfigs.SSL_PROTOCOL_CONFIG, "SSLv3");
 
     // When:
-    final SchemaRegistryClient client =
-        new KsqlSchemaRegistryClientFactory(config, restServiceSupplier, sslFactory,
-            srClientFactory, Collections.emptyMap()).get();
+    KsqlSchemaRegistryClientFactory.configureSslFactory(config, sslFactory);
 
 
     // Then:
-    assertThat(client, is(notNullValue()));
     verify(sslFactory).configure(expectedConfigs);
-    verify(restService).setSslSocketFactory(isA(SSL_CONTEXT.getSocketFactory().getClass()));
   }
 
   @Test
@@ -160,6 +148,7 @@ public class KsqlSchemaRegistryClientFactoryTest {
         config, restServiceSupplier, sslFactory, srClientFactory, Collections.emptyMap()).get();
 
     // Then:
+    verify(restService).setSslSocketFactory(isA(SSL_CONTEXT.getSocketFactory().getClass()));
     srClientFactory.create(same(restService), anyInt(), eq(expectedConfigs), any());
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -448,7 +448,7 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
                       errorHandler,
                       securityExtension,
                       serverState,
-                      serviceContext
+                      serviceContext.getSchemaRegistryClientFactory()
                   );
                 }
               })
@@ -467,8 +467,8 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
     final Supplier<SchemaRegistryClient> schemaRegistryClientFactory =
         new KsqlSchemaRegistryClientFactory(ksqlConfig, Collections.emptyMap())::get;
     final ServiceContext serviceContext = new LazyServiceContext(() ->
-        RestServiceContextFactory.create(ksqlConfig, schemaRegistryClientFactory,
-            Optional.empty()));
+        RestServiceContextFactory.create(ksqlConfig, Optional.empty(),
+            schemaRegistryClientFactory));
 
     return buildApplication(
         "",

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/context/KsqlSecurityContextBinder.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/context/KsqlSecurityContextBinder.java
@@ -15,10 +15,11 @@
 
 package io.confluent.ksql.rest.server.context;
 
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.security.KsqlSecurityContext;
 import io.confluent.ksql.security.KsqlSecurityExtension;
-import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
+import java.util.function.Supplier;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.process.internal.RequestScoped;
 
@@ -33,9 +34,10 @@ public class KsqlSecurityContextBinder extends AbstractBinder {
   public KsqlSecurityContextBinder(
       final KsqlConfig ksqlConfig,
       final KsqlSecurityExtension securityExtension,
-      final ServiceContext serviceContext
+      final Supplier<SchemaRegistryClient> schemaRegistryClientFactory
   ) {
-    KsqlSecurityContextBinderFactory.configure(ksqlConfig, securityExtension, serviceContext);
+    KsqlSecurityContextBinderFactory.configure(ksqlConfig, securityExtension,
+        schemaRegistryClientFactory);
   }
 
   @Override

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/context/KsqlSecurityContextBinder.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/context/KsqlSecurityContextBinder.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.rest.server.context;
 
 import io.confluent.ksql.security.KsqlSecurityContext;
 import io.confluent.ksql.security.KsqlSecurityExtension;
+import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.process.internal.RequestScoped;
@@ -31,9 +32,10 @@ import org.glassfish.jersey.process.internal.RequestScoped;
 public class KsqlSecurityContextBinder extends AbstractBinder {
   public KsqlSecurityContextBinder(
       final KsqlConfig ksqlConfig,
-      final KsqlSecurityExtension securityExtension
+      final KsqlSecurityExtension securityExtension,
+      final ServiceContext serviceContext
   ) {
-    KsqlSecurityContextBinderFactory.configure(ksqlConfig, securityExtension);
+    KsqlSecurityContextBinderFactory.configure(ksqlConfig, securityExtension, serviceContext);
   }
 
   @Override

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/context/KsqlSecurityContextBinderFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/context/KsqlSecurityContextBinderFactory.java
@@ -68,8 +68,7 @@ public class KsqlSecurityContextBinderFactory implements Factory<KsqlSecurityCon
     this(
         securityContext,
         request,
-        (config, authHeader) ->
-            RestServiceContextFactory.create(config, schemaRegistryClientFactory, authHeader),
+        RestServiceContextFactory::create,
         RestServiceContextFactory::create
     );
   }
@@ -97,8 +96,8 @@ public class KsqlSecurityContextBinderFactory implements Factory<KsqlSecurityCon
 
     if (!securityExtension.getUserContextProvider().isPresent()) {
       return new KsqlSecurityContext(
-      Optional.ofNullable(principal),
-          defaultServiceContextFactory.create(ksqlConfig, authHeader)
+          Optional.ofNullable(principal),
+          defaultServiceContextFactory.create(ksqlConfig, authHeader, schemaRegistryClientFactory)
       );
     }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/services/RestServiceContextFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/services/RestServiceContextFactory.java
@@ -32,14 +32,6 @@ public final class RestServiceContextFactory {
   private RestServiceContextFactory() {
   }
 
-  public interface DefaultServiceContextFactory {
-
-    ServiceContext create(
-        KsqlConfig config,
-        Optional<String> authHeader
-    );
-  }
-
   public interface UserServiceContextFactory {
 
     ServiceContext create(

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/services/RestServiceContextFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/services/RestServiceContextFactory.java
@@ -34,7 +34,8 @@ public final class RestServiceContextFactory {
 
     ServiceContext create(
         KsqlConfig config,
-        Optional<String> authHeader
+        Optional<String> authHeader,
+        Supplier<SchemaRegistryClient> srClientFactory
     );
   }
 
@@ -50,8 +51,8 @@ public final class RestServiceContextFactory {
 
   public static ServiceContext create(
       final KsqlConfig ksqlConfig,
-      final Supplier<SchemaRegistryClient> schemaRegistryClientFactory,
-      final Optional<String> authHeader
+      final Optional<String> authHeader,
+      final Supplier<SchemaRegistryClient> schemaRegistryClientFactory
   ) {
     return create(
         ksqlConfig,

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/services/RestServiceContextFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/services/RestServiceContextFactory.java
@@ -16,12 +16,10 @@
 package io.confluent.ksql.rest.server.services;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.ksql.schema.registry.KsqlSchemaRegistryClientFactory;
 import io.confluent.ksql.services.DefaultConnectClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.ServiceContextFactory;
 import io.confluent.ksql.util.KsqlConfig;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.kafka.streams.KafkaClientSupplier;
@@ -30,6 +28,14 @@ import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
 public final class RestServiceContextFactory {
 
   private RestServiceContextFactory() {
+  }
+
+  public interface DefaultServiceContextFactory {
+
+    ServiceContext create(
+        KsqlConfig config,
+        Optional<String> authHeader
+    );
   }
 
   public interface UserServiceContextFactory {
@@ -44,13 +50,14 @@ public final class RestServiceContextFactory {
 
   public static ServiceContext create(
       final KsqlConfig ksqlConfig,
+      final Supplier<SchemaRegistryClient> schemaRegistryClientFactory,
       final Optional<String> authHeader
   ) {
     return create(
         ksqlConfig,
         authHeader,
         new DefaultKafkaClientSupplier(),
-        new KsqlSchemaRegistryClientFactory(ksqlConfig, Collections.emptyMap())::get
+        schemaRegistryClientFactory
     );
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.logging.processing.ProcessingLogConfig;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
@@ -40,7 +41,6 @@ import io.confluent.ksql.rest.entity.KsqlErrorMessage;
 import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.server.computation.CommandRunner;
 import io.confluent.ksql.rest.server.computation.CommandStore;
-import io.confluent.ksql.rest.server.context.KsqlSecurityContextBinder;
 import io.confluent.ksql.rest.server.filters.KsqlAuthorizationFilter;
 import io.confluent.ksql.rest.server.resources.KsqlResource;
 import io.confluent.ksql.rest.server.resources.RootDocument;
@@ -125,6 +125,8 @@ public class KsqlRestApplicationTest {
   @Mock
   private Consumer<KsqlConfig> rocksDBConfigSetterHandler;
 
+  @Mock
+  private SchemaRegistryClient schemaRegistryClient;
   private String logCreateStatement;
   private KsqlRestApplication app;
   private KsqlRestConfig restConfig;
@@ -417,7 +419,6 @@ public class KsqlRestApplicationTest {
         streamedQueryResource,
         ksqlResource,
         versionCheckerAgent,
-        KsqlSecurityContextBinder::new,
         securityExtension,
         serverState,
         processingLogContext,

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -36,10 +36,7 @@ import io.confluent.ksql.rest.entity.RunningQuery;
 import io.confluent.ksql.rest.entity.SourceInfo;
 import io.confluent.ksql.rest.entity.StreamsList;
 import io.confluent.ksql.rest.entity.TablesList;
-import io.confluent.ksql.rest.server.context.KsqlSecurityContextBinder;
 import io.confluent.ksql.rest.util.KsqlInternalTopicUtils;
-import io.confluent.ksql.security.KsqlSecurityContext;
-import io.confluent.ksql.security.KsqlSecurityExtension;
 import io.confluent.ksql.services.DisabledKsqlClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.ServiceContextFactory;
@@ -61,17 +58,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.eclipse.jetty.websocket.api.util.WSURI;
-import org.glassfish.hk2.api.Factory;
-import org.glassfish.hk2.utilities.Binder;
-import org.glassfish.hk2.utilities.binding.AbstractBinder;
-import org.glassfish.jersey.process.internal.RequestScoped;
 import org.junit.rules.ExternalResource;
 
 /**
@@ -98,7 +90,6 @@ public class TestKsqlRestApp extends ExternalResource {
   private final Map<String, ?> baseConfig;
   private final Supplier<String> bootstrapServers;
   private final Supplier<ServiceContext> serviceContext;
-  private final BiFunction<KsqlConfig, KsqlSecurityExtension, Binder> serviceContextBinderFactory;
   private final List<URL> listeners = new ArrayList<>();
   private final Optional<BasicCredentials> credentials;
   private ExecutableServer<KsqlRestConfig> restServer;
@@ -108,14 +99,11 @@ public class TestKsqlRestApp extends ExternalResource {
       final Supplier<String> bootstrapServers,
       final Map<String, Object> additionalProps,
       final Supplier<ServiceContext> serviceContext,
-      final BiFunction<KsqlConfig, KsqlSecurityExtension, Binder> serviceContextBinderFactory,
       final Optional<BasicCredentials> credentials
   ) {
     this.baseConfig = buildBaseConfig(additionalProps);
     this.bootstrapServers = requireNonNull(bootstrapServers, "bootstrapServers");
     this.serviceContext = requireNonNull(serviceContext, "serviceContext");
-    this.serviceContextBinderFactory =
-        requireNonNull(serviceContextBinderFactory, "serviceContextBinderFactory");
     this.credentials = requireNonNull(credentials, "credentials");
   }
 
@@ -251,8 +239,7 @@ public class TestKsqlRestApp extends ExternalResource {
           config,
           (booleanSupplier) -> niceMock(VersionCheckerAgent.class),
           3,
-          serviceContext.get(),
-          serviceContextBinderFactory
+          serviceContext.get()
       );
       restServer = new ExecutableServer<>(
           new ApplicationServer<>(config),
@@ -432,8 +419,6 @@ public class TestKsqlRestApp extends ExternalResource {
     private final Map<String, Object> additionalProps = new HashMap<>();
 
     private Supplier<ServiceContext> serviceContext;
-    private BiFunction<KsqlConfig, KsqlSecurityExtension, Binder> securityContextBinder
-        = KsqlSecurityContextBinder::new;
 
     private Optional<BasicCredentials> credentials = Optional.empty();
 
@@ -457,26 +442,6 @@ public class TestKsqlRestApp extends ExternalResource {
 
     public Builder withStaticServiceContext(final Supplier<ServiceContext> serviceContext) {
       this.serviceContext = serviceContext;
-      this.securityContextBinder = (config, extension) -> new AbstractBinder() {
-        @Override
-        protected void configure() {
-          final Factory<KsqlSecurityContext> factory = new Factory<KsqlSecurityContext>() {
-            @Override
-            public KsqlSecurityContext provide() {
-              return new KsqlSecurityContext(Optional.empty(), serviceContext.get());
-            }
-
-            @Override
-            public void dispose(final KsqlSecurityContext securityContext) {
-              // do nothing because context is shared
-            }
-          };
-
-          bindFactory(factory)
-              .to(KsqlSecurityContext.class)
-              .in(RequestScoped.class);
-        }
-      };
 
       return this;
     }
@@ -502,7 +467,6 @@ public class TestKsqlRestApp extends ExternalResource {
           bootstrapServers,
           additionalProps,
           serviceContext,
-          securityContextBinder,
           credentials
       );
     }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/context/KsqlSecurityContextBinderFactoryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/context/KsqlSecurityContextBinderFactoryTest.java
@@ -80,7 +80,8 @@ public class KsqlSecurityContextBinderFactoryTest {
     );
 
     when(securityContext.getUserPrincipal()).thenReturn(user1);
-    when(defaultServiceContextProvider.create(any(), any())).thenReturn(defaultServiceContext);
+    when(defaultServiceContextProvider.create(any(), any(), any()))
+        .thenReturn(defaultServiceContext);
     when(userServiceContextFactory.create(any(), any(), any(), any()))
         .thenReturn(userServiceContext);
   }
@@ -123,7 +124,7 @@ public class KsqlSecurityContextBinderFactoryTest {
     securityContextBinderFactory.provide();
 
     // Then:
-    verify(defaultServiceContextProvider).create(any(), eq(Optional.of("some-auth")));
+    verify(defaultServiceContextProvider).create(any(), eq(Optional.of("some-auth")), any());
   }
 
   @Test


### PR DESCRIPTION
Using this singleton, locally on my Mac I'm able to increase the performance in a simple benchmark we have from 10k qps to about 14.5k qps.

### Description 
I factored the context to be a singleton because the call to the constructor of `KsqlSchemaRegistryClientFactory` calls `sslFactory.configure()` which is an expensive operation.  By doing this, sslFactory.configure isn't done for every request, which saves a lot of work.

### Testing done 
Ran `mvn clean package integration-test`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

