### PR TITLE
fix: deadlock when closing transient push query

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/query/BlockingQueryQueue.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/query/BlockingQueryQueue.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.query;
+
+import io.confluent.ksql.GenericRow;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.streams.KeyValue;
+
+/**
+ * The queue between the Kafka-streams topology and the client connection.
+ *
+ * <p>The KS topology writes to the queue from its {@code StreamThread}, while the KSQL server
+ * thread that is servicing the client request reads from the queue and writes to the client
+ * socket.
+ */
+public interface BlockingQueryQueue {
+
+  void setLimitHandler(LimitHandler limitHandler);
+
+  /**
+   * Poll the queue for a single row
+   *
+   * @see BlockingQueryQueue#poll(long, TimeUnit)
+   */
+  KeyValue<String, GenericRow> poll(long timeout, TimeUnit unit)
+      throws InterruptedException;
+
+  /**
+   * Drain the queue to the supplied {@code collection}.
+   *
+   * @see BlockingQueryQueue#drainTo(Collection)
+   */
+  void drainTo(Collection<? super KeyValue<String, GenericRow>> collection);
+
+  /**
+   * The size of the queue.
+   *
+   * @see BlockingQueryQueue#size()
+   */
+  int size();
+
+  /**
+   * Close the queue.
+   */
+  void close();
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/query/BlockingRowQueue.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/query/BlockingRowQueue.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.query;
 
 import io.confluent.ksql.GenericRow;
 import java.util.Collection;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.streams.KeyValue;
 
@@ -27,14 +28,21 @@ import org.apache.kafka.streams.KeyValue;
  * thread that is servicing the client request reads from the queue and writes to the client
  * socket.
  */
-public interface BlockingQueryQueue {
+public interface BlockingRowQueue {
 
+  /**
+   * Sets the limit handler that will be called when any row limit is reached.
+   *
+   * <p>Replaces any previous handler.
+   *
+   * @param limitHandler the handler.
+   */
   void setLimitHandler(LimitHandler limitHandler);
 
   /**
    * Poll the queue for a single row
    *
-   * @see BlockingQueryQueue#poll(long, TimeUnit)
+   * @see BlockingQueue#poll(long, TimeUnit)
    */
   KeyValue<String, GenericRow> poll(long timeout, TimeUnit unit)
       throws InterruptedException;
@@ -42,14 +50,14 @@ public interface BlockingQueryQueue {
   /**
    * Drain the queue to the supplied {@code collection}.
    *
-   * @see BlockingQueryQueue#drainTo(Collection)
+   * @see BlockingQueue#drainTo(Collection)
    */
   void drainTo(Collection<? super KeyValue<String, GenericRow>> collection);
 
   /**
    * The size of the queue.
    *
-   * @see BlockingQueryQueue#size()
+   * @see BlockingQueue#size()
    */
   int size();
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -151,7 +151,7 @@ public final class QueryExecutor {
       final LogicalSchema schema,
       final OptionalInt limit
   ) {
-    final BlockingQueryQueue queue = buildTransientQueryQueue(queryId, physicalPlan, limit);
+    final BlockingRowQueue queue = buildTransientQueryQueue(queryId, physicalPlan, limit);
 
     final String applicationId = addTimeSuffix(getQueryApplicationId(
         getServiceId(),

--- a/ksql-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -151,7 +151,7 @@ public final class QueryExecutor {
       final LogicalSchema schema,
       final OptionalInt limit
   ) {
-    final TransientQueryQueue queue = buildTransientQueryQueue(queryId, physicalPlan, limit);
+    final BlockingQueryQueue queue = buildTransientQueryQueue(queryId, physicalPlan, limit);
 
     final String applicationId = addTimeSuffix(getQueryApplicationId(
         getServiceId(),
@@ -171,15 +171,15 @@ public final class QueryExecutor {
         built.kafkaStreams,
         transientSchema,
         sources,
-        queue::setLimitHandler,
         planSummary,
-        queue.getQueue(),
+        queue,
         applicationId,
         built.topology,
         streamsProperties,
         overrides,
         queryCloseCallback,
-        ksqlConfig.getLong(KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG));
+        ksqlConfig.getLong(KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG)
+    );
   }
 
   private static Optional<MaterializationInfo> getMaterializationInfo(final Object result) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/query/TransientQueryQueue.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/query/TransientQueryQueue.java
@@ -32,7 +32,7 @@ import org.apache.kafka.streams.kstream.Windowed;
 /**
  * A queue of rows for transient queries.
  */
-class TransientQueryQueue implements BlockingQueryQueue {
+class TransientQueryQueue implements BlockingRowQueue {
 
   private final LimitQueueCallback callback;
   private final BlockingQueue<KeyValue<String, GenericRow>> rowQueue;

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -64,7 +64,7 @@ public class PersistentQueryMetadata extends QueryMetadata {
       final Map<String, Object> streamsProperties,
       final Map<String, Object> overriddenProperties,
       final Consumer<QueryMetadata> closeCallback,
-      final Long closeTimeout) {
+      final long closeTimeout) {
     // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     super(
         statementString,

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -62,7 +62,8 @@ public class QueryMetadata {
       final Map<String, Object> streamsProperties,
       final Map<String, Object> overriddenProperties,
       final Consumer<QueryMetadata> closeCallback,
-      final Long closeTimeout) {
+      final long closeTimeout
+  ) {
     // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     this.statementString = Objects.requireNonNull(statementString, "statementString");
     this.kafkaStreams = Objects.requireNonNull(kafkaStreams, "kafkaStreams");
@@ -78,7 +79,7 @@ public class QueryMetadata {
     this.closeCallback = Objects.requireNonNull(closeCallback, "closeCallback");
     this.sourceNames = Objects.requireNonNull(sourceNames, "sourceNames");
     this.logicalSchema = Objects.requireNonNull(logicalSchema, "logicalSchema");
-    this.closeTimeout = Objects.requireNonNull(closeTimeout, "closeTimeout");
+    this.closeTimeout = closeTimeout;
   }
 
   protected QueryMetadata(final QueryMetadata other, final Consumer<QueryMetadata> closeCallback) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.util;
 
 import io.confluent.ksql.name.SourceName;
-import io.confluent.ksql.query.BlockingQueryQueue;
+import io.confluent.ksql.query.BlockingRowQueue;
 import io.confluent.ksql.query.LimitHandler;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.Map;
@@ -32,7 +32,7 @@ import org.apache.kafka.streams.Topology;
  */
 public class TransientQueryMetadata extends QueryMetadata {
 
-  private final BlockingQueryQueue rowQueue;
+  private final BlockingRowQueue rowQueue;
   private final AtomicBoolean isRunning = new AtomicBoolean(true);
 
   // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
@@ -42,7 +42,7 @@ public class TransientQueryMetadata extends QueryMetadata {
       final LogicalSchema logicalSchema,
       final Set<SourceName> sourceNames,
       final String executionPlan,
-      final BlockingQueryQueue rowQueue,
+      final BlockingRowQueue rowQueue,
       final String queryApplicationId,
       final Topology topology,
       final Map<String, Object> streamsProperties,
@@ -74,7 +74,7 @@ public class TransientQueryMetadata extends QueryMetadata {
     return isRunning.get();
   }
 
-  public BlockingQueryQueue getRowQueue() {
+  public BlockingRowQueue getRowQueue() {
     return rowQueue;
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
@@ -15,18 +15,16 @@
 
 package io.confluent.ksql.util;
 
-import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.query.BlockingQueryQueue;
 import io.confluent.ksql.query.LimitHandler;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import org.apache.kafka.streams.KafkaStreams;
-import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.Topology;
 
 /**
@@ -34,9 +32,8 @@ import org.apache.kafka.streams.Topology;
  */
 public class TransientQueryMetadata extends QueryMetadata {
 
-  private final BlockingQueue<KeyValue<String, GenericRow>> rowQueue;
+  private final BlockingQueryQueue rowQueue;
   private final AtomicBoolean isRunning = new AtomicBoolean(true);
-  private final Consumer<LimitHandler> limitHandlerSetter;
 
   // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
   public TransientQueryMetadata(
@@ -44,15 +41,14 @@ public class TransientQueryMetadata extends QueryMetadata {
       final KafkaStreams kafkaStreams,
       final LogicalSchema logicalSchema,
       final Set<SourceName> sourceNames,
-      final Consumer<LimitHandler> limitHandlerSetter,
       final String executionPlan,
-      final BlockingQueue<KeyValue<String, GenericRow>> rowQueue,
+      final BlockingQueryQueue rowQueue,
       final String queryApplicationId,
       final Topology topology,
       final Map<String, Object> streamsProperties,
       final Map<String, Object> overriddenProperties,
       final Consumer<QueryMetadata> closeCallback,
-      final Long closeTimeout) {
+      final long closeTimeout) {
     // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     super(
         statementString,
@@ -65,8 +61,8 @@ public class TransientQueryMetadata extends QueryMetadata {
         streamsProperties,
         overriddenProperties,
         closeCallback,
-        closeTimeout);
-    this.limitHandlerSetter = Objects.requireNonNull(limitHandlerSetter, "limitHandlerSetter");
+        closeTimeout
+    );
     this.rowQueue = Objects.requireNonNull(rowQueue, "rowQueue");
 
     if (!logicalSchema.metadata().isEmpty() || !logicalSchema.key().isEmpty()) {
@@ -78,7 +74,7 @@ public class TransientQueryMetadata extends QueryMetadata {
     return isRunning.get();
   }
 
-  public BlockingQueue<KeyValue<String, GenericRow>> getRowQueue() {
+  public BlockingQueryQueue getRowQueue() {
     return rowQueue;
   }
 
@@ -99,11 +95,16 @@ public class TransientQueryMetadata extends QueryMetadata {
   }
 
   public void setLimitHandler(final LimitHandler limitHandler) {
-    limitHandlerSetter.accept(limitHandler);
+    rowQueue.setLimitHandler(limitHandler);
   }
 
   @Override
   public void close() {
+    // To avoid deadlock, close the queue first to ensure producer side isn't blocked trying to
+    // write to the blocking queue, otherwise super.close call can deadlock:
+    rowQueue.close();
+
+    // Now safe to close:
     super.close();
     isRunning.set(false);
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
@@ -30,6 +30,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.query.BlockingQueryQueue;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.util.KsqlConstants;
@@ -44,7 +45,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -216,7 +216,7 @@ public class EndToEndIntegrationTest {
         "SELECT * from pageviews_female EMIT CHANGES;");
 
     final List<KeyValue<String, GenericRow>> results = new ArrayList<>();
-    final BlockingQueue<KeyValue<String, GenericRow>> rowQueue = queryMetadata.getRowQueue();
+    final BlockingQueryQueue rowQueue = queryMetadata.getRowQueue();
 
     // From the mock data, we expect exactly 3 page views from female users.
     final List<String> expectedPages = ImmutableList.of("PAGE_2", "PAGE_5", "PAGE_5");
@@ -402,7 +402,7 @@ public class EndToEndIntegrationTest {
       final TransientQueryMetadata queryMetadata,
       final int expectedRows
   ) throws Exception {
-    final BlockingQueue<KeyValue<String, GenericRow>> rowQueue = queryMetadata.getRowQueue();
+    final BlockingQueryQueue rowQueue = queryMetadata.getRowQueue();
 
     TestUtils.waitForCondition(
         () -> rowQueue.size() >= expectedRows,

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
@@ -30,7 +30,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
-import io.confluent.ksql.query.BlockingQueryQueue;
+import io.confluent.ksql.query.BlockingRowQueue;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.util.KsqlConstants;
@@ -216,7 +216,7 @@ public class EndToEndIntegrationTest {
         "SELECT * from pageviews_female EMIT CHANGES;");
 
     final List<KeyValue<String, GenericRow>> results = new ArrayList<>();
-    final BlockingQueryQueue rowQueue = queryMetadata.getRowQueue();
+    final BlockingRowQueue rowQueue = queryMetadata.getRowQueue();
 
     // From the mock data, we expect exactly 3 page views from female users.
     final List<String> expectedPages = ImmutableList.of("PAGE_2", "PAGE_5", "PAGE_5");
@@ -402,7 +402,7 @@ public class EndToEndIntegrationTest {
       final TransientQueryMetadata queryMetadata,
       final int expectedRows
   ) throws Exception {
-    final BlockingQueryQueue rowQueue = queryMetadata.getRowQueue();
+    final BlockingRowQueue rowQueue = queryMetadata.getRowQueue();
 
     TestUtils.waitForCondition(
         () -> rowQueue.size() >= expectedRows,

--- a/ksql-engine/src/test/java/io/confluent/ksql/query/TransientQueryQueueTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/query/TransientQueryQueueTest.java
@@ -56,7 +56,7 @@ public class TransientQueryQueueTest {
   private static final GenericRow ROW_TWO = mock(GenericRow.class);
 
   @Rule
-  public Timeout timeout = Timeout.seconds(10);
+  public final Timeout timeout = Timeout.seconds(10);
 
   @Mock
   private LimitHandler limitHandler;

--- a/ksql-engine/src/test/java/io/confluent/ksql/query/TransientQueryQueueTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/query/TransientQueryQueueTest.java
@@ -16,9 +16,9 @@
 package io.confluent.ksql.query;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -26,26 +26,37 @@ import static org.mockito.Mockito.verify;
 
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.query.TransientQueryQueue.QueuePopulator;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.OptionalInt;
-import java.util.Queue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.KStream;
+import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-@SuppressWarnings("ConstantConditions")
+@SuppressWarnings("unchecked")
 @RunWith(MockitoJUnitRunner.class)
 public class TransientQueryQueueTest {
 
   private static final int SOME_LIMIT = 4;
+  private static final int MAX_LIMIT = SOME_LIMIT * 2;
   private static final GenericRow ROW_ONE = mock(GenericRow.class);
   private static final GenericRow ROW_TWO = mock(GenericRow.class);
+
+  @Rule
+  public Timeout timeout = Timeout.seconds(10);
 
   @Mock
   private LimitHandler limitHandler;
@@ -53,20 +64,20 @@ public class TransientQueryQueueTest {
   private KStream<String, GenericRow> kStreamsApp;
   @Captor
   private ArgumentCaptor<QueuePopulator<String>> queuePopulatorCaptor;
-  private Queue<KeyValue<String, GenericRow>> queue;
   private QueuePopulator<String> queuePopulator;
+  private TransientQueryQueue queue;
+  private ScheduledExecutorService executorService;
 
   @Before
   public void setUp() {
-    final TransientQueryQueue queuer =
-        new TransientQueryQueue(kStreamsApp, OptionalInt.of(SOME_LIMIT));
+    givenQueue(OptionalInt.of(SOME_LIMIT));
+  }
 
-    queuer.setLimitHandler(limitHandler);
-
-    queue = queuer.getQueue();
-
-    verify(kStreamsApp).foreach(queuePopulatorCaptor.capture());
-    queuePopulator = queuePopulatorCaptor.getValue();
+  @After
+  public void tearDown() {
+    if (executorService != null) {
+      executorService.shutdownNow();
+    }
   }
 
   @Test
@@ -76,11 +87,10 @@ public class TransientQueryQueueTest {
     queuePopulator.apply("key2", ROW_TWO);
 
     // Then:
-    assertThat(queue, hasSize(2));
-    assertThat(queue.peek().key, is("key1"));
-    assertThat(queue.remove().value, is(ROW_ONE));
-    assertThat(queue.peek().key, is("key2"));
-    assertThat(queue.remove().value, is(ROW_TWO));
+    assertThat(drainValues(), contains(
+        new KeyValue<>("key1", ROW_ONE),
+        new KeyValue<>("key2", ROW_TWO)
+    ));
   }
 
   @Test
@@ -89,7 +99,7 @@ public class TransientQueryQueueTest {
     queuePopulator.apply("key1", null);
 
     // Then:
-    assertThat(queue, is(empty()));
+    assertThat(queue.size(), is(0));
   }
 
   @Test
@@ -99,7 +109,21 @@ public class TransientQueryQueueTest {
         .forEach(idx -> queuePopulator.apply("key1", ROW_ONE));
 
     // Then:
-    assertThat(queue, hasSize(SOME_LIMIT));
+    assertThat(queue.size(), is(SOME_LIMIT));
+  }
+
+  @Test
+  public void shouldPoll() throws Exception {
+    // Given:
+    queuePopulator.apply("key1", ROW_ONE);
+    queuePopulator.apply("key2", ROW_TWO);
+
+    // When:
+    final KeyValue<String, GenericRow> result = queue.poll(1, TimeUnit.SECONDS);
+
+    // Then:
+    assertThat(result, is(new KeyValue<>("key1", ROW_ONE)));
+    assertThat(drainValues(), contains(new KeyValue<>("key2", ROW_TWO)));
   }
 
   @Test
@@ -130,5 +154,43 @@ public class TransientQueryQueueTest {
 
     // Then:
     verify(limitHandler, times(1)).limitReached();
+  }
+
+  @Test
+  public void shouldBlockOnProduceOnceQueueLimitReachedAndUnblockOnClose() {
+    // Given:
+    givenQueue(OptionalInt.empty());
+
+    IntStream.range(0, MAX_LIMIT)
+        .forEach(idx -> queuePopulator.apply("key1", ROW_ONE));
+
+    givenWillCloseQueueAsync();
+
+    // When:
+    queuePopulator.apply("should not be queued", ROW_TWO);
+
+    // Then: did not block and:
+    assertThat(queue.size(), is(MAX_LIMIT));
+  }
+
+  private void givenWillCloseQueueAsync() {
+    executorService = Executors.newSingleThreadScheduledExecutor();
+    executorService.schedule(queue::close, 200, TimeUnit.MILLISECONDS);
+  }
+
+  private void givenQueue(final OptionalInt limit) {
+    clearInvocations(kStreamsApp);
+    queue = new TransientQueryQueue(kStreamsApp, limit, MAX_LIMIT, 1);
+
+    queue.setLimitHandler(limitHandler);
+
+    verify(kStreamsApp).foreach(queuePopulatorCaptor.capture());
+    queuePopulator = queuePopulatorCaptor.getValue();
+  }
+
+  private List<KeyValue<String, GenericRow>> drainValues() {
+    final List<KeyValue<String, GenericRow>> entries = new ArrayList<>();
+    queue.drainTo(entries);
+    return entries;
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/TransientQueryMetadataTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/TransientQueryMetadataTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.query.BlockingQueryQueue;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.Topology;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TransientQueryMetadataTest {
+
+  private static final String QUERY_ID = "queryId";
+  private static final String EXECUTION_PLAN = "execution plan";
+  private static final String SQL = "sql";
+  private static final long CLOSE_TIMEOUT = 10L;
+
+  @Mock
+  private KafkaStreams kafkaStreams;
+  @Mock
+  private LogicalSchema logicalSchema;
+  @Mock
+  private Set<SourceName> sourceNames;
+  @Mock
+  private BlockingQueryQueue rowQueue;
+  @Mock
+  private Topology topology;
+  @Mock
+  private Map<String, Object> props;
+  @Mock
+  private Map<String, Object> overrides;
+  @Mock
+  private Consumer<QueryMetadata> closeCallback;
+  private TransientQueryMetadata query;
+
+  @Before
+  public void setUp()  {
+    query = new TransientQueryMetadata(
+        SQL,
+        kafkaStreams,
+        logicalSchema,
+        sourceNames,
+        EXECUTION_PLAN,
+        rowQueue,
+        QUERY_ID,
+        topology,
+        props,
+        overrides,
+        closeCallback,
+        CLOSE_TIMEOUT
+    );
+  }
+
+  @Test
+  public void shouldCloseQueueBeforeTopologyToAvoidDeadLock() {
+    // When:
+    query.close();
+
+    // Then:
+    final InOrder inOrder = inOrder(rowQueue, kafkaStreams);
+    inOrder.verify(rowQueue).close();
+    inOrder.verify(kafkaStreams).close(any());
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/TransientQueryMetadataTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/TransientQueryMetadataTest.java
@@ -19,7 +19,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.inOrder;
 
 import io.confluent.ksql.name.SourceName;
-import io.confluent.ksql.query.BlockingQueryQueue;
+import io.confluent.ksql.query.BlockingRowQueue;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.Map;
 import java.util.Set;
@@ -48,7 +48,7 @@ public class TransientQueryMetadataTest {
   @Mock
   private Set<SourceName> sourceNames;
   @Mock
-  private BlockingQueryQueue rowQueue;
+  private BlockingRowQueue rowQueue;
   @Mock
   private Topology topology;
   @Mock

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
@@ -26,7 +26,7 @@ import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
-import io.confluent.ksql.query.LimitHandler;
+import io.confluent.ksql.query.BlockingQueryQueue;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
@@ -42,7 +42,6 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.apache.kafka.streams.KafkaStreams;
@@ -86,7 +85,7 @@ public class QueryDescriptionFactoryTest {
   @Mock(name = TOPOLOGY_TEXT)
   private TopologyDescription topologyDescription;
   @Mock
-  private Consumer<LimitHandler> limitHandler;
+  private BlockingQueryQueue queryQueue;
   @Mock
   private KsqlTopic sinkTopic;
   private QueryMetadata transientQuery;
@@ -103,9 +102,8 @@ public class QueryDescriptionFactoryTest {
         queryStreams,
         TRANSIENT_SCHEMA,
         SOURCE_NAMES,
-        limitHandler,
         "execution plan",
-        new LinkedBlockingQueue<>(),
+        queryQueue,
         "app id",
         topology,
         STREAMS_PROPS,
@@ -218,9 +216,8 @@ public class QueryDescriptionFactoryTest {
         queryStreams,
         schema,
         SOURCE_NAMES,
-        limitHandler,
         "execution plan",
-        new LinkedBlockingQueue<>(),
+        queryQueue,
         "app id",
         topology,
         STREAMS_PROPS,
@@ -253,9 +250,8 @@ public class QueryDescriptionFactoryTest {
         queryStreams,
         schema,
         SOURCE_NAMES,
-        limitHandler,
         "execution plan",
-        new LinkedBlockingQueue<>(),
+        queryQueue,
         "app id",
         topology,
         STREAMS_PROPS,

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
@@ -26,7 +26,7 @@ import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
-import io.confluent.ksql.query.BlockingQueryQueue;
+import io.confluent.ksql.query.BlockingRowQueue;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
@@ -85,7 +85,7 @@ public class QueryDescriptionFactoryTest {
   @Mock(name = TOPOLOGY_TEXT)
   private TopologyDescription topologyDescription;
   @Mock
-  private BlockingQueryQueue queryQueue;
+  private BlockingRowQueue queryQueue;
   @Mock
   private KsqlTopic sinkTopic;
   private QueryMetadata transientQuery;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriterTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriterTest.java
@@ -32,6 +32,7 @@ import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.json.JsonMapper;
 import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.query.BlockingQueryQueue;
 import io.confluent.ksql.query.LimitHandler;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
@@ -42,7 +43,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.kafka.streams.KafkaStreams;
@@ -59,7 +59,7 @@ import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 
-@SuppressWarnings({"unchecked", "ConstantConditions"})
+@SuppressWarnings("unchecked")
 @RunWith(EasyMockRunner.class)
 public class QueryStreamWriterTest {
 
@@ -74,7 +74,7 @@ public class QueryStreamWriterTest {
   @Mock(MockType.NICE)
   private TransientQueryMetadata queryMetadata;
   @Mock(MockType.NICE)
-  private BlockingQueue<KeyValue<String, GenericRow>> rowQueue;
+  private BlockingQueryQueue rowQueue;
   private Capture<Thread.UncaughtExceptionHandler> ehCapture;
   private Capture<Collection<KeyValue<String, GenericRow>>> drainCapture;
   private Capture<LimitHandler> limitHandlerCapture;
@@ -115,10 +115,11 @@ public class QueryStreamWriterTest {
   }
 
   @Test
-  public void shouldWriteAnyPendingRowsBeforeReportingException() throws Exception {
+  public void shouldWriteAnyPendingRowsBeforeReportingException() {
     // Given:
     expect(queryMetadata.isRunning()).andReturn(true).anyTimes();
-    expect(rowQueue.drainTo(capture(drainCapture))).andAnswer(rows("Row1", "Row2", "Row3"));
+    rowQueue.drainTo(capture(drainCapture));
+    expectLastCall().andAnswer(rows("Row1", "Row2", "Row3"));
 
     createWriter();
 
@@ -136,10 +137,11 @@ public class QueryStreamWriterTest {
   }
 
   @Test
-  public void shouldExitAndDrainIfQueryStopsRunning() throws Exception {
+  public void shouldExitAndDrainIfQueryStopsRunning() {
     // Given:
     expect(queryMetadata.isRunning()).andReturn(true).andReturn(false);
-    expect(rowQueue.drainTo(capture(drainCapture))).andAnswer(rows("Row1", "Row2", "Row3"));
+    rowQueue.drainTo(capture(drainCapture));
+    expectLastCall().andAnswer(rows("Row1", "Row2", "Row3"));
 
     createWriter();
 
@@ -155,10 +157,11 @@ public class QueryStreamWriterTest {
   }
 
   @Test
-  public void shouldExitAndDrainIfLimitReached() throws Exception {
+  public void shouldExitAndDrainIfLimitReached() {
     // Given:
     expect(queryMetadata.isRunning()).andReturn(true).anyTimes();
-    expect(rowQueue.drainTo(capture(drainCapture))).andAnswer(rows("Row1", "Row2", "Row3"));
+    rowQueue.drainTo(capture(drainCapture));
+    expectLastCall().andAnswer(rows("Row1", "Row2", "Row3"));
 
     createWriter();
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriterTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriterTest.java
@@ -32,7 +32,7 @@ import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.json.JsonMapper;
 import io.confluent.ksql.name.ColumnName;
-import io.confluent.ksql.query.BlockingQueryQueue;
+import io.confluent.ksql.query.BlockingRowQueue;
 import io.confluent.ksql.query.LimitHandler;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
@@ -74,7 +74,7 @@ public class QueryStreamWriterTest {
   @Mock(MockType.NICE)
   private TransientQueryMetadata queryMetadata;
   @Mock(MockType.NICE)
-  private BlockingQueryQueue rowQueue;
+  private BlockingRowQueue rowQueue;
   private Capture<Thread.UncaughtExceptionHandler> ehCapture;
   private Capture<Collection<KeyValue<String, GenericRow>>> drainCapture;
   private Capture<LimitHandler> limitHandlerCapture;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -46,7 +46,7 @@ import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.PrintTopic;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Statement;
-import io.confluent.ksql.query.BlockingQueryQueue;
+import io.confluent.ksql.query.BlockingRowQueue;
 import io.confluent.ksql.query.LimitHandler;
 import io.confluent.ksql.rest.Errors;
 import io.confluent.ksql.rest.entity.KsqlErrorMessage;
@@ -616,7 +616,7 @@ public class StreamedQueryResourceTest {
     );
   }
 
-  private static class TestRowQueue implements BlockingQueryQueue {
+  private static class TestRowQueue implements BlockingRowQueue {
 
     private final SynchronousQueue<KeyValue<String, GenericRow>> rowQueue;
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -24,7 +24,6 @@ import static javax.ws.rs.core.Response.Status.FORBIDDEN;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -47,6 +46,8 @@ import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.PrintTopic;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.query.BlockingQueryQueue;
+import io.confluent.ksql.query.LimitHandler;
 import io.confluent.ksql.rest.Errors;
 import io.confluent.ksql.rest.entity.KsqlErrorMessage;
 import io.confluent.ksql.rest.entity.KsqlRequest;
@@ -70,12 +71,15 @@ import java.io.IOException;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Scanner;
 import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -365,9 +369,8 @@ public class StreamedQueryResourceTest {
             mockKafkaStreams,
             SOME_SCHEMA,
             Collections.emptySet(),
-            limitHandler -> {},
             "",
-            rowQueue,
+            new TestRowQueue(rowQueue),
             "",
             mock(Topology.class),
             Collections.emptyMap(),
@@ -611,5 +614,42 @@ public class StreamedQueryResourceTest {
         securityContext,
         new KsqlRequest(PRINT_TOPIC, Collections.emptyMap(), null)
     );
+  }
+
+  private static class TestRowQueue implements BlockingQueryQueue {
+
+    private final SynchronousQueue<KeyValue<String, GenericRow>> rowQueue;
+
+    TestRowQueue(
+        final SynchronousQueue<KeyValue<String, GenericRow>> rowQueue
+    ) {
+      this.rowQueue = Objects.requireNonNull(rowQueue, "rowQueue");
+    }
+
+    @Override
+    public void setLimitHandler(final LimitHandler limitHandler) {
+
+    }
+
+    @Override
+    public KeyValue<String, GenericRow> poll(final long timeout, final TimeUnit unit)
+        throws InterruptedException {
+      return rowQueue.poll(timeout, unit);
+    }
+
+    @Override
+    public void drainTo(final Collection<? super KeyValue<String, GenericRow>> collection) {
+      rowQueue.drainTo(collection);
+    }
+
+    @Override
+    public int size() {
+      return rowQueue.size();
+    }
+
+    @Override
+    public void close() {
+
+    }
   }
 }


### PR DESCRIPTION
### Description 
fixes: https://github.com/confluentinc/ksql/issues/4296

The produce side not calls `offer` in a loop, with a short timeout, to try and put the row into the blocking queue. When the consume side closes the query, e.g. on an `EOFException` if the user has closed the connection, the query first closes the queue; setting a flag the producers are checking on each loop; causing any producers to exit the loop. Then it can safely close the KS topology.

### Testing done 

Added unit tests and manual testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

