### PR TITLE
feat: extend INSERT/VALUES syntax for multiple rows

### DIFF
--- a/docs-md/developer-guide/ksqldb-reference/insert-values.md
+++ b/docs-md/developer-guide/ksqldb-reference/insert-values.md
@@ -14,13 +14,13 @@ Synopsis
 
 ```sql
 INSERT INTO <stream_name|table_name> [(column_name [, ...]])]
-  VALUES (value [,...]);
+  VALUES (value [,...])[, (value [,...])];
 ```
 
 Description
 -----------
 
-Produce a row into an existing stream or table and its underlying topic
+Produce rows into an existing stream or table and its underlying topic
 based on explicitly specified values. The first `column_name` of every
 schema is `ROWKEY`, which defines the corresponding Kafka key. If the
 source specifies a `key` and that column is present in the column names
@@ -56,6 +56,9 @@ INSERT INTO foo (KEY_COL, COL_A) VALUES ('key', 'A');
 
 -- inserts (current_time(), "key", "key", null)
 INSERT INTO foo (KEY_COL) VALUES ('key');
+
+-- inserts multimple rows (current_time(), "key", "key", null), (current_time(), "key2", "key2", null)
+INSERT INTO foo (KEY_COL) VALUES ('key'), ('key2');
 ```
 
 The values are serialized by using the `value_format` specified in the

--- a/ksql-functional-tests/src/test/resources/rest-query-validation-tests/insert-values.json
+++ b/ksql-functional-tests/src/test/resources/rest-query-validation-tests/insert-values.json
@@ -7,12 +7,13 @@
       "name": "explicitly supply all column values",
       "statements": [
         "CREATE STREAM TEST (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "INSERT INTO TEST (ROWTIME, ROWKEY, ID) VALUES (1234, 'key', 10);"
+        "INSERT INTO TEST (ROWTIME, ROWKEY, ID) VALUES (1234, 'key', 10), (5678, 'lfz', 11);"
       ],
       "inputs": [
       ],
       "outputs": [
-        {"topic": "test_topic", "timestamp": 1234, "key": "key", "value": {"ID": 10}}
+        {"topic": "test_topic", "timestamp": 1234, "key": "key", "value": {"ID": 10}},
+        {"topic": "test_topic", "timestamp": 5678, "key": "lfz", "value": {"ID": 11}}
       ],
       "responses": [
         {"admin": {"@type": "currentStatus", "statementText": "{STATEMENT}"}}
@@ -34,24 +35,26 @@
       "name": "explicitly supply default set of column values",
       "statements": [
         "CREATE STREAM TEST (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "INSERT INTO TEST (ROWKEY, ID) VALUES ('key', 10);"
+        "INSERT INTO TEST (ROWKEY, ID) VALUES ('key', 10), ('lzf', 11);"
       ],
       "inputs": [
       ],
       "outputs": [
-        {"topic": "test_topic", "key": "key", "value": {"ID": 10}}
+        {"topic": "test_topic", "key": "key", "value": {"ID": 10}},
+        {"topic": "test_topic", "key": "lzf", "value": {"ID": 11}}
       ]
     },
     {
       "name": "implicitly supply default set of column values",
       "statements": [
         "CREATE STREAM TEST (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "INSERT INTO TEST VALUES ('key', 10);"
+        "INSERT INTO TEST VALUES ('key', 10), ('lzf', 11);"
       ],
       "inputs": [
       ],
       "outputs": [
-        {"topic": "test_topic", "key": "key", "value": {"ID": 10}}
+        {"topic": "test_topic", "key": "key", "value": {"ID": 10}},
+        {"topic": "test_topic", "key": "lzf", "value": {"ID": 11}}
       ]
     },
     {
@@ -194,7 +197,19 @@
       ],
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "Failed to prepare statement: Expected number columns and values to match: [ROWKEY, ID], ['10']",
+        "message": "Failed to prepare statement: Expected number columns and values to match  (row 0): [ROWKEY, ID], ['10']",
+        "status": 400
+      }
+    },
+    {
+      "name": "should fail on mismatch between explicit columns and value counts on second row",
+      "statements": [
+        "CREATE STREAM TEST (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "INSERT INTO TEST (ROWKEY, ID) VALUES ('key', 10), ('10');"
+      ],
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
+        "message": "Failed to prepare statement: Expected number columns and values to match (row 1): [ROWKEY, ID], ['10']",
         "status": 400
       }
     },
@@ -206,7 +221,19 @@
       ],
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "Failed to insert values into 'TEST'. Expected ROWKEY and ID to match but got 10 and 5 respectively.",
+        "message": "Failed to insert values (row 0) into 'TEST'. Expected ROWKEY and ID to match but got 10 and 5 respectively.",
+        "status": 400
+      }
+    },
+    {
+      "name": "should fail on mismatch between rowkey and key values when stream has key on second row",
+      "statements": [
+        "CREATE STREAM TEST (ROWKEY INT KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "INSERT INTO TEST (ROWKEY, ID) VALUES ('key', 5), (10, 5);"
+      ],
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
+        "message": "Failed to insert values (row 1) into 'TEST'. Expected ROWKEY and ID to match but got 10 and 5 respectively.",
         "status": 400
       }
     },

--- a/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -61,7 +61,7 @@ statement
             (WITH tableProperties)? AS query                                #createTableAs
     | CREATE (SINK | SOURCE) CONNECTOR identifier WITH tableProperties      #createConnector
     | INSERT INTO sourceName query                                          #insertInto
-    | INSERT INTO sourceName (columns)? VALUES values                       #insertValues
+    | INSERT INTO sourceName (columns)? VALUES values(',' values)*          #insertValues
     | DROP STREAM (IF EXISTS)? sourceName (DELETE TOPIC)?                   #dropStream
     | DROP TABLE (IF EXISTS)? sourceName (DELETE TOPIC)?                    #dropTable
     | DROP CONNECTOR identifier                                             #dropConnector

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -339,11 +339,16 @@ public class AstBuilder {
         columns = ImmutableList.of();
       }
 
+      final List<List<Expression>> values = context.values()
+          .stream()
+          .map(v -> visit(v.valueExpression(), Expression.class))
+          .collect(Collectors.toList());
+
       return new InsertValues(
           targetLocation,
           targetName,
           columns,
-          visit(context.values().valueExpression(), Expression.class));
+          values);
     }
 
     @Override

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
@@ -63,6 +63,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import org.apache.commons.lang3.StringUtils;
 
 public final class SqlFormatter {
@@ -323,13 +325,18 @@ public final class SqlFormatter {
 
       builder.append("VALUES ");
 
-      builder.append("(");
-      builder.append(
-          node.getValues()
-              .stream()
-              .map(ExpressionFormatterUtil::formatExpression)
-              .collect(Collectors.joining(", ")));
-      builder.append(")");
+      IntStream.range(0, node.getValues().size()).forEach(idx -> {
+        if (idx > 0) {
+          builder.append(", ");
+        }
+
+        builder.append("(");
+        builder.append(
+            node.getValues().get(idx).stream()
+                .map(ExpressionFormatterUtil::formatExpression)
+                .collect(Collectors.joining(", ")));
+        builder.append(")");
+      });
 
       return null;
     }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
@@ -684,35 +684,37 @@ public class SqlFormatterTest {
 
   @Test
   public void shouldFormatInsertValuesStatement() {
-    final String statementString = "INSERT INTO ADDRESS (NUMBER, STREET, CITY) VALUES (2, 'high', 'palo alto');";
+    final String statementString = "INSERT INTO ADDRESS (NUMBER, STREET, CITY) VALUES "
+        + "(2, 'high', 'palo alto'), (3, 'low', 'mountain view');";
     final Statement statement = parseSingle(statementString);
 
     final String result = SqlFormatter.formatSql(statement);
 
-    assertThat(result, is("INSERT INTO ADDRESS (NUMBER, STREET, CITY) VALUES (2, 'high', 'palo alto')"));
+    assertThat(result, is("INSERT INTO ADDRESS (NUMBER, STREET, CITY) VALUES "
+        + "(2, 'high', 'palo alto'), (3, 'low', 'mountain view')"));
   }
 
   @Test
   public void shouldFormatInsertValuesNoSchema() {
-    final String statementString = "INSERT INTO ADDRESS VALUES (2);";
+    final String statementString = "INSERT INTO ADDRESS VALUES (2),(3),(4),(5);";
     final Statement statement = parseSingle(statementString);
 
     final String result = SqlFormatter.formatSql(statement);
 
-    assertThat(result, is("INSERT INTO ADDRESS VALUES (2)"));
+    assertThat(result, is("INSERT INTO ADDRESS VALUES (2), (3), (4), (5)"));
   }
 
   @Test
   public void shouldParseArbitraryExpressions() {
     // Given:
-    final String statementString = "INSERT INTO ADDRESS VALUES (2 + 1);";
+    final String statementString = "INSERT INTO ADDRESS VALUES (2 + 1), (3 + 3);";
     final Statement statement = KsqlParserTestUtil.buildSingleAst(statementString, metaStore).getStatement();
 
     // When:
     final String result = SqlFormatter.formatSql(statement);
 
     // Then:
-    assertThat(result, is("INSERT INTO ADDRESS VALUES ((2 + 1))"));
+    assertThat(result, is("INSERT INTO ADDRESS VALUES ((2 + 1)), ((3 + 3))"));
   }
 
   @Test

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/InsertValuesTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/InsertValuesTest.java
@@ -26,6 +26,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.Collections;
+
 public class InsertValuesTest {
 
   private static final SourceName SOME_NAME = SourceName.of("bob");
@@ -37,14 +39,24 @@ public class InsertValuesTest {
   public void shouldImplementEqualsHashcode() {
     new EqualsTester()
         .addEqualityGroup(
-            new InsertValues(SOME_NAME, ImmutableList.of(), ImmutableList.of(new NullLiteral())),
-            new InsertValues(SOME_NAME, ImmutableList.of(), ImmutableList.of(new NullLiteral())))
+            new InsertValues(SOME_NAME, ImmutableList.of(),
+                Collections.singletonList(ImmutableList.of(new NullLiteral()))),
+            new InsertValues(SOME_NAME, ImmutableList.of(),
+                Collections.singletonList(ImmutableList.of(new NullLiteral()))))
         .addEqualityGroup(new InsertValues(
-            SourceName.of("diff"), ImmutableList.of(), ImmutableList.of(new StringLiteral("b"))))
+            SourceName.of("diff"), ImmutableList.of(),
+            Collections.singletonList(ImmutableList.of(new StringLiteral("b")))))
         .addEqualityGroup(new InsertValues(
-            SOME_NAME, ImmutableList.of(ColumnName.of("diff")), ImmutableList.of(new StringLiteral("b"))))
+            SOME_NAME, ImmutableList.of(ColumnName.of("diff")),
+            Collections.singletonList(ImmutableList.of(new StringLiteral("b")))))
         .addEqualityGroup(new InsertValues(
-            SOME_NAME, ImmutableList.of(), ImmutableList.of(new StringLiteral("diff"))))
+            SOME_NAME, ImmutableList.of(),
+            Collections.singletonList(ImmutableList.of(new StringLiteral("diff")))))
+        .addEqualityGroup(new InsertValues(
+            SOME_NAME, ImmutableList.of(),
+            ImmutableList.of(
+                ImmutableList.of(
+                    new StringLiteral("a")), ImmutableList.of(new StringLiteral("b")))))
         .testEquals();
   }
 
@@ -71,7 +83,21 @@ public class InsertValuesTest {
     new InsertValues(
         SOME_NAME,
         ImmutableList.of(ColumnName.of("col1")),
-        ImmutableList.of(new StringLiteral("val1"), new StringLiteral("val2")));
+        ImmutableList.of(ImmutableList.of(new StringLiteral("val1"), new StringLiteral("val2"))));
   }
 
+  @Test
+  public void shouldThrowIfOneRowNonEmptyColumnsValuesDoNotMatch() {
+    // Expect:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("Expected number columns and values to match");
+
+    // When:
+    new InsertValues(
+        SOME_NAME,
+        ImmutableList.of(ColumnName.of("col1")),
+        ImmutableList.of(
+            ImmutableList.of(new StringLiteral("val1")),
+            ImmutableList.of()));
+  }
 }


### PR DESCRIPTION

### Description 
Extends the `INSERT ... VALUES` syntax to accept multiple rows. For instance:
```
INSERT INTO foo VALUES (10), (11), (12);
```
The topic `foo` will contain three 3 rows (10, 11 and 12)

The above statement is equivalent to:
```
INSERT INTO foo VALUES (10);
INSERT INTO foo VALUES (11);
INSERT INTO foo VALUES (12);
```

### Testing done 
Modified unit tests
Verified manually running the CLI
```
ksql> insert into t1(id) values (1),(2);
ksql> select * from t1 emit changes;
+-------------------------------------------+-------------------------------------------+-------------------------------------------+
|ROWTIME                                    |ROWKEY                                     |ID                                         |
+-------------------------------------------+-------------------------------------------+-------------------------------------------+
|1578687132771                              |null                                       |1                                          |
|1578687132796                              |null                                       |2                                          |
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

