### PR TITLE
fix: better error message on self-join

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -341,6 +341,14 @@ class Analyzer {
         throw new KsqlException("Only equality join criteria is supported.");
       }
 
+      if (left.getDataSource().getName().equals(right.getDataSource().getName())) {
+        throw new KsqlException(
+            "Can not join '" + left.getDataSource().getName().toString(FormatOptions.noEscape())
+                + "' to '" + right.getDataSource().getName().toString(FormatOptions.noEscape())
+                + "': self joins are not yet supported."
+        );
+      }
+
       final ColumnRef leftJoinField = getJoinFieldName(
           comparisonExpression,
           left.getAlias(),

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/joins.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/joins.json
@@ -1922,6 +1922,17 @@
           {"name": "OUTPUT", "type": "stream", "schema": "ROWKEY STRING KEY, L_ROWKEY STRING, L1 INT, R1 INT"}
         ]
       }
+    },
+    {
+      "name": "self join",
+      "statements": [
+        "CREATE STREAM INPUT (ID bigint) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT * FROM INPUT s1 JOIN INPUT s2 WITHIN 1 HOUR ON s1.id = s2.id;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Can not join 'INPUT' to 'INPUT': self joins are not yet supported."
+      }
     }
   ]
 }


### PR DESCRIPTION
### Description 

Fixes: https://github.com/confluentinc/ksql/issues/4241

Self-joins are not yet supported. Previously they resulted in an confusing error message:

>  Invalid topology: Topic <something> has already been registered by another source.

They not result in:

> Can not join 'something' to 'something': self joins are not yet supported.


### Testing done 

Tests added.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

