### PR TITLE
build: Do not run twist lock scan and other docker image operations since we no longer build images in this repo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,8 @@
 dockerfile {
     slackChannel = '#ksql-alerts'
     upstreamProjects = 'confluentinc/schema-registry'
-    dockerRepos = ['confluentinc/ksql-cli']
     extraDeployArgs = '-Ddocker.skip=true'
+    dockerPush = false
+    dockerScan = false
+    dockerImageClean = false
 }


### PR DESCRIPTION
### Description 
The builds were failing because the twist lock scan was running but since we no longer build docker images from this repo it could not find any images to scan. This will disable running twist lock scan, as well as cleaning and trying to publish docker images.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

