### PR TITLE
test: push queries work with non-windowed primitive keys

### DIFF
--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
@@ -455,6 +455,7 @@ public class RestTestExecutor implements Closeable {
   ) {
     // Special handling for pull queries is required, as they depend on materialized state stores
     // being warmed up.  Initial requests may return no rows.
+    
     if (querySql.contains("EMIT CHANGES")) {
       // Push, not pull query:
       return;

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
@@ -455,6 +455,10 @@ public class RestTestExecutor implements Closeable {
   ) {
     // Special handling for pull queries is required, as they depend on materialized state stores
     // being warmed up.  Initial requests may return no rows.
+    if (querySql.contains("EMIT CHANGES")) {
+      // Push, not pull query:
+      return;
+    }
 
     final ImmutableList<Response> expectedResponse = ImmutableList.of(queryResponse);
     final ImmutableList<String> statements = ImmutableList.of(querySql);

--- a/ksql-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
+++ b/ksql-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
@@ -1,0 +1,87 @@
+{
+  "comments": [
+    "Tests covering Push queries"
+  ],
+  "tests": [
+    {
+      "name": "non-windowed transient stream query - STRING key",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "SELECT * FROM INPUT EMIT CHANGES LIMIT 2;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": "11", "value": {"id": 100}},
+        {"topic": "test_topic", "timestamp": 12365, "key": "11", "value": {"id": 101}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ROWTIME` BIGINT, `ROWKEY` STRING, `ID` INTEGER"}},
+          {"row":{"columns":[12345, "11", 100]}},
+          {"row":{"columns":[12365, "11", 101]}},
+          {"finalMessage":"Limit Reached"}
+        ]}
+      ]
+    },
+    {
+      "name": "non-windowed transient stream query - INT key",
+      "statements": [
+        "CREATE STREAM INPUT (ROWKEY INT KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "SELECT * FROM INPUT EMIT CHANGES LIMIT 2;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": 11, "value": {"id": 100}},
+        {"topic": "test_topic", "timestamp": 12365, "key": 11, "value": {"id": 101}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ROWTIME` BIGINT, `ROWKEY` INTEGER, `ID` INTEGER"}},
+          {"row":{"columns":[12345, 11, 100]}},
+          {"row":{"columns":[12365, 11, 101]}},
+          {"finalMessage":"Limit Reached"}
+        ]}
+      ]
+    },
+    {
+      "name": "non-windowed transient stream query - BIGINT key",
+      "statements": [
+        "CREATE STREAM INPUT (ROWKEY BIGINT KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "SELECT * FROM INPUT EMIT CHANGES LIMIT 2;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": 11, "value": {"id": 100}},
+        {"topic": "test_topic", "timestamp": 12365, "key": 11, "value": {"id": 101}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ROWTIME` BIGINT, `ROWKEY` BIGINT, `ID` INTEGER"}},
+          {"row":{"columns":[12345, 11, 100]}},
+          {"row":{"columns":[12365, 11, 101]}},
+          {"finalMessage":"Limit Reached"}
+        ]}
+      ]
+    },
+    {
+      "name": "non-windowed transient stream query - DOUBLE key",
+      "statements": [
+        "CREATE STREAM INPUT (ROWKEY DOUBLE KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "SELECT * FROM INPUT EMIT CHANGES LIMIT 2;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": 11.0, "value": {"id": 100}},
+        {"topic": "test_topic", "timestamp": 12365, "key": 11.0, "value": {"id": 101}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ROWTIME` BIGINT, `ROWKEY` DOUBLE, `ID` INTEGER"}},
+          {"row":{"columns":[12345, 11.0, 100]}},
+          {"row":{"columns":[12365, 11.0, 101]}},
+          {"finalMessage":"Limit Reached"}
+        ]}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Description 

Fixes: https://github.com/confluentinc/ksql/issues/4123

Add test cases to test push queries work with non-windowed primitive keys

### Testing done 

test only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

