### PR TITLE
refactor: Use FunctionName not String in FunctionRegistry API

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/function/FunctionRegistry.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/FunctionRegistry.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function;
 
+import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.testing.EffectivelyImmutable;
@@ -34,7 +35,7 @@ public interface FunctionRegistry {
    * @param functionName the name of the function to test
    * @return {@code true} if it is an aggregate function, {@code false} otherwise.
    */
-  boolean isAggregate(String functionName);
+  boolean isAggregate(FunctionName functionName);
 
   /**
    * Test if the supplied {@code functionName} is a table function.
@@ -44,7 +45,7 @@ public interface FunctionRegistry {
    * @param functionName the name of the function to test
    * @return {@code true} if it is a table function, {@code false} otherwise.
    */
-  boolean isTableFunction(String functionName);
+  boolean isTableFunction(FunctionName functionName);
 
   /**
    * Get the factory for a UDF.
@@ -53,7 +54,7 @@ public interface FunctionRegistry {
    * @return the factory.
    * @throws KsqlException on unknown UDF.
    */
-  UdfFactory getUdfFactory(String functionName);
+  UdfFactory getUdfFactory(FunctionName functionName);
 
   /**
    * Get the factory for a table function.
@@ -62,7 +63,7 @@ public interface FunctionRegistry {
    * @return the factory.
    * @throws KsqlException on unknown table function.
    */
-  TableFunctionFactory getTableFunctionFactory(String functionName);
+  TableFunctionFactory getTableFunctionFactory(FunctionName functionName);
 
   /**
    * Get the factory for a UDAF.
@@ -71,7 +72,7 @@ public interface FunctionRegistry {
    * @return the factory.
    * @throws KsqlException on unknown UDAF.
    */
-  AggregateFunctionFactory getAggregateFactory(String functionName);
+  AggregateFunctionFactory getAggregateFactory(FunctionName functionName);
 
   /**
    * Get an instance of an aggregate function.
@@ -92,7 +93,7 @@ public interface FunctionRegistry {
    * @throws KsqlException on unknown UDAF, or on unsupported {@code argumentType}.
    */
   KsqlAggregateFunction<?, ?, ?> getAggregateFunction(
-      String functionName,
+      FunctionName functionName,
       SqlType argumentType,
       AggregateFunctionInitArguments initArgs
   );
@@ -100,12 +101,12 @@ public interface FunctionRegistry {
   /**
    * Get a table function.
    *
-   * @param functionName the name of the function.
+   * @param functionName  the name of the function.
    * @param argumentTypes the schemas of the arguments.
    * @return the function instance.
    * @throws KsqlException on unknown table function, or on unsupported {@code argumentType}.
    */
-  KsqlTableFunction getTableFunction(String functionName, List<SqlType> argumentTypes);
+  KsqlTableFunction getTableFunction(FunctionName functionName, List<SqlType> argumentTypes);
 
   /**
    * @return all UDF factories.

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/AggregateExpressionRewriter.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/AggregateExpressionRewriter.java
@@ -23,6 +23,7 @@ import io.confluent.ksql.execution.expression.tree.FunctionCall;
 import io.confluent.ksql.execution.expression.tree.VisitParentExpressionVisitor;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.schema.ksql.ColumnRef;
 import java.util.ArrayList;
 import java.util.List;
@@ -43,7 +44,7 @@ public class AggregateExpressionRewriter
   public Optional<Expression> visitFunctionCall(
       final FunctionCall node,
       final ExpressionTreeRewriter.Context<Void> context) {
-    final String functionName = node.getName().name();
+    final FunctionName functionName = node.getName();
     if (functionRegistry.isAggregate(functionName)) {
       final ColumnName aggVarName = ColumnName.aggregateColumn(aggVariableIndex);
       aggVariableIndex++;

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -33,6 +33,7 @@ import io.confluent.ksql.execution.windows.KsqlWindowExpression;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.DefaultTraversalVisitor;
 import io.confluent.ksql.parser.NodeLocation;
@@ -620,11 +621,11 @@ class Analyzer {
 
     private final class TableFunctionVisitor extends TraversalExpressionVisitor<Void> {
 
-      private Optional<String> tableFunctionName = Optional.empty();
+      private Optional<FunctionName> tableFunctionName = Optional.empty();
 
       @Override
       public Void visitFunctionCall(final FunctionCall functionCall, final Void context) {
-        final String functionName = functionCall.getName().name();
+        final FunctionName functionName = functionCall.getName();
         final boolean isTableFunction = metaStore.isTableFunction(functionName);
 
         if (isTableFunction) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/InternalFunctionRegistry.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/InternalFunctionRegistry.java
@@ -58,10 +58,11 @@ public class InternalFunctionRegistry implements MutableFunctionRegistry {
   }
 
   @Override
-  public synchronized UdfFactory getUdfFactory(final String functionName) {
-    final UdfFactory udfFactory = udfs.get(functionName.toUpperCase());
+  public synchronized UdfFactory getUdfFactory(final FunctionName functionName) {
+    final UdfFactory udfFactory = udfs.get(functionName.name().toUpperCase());
     if (udfFactory == null) {
-      throw new KsqlException("Can't find any functions with the name '" + functionName + "'");
+      throw new KsqlException(
+          "Can't find any functions with the name '" + functionName.name() + "'");
     }
     return udfFactory;
   }
@@ -99,22 +100,22 @@ public class InternalFunctionRegistry implements MutableFunctionRegistry {
   }
 
   @Override
-  public synchronized boolean isAggregate(final String functionName) {
-    return udafs.containsKey(functionName.toUpperCase());
+  public synchronized boolean isAggregate(final FunctionName functionName) {
+    return udafs.containsKey(functionName.name().toUpperCase());
   }
 
   @Override
-  public synchronized boolean isTableFunction(final String functionName) {
-    return udtfs.containsKey(functionName.toUpperCase());
+  public synchronized boolean isTableFunction(final FunctionName functionName) {
+    return udtfs.containsKey(functionName.name().toUpperCase());
   }
 
   @Override
   public synchronized KsqlAggregateFunction getAggregateFunction(
-      final String functionName,
+      final FunctionName functionName,
       final SqlType argumentType,
       final AggregateFunctionInitArguments initArgs
   ) {
-    final AggregateFunctionFactory udafFactory = udafs.get(functionName.toUpperCase());
+    final AggregateFunctionFactory udafFactory = udafs.get(functionName.name().toUpperCase());
     if (udafFactory == null) {
       throw new KsqlException("No aggregate function with name " + functionName + " exists!");
     }
@@ -126,10 +127,10 @@ public class InternalFunctionRegistry implements MutableFunctionRegistry {
 
   @Override
   public synchronized KsqlTableFunction getTableFunction(
-      final String functionName,
+      final FunctionName functionName,
       final List<SqlType> argumentTypes
   ) {
-    final TableFunctionFactory udtfFactory = udtfs.get(functionName.toUpperCase());
+    final TableFunctionFactory udtfFactory = udtfs.get(functionName.name().toUpperCase());
     if (udtfFactory == null) {
       throw new KsqlException("No table function with name " + functionName + " exists!");
     }
@@ -187,8 +188,9 @@ public class InternalFunctionRegistry implements MutableFunctionRegistry {
   }
 
   @Override
-  public synchronized AggregateFunctionFactory getAggregateFactory(final String functionName) {
-    final AggregateFunctionFactory udafFactory = udafs.get(functionName.toUpperCase());
+  public synchronized AggregateFunctionFactory getAggregateFactory(
+      final FunctionName functionName) {
+    final AggregateFunctionFactory udafFactory = udafs.get(functionName.name().toUpperCase());
     if (udafFactory == null) {
       throw new KsqlException(
           "Can not find any aggregate functions with the name '" + functionName + "'");
@@ -198,8 +200,9 @@ public class InternalFunctionRegistry implements MutableFunctionRegistry {
   }
 
   @Override
-  public synchronized TableFunctionFactory getTableFunctionFactory(final String functionName) {
-    final TableFunctionFactory tableFunctionFactory = udtfs.get(functionName.toUpperCase());
+  public synchronized TableFunctionFactory getTableFunctionFactory(
+      final FunctionName functionName) {
+    final TableFunctionFactory tableFunctionFactory = udtfs.get(functionName.name().toUpperCase());
     if (tableFunctionFactory == null) {
       throw new KsqlException(
           "Can not find any table functions with the name '" + functionName + "'");

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/FlatMapNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/FlatMapNode.java
@@ -31,6 +31,7 @@ import io.confluent.ksql.execution.streams.StreamFlatMapBuilder;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.services.KafkaTopicClient;
@@ -147,7 +148,7 @@ public class FlatMapNode extends PlanNode {
         final FunctionCall node,
         final Context<Void> context
     ) {
-      final String functionName = node.getName().name();
+      final FunctionName functionName = node.getName();
       if (functionRegistry.isTableFunction(functionName)) {
         final ColumnName varName = ColumnName.synthesisedSchemaColumn(variableIndex);
         variableIndex++;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/InternalFunctionRegistryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/InternalFunctionRegistryTest.java
@@ -114,7 +114,7 @@ public class InternalFunctionRegistryTest {
     functionRegistry.addFunction(func);
 
     // Then:
-    final UdfFactory factory = functionRegistry.getUdfFactory("func");
+    final UdfFactory factory = functionRegistry.getUdfFactory(FunctionName.of("func"));
     assertThat(factory.getFunction(Collections.emptyList()), is(this.func));
   }
 
@@ -235,14 +235,14 @@ public class InternalFunctionRegistryTest {
 
   @Test
   public void shouldKnowIfFunctionIsAggregate() {
-    assertFalse(functionRegistry.isAggregate("lcase"));
-    assertTrue(functionRegistry.isAggregate("topk"));
+    assertFalse(functionRegistry.isAggregate(FunctionName.of("lcase")));
+    assertTrue(functionRegistry.isAggregate(FunctionName.of("topk")));
   }
 
   @Test
   public void shouldAddAggregateFunction() {
     functionRegistry.addAggregateFunctionFactory(createAggregateFunctionFactory());
-    assertThat(functionRegistry.getAggregateFunction("my_aggregate",
+    assertThat(functionRegistry.getAggregateFunction(FunctionName.of("my_aggregate"),
         SqlTypes.INTEGER,
         AggregateFunctionInitArguments.EMPTY_ARGS), not(nullValue()));
   }
@@ -250,7 +250,7 @@ public class InternalFunctionRegistryTest {
   @Test
   public void shouldAddTableFunction() {
     functionRegistry.addTableFunctionFactory(createTableFunctionFactory());
-    assertThat(functionRegistry.getTableFunction("my_tablefunction",
+    assertThat(functionRegistry.getTableFunction(FunctionName.of("my_tablefunction"),
         ImmutableList.of(SqlTypes.INTEGER)
     ), not(nullValue()));
   }
@@ -288,9 +288,9 @@ public class InternalFunctionRegistryTest {
     functionRegistry.addFunction(func2);
 
     // Then:
-    assertThat(functionRegistry.getUdfFactory("func")
+    assertThat(functionRegistry.getUdfFactory(FunctionName.of("func"))
         .getFunction(Collections.singletonList(SqlTypes.BIGINT)), equalTo(func2));
-    assertThat(functionRegistry.getUdfFactory("func")
+    assertThat(functionRegistry.getUdfFactory(FunctionName.of("func"))
         .getFunction(Collections.emptyList()), equalTo(func));
   }
 
@@ -298,7 +298,7 @@ public class InternalFunctionRegistryTest {
   public void shouldThrowExceptionIfNoFunctionsWithNameExist() {
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage("'foo_bar'");
-    functionRegistry.getUdfFactory("foo_bar");
+    functionRegistry.getUdfFactory(FunctionName.of("foo_bar"));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/KudafUndoAggregatorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/KudafUndoAggregatorTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.function.TableAggregationFunction;
 import io.confluent.ksql.execution.function.udaf.KudafUndoAggregator;
+import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.util.Arrays;
 import java.util.List;
@@ -31,7 +32,7 @@ import org.junit.Test;
 public class KudafUndoAggregatorTest {
   private static final InternalFunctionRegistry FUNCTION_REGISTRY = new InternalFunctionRegistry();
   private static final KsqlAggregateFunction SUM_INFO = FUNCTION_REGISTRY.getAggregateFunction(
-      "SUM",
+      FunctionName.of("SUM"),
       SqlTypes.INTEGER,
       new AggregateFunctionInitArguments(2)
   );

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/UdtfLoaderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/UdtfLoaderTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.function.udtf.Udtf;
 import io.confluent.ksql.function.udtf.UdtfDescription;
 import io.confluent.ksql.metastore.TypeRegistry;
+import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.schema.ksql.SqlTypeParser;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
@@ -63,7 +64,8 @@ public class UdtfLoaderTest {
     );
 
     // When:
-    final KsqlTableFunction function = FUNC_REG.getTableFunction("test_udtf", args);
+    final KsqlTableFunction function = FUNC_REG
+        .getTableFunction(FunctionName.of("test_udtf"), args);
 
     // Then:
     assertThat(function.getReturnType(args), equalTo(SqlTypes.STRING));
@@ -84,7 +86,8 @@ public class UdtfLoaderTest {
     );
 
     // When:
-    final KsqlTableFunction function = FUNC_REG.getTableFunction("test_udtf", args);
+    final KsqlTableFunction function = FUNC_REG
+        .getTableFunction(FunctionName.of("test_udtf"), args);
 
     // Then:
     assertThat(function.getReturnType(args), equalTo(SqlTypes.STRING));
@@ -105,7 +108,8 @@ public class UdtfLoaderTest {
     );
 
     // When:
-    final KsqlTableFunction function = FUNC_REG.getTableFunction("test_udtf", args);
+    final KsqlTableFunction function = FUNC_REG
+        .getTableFunction(FunctionName.of("test_udtf"), args);
 
     // Then:
     assertThat(function.getReturnType(args), equalTo(SqlTypes.STRING));
@@ -118,7 +122,8 @@ public class UdtfLoaderTest {
     final List<SqlType> args = ImmutableList.of(SqlTypes.INTEGER);
 
     // When:
-    final KsqlTableFunction function = FUNC_REG.getTableFunction("test_udtf", args);
+    final KsqlTableFunction function = FUNC_REG
+        .getTableFunction(FunctionName.of("test_udtf"), args);
 
     // Then:
     assertThat(function.getReturnType(args), equalTo(SqlTypes.INTEGER));
@@ -131,7 +136,8 @@ public class UdtfLoaderTest {
     final List<SqlType> args = ImmutableList.of(SqlTypes.BIGINT);
 
     // When:
-    final KsqlTableFunction function = FUNC_REG.getTableFunction("test_udtf", args);
+    final KsqlTableFunction function = FUNC_REG
+        .getTableFunction(FunctionName.of("test_udtf"), args);
 
     // Then:
     assertThat(function.getReturnType(args), equalTo(SqlTypes.BIGINT));
@@ -144,7 +150,8 @@ public class UdtfLoaderTest {
     final List<SqlType> args = ImmutableList.of(SqlTypes.DOUBLE);
 
     // When:
-    final KsqlTableFunction function = FUNC_REG.getTableFunction("test_udtf", args);
+    final KsqlTableFunction function = FUNC_REG
+        .getTableFunction(FunctionName.of("test_udtf"), args);
 
     // Then:
     assertThat(function.getReturnType(args), equalTo(SqlTypes.DOUBLE));
@@ -157,7 +164,8 @@ public class UdtfLoaderTest {
     final List<SqlType> args = ImmutableList.of(SqlTypes.BOOLEAN);
 
     // When:
-    final KsqlTableFunction function = FUNC_REG.getTableFunction("test_udtf", args);
+    final KsqlTableFunction function = FUNC_REG
+        .getTableFunction(FunctionName.of("test_udtf"), args);
 
     // Then:
     assertThat(function.getReturnType(args), equalTo(SqlTypes.BOOLEAN));
@@ -170,7 +178,8 @@ public class UdtfLoaderTest {
     final List<SqlType> args = ImmutableList.of(SqlTypes.STRING);
 
     // When:
-    final KsqlTableFunction function = FUNC_REG.getTableFunction("test_udtf", args);
+    final KsqlTableFunction function = FUNC_REG
+        .getTableFunction(FunctionName.of("test_udtf"), args);
 
     // Then:
     assertThat(function.getReturnType(args), equalTo(SqlTypes.STRING));
@@ -183,7 +192,8 @@ public class UdtfLoaderTest {
     final List<SqlType> args = ImmutableList.of(DECIMAL_SCHEMA);
 
     // When:
-    final KsqlTableFunction function = FUNC_REG.getTableFunction("test_udtf", args);
+    final KsqlTableFunction function = FUNC_REG
+        .getTableFunction(FunctionName.of("test_udtf"), args);
 
     // Then:
     assertThat(function.getReturnType(args), equalTo(SqlTypes.decimal(30, 10)));
@@ -196,7 +206,8 @@ public class UdtfLoaderTest {
     final List<SqlType> args = ImmutableList.of(STRUCT_SCHEMA);
 
     // When:
-    final KsqlTableFunction function = FUNC_REG.getTableFunction("test_udtf", args);
+    final KsqlTableFunction function = FUNC_REG
+        .getTableFunction(FunctionName.of("test_udtf"), args);
 
     // Then:
     assertThat(function.getReturnType(args), equalTo(STRUCT_SCHEMA));
@@ -209,7 +220,8 @@ public class UdtfLoaderTest {
     final List<SqlType> args = ImmutableList.of(STRUCT_SCHEMA);
 
     // When:
-    final KsqlTableFunction function = FUNC_REG.getTableFunction("test_udtf", args);
+    final KsqlTableFunction function = FUNC_REG
+        .getTableFunction(FunctionName.of("test_udtf"), args);
 
     // Then:
     assertThat(function.getReturnType(args), equalTo(STRUCT_SCHEMA));

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenRunner.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenRunner.java
@@ -163,7 +163,7 @@ public class CodeGenRunner {
         argumentTypes.add(expressionTypeManager.getExpressionSqlType(argExpr));
       }
 
-      final UdfFactory holder = functionRegistry.getUdfFactory(functionName.name());
+      final UdfFactory holder = functionRegistry.getUdfFactory(functionName);
       final KsqlScalarFunction function = holder.getFunction(argumentTypes);
       spec.addFunction(
           function.name(),

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
@@ -346,7 +346,7 @@ public class SqlToJavaVisitor {
     }
 
     private SqlType getFunctionReturnSchema(final FunctionCall node) {
-      final UdfFactory udfFactory = functionRegistry.getUdfFactory(node.getName().name());
+      final UdfFactory udfFactory = functionRegistry.getUdfFactory(node.getName());
       final List<SqlType> argumentSchemas = node.getArguments().stream()
           .map(expressionTypeManager::getExpressionSqlType)
           .collect(Collectors.toList());

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/function/UdafUtil.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/function/UdafUtil.java
@@ -65,7 +65,7 @@ public final class UdafUtil {
           createAggregateFunctionInitArgs(valueColumn.index(), functionCall);
 
       return functionRegistry.getAggregateFunction(
-          functionCall.getName().name(),
+          functionCall.getName(),
           argumentType,
           aggregateFunctionInitArguments
       );

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/function/UdtfUtil.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/function/UdtfUtil.java
@@ -47,7 +47,7 @@ public final class UdtfUtil {
             .collect(Collectors.toList());
 
     return functionRegistry.getTableFunction(
-        functionCall.getName().name(),
+        functionCall.getName(),
         argTypes
     );
   }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
@@ -352,7 +352,7 @@ public class ExpressionTypeManager {
         final FunctionCall node,
         final ExpressionTypeContext expressionTypeContext
     ) {
-      if (functionRegistry.isAggregate(node.getName().name())) {
+      if (functionRegistry.isAggregate(node.getName())) {
         final SqlType schema = node.getArguments().isEmpty()
             ? FunctionRegistry.DEFAULT_FUNCTION_ARG_SCHEMA
             : getExpressionSqlType(node.getArguments().get(0));
@@ -361,26 +361,26 @@ public class ExpressionTypeManager {
             UdafUtil.createAggregateFunctionInitArgs(0, node);
 
         final KsqlAggregateFunction aggFunc = functionRegistry
-            .getAggregateFunction(node.getName().name(), schema, args);
+            .getAggregateFunction(node.getName(), schema, args);
 
         expressionTypeContext.setSqlType(aggFunc.returnType());
         return null;
       }
 
-      if (functionRegistry.isTableFunction(node.getName().name())) {
+      if (functionRegistry.isTableFunction(node.getName())) {
         final List<SqlType> argumentTypes = node.getArguments().isEmpty()
             ? ImmutableList.of(FunctionRegistry.DEFAULT_FUNCTION_ARG_SCHEMA)
             : node.getArguments().stream().map(ExpressionTypeManager.this::getExpressionSqlType)
                 .collect(Collectors.toList());
 
         final KsqlTableFunction tableFunction = functionRegistry
-            .getTableFunction(node.getName().name(), argumentTypes);
+            .getTableFunction(node.getName(), argumentTypes);
 
         expressionTypeContext.setSqlType(tableFunction.getReturnType(argumentTypes));
         return null;
       }
 
-      final UdfFactory udfFactory = functionRegistry.getUdfFactory(node.getName().name());
+      final UdfFactory udfFactory = functionRegistry.getUdfFactory(node.getName());
 
       final List<SqlType> argTypes = new ArrayList<>();
       for (final Expression expression : node.getArguments()) {

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitorTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitorTest.java
@@ -808,8 +808,8 @@ public class SqlToJavaVisitorTest {
   private void givenUdf(
       final String name, final UdfFactory factory, final KsqlScalarFunction function
   ) {
-    when(functionRegistry.isAggregate(name)).thenReturn(false);
-    when(functionRegistry.getUdfFactory(name)).thenReturn(factory);
+    when(functionRegistry.isAggregate(FunctionName.of(name))).thenReturn(false);
+    when(functionRegistry.getUdfFactory(FunctionName.of(name))).thenReturn(factory);
     when(factory.getFunction(anyList())).thenReturn(function);
     when(function.getReturnType(anyList())).thenReturn(SqlTypes.STRING);
     final UdfMetadata metadata = mock(UdfMetadata.class);

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/function/UdafUtilTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/function/UdafUtilTest.java
@@ -81,7 +81,7 @@ public class UdafUtilTest {
     UdafUtil.resolveAggregateFunction(functionRegistry, FUNCTION_CALL, SCHEMA);
 
     // Then:
-    verify(functionRegistry).getAggregateFunction(eq("AGG"), any(), any());
+    verify(functionRegistry).getAggregateFunction(eq(FunctionName.of("AGG")), any(), any());
   }
 
   @Test

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/transform/sqlpredicate/SqlPredicateTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/transform/sqlpredicate/SqlPredicateTest.java
@@ -108,7 +108,7 @@ public class SqlPredicateTest {
 
   @Before
   public void init() {
-    when(functionRegistry.getUdfFactory("LEN")).thenReturn(lenFactory);
+    when(functionRegistry.getUdfFactory(FunctionName.of("LEN"))).thenReturn(lenFactory);
     when(lenFactory.getFunction(any())).thenReturn(LEN_FUNCTION);
   }
 

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
@@ -26,8 +26,8 @@ import static io.confluent.ksql.execution.testutil.TestExpressions.literal;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -108,7 +108,7 @@ public class ExpressionTypeManagerTest {
     final UdfMetadata metadata = mock(UdfMetadata.class);
     when(internalFactory.getMetadata()).thenReturn(metadata);
 
-    when(functionRegistry.getUdfFactory(anyString()))
+    when(functionRegistry.getUdfFactory(any()))
         .thenReturn(internalFactory);
   }
 
@@ -579,8 +579,8 @@ public class ExpressionTypeManagerTest {
   private void givenUdfWithNameAndReturnType(
       final String name, final SqlType returnType, final UdfFactory factory, final KsqlScalarFunction function
   ) {
-    when(functionRegistry.isAggregate(name)).thenReturn(false);
-    when(functionRegistry.getUdfFactory(name)).thenReturn(factory);
+    when(functionRegistry.isAggregate(FunctionName.of(name))).thenReturn(false);
+    when(functionRegistry.getUdfFactory(FunctionName.of(name))).thenReturn(factory);
     when(factory.getFunction(anyList())).thenReturn(function);
     when(function.getReturnType(anyList())).thenReturn(returnType);
     final UdfMetadata metadata = mock(UdfMetadata.class);

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/MetaStoreImpl.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/MetaStoreImpl.java
@@ -23,6 +23,7 @@ import io.confluent.ksql.function.KsqlTableFunction;
 import io.confluent.ksql.function.TableFunctionFactory;
 import io.confluent.ksql.function.UdfFactory;
 import io.confluent.ksql.metastore.model.DataSource;
+import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.FormatOptions;
 import io.confluent.ksql.schema.ksql.types.SqlType;
@@ -203,20 +204,20 @@ public final class MetaStoreImpl implements MutableMetaStore {
   }
 
   @Override
-  public UdfFactory getUdfFactory(final String functionName) {
+  public UdfFactory getUdfFactory(final FunctionName functionName) {
     return functionRegistry.getUdfFactory(functionName);
   }
 
-  public boolean isAggregate(final String functionName) {
+  public boolean isAggregate(final FunctionName functionName) {
     return functionRegistry.isAggregate(functionName);
   }
 
-  public boolean isTableFunction(final String functionName) {
+  public boolean isTableFunction(final FunctionName functionName) {
     return functionRegistry.isTableFunction(functionName);
   }
 
   public KsqlAggregateFunction<?, ?, ?> getAggregateFunction(
-      final String functionName,
+      final FunctionName functionName,
       final SqlType argumentType,
       final AggregateFunctionInitArguments initArgs
   ) {
@@ -224,7 +225,7 @@ public final class MetaStoreImpl implements MutableMetaStore {
   }
 
   public KsqlTableFunction getTableFunction(
-      final String functionName,
+      final FunctionName functionName,
       final List<SqlType> argumentTypes
   ) {
     return functionRegistry.getTableFunction(functionName, argumentTypes);
@@ -236,12 +237,12 @@ public final class MetaStoreImpl implements MutableMetaStore {
   }
 
   @Override
-  public AggregateFunctionFactory getAggregateFactory(final String functionName) {
+  public AggregateFunctionFactory getAggregateFactory(final FunctionName functionName) {
     return functionRegistry.getAggregateFactory(functionName);
   }
 
   @Override
-  public TableFunctionFactory getTableFunctionFactory(final String functionName) {
+  public TableFunctionFactory getTableFunctionFactory(final FunctionName functionName) {
     return functionRegistry.getTableFunctionFactory(functionName);
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeFunctionExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeFunctionExecutor.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.function.UdfFactory;
 import io.confluent.ksql.function.types.ArrayType;
 import io.confluent.ksql.function.types.ParamType;
 import io.confluent.ksql.function.udf.UdfMetadata;
+import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.parser.tree.DescribeFunction;
 import io.confluent.ksql.rest.entity.ArgumentInfo;
 import io.confluent.ksql.rest.entity.FunctionDescriptionList;
@@ -53,25 +54,28 @@ public final class DescribeFunctionExecutor {
       final ServiceContext serviceContext
   ) {
     final DescribeFunction describeFunction = statement.getStatement();
-    final String functionName = describeFunction.getFunctionName();
+    final FunctionName functionName = FunctionName.of(describeFunction.getFunctionName());
 
     if (executionContext.getMetaStore().isAggregate(functionName)) {
       return Optional.of(
-          describeAggregateFunction(executionContext, functionName, statement.getStatementText()));
+          describeAggregateFunction(executionContext, functionName,
+              statement.getStatementText()));
     }
 
     if (executionContext.getMetaStore().isTableFunction(functionName)) {
       return Optional.of(
-          describeTableFunction(executionContext, functionName, statement.getStatementText()));
+          describeTableFunction(executionContext, functionName,
+              statement.getStatementText()));
     }
 
     return Optional.of(
-        describeNonAggregateFunction(executionContext, functionName, statement.getStatementText()));
+        describeNonAggregateFunction(executionContext, functionName,
+            statement.getStatementText()));
   }
 
   private static FunctionDescriptionList describeAggregateFunction(
       final KsqlExecutionContext ksqlEngine,
-      final String functionName,
+      final FunctionName functionName,
       final String statementText
   ) {
     final AggregateFunctionFactory aggregateFactory
@@ -89,7 +93,7 @@ public final class DescribeFunctionExecutor {
 
   private static FunctionDescriptionList describeTableFunction(
       final KsqlExecutionContext executionContext,
-      final String functionName,
+      final FunctionName functionName,
       final String statementText
   ) {
     final TableFunctionFactory tableFunctionFactory = executionContext.getMetaStore()
@@ -115,7 +119,7 @@ public final class DescribeFunctionExecutor {
 
   private static FunctionDescriptionList describeNonAggregateFunction(
       final KsqlExecutionContext executionContext,
-      final String functionName,
+      final FunctionName functionName,
       final String statementText
   ) {
     final UdfFactory udfFactory = executionContext.getMetaStore().getUdfFactory(functionName);

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/AggregateParamsFactoryTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/AggregateParamsFactoryTest.java
@@ -94,23 +94,25 @@ public class AggregateParamsFactoryTest {
   @Before
   @SuppressWarnings("unchecked")
   public void init() {
-    when(functionRegistry.getAggregateFunction(same(AGG0.getName().name()), any(), any())).thenReturn(agg0);
+    when(functionRegistry.getAggregateFunction(same(AGG0.getName()), any(), any()))
+        .thenReturn(agg0);
     when(agg0.getInitialValueSupplier()).thenReturn(() -> INITIAL_VALUE0);
     when(agg0.name()).thenReturn(AGG0.getName());
     when(agg0.returnType()).thenReturn(SqlTypes.INTEGER);
     when(agg0.getAggregateType()).thenReturn(SqlTypes.BIGINT);
-    when(functionRegistry.getAggregateFunction(same(AGG1.getName().name()), any(), any())).thenReturn(agg1);
+    when(functionRegistry.getAggregateFunction(same(AGG1.getName()), any(), any()))
+        .thenReturn(agg1);
     when(agg1.getInitialValueSupplier()).thenReturn(() -> INITIAL_VALUE1);
     when(agg1.name()).thenReturn(AGG1.getName());
     when(agg1.returnType()).thenReturn(SqlTypes.STRING);
     when(agg1.getAggregateType()).thenReturn(SqlTypes.DOUBLE);
-    when(functionRegistry.getAggregateFunction(same(TABLE_AGG.getName().name()), any(), any()))
+    when(functionRegistry.getAggregateFunction(same(TABLE_AGG.getName()), any(), any()))
         .thenReturn(tableAgg);
     when(tableAgg.getInitialValueSupplier()).thenReturn(() -> INITIAL_VALUE0);
     when(tableAgg.returnType()).thenReturn(SqlTypes.INTEGER);
     when(tableAgg.getAggregateType()).thenReturn(SqlTypes.BIGINT);
     when(tableAgg.name()).thenReturn(TABLE_AGG.getName());
-    when(functionRegistry.getAggregateFunction(same(WINDOW_START.getName().name()), any(), any()))
+    when(functionRegistry.getAggregateFunction(same(WINDOW_START.getName()), any(), any()))
         .thenReturn(windowStart);
     when(windowStart.getInitialValueSupplier()).thenReturn(() -> INITIAL_VALUE0);
     when(windowStart.name()).thenReturn(WINDOW_START.getName());

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StepSchemaResolverTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StepSchemaResolverTest.java
@@ -450,15 +450,16 @@ public class StepSchemaResolverTest {
 
   private void givenTableFunction(final String name, final SqlType returnType) {
     final KsqlTableFunction tableFunction = mock(KsqlTableFunction.class);
-    when(functionRegistry.isTableFunction(name)).thenReturn(true);
-    when(functionRegistry.getTableFunction(eq(name), any())).thenReturn(tableFunction);
+    when(functionRegistry.isTableFunction(FunctionName.of(name))).thenReturn(true);
+    when(functionRegistry.getTableFunction(eq(FunctionName.of(name)), any()))
+        .thenReturn(tableFunction);
     when(tableFunction.getReturnType(any())).thenReturn(returnType);
   }
 
   @SuppressWarnings("unchecked")
   private void givenAggregateFunction(final String name, final SqlType returnType) {
     final KsqlAggregateFunction aggregateFunction = mock(KsqlAggregateFunction.class);
-    when(functionRegistry.getAggregateFunction(eq(name), any(), any()))
+    when(functionRegistry.getAggregateFunction(eq(FunctionName.of(name)), any(), any()))
         .thenReturn(aggregateFunction);
     when(aggregateFunction.name()).thenReturn(FunctionName.of(name));
     when(aggregateFunction.getAggregateType()).thenReturn(SqlTypes.INTEGER);


### PR DESCRIPTION
### Description 

Use FunctionName to specify the name of a function, not String, in FunctionRegistry

Fixes https://github.com/confluentinc/ksql/issues/3626

### Testing done 

Updated all relevant tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

