### PR TITLE
fix: don't load current qtt test case from legacy loader

### DIFF
--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/loader/ExpectedTopologiesTestLoader.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/loader/ExpectedTopologiesTestLoader.java
@@ -182,9 +182,6 @@ public class ExpectedTopologiesTestLoader<T extends VersionedTest> implements Te
       final List<TopologiesAndVersion> expectedTopologies
   ) {
     Stream.Builder<T> builder = Stream.builder();
-    if (test.getVersionBounds().contains(CURRENT_VERSION)) {
-      builder.add(test);
-    }
 
     for (final TopologiesAndVersion topologies : expectedTopologies) {
       if (!test.getVersionBounds().contains(topologies.getVersion())) {


### PR DESCRIPTION
don't load current qtt test case from the legacy loader (ExpectedTopologiesTestLoader).
The new loader (PlannedTestLoader) already loads these, and ExpectedTopologiesTestLoader
will soon be removed.