### PR TITLE
fix: report clearer error message when AVG used with DELIMITED

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/SchemaNotSupportedException.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/SchemaNotSupportedException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql;
+
+import io.confluent.ksql.util.KsqlException;
+
+/**
+ * Thrown to indicate the schema is not supported.
+ */
+public class SchemaNotSupportedException extends KsqlException {
+
+  public SchemaNotSupportedException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/average-udaf.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/average-udaf.json
@@ -77,6 +77,18 @@
         {"topic": "OUTPUT", "key": "bob", "value": {"AVG": -66666.1}},
         {"topic": "OUTPUT", "key": "alice", "value": {"AVG": 3.074457345651058E12}}
       ]
+    },
+    {
+      "name": "average - DELIMITED",
+      "comment": "DELIMITED does not support STRUCT, so can't support AVG until we use a different internal format",
+      "statements": [
+        "CREATE STREAM INPUT (VALUE integer) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "CREATE TABLE OUTPUT AS SELECT avg(value) AS avg FROM INPUT group by ROWKEY;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.SchemaNotSupportedException",
+        "message": "One of the functions used in the statement has an intermediate type that the value format can not handle. Please remove the function or change the format."
+      }
     }
   ]
 }

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/GenericKeySerDe.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/GenericKeySerDe.java
@@ -20,12 +20,12 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.ksql.SchemaNotSupportedException;
 import io.confluent.ksql.logging.processing.LoggingDeserializer;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.SchemaUtil;
 import java.util.Collections;
 import java.util.Map;
@@ -116,7 +116,7 @@ public final class GenericKeySerDe implements KeySerdeFactory {
     try {
       serdeFactories.validate(format, schema);
     } catch (final Exception e) {
-      throw new KsqlException("Key format does not support key schema."
+      throw new SchemaNotSupportedException("Key format does not support key schema."
           + System.lineSeparator()
           + "format: " + format.getFormat()
           + System.lineSeparator()

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/GenericRowSerDe.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/GenericRowSerDe.java
@@ -21,12 +21,12 @@ import static java.util.Objects.requireNonNull;
 import com.google.common.annotations.VisibleForTesting;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.SchemaNotSupportedException;
 import io.confluent.ksql.logging.processing.LoggingDeserializer;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.SchemaUtil;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -106,7 +106,7 @@ public final class GenericRowSerDe implements ValueSerdeFactory {
     try {
       serdeFactories.validate(format, schema);
     } catch (final Exception e) {
-      throw new KsqlException("Value format does not support value schema."
+      throw new SchemaNotSupportedException("Value format does not support value schema."
           + System.lineSeparator()
           + "format: " + format.getFormat()
           + System.lineSeparator()

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/GenericKeySerDeTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/GenericKeySerDeTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.ksql.SchemaNotSupportedException;
 import io.confluent.ksql.logging.processing.LoggingDeserializer;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
@@ -33,7 +34,6 @@ import io.confluent.ksql.model.WindowType;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.serde.GenericKeySerDe.UnwrappedKeySerializer;
 import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.KsqlException;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Optional;
@@ -122,7 +122,7 @@ public class GenericKeySerDeTest {
         .when(serdeFactories).validate(FORMAT, WRAPPED_SCHEMA);
 
     // Expect:
-    expectedException.expect(KsqlException.class);
+    expectedException.expect(SchemaNotSupportedException.class);
     expectedException.expectMessage("Key format does not support key schema."
         + System.lineSeparator()
         + "format: JSON"

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/GenericRowSerDeTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/GenericRowSerDeTest.java
@@ -27,12 +27,12 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.SchemaNotSupportedException;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.logging.processing.ProcessingLoggerFactory;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.KsqlException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Optional;
@@ -131,7 +131,7 @@ public class GenericRowSerDeTest {
         .when(serdesFactories).validate(FORMAT, MUTLI_FIELD_SCHEMA);
 
     // Expect:
-    expectedException.expect(KsqlException.class);
+    expectedException.expect(SchemaNotSupportedException.class);
     expectedException.expectMessage("Value format does not support value schema."
         + System.lineSeparator()
         + "format: JSON"


### PR DESCRIPTION
### Description 

See https://github.com/confluentinc/ksql/issues/4294

`AVG` doesn't work with `DELIMITED` format and the error message isn't great.

Example statements that cause the error:

```sql
-- Given:
CREATE STREAM INPUT (VALUE integer) WITH (kafka_topic='test_topic', value_format='DELIMITED');

-- When:
CREATE TABLE OUTPUT AS SELECT avg(value) AS avg FROM INPUT group by ROWKEY;
```

Old error message:

```
ksql> CREATE TABLE OUTPUT AS SELECT avg(value) AS avg FROM INPUT group by ROWKEY;
CREATE TABLE OUTPUT AS SELECT avg(value)Value format does not support value schema.
format: DELIMITED
schema: Persistence{schema=STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_AGG_VARIABLE_0 STRUCT<SUM INT, COUNT BIGINT>> NOT NULL, unwrapped=false}
reason: The 'DELIMITED' format does not support type 'STRUCT'
Caused by: The 'DELIMITED' format does not support type 'STRUCT'
```

This PR improves the error message a bit:

New error message:

```
One of the functions used in the statement has an intermediate type that the value format can not handle. Please remove the function or change the format.
Consider up-voting https://github.com/confluentinc/ksql/issues/3950, which will resolve this limitation
Caused by: Value format does not support value schema.
format: DELIMITED
schema:
	Persistence{schema=STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 VARCHAR,
	KSQL_AGG_VARIABLE_0 STRUCT<SUM INT, COUNT BIGINT>> NOT NULL,
	unwrapped=false}
reason: The 'DELIMITED' format does not support type 'STRUCT'
Caused by: The 'DELIMITED' format does not support type 'STRUCT'
```

### Testing done 

manual, unit and QTT.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

