### PR TITLE
chore: don't allow persistent push query of windowed table (MINOR)

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/PushQueryValidator.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/PushQueryValidator.java
@@ -15,7 +15,10 @@
 
 package io.confluent.ksql.analyzer;
 
+import io.confluent.ksql.analyzer.Analysis.AliasedDataSource;
+import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.parser.tree.ResultMaterialization;
+import io.confluent.ksql.util.KsqlException;
 
 public class PushQueryValidator implements QueryValidator {
 
@@ -24,5 +27,21 @@ public class PushQueryValidator implements QueryValidator {
     if (analysis.getResultMaterialization() != ResultMaterialization.CHANGES) {
       throw new IllegalArgumentException("Push queries don't support `EMIT FINAL`.");
     }
+
+    failPersistentQueryOnWindowedTable(analysis);
+  }
+
+  private static void failPersistentQueryOnWindowedTable(final Analysis analysis) {
+    if (!analysis.getInto().isPresent()) {
+      return;
+    }
+    if (analysis.getFromDataSources().stream().anyMatch(PushQueryValidator::isWindowedTable)) {
+      throw new KsqlException("KSQL does not support persistent push queries on windowed tables.");
+    }
+  }
+
+  private static boolean isWindowedTable(final AliasedDataSource dataSource) {
+    return dataSource.getDataSource().getDataSourceType() == DataSourceType.KTABLE
+        && dataSource.getDataSource().getKsqlTopic().getKeyFormat().isWindowed();
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/PushQueryValidatorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/PushQueryValidatorTest.java
@@ -15,9 +15,19 @@
 
 package io.confluent.ksql.analyzer;
 
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.analyzer.Analysis.AliasedDataSource;
+import io.confluent.ksql.analyzer.Analysis.Into;
+import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
+import io.confluent.ksql.metastore.model.DataSource;
+import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.parser.tree.ResultMaterialization;
+import io.confluent.ksql.serde.KeyFormat;
+import io.confluent.ksql.util.KsqlException;
+import java.util.Optional;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,6 +44,14 @@ public class PushQueryValidatorTest {
 
   @Mock
   private Analysis analysis;
+  @Mock
+  private AliasedDataSource aliasedSource;
+  @Mock
+  private DataSource source;
+  @Mock
+  private KsqlTopic topic;
+  @Mock
+  private KeyFormat keyFormat;
 
   private QueryValidator validator;
 
@@ -53,5 +71,96 @@ public class PushQueryValidatorTest {
 
     // When:
     validator.validate(analysis);
+  }
+
+  @Test
+  public void shouldThrowOnPersistentPushQueryOnWindowedTable() {
+    // Given:
+    givenPushQuery();
+    givenPersistentQuery();
+    givenSourceTable();
+    givenWindowedSource();
+
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage(
+        "KSQL does not support persistent push queries on windowed tables.");
+
+    // When:
+    validator.validate(analysis);
+  }
+
+  @Test
+  public void shouldNotThrowOnTransientPushQueryOnWindowedTable() {
+    // Given:
+    givenPushQuery();
+    givenTransientQuery();
+    givenSourceTable();
+    givenWindowedSource();
+
+    // When/Then:
+    validator.validate(analysis);
+  }
+
+  @Test
+  public void shouldNotThrowOnPersistentPushQueryOnWindowedStream() {
+    // Given:
+    givenPushQuery();
+    givenPersistentQuery();
+    givenSourceStream();
+    givenWindowedSource();
+
+    // When/Then:
+    validator.validate(analysis);
+  }
+
+  @Test
+  public void shouldNotThrowOnPersistentPushQueryOnUnwindowedTable() {
+    // Given:
+    givenPushQuery();
+    givenPersistentQuery();
+    givenSourceTable();
+    givenUnwindowedSource();
+
+    // When/Then(don't throw):
+    validator.validate(analysis);
+  }
+
+  private void givenPushQuery() {
+    when(analysis.getResultMaterialization()).thenReturn(ResultMaterialization.CHANGES);
+  }
+
+  private void givenPersistentQuery() {
+    when(analysis.getInto()).thenReturn(Optional.of(mock(Into.class)));
+  }
+
+  private void givenTransientQuery() {
+    when(analysis.getInto()).thenReturn(Optional.empty());
+  }
+
+  @SuppressWarnings("unchecked")
+  private void givenSourceTable() {
+    when(analysis.getFromDataSources()).thenReturn(ImmutableList.of(aliasedSource));
+    when(aliasedSource.getDataSource()).thenReturn(source);
+    when(source.getDataSourceType()).thenReturn(DataSourceType.KTABLE);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void givenSourceStream() {
+    when(analysis.getFromDataSources()).thenReturn(ImmutableList.of(aliasedSource));
+    when(aliasedSource.getDataSource()).thenReturn(source);
+    when(source.getDataSourceType()).thenReturn(DataSourceType.KSTREAM);
+  }
+
+  private void givenWindowedSource() {
+    when(source.getKsqlTopic()).thenReturn(topic);
+    when(topic.getKeyFormat()).thenReturn(keyFormat);
+    when(keyFormat.isWindowed()).thenReturn(true);
+  }
+
+  private void givenUnwindowedSource() {
+    when(source.getKsqlTopic()).thenReturn(topic);
+    when(topic.getKeyFormat()).thenReturn(keyFormat);
+    when(keyFormat.isWindowed()).thenReturn(false);
   }
 }

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/hopping-windows.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/hopping-windows.json
@@ -132,10 +132,10 @@
       ]
     },
     {
-      "name": "import hopping table",
+      "name": "import hopping stream",
       "statements": [
-        "CREATE TABLE TEST (ID bigint, VALUE bigint) WITH (kafka_topic='test_topic', value_format='DELIMITED', WINDOW_TYPE='HoPping', WINDOW_SIZE='30 seconds');",
-        "CREATE TABLE S2 as SELECT *, ROWKEY as KEY FROM test;"
+        "CREATE STREAM TEST (ID bigint, VALUE bigint) WITH (kafka_topic='test_topic', value_format='DELIMITED', WINDOW_TYPE='HoPping', WINDOW_SIZE='30 seconds');",
+        "CREATE STREAM S2 as SELECT *, ROWKEY as KEY FROM test;"
       ],
       "inputs": [
         {"topic": "test_topic", "key": "0", "value": "0,0", "timestamp": 0, "window": {"start": 0, "end": 30000, "type": "time"}},

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/session-windows.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/session-windows.json
@@ -34,27 +34,6 @@
       }
     },
     {
-      "name": "import session table",
-      "statements": [
-        "CREATE TABLE TEST (ID bigint, VALUE bigint) WITH (kafka_topic='test_topic', value_format='DELIMITED', WINDOW_TYPE='SeSSion');",
-        "CREATE TABLE S2 as SELECT *, ROWKEY as KEY FROM test;"
-      ],
-      "inputs": [
-        {"topic": "test_topic", "key": "0", "value": "0,0", "timestamp": 10, "window": {"start": 10, "end": 10, "type": "session"}},
-        {"topic": "test_topic", "key": "0", "value": null, "timestamp": 10, "window": {"start": 10, "end": 10, "type": "session"}},
-        {"topic": "test_topic", "key": "0", "value": "0,5", "timestamp": 10000, "window": {"start": 10, "end": 10000, "type": "session"}},
-        {"topic": "test_topic", "key": "1", "value": "1,100", "timestamp": 10000, "window": {"start": 800, "end": 10000, "type": "session"}},
-        {"topic": "test_topic", "key": "1", "value": "1,200", "timestamp": 40000, "window": {"start": 800, "end": 40000, "type": "session"}}
-      ],
-      "outputs": [
-        {"topic": "S2", "key": "0", "value": "0,0,0 : Window{start=10 end=10}", "timestamp": 10, "window": {"start": 10, "end": 10, "type": "session"}},
-        {"topic": "S2", "key": "0", "value": null, "timestamp": 10, "window": {"start": 10, "end": 10, "type": "session"}},
-        {"topic": "S2", "key": "0", "value": "0,5,0 : Window{start=10 end=10000}", "timestamp": 10000, "window": {"start": 10, "end": 10000, "type": "session"}},
-        {"topic": "S2", "key": "1", "value": "1,100,1 : Window{start=800 end=10000}", "timestamp": 10000, "window": {"start": 800, "end": 10000, "type": "session"}},
-        {"topic": "S2", "key": "1", "value": "1,200,1 : Window{start=800 end=40000}", "timestamp": 40000, "window": {"start": 800, "end": 40000, "type": "session"}}
-      ]
-    },
-    {
       "name": "import session stream",
       "statements": [
         "CREATE STREAM TEST (ID bigint, VALUE bigint) WITH (kafka_topic='test_topic', value_format='DELIMITED', WINDOW_TYPE='SESSION');",
@@ -74,31 +53,6 @@
         {"topic": "S2", "key": "1", "value": "1,100,1 : Window{start=10000 end=10000}", "timestamp": 10000, "window": {"start": 10000, "end": 10000, "type": "session"}},
         {"topic": "S2", "key": "1", "value": "1,200,1 : Window{start=10000 end=40000}", "timestamp": 40000, "window": {"start": 10000, "end": 40000, "type": "session"}}
       ]
-    },
-    {
-      "name": "inherit windowed keys",
-      "statements": [
-        "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='test_topic', value_format='DELIMITED', key='ID');",
-        "CREATE TABLE S2 as SELECT id, max(value) FROM test WINDOW SESSION (30 SECONDS) group by id;",
-        "CREATE TABLE S3 as SELECT * FROM S2;"
-      ],
-      "inputs": [
-        {"topic": "S2", "key": 0,"value": "0,0", "timestamp": 0, "window": {"start": 0, "end": 0, "type": "session"}},
-        {"topic": "S2", "key": 0,"value": null, "timestamp": 0, "window": {"start": 0, "end": 0, "type": "session"}}
-      ],
-      "outputs": [
-        {"topic": "S3", "key": 0,"value": "0,0", "timestamp": 0, "window": {"start": 0, "end": 0, "type": "session"}},
-        {"topic": "S3", "key": 0,"value": null, "timestamp": 0, "window": {"start": 0, "end": 0, "type": "session"}}
-      ],
-      "post": {
-        "sources": [
-          {
-            "name": "S3",
-            "type": "table",
-            "keyFormat": {"format": "KAFKA", "windowType": "SESSION", "windowSize": null}
-          }
-        ]
-      }
     },
     {
       "name": "import table with invalid window size",

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/tumbling-windows.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/tumbling-windows.json
@@ -104,10 +104,10 @@
       ]
     },
     {
-      "name": "import tumbling table",
+      "name": "import tumbling stream",
       "statements": [
-        "CREATE TABLE TEST (ID bigint, VALUE bigint) WITH (kafka_topic='test_topic', value_format='DELIMITED', WINDOW_TYPE='Tumbling', WINDOW_SIZE='30 seconds');",
-        "CREATE TABLE S2 as SELECT *, ROWKEY as KEY FROM test;"
+        "CREATE STREAM TEST (ID bigint, VALUE bigint) WITH (kafka_topic='test_topic', value_format='DELIMITED', WINDOW_TYPE='Tumbling', WINDOW_SIZE='30 seconds');",
+        "CREATE STREAM S2 as SELECT *, ROWKEY as KEY FROM test;"
       ],
       "inputs": [
         {"topic": "test_topic", "key": "0", "value": "0,0", "timestamp": 0, "window": {"start": 0, "end": 30000, "type": "time"}},
@@ -121,29 +121,6 @@
         {"topic": "S2", "key": "0", "value": "0,10,0 : Window{start=0 end=-}", "timestamp": 0, "window": {"start": 0, "end": 30000, "type": "time"}},
         {"topic": "S2", "key": "0", "value": "0,50,0 : Window{start=30000 end=-}", "timestamp": 30000, "window": {"start": 30000, "end": 60000, "type": "time"}}
       ]
-    },
-    {
-      "name": "inherit windowed keys",
-      "statements": [
-        "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='test_topic', value_format='DELIMITED', key='ID');",
-        "CREATE TABLE S2 as SELECT id, max(value) FROM test WINDOW TUMBLING (SIZE 30 SECONDS) group by id;",
-        "CREATE TABLE S3 as SELECT * FROM S2;"
-      ],
-      "inputs": [
-        {"topic": "S2", "key": 0,"value": "0,0", "timestamp": 0, "window": {"start": 0, "end": 30000, "type": "time"}}
-      ],
-      "outputs": [
-        {"topic": "S3", "key": 0,"value": "0,0", "timestamp": 0, "window": {"start": 0, "end": 30000, "type": "time"}}
-      ],
-      "post": {
-        "sources": [
-          {
-            "name": "S3",
-            "type": "table",
-            "keyFormat": {"format": "KAFKA", "windowType": "TUMBLING", "windowSize": 30000}
-          }
-        ]
-      }
     }
   ]
 }

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/windowed-source.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/windowed-source.json
@@ -1,0 +1,18 @@
+{
+  "comments": [
+    "Test that ensures we fail querying a windowed table"
+  ],
+  "tests": [
+    {
+      "name": "Should fail querying windowed table",
+      "statements": [
+        "CREATE TABLE INPUT (x int) WITH (kafka_topic='test', value_format='JSON', WINDOW_TYPE='Session');",
+        "CREATE TABLE OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "KSQL does not support persistent push queries on windowed tables."
+      }
+    }
+  ]
+}

