### PR TITLE
feat: expression support in JOINs

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analysis.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analysis.java
@@ -281,30 +281,30 @@ public class Analysis implements ImmutableAnalysis {
   @Immutable
   public static final class JoinInfo {
 
-    private final ColumnRef leftJoinField;
-    private final ColumnRef rightJoinField;
+    private final Expression leftJoinExpression;
+    private final Expression rightJoinExpression;
     private final JoinNode.JoinType type;
     private final Optional<WithinExpression> withinExpression;
 
     JoinInfo(
-        final ColumnRef leftJoinField,
-        final ColumnRef rightJoinField,
+        final Expression leftJoinExpression,
+        final Expression rightJoinExpression,
         final JoinType type,
         final Optional<WithinExpression> withinExpression
 
     ) {
-      this.leftJoinField =  requireNonNull(leftJoinField, "leftJoinField");
-      this.rightJoinField =  requireNonNull(rightJoinField, "rightJoinField");
+      this.leftJoinExpression = requireNonNull(leftJoinExpression, "leftJoinExpression");
+      this.rightJoinExpression = requireNonNull(rightJoinExpression, "rightJoinExpression");
       this.type = requireNonNull(type, "type");
       this.withinExpression = requireNonNull(withinExpression, "withinExpression");
     }
 
-    public ColumnRef getLeftJoinField() {
-      return leftJoinField;
+    public Expression getLeftJoinExpression() {
+      return leftJoinExpression;
     }
 
-    public ColumnRef getRightJoinField() {
-      return rightJoinField;
+    public Expression getRightJoinExpression() {
+      return rightJoinExpression;
     }
 
     public JoinType getType() {

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -84,7 +84,8 @@ public class LogicalPlanner {
     }
 
     if (analysis.getPartitionBy().isPresent()) {
-      currentNode = buildRepartitionNode(currentNode, analysis.getPartitionBy().get());
+      currentNode = buildRepartitionNode(
+          "PartitionBy", currentNode, analysis.getPartitionBy().get());
     }
 
     if (!analysis.getTableFunctions().isEmpty()) {
@@ -207,6 +208,7 @@ public class LogicalPlanner {
   }
 
   private RepartitionNode buildRepartitionNode(
+      final String planId,
       final PlanNode sourceNode,
       final Expression partitionBy
   ) {
@@ -240,7 +242,7 @@ public class LogicalPlanner {
     final LogicalSchema schema = buildRepartitionedSchema(sourceNode, partitionBy);
 
     return new RepartitionNode(
-        new PlanNodeId("PartitionBy"),
+        new PlanNodeId(planId),
         sourceNode,
         schema,
         partitionBy,
@@ -289,8 +291,10 @@ public class LogicalPlanner {
         // it is always safe to build the repartition node - this operation will be
         // a no-op if a repartition is not required. if the source is a table, and
         // a repartition is needed, then an exception will be thrown
-        buildRepartitionNode(leftSourceNode, joinInfo.get().getLeftJoinExpression()),
-        buildRepartitionNode(rightSourceNode, joinInfo.get().getRightJoinExpression()),
+        buildRepartitionNode(
+            "LeftSourceKeyed", leftSourceNode, joinInfo.get().getLeftJoinExpression()),
+        buildRepartitionNode(
+            "RightSourceKeyed", rightSourceNode, joinInfo.get().getRightJoinExpression()),
         joinInfo.get().getWithinExpression()
     );
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -219,7 +219,7 @@ public class LogicalPlanner {
       final LogicalSchema sourceSchema = sourceNode.getSchema();
 
       final Column proposedKey = sourceSchema
-          .findValueColumn(columnRef)
+          .findColumn(columnRef)
           .orElseThrow(() -> new KsqlException("Invalid identifier for PARTITION BY clause: '"
               + columnRef.name().toString(FormatOptions.noEscape()) + "' Only columns from the "
               + "source schema can be referenced in the PARTITION BY clause."));
@@ -286,10 +286,11 @@ public class LogicalPlanner {
         new PlanNodeId("Join"),
         analysis.getSelectExpressions(),
         joinInfo.get().getType(),
-        leftSourceNode,
-        rightSourceNode,
-        joinInfo.get().getLeftJoinField(),
-        joinInfo.get().getRightJoinField(),
+        // it is always safe to build the repartition node - this operation will be
+        // a no-op if a repartition is not required. if the source is a table, and
+        // a repartition is needed, then an exception will be thrown
+        buildRepartitionNode(leftSourceNode, joinInfo.get().getLeftJoinExpression()),
+        buildRepartitionNode(rightSourceNode, joinInfo.get().getRightJoinExpression()),
         joinInfo.get().getWithinExpression()
     );
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -334,13 +334,6 @@ public class SchemaKStream<K> {
       return (SchemaKStream<Struct>) this;
     }
 
-    if (this instanceof SchemaKTable) {
-      throw new UnsupportedOperationException("Cannot repartition a TABLE source. "
-          + "If this is a join, make sure that the criteria uses the TABLE key "
-          + this.keyField.ref().map(ColumnRef::toString).orElse("ROWKEY") + " instead of "
-          + keyExpression);
-    }
-
     final StreamSelectKey step = ExecutionStepFactory.streamSelectKey(
         contextStacker,
         sourceStep,
@@ -367,7 +360,7 @@ public class SchemaKStream<K> {
     return getSchema().isMetaColumn(columnRef.name()) ? KeyField.none() : newKeyField;
   }
 
-  private boolean needsRepartition(final Expression expression) {
+  protected boolean needsRepartition(final Expression expression) {
     if (!(expression instanceof ColumnReferenceExp)) {
       return true;
     }

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -334,6 +334,13 @@ public class SchemaKStream<K> {
       return (SchemaKStream<Struct>) this;
     }
 
+    if (this instanceof SchemaKTable) {
+      throw new UnsupportedOperationException("Cannot repartition a TABLE source. "
+          + "If this is a join, make sure that the criteria uses the TABLE key "
+          + this.keyField.ref().map(ColumnRef::toString).orElse("ROWKEY") + " instead of "
+          + keyExpression);
+    }
+
     final StreamSelectKey step = ExecutionStepFactory.streamSelectKey(
         contextStacker,
         sourceStep,

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
@@ -42,6 +42,7 @@ import io.confluent.ksql.util.KsqlConfig;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.apache.kafka.connect.data.Struct;
 
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
 public class SchemaKTable<K> extends SchemaKStream<K> {
@@ -132,6 +133,20 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
         ksqlConfig,
         functionRegistry
     );
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public SchemaKStream<Struct> selectKey(final Expression keyExpression,
+      final Stacker contextStacker) {
+    if (!needsRepartition(keyExpression)) {
+      return (SchemaKStream<Struct>) this;
+    }
+
+    throw new UnsupportedOperationException("Cannot repartition a TABLE source. "
+        + "If this is a join, make sure that the criteria uses the TABLE key "
+        + this.keyField.ref().map(ColumnRef::toString).orElse("ROWKEY") + " instead of "
+        + keyExpression);
   }
 
   @Override

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/ExpressionAnalyzerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/ExpressionAnalyzerTest.java
@@ -15,11 +15,14 @@
 
 package io.confluent.ksql.analyzer;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression.Type;
@@ -33,6 +36,7 @@ import io.confluent.ksql.util.SchemaUtil;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -127,6 +131,25 @@ public class ExpressionAnalyzerTest {
 
     // When:
     analyzer.analyzeExpression(expression, true);
+  }
+
+  @Test
+  public void shouldAddQualifier() {
+    // Given:
+    final Expression expression = new ColumnReferenceExp(
+        ColumnRef.withoutSource(ColumnName.of("else"))
+    );
+
+    when(sourceSchemas.sourcesWithField(any()))
+        .thenReturn(ImmutableSet.of(SourceName.of("something")));
+
+    // When:
+    final Set<ColumnRef> columnRefs = analyzer.analyzeExpression(expression, true);
+
+    // Then:
+    assertThat(
+        Iterables.getOnlyElement(columnRefs),
+        is(ColumnRef.of(SourceName.of("something"), ColumnName.of("else"))));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -76,11 +76,11 @@ public class PhysicalPlanBuilderTest {
       + " WITH (KAFKA_TOPIC = 'test3', VALUE_FORMAT = 'JSON', KEY='ID');";
 
   private static final String CREATE_TABLE_TEST4 = "CREATE TABLE TEST4 "
-      + "(ROWKEY BIGINT KEY, ID BIGINT, COL0 VARCHAR, COL1 DOUBLE) "
+      + "(ROWKEY BIGINT KEY, ID BIGINT, COL0 BIGINT, COL1 DOUBLE) "
       + " WITH (KAFKA_TOPIC = 'test4', VALUE_FORMAT = 'JSON', KEY='ID');";
 
   private static final String CREATE_TABLE_TEST5 = "CREATE TABLE TEST5 "
-      + "(ROWKEY BIGINT KEY, ID BIGINT, COL0 VARCHAR, COL1 DOUBLE) "
+      + "(ROWKEY BIGINT KEY, ID BIGINT, COL0 BIGINT, COL1 DOUBLE) "
       + " WITH (KAFKA_TOPIC = 'test5', VALUE_FORMAT = 'JSON', KEY='ID');";
 
   private static final String CREATE_STREAM_TEST6 = "CREATE STREAM TEST6 "
@@ -343,9 +343,8 @@ public class PhysicalPlanBuilderTest {
 
     // Then:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage(
-        "Source table (TEST4) key column (TEST4.ID) is not the column "
-            + "used in the join criteria (TEST4.COL0).");
+    expectedException.expectMessage("Cannot repartition a TABLE source. If this is a join, make "
+        + "sure that the criteria uses the TABLE key TEST4.ID instead of TEST4.COL0");
 
     // When:
     execute("CREATE TABLE t1 AS "
@@ -361,9 +360,8 @@ public class PhysicalPlanBuilderTest {
 
     // Then:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage(
-        "Source table (TEST5) key column (TEST5.ID) is not the column "
-            + "used in the join criteria (TEST5.COL0).");
+    expectedException.expectMessage("Cannot repartition a TABLE source. If this is a join, make "
+        + "sure that the criteria uses the TABLE key TEST5.ID instead of TEST5.COL0");
 
     // When:
     execute("CREATE TABLE t1 AS "

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/LogicalPlannerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/LogicalPlannerTest.java
@@ -32,6 +32,7 @@ import io.confluent.ksql.planner.plan.FilterNode;
 import io.confluent.ksql.planner.plan.JoinNode;
 import io.confluent.ksql.planner.plan.PlanNode;
 import io.confluent.ksql.planner.plan.ProjectNode;
+import io.confluent.ksql.planner.plan.RepartitionNode;
 import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.testutils.AnalysisTestUtil;
@@ -93,9 +94,9 @@ public class LogicalPlannerTest {
     assertThat(logicalPlan.getSources().get(0), instanceOf(ProjectNode.class));
     assertThat(logicalPlan.getSources().get(0).getSources().get(0), instanceOf(JoinNode.class));
     assertThat(logicalPlan.getSources().get(0).getSources().get(0).getSources()
-                          .get(0), instanceOf(DataSourceNode.class));
+                          .get(0), instanceOf(RepartitionNode.class));
     assertThat(logicalPlan.getSources().get(0).getSources().get(0).getSources()
-                          .get(1), instanceOf(DataSourceNode.class));
+                          .get(1), instanceOf(RepartitionNode.class));
 
     assertThat(logicalPlan.getSchema().value().size(), equalTo(4));
 
@@ -121,8 +122,8 @@ public class LogicalPlannerTest {
 
     assertThat(filterNode.getSources().get(0), instanceOf(JoinNode.class));
     final JoinNode joinNode = (JoinNode) filterNode.getSources().get(0);
-    assertThat(joinNode.getSources().get(0), instanceOf(DataSourceNode.class));
-    assertThat(joinNode.getSources().get(1), instanceOf(DataSourceNode.class));
+    assertThat(joinNode.getSources().get(0), instanceOf(RepartitionNode.class));
+    assertThat(joinNode.getSources().get(1), instanceOf(RepartitionNode.class));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
@@ -391,6 +391,21 @@ public class SchemaKStreamTest {
     assertThat(result.getKeyField(), is(KeyField.none()));
   }
 
+  @Test(expected = UnsupportedOperationException.class)
+  public void shouldFailRepartitionTable() {
+    // Given:
+    final PlanNode planNode = givenInitialKStreamOf("SELECT * FROM test2 EMIT CHANGES;");
+    final RepartitionNode repartitionNode = new RepartitionNode(
+        planNode.getId(),
+        planNode,
+        schemaKTable.schema,
+        new ColumnReferenceExp(ColumnRef.withoutSource(ColumnName.of("COL2"))),
+        KeyField.none());
+
+    // When:
+    schemaKTable.selectKey(repartitionNode.getPartitionBy(), childContextStacker);
+  }
+
   @Test
   public void testSelectWithExpression() {
     // Given:

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/joins.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/joins.json
@@ -1286,7 +1286,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Source table (NO_KEY) has no key column defined. Only 'ROWKEY' is supported in the join criteria for a TABLE."
+        "message": "Cannot repartition a TABLE source. If this is a join, make sure that the criteria uses the TABLE key ROWKEY instead of T.ID"
       }
     },
     {
@@ -1534,7 +1534,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid comparison expression '0' in join '(T.ID = 0)'. Joins must only contain a field comparison."
+        "message": "Invalid comparison expression '0' in join '(T.ID = 0)'. Each side of the join comparision must contain references from exactly one source."
       }
     },
     {
@@ -1546,176 +1546,113 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid comparison expression '0' in join '(0 = T.ID)'. Joins must only contain a field comparison."
+        "message": "Invalid comparison expression '0' in join '(0 = T.ID)'. Each side of the join comparision must contain references from exactly one source."
       }
     },
     {
-      "name": "stream stream left join - invalid join field - contains function",
+      "name": "stream stream join - contains function",
       "statements": [
-        "CREATE STREAM TEST1 (ID bigint) WITH (kafka_topic='left_topic', value_format='JSON');",
-        "CREATE STREAM TEST2 (ID bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
-        "CREATE STREAM LEFT_OUTER_JOIN as SELECT * FROM test1 t left join test2 tt ON t.id = test_udf(tt.id);"
+        "CREATE STREAM TEST1 (ID varchar) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE STREAM TEST2 (ID varchar) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT T.ID FROM test1 t join test2 tt WITHIN 30 SECONDS ON t.id = SUBSTRING(tt.id, 2);"
       ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid comparison expression 'TEST_UDF(TT.ID)' in join '(T.ID = TEST_UDF(TT.ID))'. Joins must only contain a field comparison."
-      }
+      "inputs": [
+        {"topic": "left_topic", "key": "foo", "value": {"id": "foo"}, "timestamp": 0},
+        {"topic": "right_topic", "key": "!foo", "value": {"id": "!foo"}, "timestamp": 10}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "foo", "value": {"T_ID":  "foo"}, "timestamp": 10}
+      ]
     },
     {
-      "name": "stream stream left join - invalid join field - contains CAST",
+      "name": "stream stream join - contains CAST",
       "statements": [
         "CREATE STREAM TEST1 (ID bigint) WITH (kafka_topic='left_topic', value_format='JSON');",
-        "CREATE STREAM TEST2 (ID bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
-        "CREATE STREAM LEFT_OUTER_JOIN as SELECT * FROM test1 t left join test2 tt ON t.id = CAST(tt.id AS BIGINT);"
+        "CREATE STREAM TEST2 (ID int) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT t.ID FROM test1 t JOIN test2 tt WITHIN 30 seconds ON t.id = CAST(tt.id AS BIGINT);"
       ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid comparison expression 'CAST(TT.ID AS BIGINT)' in join '(T.ID = CAST(TT.ID AS BIGINT))'. Joins must only contain a field comparison."
-      }
+      "inputs": [
+        {"topic": "left_topic", "key": "1", "value": {"id": 1}, "timestamp": 10},
+        {"topic": "right_topic", "key": "1", "value": {"id": 1}, "timestamp": 10}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"T_ID": 1}, "timestamp": 10}
+      ]
     },
     {
-      "name": "stream stream left join - invalid join field - contains subscript",
+      "name": "stream stream join - contains subscript",
       "statements": [
         "CREATE STREAM TEST1 (ID bigint) WITH (kafka_topic='left_topic', value_format='JSON');",
-        "CREATE STREAM TEST2 (ID bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
-        "CREATE STREAM LEFT_OUTER_JOIN as SELECT * FROM test1 t left join test2 tt ON t.id = tt.id[0];"
+        "CREATE STREAM TEST2 (ID ARRAY<bigint>) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT T.ID FROM test1 t JOIN test2 tt WITHIN 30 SECONDS ON t.id = tt.id[1];"
       ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid comparison expression 'TT.ID[0]' in join '(T.ID = TT.ID[0])'. Joins must only contain a field comparison."
-      }
+      "inputs": [
+        {"topic": "left_topic", "key": "1", "value": {"id": 1}, "timestamp": 0},
+        {"topic": "right_topic", "key": "1", "value": {"id": [1]}, "timestamp": 10}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"T_ID": 1}, "timestamp": 10}
+      ]
     },
     {
-      "name": "stream stream left join - invalid join field - contains subexpression",
+      "name": "stream stream join - contains arithmetic binary expression",
       "statements": [
         "CREATE STREAM TEST1 (ID bigint) WITH (kafka_topic='left_topic', value_format='JSON');",
         "CREATE STREAM TEST2 (ID bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
-        "CREATE STREAM LEFT_OUTER_JOIN as SELECT * FROM test1 t left join test2 tt ON t.id = (tt.id = 0);"
+        "CREATE STREAM OUTPUT as SELECT T.ID FROM test1 t join test2 tt WITHIN 30 seconds ON t.id = tt.id + 1;"
       ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid comparison expression '(TT.ID = 0)' in join '(T.ID = (TT.ID = 0))'. Joins must only contain a field comparison."
-      }
+      "inputs": [
+        {"topic": "left_topic", "key": "1", "value": {"id": 1}, "timestamp": 0},
+        {"topic": "right_topic", "key": "0", "value": {"id": 0}, "timestamp": 10}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"T_ID": 1}, "timestamp": 10}
+      ]
     },
     {
-      "name": "stream stream left join - invalid join field - contains arithmetic binary expression",
+      "name": "stream stream join - contains arithmetic unary expression",
       "statements": [
         "CREATE STREAM TEST1 (ID bigint) WITH (kafka_topic='left_topic', value_format='JSON');",
         "CREATE STREAM TEST2 (ID bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
-        "CREATE STREAM LEFT_OUTER_JOIN as SELECT * FROM test1 t left join test2 tt ON t.id = tt.id + 1;"
+        "CREATE STREAM OUTPUT as SELECT T.ID FROM test1 t join test2 tt WITHIN 30 seconds ON t.id = -tt.id;"
       ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid comparison expression '(TT.ID + 1)' in join '(T.ID = (TT.ID + 1))'. Joins must only contain a field comparison."
-      }
+      "inputs": [
+        {"topic": "left_topic", "key": "1", "value": {"id": 1}, "timestamp": 0},
+        {"topic": "right_topic", "key": "1", "value": {"id": -1}, "timestamp": 10}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"T_ID": 1}, "timestamp": 10}
+      ]
     },
     {
-      "name": "stream stream left join - invalid join field - contains IS NULL expression",
+      "name": "stream stream join - contains CASE expression",
       "statements": [
-        "CREATE STREAM TEST1 (ID bigint) WITH (kafka_topic='left_topic', value_format='JSON');",
-        "CREATE STREAM TEST2 (ID bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
-        "CREATE STREAM LEFT_OUTER_JOIN as SELECT * FROM test1 t left join test2 tt ON t.id = (tt.id IS NULL);"
+        "CREATE STREAM TEST1 (ID int) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE STREAM TEST2 (ID int) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT T.ID FROM test1 t join test2 tt WITHIN 30 SECONDS ON t.id = (CASE WHEN tt.id = 2 THEN 1 ELSE 3 END);"
       ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid comparison expression '(TT.ID IS NULL)' in join '(T.ID = (TT.ID IS NULL))'. Joins must only contain a field comparison."
-      }
+      "inputs": [
+        {"topic": "left_topic", "key": "1", "value": {"id": 1}, "timestamp": 0},
+        {"topic": "right_topic", "key": "1", "value": {"id": 2}, "timestamp": 10}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"T_ID": 1}, "timestamp": 10}
+      ]
     },
     {
-      "name": "stream stream left join - invalid join field - contains IS NOT NULL expression",
+      "name": "stream stream join - contains arithmetic unary expression flipped sides",
       "statements": [
         "CREATE STREAM TEST1 (ID bigint) WITH (kafka_topic='left_topic', value_format='JSON');",
         "CREATE STREAM TEST2 (ID bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
-        "CREATE STREAM LEFT_OUTER_JOIN as SELECT * FROM test1 t left join test2 tt ON t.id = (tt.id IS NOT NULL);"
+        "CREATE STREAM OUTPUT as SELECT T.ID FROM test1 t join test2 tt WITHIN 30 seconds ON -tt.id = t.id;"
       ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid comparison expression '(TT.ID IS NOT NULL)' in join '(T.ID = (TT.ID IS NOT NULL))'. Joins must only contain a field comparison."
-      }
-    },
-    {
-      "name": "stream stream left join - invalid join field - contains logical binary expression",
-      "statements": [
-        "CREATE STREAM TEST1 (ID bigint) WITH (kafka_topic='left_topic', value_format='JSON');",
-        "CREATE STREAM TEST2 (ID bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
-        "CREATE STREAM LEFT_OUTER_JOIN as SELECT * FROM test1 t left join test2 tt ON t.id = (tt.id AND tt.f1);"
+      "inputs": [
+        {"topic": "left_topic", "key": "1", "value": {"id": 1}, "timestamp": 0},
+        {"topic": "right_topic", "key": "1", "value": {"id": -1}, "timestamp": 10}
       ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid comparison expression '(TT.ID AND TT.F1)' in join '(T.ID = (TT.ID AND TT.F1))'. Joins must only contain a field comparison."
-      }
-    },
-    {
-      "name": "stream stream left join - invalid join field - contains not expression",
-      "statements": [
-        "CREATE STREAM TEST1 (ID bigint) WITH (kafka_topic='left_topic', value_format='JSON');",
-        "CREATE STREAM TEST2 (ID bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
-        "CREATE STREAM LEFT_OUTER_JOIN as SELECT * FROM test1 t left join test2 tt ON t.id = (NOT tt.id);"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid comparison expression '(NOT TT.ID)' in join '(T.ID = (NOT TT.ID))'. Joins must only contain a field comparison."
-      }
-    },
-    {
-      "name": "stream stream left join - invalid join field - contains arithmetic unary expression",
-      "statements": [
-        "CREATE STREAM TEST1 (ID bigint) WITH (kafka_topic='left_topic', value_format='JSON');",
-        "CREATE STREAM TEST2 (ID bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
-        "CREATE STREAM LEFT_OUTER_JOIN as SELECT * FROM test1 t left join test2 tt ON t.id = -tt.id;"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid comparison expression '-TT.ID' in join '(T.ID = -TT.ID)'. Joins must only contain a field comparison."
-      }
-    },
-    {
-      "name": "stream stream left join - invalid join field - contains LIKE expression",
-      "statements": [
-        "CREATE STREAM TEST1 (ID bigint) WITH (kafka_topic='left_topic', value_format='JSON');",
-        "CREATE STREAM TEST2 (ID bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
-        "CREATE STREAM LEFT_OUTER_JOIN as SELECT * FROM test1 t left join test2 tt ON t.id = (tt.id LIKE '%x');"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid comparison expression '(TT.ID LIKE '%x')' in join '(T.ID = (TT.ID LIKE '%x'))'. Joins must only contain a field comparison."
-      }
-    },
-    {
-      "name": "stream stream left join - invalid join field - contains CASE expression",
-      "statements": [
-        "CREATE STREAM TEST1 (ID bigint) WITH (kafka_topic='left_topic', value_format='JSON');",
-        "CREATE STREAM TEST2 (ID bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
-        "CREATE STREAM LEFT_OUTER_JOIN as SELECT * FROM test1 t left join test2 tt ON t.id = (CASE WHEN 1 THEN 2 END);"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid comparison expression '(CASE WHEN 1 THEN 2 END)' in join '(T.ID = (CASE WHEN 1 THEN 2 END))'. Joins must only contain a field comparison."
-      }
-    },
-    {
-      "name": "stream stream left join - invalid join field - contains IN expression",
-      "statements": [
-        "CREATE STREAM TEST1 (ID bigint) WITH (kafka_topic='left_topic', value_format='JSON');",
-        "CREATE STREAM TEST2 (ID bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
-        "CREATE STREAM LEFT_OUTER_JOIN as SELECT * FROM test1 t left join test2 tt ON t.id = (tt.id IN (1, 2, 3));"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid comparison expression '(TT.ID IN (1, 2, 3))' in join '(T.ID = (TT.ID IN (1, 2, 3)))'. Joins must only contain a field comparison."
-      }
-    },
-    {
-      "name": "stream stream left join - invalid join field - contains BETWEEN expression",
-      "statements": [
-        "CREATE STREAM TEST1 (ID bigint) WITH (kafka_topic='left_topic', value_format='JSON');",
-        "CREATE STREAM TEST2 (ID bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
-        "CREATE STREAM LEFT_OUTER_JOIN as SELECT * FROM test1 t left join test2 tt ON t.id = (tt.id BETWEEN 1 AND 3);"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid comparison expression '(TT.ID BETWEEN 1 AND 3)' in join '(T.ID = (TT.ID BETWEEN 1 AND 3))'. Joins must only contain a field comparison."
-      }
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"T_ID": 1}, "timestamp": 10}
+      ]
     },
     {
       "name": "stream stream left join - invalid left join expression - field does not exist",
@@ -1726,7 +1663,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid join criteria (T.IID = TT.ID). Column T.IID does not exist."
+        "message": "Column 'T.IID' cannot be resolved."
       }
     },
     {
@@ -1738,7 +1675,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid join criteria (T.ID = TT.IID). Column TT.IID does not exist."
+        "message": "Column 'TT.IID' cannot be resolved."
       }
     },
     {
@@ -1836,7 +1773,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid join criteria: Source table (INPUT_TABLE) has no key column defined. Only 'ROWKEY' is supported in the join criteria for a TABLE."
+        "message": "Cannot repartition a TABLE source. If this is a join, make sure that the criteria uses the TABLE key ROWKEY instead of T.ID"
       }
     },
     {


### PR DESCRIPTION
fixes #4130 

### Description 
This PR introduces the ability to do arbitrary expressions in join conditions as long as on each side of the equality exactly one join source is used, and both join sources are represented. As an added bonus, this feature actually removes more code than it adds!

To implement this, I simply removed all repartition logic from the `JoinNode` and instead added a repartition step (reusing the recently introduced `RepartitionNode`) to each of the source nodes. This path is _always_ hit, if no repartition is required then the repartition node simply returns the same source as was passed into it. Now, the `JoinNode` always joins on the keys of its input.

## Review Guide

To review, I recommend first looking at the `Analyzer` which has been simplified just to check the condition outlined above. Then, look at the `LogicalPlanner` and finally at the `JoinNode`.

### Testing done 

- Updated unit tests
- Updated all the QTT tests that failed when expressions were present in the join criteria

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

