### PR TITLE
test: fix build issue caused by new register method on SR client

### DIFF
--- a/ksql-test-util/src/main/java/io/confluent/ksql/test/util/TestMethods.java
+++ b/ksql-test-util/src/main/java/io/confluent/ksql/test/util/TestMethods.java
@@ -41,6 +41,7 @@ import java.util.stream.Collectors;
 public final class TestMethods {
 
   private static final Map<Type, Object> BUILT_IN_DEFAULTS = ImmutableMap.<Type, Object>builder()
+      .put(boolean.class, true)
       .put(int.class, 0)
       .put(long.class, 0L)
       .put(float.class, 0.0f)


### PR DESCRIPTION
### Description 

Up stream changed, (new `register` methods added to `SchemaRegistryClient`), caused build failure. This commit fixes them.

### Testing done 

Test now passes.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

