### PR TITLE
chore: migrate to use ParsedSchema for SchemaRegistryClient

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/services/SandboxedSchemaRegistryClient.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/SandboxedSchemaRegistryClient.java
@@ -41,6 +41,7 @@ final class SandboxedSchemaRegistryClient {
     return LimitedProxyBuilder.forClass(SchemaRegistryClient.class)
         .swallow("register", anyParams(), 123)
         .forward("getLatestSchemaMetadata", methodParams(String.class), delegate)
+        .forward("getSchemaBySubjectAndId", methodParams(String.class, int.class), delegate)
         .forward("testCompatibility",
             methodParams(String.class, Schema.class), delegate)
         .forward("testCompatibility",

--- a/ksql-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorFunctionalTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorFunctionalTest.java
@@ -17,10 +17,12 @@ package io.confluent.ksql.schema.ksql.inference;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.connect.avro.AvroData;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.metastore.MetaStore;
@@ -66,6 +68,8 @@ public class DefaultSchemaInjectorFunctionalTest {
 
   @Mock
   private SchemaRegistryClient srClient;
+  @Mock
+  private ParsedSchema schema;
   @Mock
   private MetaStore metaStore;
   private DefaultSchemaInjector schemaInjector;
@@ -495,6 +499,9 @@ public class DefaultSchemaInjectorFunctionalTest {
     try {
       when(srClient.getLatestSchemaMetadata(any()))
           .thenReturn(new SchemaMetadata(1, 1, avroSchema.toString()));
+      when(srClient.getSchemaBySubjectAndId(any(), anyInt())).thenReturn(schema);
+      when(schema.schemaType()).thenReturn("AVRO");
+      when(schema.canonicalString()).thenReturn(avroSchema.toString());
     } catch (final Exception e) {
       throw new AssertionError(e);
     }

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/SandboxedSchemaRegistryClientTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/SandboxedSchemaRegistryClientTest.java
@@ -57,6 +57,7 @@ public final class SandboxedSchemaRegistryClientTest {
           .ignore("register", String.class, Schema.class, int.class, int.class)
           .ignore("register", String.class, ParsedSchema.class, int.class, int.class)
           .ignore("getLatestSchemaMetadata", String.class)
+          .ignore("getSchemaBySubjectAndId", String.class, int.class)
           .ignore("testCompatibility", String.class, Schema.class)
           .ignore("testCompatibility", String.class, ParsedSchema.class)
           .ignore("deleteSubject", String.class)


### PR DESCRIPTION
### Description 
In preparation for leveraging JSON/Protobuf support for Schema Registry, this PR swaps over the code to use `ParsedSchema`, the new abstraction for accessing schemata stored in Schema Registry.

### Testing done 
- Unit Tests updates
- Local smoke testing (registered a schema, pulled a schema)

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

