### PR TITLE
test: RQTT should fail if expecting more responses than statements (MINOR)

### DIFF
--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
@@ -102,6 +102,14 @@ public class RestTestExecutor implements Closeable {
   void buildAndExecuteQuery(final RestTestCase testCase) {
     topicInfoCache.clear();
 
+    if (testCase.getStatements().size() < testCase.getExpectedResponses().size()) {
+      throw new AssertionError("Invalid test case: more expected responses than statements. "
+          + System.lineSeparator()
+          + "statementCount: " + testCase.getStatements().size()
+          + System.lineSeparator()
+          + "responsesCount: " + testCase.getExpectedResponses().size());
+    }
+
     initializeTopics(testCase.getTopics());
 
     final StatementSplit statements = splitStatements(testCase);


### PR DESCRIPTION
### Description 

This just improves the error message. Better this than an `IndexOutOfBoundsException`.


### Testing done 

test only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

