### PR TITLE
chore: ensure sensible error on use of unsupported primitive key type

### DIFF
--- a/ksql-common/src/test/java/io/confluent/ksql/serde/FormatInfoTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/serde/FormatInfoTest.java
@@ -30,6 +30,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+@SuppressWarnings("UnstableApiUsage")
 public class FormatInfoTest {
 
   @Rule

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -228,17 +228,20 @@ final class EngineExecutor {
   private Optional<DdlCommand> maybeCreateSinkDdl(
       final String sql,
       final KsqlStructuredDataOutputNode outputNode,
-      final KeyField keyField) {
+      final KeyField keyField
+  ) {
     if (!outputNode.isDoCreateInto()) {
       validateExistingSink(outputNode, keyField);
       return Optional.empty();
     }
-    final CreateSourceCommand ddl;
+
     final Formats formats = Formats.of(
         outputNode.getKsqlTopic().getKeyFormat(),
         outputNode.getKsqlTopic().getValueFormat(),
         outputNode.getSerdeOptions()
     );
+
+    final CreateSourceCommand ddl;
     if (outputNode.getNodeOutputType() == DataSourceType.KSTREAM) {
       ddl = new CreateStreamCommand(
           outputNode.getIntoSourceName(),
@@ -260,6 +263,7 @@ final class EngineExecutor {
           outputNode.getKsqlTopic().getKeyFormat().getWindowInfo()
       );
     }
+
     final SchemaRegistryClient srClient = serviceContext.getSchemaRegistryClient();
     AvroUtil.throwOnInvalidSchemaEvolution(sql, ddl, srClient, ksqlConfig);
     return Optional.of(ddl);

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/key-schemas.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/key-schemas.json
@@ -1,7 +1,7 @@
 {
   "tests": [
     {
-      "name": "stream implicit STRING ROWKEY",
+      "name": "stream implicit KAFKA STRING ROWKEY",
       "statements": [
         "CREATE STREAM INPUT (ID bigint) WITH (kafka_topic='input',value_format='JSON');",
         "CREATE STREAM OUTPUT as SELECT ID, ROWKEY as KEY FROM INPUT;"
@@ -17,10 +17,20 @@
         {"topic": "OUTPUT", "key": "1", "value": {"ID": 2, "KEY": "1"}},
         {"topic": "OUTPUT", "key": "", "value": {"ID": 3, "KEY": ""}},
         {"topic": "OUTPUT", "key": null, "value": {"ID": 4, "KEY": null}}
-      ]
+      ],
+      "post": {
+        "sources": [
+          {
+            "name": "OUTPUT",
+            "type": "stream",
+            "keyFormat": {"format": "KAFKA"},
+            "schema": "ROWKEY STRING KEY, ID BIGINT, KEY STRING"
+          }
+        ]
+      }
     },
     {
-      "name": "table implicit STRING ROWKEY",
+      "name": "table implicit KAFKA STRING ROWKEY",
       "statements": [
         "CREATE TABLE INPUT (ID bigint) WITH (kafka_topic='input',value_format='JSON');",
         "CREATE TABLE OUTPUT as SELECT ID, ROWKEY as KEY FROM INPUT;"
@@ -34,10 +44,20 @@
         {"topic": "OUTPUT", "key": "1", "value": {"ID": 1, "KEY": "1"}},
         {"topic": "OUTPUT", "key": "1", "value": {"ID": 2, "KEY": "1"}},
         {"topic": "OUTPUT", "key": "", "value": {"ID": 3, "KEY": ""}}
-      ]
+      ],
+      "post": {
+        "sources": [
+          {
+            "name": "OUTPUT",
+            "type": "table",
+            "keyFormat": {"format": "KAFKA"},
+            "schema": "ROWKEY STRING KEY, ID BIGINT, KEY STRING"
+          }
+        ]
+      }
     },
     {
-      "name": "stream explicit STRING ROWKEY",
+      "name": "stream explicit KAFKA STRING ROWKEY",
       "statements": [
         "CREATE STREAM INPUT (ROWKEY STRING KEY, ID bigint) WITH (kafka_topic='input',value_format='JSON');",
         "CREATE STREAM OUTPUT as SELECT ID, ROWKEY as KEY FROM INPUT;"
@@ -53,10 +73,20 @@
         {"topic": "OUTPUT", "key": "1", "value": {"ID": 2, "KEY": "1"}},
         {"topic": "OUTPUT", "key": "", "value": {"ID": 3, "KEY": ""}},
         {"topic": "OUTPUT", "key": null, "value": {"ID": 4, "KEY": null}}
-      ]
+      ],
+      "post": {
+        "sources": [
+          {
+            "name": "OUTPUT",
+            "type": "stream",
+            "keyFormat": {"format": "KAFKA"},
+            "schema": "ROWKEY STRING KEY, ID BIGINT, KEY STRING"
+          }
+        ]
+      }
     },
     {
-      "name": "table explicit STRING ROWKEY",
+      "name": "table explicit KAFKA STRING ROWKEY",
       "statements": [
         "CREATE TABLE INPUT (ROWKEY STRING KEY, ID bigint) WITH (kafka_topic='input',value_format='JSON');",
         "CREATE TABLE OUTPUT as SELECT ID, ROWKEY as KEY FROM INPUT;"
@@ -70,10 +100,20 @@
         {"topic": "OUTPUT", "key": "1", "value": {"ID": 1, "KEY": "1"}},
         {"topic": "OUTPUT", "key": "1", "value": {"ID": 2, "KEY": "1"}},
         {"topic": "OUTPUT", "key": "", "value": {"ID": 3, "KEY": ""}}
-      ]
+      ],
+      "post": {
+        "sources": [
+          {
+            "name": "OUTPUT",
+            "type": "table",
+            "keyFormat": {"format": "KAFKA"},
+            "schema": "ROWKEY STRING KEY, ID BIGINT, KEY STRING"
+          }
+        ]
+      }
     },
     {
-      "name": "stream explicit non-STRING ROWKEY",
+      "name": "stream explicit KAFKA INT ROWKEY",
       "statements": [
         "CREATE STREAM INPUT (ROWKEY INT KEY, ID bigint) WITH (kafka_topic='input',value_format='JSON');",
         "CREATE STREAM OUTPUT as SELECT ID, ROWKEY as KEY FROM INPUT;"
@@ -100,7 +140,61 @@
       }
     },
     {
-      "name": "table explicit non-STRING ROWKEY",
+      "name": "table explicit KAFKA INT ROWKEY",
+      "statements": [
+        "CREATE TABLE INPUT (ROWKEY INT KEY, ID bigint) WITH (kafka_topic='input',value_format='JSON');",
+        "CREATE TABLE OUTPUT as SELECT ID, ROWKEY as KEY FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input", "key": 3, "value": {"id": 1}},
+        {"topic": "input", "key": 2, "value": {"id": 2}},
+        {"topic": "input", "key": 1, "value": {"id": 3}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 3, "value": {"ID": 1, "KEY": 3}},
+        {"topic": "OUTPUT", "key": 2, "value": {"ID": 2, "KEY": 2}},
+        {"topic": "OUTPUT", "key": 1, "value": {"ID": 3, "KEY": 1}}
+      ],
+      "post": {
+        "sources": [
+          {
+            "name": "OUTPUT",
+            "type": "table",
+            "keyFormat": {"format": "KAFKA"},
+            "schema": "ROWKEY INT KEY, ID BIGINT, KEY INT"
+          }
+        ]
+      }
+    },
+    {
+      "name": "stream explicit KAFKA BIGINT ROWKEY",
+      "statements": [
+        "CREATE STREAM INPUT (ROWKEY BIGINT KEY, ID bigint) WITH (kafka_topic='input',value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT ID, ROWKEY as KEY FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input", "key": 3, "value": {"id": 1}},
+        {"topic": "input", "key": 2, "value": {"id": 2}},
+        {"topic": "input", "key": null, "value": {"id": 3}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 3, "value": {"ID": 1, "KEY": 3}},
+        {"topic": "OUTPUT", "key": 2, "value": {"ID": 2, "KEY": 2}},
+        {"topic": "OUTPUT", "key": null, "value": {"ID": 3, "KEY": null}}
+      ],
+      "post": {
+        "sources": [
+          {
+            "name": "OUTPUT",
+            "type": "stream",
+            "keyFormat": {"format": "KAFKA"},
+            "schema": "ROWKEY BIGINT KEY, ID BIGINT, KEY BIGINT"
+          }
+        ]
+      }
+    },
+    {
+      "name": "table explicit KAFKA BIGINT ROWKEY",
       "statements": [
         "CREATE TABLE INPUT (ROWKEY BIGINT KEY, ID bigint) WITH (kafka_topic='input',value_format='JSON');",
         "CREATE TABLE OUTPUT as SELECT ID, ROWKEY as KEY FROM INPUT;"
@@ -124,6 +218,102 @@
             "schema": "ROWKEY BIGINT KEY, ID BIGINT, KEY BIGINT"
           }
         ]