--- a/ksql-functional-tests/src/test/resources/test-runner/correct/aggregate/output.json
+++ b/ksql-functional-tests/src/test/resources/test-runner/correct/aggregate/output.json
@@ -6,14 +6,6 @@
     {"topic": "S2", "key": 100,"value": "100,100", "timestamp": 45000, "window": {"start": 30000, "end": 60000, "type": "time"}},
     {"topic": "S2", "key": 100,"value": "100,300", "timestamp": 50000, "window": {"start": 30000, "end": 60000, "type": "time"}},
     {"topic": "S2", "key": 0,"value": "0,100", "timestamp": 35000, "window": {"start": 30000, "end": 60000, "type": "time"}},
-    {"topic": "S2", "key": 0,"value": "0,2000", "timestamp": 40000, "window": {"start": 30000, "end": 60000, "type": "time"}},
-
-    {"topic": "FOO", "key": 0,"value": null, "timestamp": 0, "window": {"start": 0, "end": 30000, "type": "time"}},
-    {"topic": "FOO", "key": 0,"value": null, "timestamp": 10000, "window": {"start": 0, "end": 30000, "type": "time"}},
-    {"topic": "FOO", "key": 100,"value": "100", "timestamp": 30000, "window": {"start": 30000, "end": 60000, "type": "time"}},
-    {"topic": "FOO", "key": 100,"value": "100", "timestamp": 45000, "window": {"start": 30000, "end": 60000, "type": "time"}},
-    {"topic": "FOO", "key": 100,"value": "100", "timestamp": 50000, "window": {"start": 30000, "end": 60000, "type": "time"}},
-    {"topic": "FOO", "key": 0,"value": null, "timestamp": 35000, "window": {"start": 30000, "end": 60000, "type": "time"}},
-    {"topic": "FOO", "key": 0,"value": null, "timestamp": 40000, "window": {"start": 30000, "end": 60000, "type": "time"}}
+    {"topic": "S2", "key": 0,"value": "0,2000", "timestamp": 40000, "window": {"start": 30000, "end": 60000, "type": "time"}}
   ]
 }

--- a/ksql-functional-tests/src/test/resources/test-runner/correct/aggregate/statements.sql
+++ b/ksql-functional-tests/src/test/resources/test-runner/correct/aggregate/statements.sql
@@ -1,3 +1,2 @@
 CREATE STREAM TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='test_topic', value_format='DELIMITED', key='ID');
 CREATE TABLE S2 as SELECT id, max(value) FROM test WINDOW TUMBLING (SIZE 30 SECONDS) group by id;
-CREATE TABLE foo AS SELECT id from s2 where id = 100;


### PR DESCRIPTION
BREAKING CHANGE: Disallows persistent push queries of windowed tables.
We can revert when streams adds support for loading these with a windowed
state store. Note that we still allow transient queries on windowed tables, as
these are useful for testing the results of a persistent push query that creates
a windowed table.