### PR TITLE
test: Fix Schema Registry tests after new SR API changes

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/services/SandboxedSchemaRegistryClient.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/SandboxedSchemaRegistryClient.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.services;
 import static io.confluent.ksql.util.LimitedProxyBuilder.anyParams;
 import static io.confluent.ksql.util.LimitedProxyBuilder.methodParams;
 
+import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.util.LimitedProxyBuilder;
 import java.util.Collections;
@@ -42,6 +43,8 @@ final class SandboxedSchemaRegistryClient {
         .forward("getLatestSchemaMetadata", methodParams(String.class), delegate)
         .forward("testCompatibility",
             methodParams(String.class, Schema.class), delegate)
+        .forward("testCompatibility",
+            methodParams(String.class, ParsedSchema.class), delegate)
         .swallow("deleteSubject", methodParams(String.class), Collections.emptyList())
         .build();
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/SandboxedSchemaRegistryClientTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/SandboxedSchemaRegistryClientTest.java
@@ -58,6 +58,7 @@ public final class SandboxedSchemaRegistryClientTest {
           .ignore("register", String.class, ParsedSchema.class, int.class, int.class)
           .ignore("getLatestSchemaMetadata", String.class)
           .ignore("testCompatibility", String.class, Schema.class)
+          .ignore("testCompatibility", String.class, ParsedSchema.class)
           .ignore("deleteSubject", String.class)
           .build();
     }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamTest.java
@@ -30,6 +30,9 @@ import static org.hamcrest.Matchers.not;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
 import io.confluent.ksql.rest.server.resources.streaming.TopicStream.Format;
@@ -66,7 +69,6 @@ public class TopicStreamTest {
   }
 
   @Test
-  @Ignore("Temporarily disable this test until new Schema Registry changes land")
   public void shouldMatchAvroFormatter() throws Exception {
     // Given:
     final Schema schema = parseAvroSchema(
@@ -81,8 +83,8 @@ public class TopicStreamTest {
     final GenericData.Record avroRecord = new GenericData.Record(schema);
     avroRecord.put("str1", "My first string");
 
-    expect(schemaRegistryClient.register(anyString(), anyObject(Schema.class))).andReturn(1);
-    expect(schemaRegistryClient.getById(anyInt())).andReturn(schema).times(2);
+    expect(schemaRegistryClient.register(anyString(), anyObject(ParsedSchema.class))).andReturn(1);
+    expect(schemaRegistryClient.getSchemaById(anyInt())).andReturn(new AvroSchema(schema)).times(2);
 
     replay(schemaRegistryClient);
 

--- a/ksql-test-util/src/main/java/io/confluent/ksql/test/util/TestMethods.java
+++ b/ksql-test-util/src/main/java/io/confluent/ksql/test/util/TestMethods.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 public final class TestMethods {
 
   private static final Map<Type, Object> BUILT_IN_DEFAULTS = ImmutableMap.<Type, Object>builder()
-      .put(boolean.class, true)
+      .put(boolean.class, false)
       .put(int.class, 0)
       .put(long.class, 0L)
       .put(float.class, 0.0f)


### PR DESCRIPTION
Schema Registry has added some new APIs as a result of adding
pluggable schema support.  This PR fixes tests which relied on older
APIs.