+      }
+    },
+    {
+      "name": "stream explicit KAFKA DOUBLE ROWKEY",
+      "statements": [
+        "CREATE STREAM INPUT (ROWKEY DOUBLE KEY, ID bigint) WITH (kafka_topic='input',value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT ID, ROWKEY as KEY FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input", "key": 3.0, "value": {"id": 1}},
+        {"topic": "input", "key": 2.0, "value": {"id": 2}},
+        {"topic": "input", "key": null, "value": {"id": 3}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 3.0, "value": {"ID": 1, "KEY": 3.0}},
+        {"topic": "OUTPUT", "key": 2.0, "value": {"ID": 2, "KEY": 2.0}},
+        {"topic": "OUTPUT", "key": null, "value": {"ID": 3, "KEY": null}}
+      ],
+      "post": {
+        "sources": [
+          {
+            "name": "OUTPUT",
+            "type": "stream",
+            "keyFormat": {"format": "KAFKA"},
+            "schema": "ROWKEY DOUBLE KEY, ID BIGINT, KEY DOUBLE"
+          }
+        ]
+      }
+    },
+    {
+      "name": "table explicit KAFKA DOUBLE ROWKEY",
+      "statements": [
+        "CREATE TABLE INPUT (ROWKEY DOUBLE KEY, ID bigint) WITH (kafka_topic='input',value_format='JSON');",
+        "CREATE TABLE OUTPUT as SELECT ID, ROWKEY as KEY FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input", "key": 3.0, "value": {"id": 1}},
+        {"topic": "input", "key": 2.0, "value": {"id": 2}},
+        {"topic": "input", "key": 1.0, "value": {"id": 3}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 3.0, "value": {"ID": 1, "KEY": 3.0}},
+        {"topic": "OUTPUT", "key": 2.0, "value": {"ID": 2, "KEY": 2.0}},
+        {"topic": "OUTPUT", "key": 1.0, "value": {"ID": 3, "KEY": 1.0}}
+      ],
+      "post": {
+        "sources": [
+          {
+            "name": "OUTPUT",
+            "type": "table",
+            "keyFormat": {"format": "KAFKA"},
+            "schema": "ROWKEY DOUBLE KEY, ID BIGINT, KEY DOUBLE"
+          }
+        ]
+      }
+    },
+    {
+      "name": "create stream explicit unsupported ROWKEY type",
+      "statements": [
+        "CREATE STREAM INPUT (ROWKEY BOOLEAN KEY, ID bigint) WITH (kafka_topic='input',value_format='JSON');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Key format does not support key schema.\nformat: KAFKA\nschema: Persistence{schema=STRUCT<ROWKEY BOOLEAN> NOT NULL, unwrapped=false}\nreason: The 'KAFKA' format does not support type 'BOOLEAN'"
+      }
+    },
+    {
+      "name": "create table explicit unsupported ROWKEY type",
+      "statements": [
+        "CREATE TABLE INPUT (ROWKEY DECIMAL(21,19) KEY, ID bigint) WITH (kafka_topic='input',value_format='JSON');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Key format does not support key schema.\nformat: KAFKA\nschema: Persistence{schema=STRUCT<ROWKEY DECIMAL(21, 19)> NOT NULL, unwrapped=false}\nreason: The 'KAFKA' format does not support type 'DECIMAL'"
+      }
+    },
+    {
+      "name": "create stream as explicit unsupported ROWKEY type",
+      "statements": [
+        "CREATE STREAM INPUT (ROWKEY STRING KEY, ID ARRAY<INT>) WITH (kafka_topic='input',value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT PARTITION BY ID;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Key format does not support key schema.\nformat: KAFKA\nschema: Persistence{schema=STRUCT<ROWKEY ARRAY<INT>> NOT NULL, unwrapped=false}\nreason: The 'KAFKA' format does not support type 'ARRAY'"
+      }
+    },
+    {
+      "name": "create table as explicit unsupported ROWKEY type",
+      "statements": [
+        "CREATE STREAM INPUT (ROWKEY STRING KEY, ID MAP<STRING, INT>) WITH (kafka_topic='input',value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT COUNT() FROM INPUT GROUP BY ID;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Key format does not support key schema.\nformat: KAFKA\nschema: Persistence{schema=STRUCT<ROWKEY MAP<VARCHAR, INT>> NOT NULL, unwrapped=false}\nreason: The 'KAFKA' format does not support type 'MAP'"
       }
     },
     {

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/serdes.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/serdes.json
@@ -628,7 +628,7 @@
       "format": ["JSON", "AVRO"],
       "statements": [
         "CREATE TABLE INPUT (f0 STRING, f1 STRING) WITH (kafka_topic='input_topic', value_format='{FORMAT}');",
-        "CREATE TABLE OUTPUT WITH(WRAP_SINGLE_VALUE=true) AS SELECT * FROM INPUT;"
+        "CREATE TABLE OUTPUT WITH(WRAP_SINGLE_VALUE=false) AS SELECT * FROM INPUT;"
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/GenericRowSerDe.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/GenericRowSerDe.java
@@ -26,6 +26,7 @@ import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.SchemaUtil;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -102,6 +103,20 @@ public final class GenericRowSerDe implements ValueSerdeFactory {
       final ProcessingLogContext processingLogContext,
       final Class<T> targetType
   ) {
+    try {
+      serdeFactories.validate(format, schema);
+    } catch (final Exception e) {
+      throw new KsqlException("Value format does not support value schema."
+          + System.lineSeparator()
+          + "format: " + format.getFormat()
+          + System.lineSeparator()
+          + "schema: " + schema
+          + System.lineSeparator()
+          + "reason: " + e.getMessage(),
+          e
+      );
+    }
+
     final Serde<T> serde = serdeFactories
         .create(format, schema, ksqlConfig, schemaRegistryClientFactory, targetType);
 

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/KsqlSerdeFactories.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/KsqlSerdeFactories.java
@@ -44,6 +44,11 @@ final class KsqlSerdeFactories implements SerdeFactories {
   }
 
   @Override
+  public void validate(final FormatInfo format, final PersistenceSchema schema) {
+    factoryMethod.apply(format).validate(schema);
+  }
+
+  @Override
   public <K> Serde<K> create(
       final FormatInfo format,
       final PersistenceSchema schema,

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/SerdeFactories.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/SerdeFactories.java
@@ -24,6 +24,17 @@ import org.apache.kafka.common.serialization.Serde;
 interface SerdeFactories {
 
   /**
+   * Validate that supplied {@code format} can handle the supplied {@code schema}.
+   * @param format the format to validate.
+   * @param schema the schema to validate.
+   * @throws RuntimeException if format does not support schema.
+   */
+  void validate(
+      FormatInfo format,
+      PersistenceSchema schema
+  );
+
+  /**
    * Create {@link Serde} for supported KSQL formats.
    *
    * @param format required format.

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/KsqlSerdeFactoriesTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/KsqlSerdeFactoriesTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -77,6 +78,28 @@ public class KsqlSerdeFactoriesTest {
   }
 
   @Test
+  public void shouldValidateOnValidate() {
+    // When:
+    factory.validate(formatInfo, schema);
+
+    // Then:
+    verify(ksqlSerdeFactory).validate(schema);
+  }
+
+  @Test
+  public void shouldThrowOnValidateIfValidationFails() {
+    // Given:
+    doThrow(new RuntimeException("Boom!"))
+        .when(ksqlSerdeFactory).validate(any());
+
+    // Expect:
+    expectedException.expectMessage("Boom!");
+
+    // When:
+    factory.validate(formatInfo, schema);
+  }
+
+  @Test
   public void shouldCreateFactory() {
     // When:
     factory.create(
@@ -106,7 +129,7 @@ public class KsqlSerdeFactoriesTest {
     verify(ksqlSerdeFactory).validate(schema);
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "rawtypes"})
   @Test
   public void shouldCreateSerde() {
     // Given:


### PR DESCRIPTION
### Description 

fixes: https://github.com/confluentinc/ksql/issues/4113

Added QTT tests to ensure sensible error messages are output from `CT`/`CS` and `CTAS`/`CSAS` statements where the key format, (currently always `KAFKA`), does not support the Sql type of the key column, e.g. the `KAFKA` format does not support `BOOLEAN`, `DECIMAL`, `MAP`, ARRAY` or `STRUCT` types.

Error message will look something like:

```
Key format does not support key schema.
format: KAFKA
schema: Persistence{schema=STRUCT<ROWKEY MAP<VARCHAR, INT>> NOT NULL, unwrapped=false}
reason: The 'KAFKA' format does not support type 'MAP'
```

### Testing done 

This PR is all about adding tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

