### PR TITLE
fix: CLI commands may be terminated with semicolon+whitespace (MINOR)

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -409,7 +409,7 @@ public class Console implements Closeable {
   }
 
   private Optional<CliCmdExecutor> getCliCommand(final String line) {
-    final List<String> parts = splitByUnquotedWhitespace(StringUtils.stripEnd(line, ";"));
+    final List<String> parts = splitByUnquotedWhitespace(StringUtils.stripEnd(line.trim(), ";"));
     if (parts.isEmpty()) {
       return Optional.empty();
     }

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -1357,6 +1357,20 @@ public class ConsoleTest {
   }
 
   @Test
+  public void shouldSupportCmdBeingTerminatedWithSemiColonAndWhitespace() {
+    // Given:
+    when(lineSupplier.get())
+        .thenReturn(CLI_CMD_NAME + WHITE_SPACE  + "Arg0; \n")
+        .thenReturn("not a CLI command;");
+
+    // When:
+    console.readLine();
+
+    // Then:
+    verify(cliCommand).execute(eq(ImmutableList.of("Arg0")), any());
+  }
+
+  @Test
   public void shouldSupportCmdWithQuotedArgBeingTerminatedWithSemiColon() {
     // Given:
     when(lineSupplier.get())


### PR DESCRIPTION
### Description 

CLI-specific commands (including `run script`) may be optionally terminated with a semicolon. However, the KSQL CLI doesn't currently support trailing whitespace for CLI-specific commands terminated with a semicolon, which leads to confusing behavior in some of our demos, as many of them include `run script` commands terminated with semicolons and newlines. For example:
```
ksql> RUN SCRIPT '/usr/share/doc/clickstream/clickstream-schema.sql';
```
(with a new line at the end) results in
```
Failed to read file: /usr/share/doc/clickstream/clickstream-schema.sql;
Caused by: /usr/share/doc/clickstream/clickstream-schema.sql;
```
since the presence of the newline causes the semicolon to fail to be stripped, and it gets attached to the end of the filename argument as a result.

This PR fixes the confusing behavior.

### Testing done 

Unit test + manual.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

