### PR TITLE
feat: allow environment variables to configure embedded connect

### DIFF
--- a/config/connect.properties.template
+++ b/config/connect.properties.template
@@ -1,0 +1,19 @@
+#
+# Copyright 2020 Confluent Inc.
+#
+# Licensed under the Confluent Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+# http://www.confluent.io/confluent-community-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+{% set kr_props = env_to_props('CONNECT_', '') -%}
+{% for name, value in kr_props.iteritems() -%}
+{{name}}={{value}}
+{% endfor -%}

--- a/config/connect.properties.template
+++ b/config/connect.properties.template
@@ -13,7 +13,7 @@
 # specific language governing permissions and limitations under the License.
 #
 
-{% set kr_props = env_to_props('CONNECT_', '') -%}
+{% set kr_props = env_to_props('KSQL_CONNECT_', '') -%}
 {% for name, value in kr_props.iteritems() -%}
 {{name}}={{value}}
 {% endfor -%}

--- a/ksql-rest-app/Dockerfile
+++ b/ksql-rest-app/Dockerfile
@@ -12,5 +12,7 @@ ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/bin/docker/* /usr/bin/docke
 ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/etc/* /etc/ksql/
 ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/
 
+RUN chmod +x /usr/bin/docker/configure
 RUN chmod +x /usr/bin/docker/run
+
 CMD ["/usr/bin/docker/run"]

--- a/ksql-rest-app/src/include/docker/configure
+++ b/ksql-rest-app/src/include/docker/configure
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2020 Confluent Inc.
+#
+# Licensed under the Confluent Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+# http://www.confluent.io/confluent-community-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+
+
+dub ensure KSQL_CONNECT_BOOTSTRAP_SERVERS
+dub ensure KSQL_CONNECT_GROUP_ID
+dub ensure KSQL_CONNECT_CONFIG_STORAGE_TOPIC
+dub ensure KSQL_CONNECT_OFFSET_STORAGE_TOPIC
+dub ensure KSQL_CONNECT_STATUS_STORAGE_TOPIC
+dub ensure KSQL_CONNECT_KEY_CONVERTER
+dub ensure KSQL_CONNECT_VALUE_CONVERTER
+# This is required to avoid config bugs. You should set this to a value that is
+# resolvable by all containers.
+dub ensure KSQL_CONNECT_REST_ADVERTISED_HOST_NAME
+
+# Default to 8083, which matches the mesos-overrides. This is here in case we extend the containers to remove the mesos overrides.
+if [ -z "$KSQL_CONNECT_REST_PORT" ]; then
+  export KSQL_CONNECT_REST_PORT=8083
+fi
+
+if [[ $KSQL_CONNECT_KEY_CONVERTER == "io.confluent.connect.avro.AvroConverter" ]]
+then
+  dub ensure KSQL_CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL
+fi
+
+if [[ $KSQL_CONNECT_VALUE_CONVERTER == "io.confluent.connect.avro.AvroConverter" ]]
+then
+  dub ensure KSQL_CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL
+fi
+

--- a/ksql-rest-app/src/include/docker/run
+++ b/ksql-rest-app/src/include/docker/run
@@ -17,6 +17,15 @@
 
 
 echo "===> Configuring ksqlDB..."
+dub template "/etc/ksql/connect.properties.template" "/etc/ksql/connect.properties"
+
+# CONNECT_GROUP_ID is a required configuration for running embedded connect,
+# so we can proxy it to check whether or not to start an embedded connect worker
+if ! [[ -z "${CONNECT_GROUP_ID}" ]]; then
+  echo "===> Enabling Embedded Connect"
+  export KSQL_KSQL_CONNECT_WORKER_CONFIG="/etc/ksql/connect.properties"
+fi
+
 dub template "/etc/ksql/ksqldb-server.properties.template" "/etc/ksql/ksqldb-server.properties"
 
 echo "===> Launching ksqlDB Server..."

--- a/ksql-rest-app/src/include/docker/run
+++ b/ksql-rest-app/src/include/docker/run
@@ -19,9 +19,12 @@
 echo "===> Configuring ksqlDB..."
 dub template "/etc/ksql/connect.properties.template" "/etc/ksql/connect.properties"
 
-# CONNECT_GROUP_ID is a required configuration for running embedded connect,
+# KSQL_CONNECT_GROUP_ID is a required configuration for running embedded connect,
 # so we can proxy it to check whether or not to start an embedded connect worker
-if ! [[ -z "${CONNECT_GROUP_ID}" ]]; then
+if ! [[ -z "${KSQL_CONNECT_GROUP_ID}" ]]; then
+  echo "===> Configuring Embedded Connect"
+  /usr/bin/docker/configure
+
   echo "===> Enabling Embedded Connect"
   export KSQL_KSQL_CONNECT_WORKER_CONFIG="/etc/ksql/connect.properties"
 fi


### PR DESCRIPTION
### Description 
With this patch, docker users will be able to configure their embedded connect cluster using env variables prefixed with `KSQL_CONNECT_`.

### Testing done 
Spun up ksqldb using the following docker compose:
```yml
  ksqldb-server:
    image: placeholder/confluentinc/ksql-rest-app:local.build
    hostname: ksqldb-server
    container_name: ksqldb-server
    depends_on:
      - broker
      - schema-registry
    ports:
      - "8088:8088"
    environment:
      KSQL_BOOTSTRAP_SERVERS: "broker:9092"
      KSQL_HOST_NAME: ksqldb-server
      KSQL_LISTENERS: "http://0.0.0.0:8088"
      KSQL_CACHE_MAX_BYTES_BUFFERING: 0
      KSQL_KSQL_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
      KSQL_KSQL_LOGGING_PROCESSING_STREAM_AUTO_CREATE: "true"
      KSQL_KSQL_LOGGING_PROCESSING_TOPIC_AUTO_CREATE: "true"
      KSQL_LOG4J_OPTS: "-Dlog4j.configuration=file:/etc/ksql/log4j-rolling2.properties -Dlog4j.debug"
      KSQL_CONNECT_GROUP_ID: "ksql-connect-cluster"
      KSQL_CONNECT_BOOTSTRAP_SERVERS: "broker:9092"
      KSQL_CONNECT_KEY_CONVERTER: "io.confluent.connect.avro.AvroConverter"
      KSQL_CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY: "http://schema-registry:8081"
      KSQL_CONNECT_VALUE_CONVERTER: "io.confluent.connect.avro.AvroConverter"
      KSQL_CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY: "http://schema-registry:8081"
      KSQL_CONNECT_CONFIG_STORAGE_TOPIC: "ksql-connect-configs"
      KSQL_CONNECT_OFFSET_STORAGE_TOPIC: "ksql-connect-offsets"
      KSQL_CONNECT_STATUS_STORAGE_TOPIC: "ksql-connect-statuses"
      KSQL_CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR: 1
      KSQL_CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: 1
      KSQL_CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: 1
    volumes:
      - ./log4j-rolling.properties:/etc/ksql/log4j-rolling2.properties
```

Also tested without a required param and it failed with the correct error message.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

