### PR TITLE
perf: Avoids logging INFO for rest-util requests, since it hurts pull query performance

### DIFF
--- a/config/log4j-rolling.properties
+++ b/config/log4j-rolling.properties
@@ -77,3 +77,5 @@ log4j.additivity.org.apache.kafka=false
 log4j.logger.org.I0Itec.zkclient=WARN, kafka
 log4j.additivity.org.I0Itec.zkclient=false
 
+# To acheive high throughput on pull queries, avoid logging every request from Jetty
+log4j.logger.io.confluent.rest-utils.requests=WARN

--- a/config/log4j-rolling.properties
+++ b/config/log4j-rolling.properties
@@ -77,5 +77,5 @@ log4j.additivity.org.apache.kafka=false
 log4j.logger.org.I0Itec.zkclient=WARN, kafka
 log4j.additivity.org.I0Itec.zkclient=false
 
-# To acheive high throughput on pull queries, avoid logging every request from Jetty
+# To achieve high throughput on pull queries, avoid logging every request from Jetty
 log4j.logger.io.confluent.rest-utils.requests=WARN


### PR DESCRIPTION
### Description 
Avoids logging every request to come in at the Jetty level since that hurst pull query performance.  Before this change, on my Mac, I was getting 14k qps and with this change, I'm getting 30k.

Fixes #4306 

### Testing done 
Ran benchmarks.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

