### PR TITLE
fix: add ksql-test-runner deps to ksql package lib

### DIFF
--- a/ksql-package/pom.xml
+++ b/ksql-package/pom.xml
@@ -80,6 +80,33 @@
             <version>${project.version}</version>
         </dependency>
 
+        <!-- Required for ksql-test-runner -->
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <classifier>test</classifier>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
       <!-- Required for running tests -->
 
       <dependency>

--- a/ksql-package/src/assembly/package.xml
+++ b/ksql-package/src/assembly/package.xml
@@ -83,7 +83,6 @@
             <excludes>
                 <exclude>io.confluent:rest-utils</exclude>
                 <exclude>io.confluent:common-config</exclude>
-                <exclude>io.confluent:common-utils</exclude>
                 <exclude>io.confluent:common-metrics</exclude>
             </excludes>
         </dependencySet>


### PR DESCRIPTION
### Description 
Fixes https://github.com/confluentinc/ksql/issues/3387

Adds the necessary dependencies on the KSQL package so ksql-test-runner can run without issues.

### Testing done 
Executed a ksql-test-runner test from withing the `ksql-package-5.5.0-SNAPSHOT-package/bin` directory. The test passed.
```
ksql/ksql-package/target/ksql-package-5.5.0-SNAPSHOT-package/bin$ ./ksql-test-runner -s /tmp/statements.sql -i /tmp/input.json -o /tmp/output.json | grep 'Test passed'
	 >>> Test passed!
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

