### PR TITLE
fix: report window type and query status better from API

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/Ksql.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/Ksql.java
@@ -25,7 +25,6 @@ import io.confluent.ksql.rest.client.KsqlRestClient;
 import io.confluent.ksql.util.ErrorMessageUtil;
 import io.confluent.ksql.version.metrics.KsqlVersionCheckerAgent;
 import io.confluent.ksql.version.metrics.collector.KsqlModuleType;
-
 import java.io.Console;
 import java.io.File;
 import java.io.IOException;

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/QueriesTableBuilder.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/QueriesTableBuilder.java
@@ -25,14 +25,17 @@ import java.util.stream.Stream;
 public class QueriesTableBuilder implements TableBuilder<Queries> {
 
   private static final List<String> HEADERS =
-      ImmutableList.of("Query ID", "Kafka Topic", "Query String");
+      ImmutableList.of("Query ID", "Status", "Kafka Topic", "Query String");
 
   @Override
   public Table buildTable(final Queries entity) {
     final Stream<List<String>> rows = entity.getQueries().stream()
         .map(r -> ImmutableList.of(
             r.getId().getId(),
-            String.join(",", r.getSinks()), r.getQueryString()));
+            r.getState().orElse("N/A"),
+            String.join(",", r.getSinks()),
+            r.getQuerySingleLine()
+        ));
 
     return new Builder()
         .withColumnHeaders(HEADERS)

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescriptionFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescriptionFactory.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.rest.entity;
 
 import com.google.common.collect.ImmutableSet;
+import io.confluent.ksql.model.WindowType;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.util.EntityUtil;
@@ -37,6 +38,7 @@ public final class QueryDescriptionFactory {
       return create(
           persistentQuery.getQueryId(),
           persistentQuery,
+          persistentQuery.getResultTopic().getKeyFormat().getWindowType(),
           ImmutableSet.of(persistentQuery.getSinkName()),
           Optional.of(persistentQuery.getState())
       );
@@ -45,6 +47,7 @@ public final class QueryDescriptionFactory {
     return create(
         new QueryId(""),
         queryMetadata,
+        Optional.empty(),
         Collections.emptySet(),
         Optional.empty()
     );
@@ -53,12 +56,14 @@ public final class QueryDescriptionFactory {
   private static QueryDescription create(
       final QueryId id,
       final QueryMetadata queryMetadata,
+      final Optional<WindowType> windowType,
       final Set<SourceName> sinks,
       final Optional<String> state
   ) {
     return new QueryDescription(
         id,
         queryMetadata.getStatementString(),
+        windowType,
         EntityUtil.buildSourceSchemaEntity(queryMetadata.getLogicalSchema()),
         queryMetadata.getSourceNames().stream().map(SourceName::name).collect(Collectors.toSet()),
         sinks.stream().map(SourceName::name).collect(Collectors.toSet()),

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionFactory.java
@@ -32,13 +32,13 @@ public final class SourceDescriptionFactory {
   public static SourceDescription create(
       final DataSource<?> dataSource,
       final boolean extended,
-      final String format,
       final List<RunningQuery> readQueries,
       final List<RunningQuery> writeQueries,
       final Optional<TopicDescription> topicDescription
   ) {
     return new SourceDescription(
         dataSource.getName().toString(FormatOptions.noEscape()),
+        dataSource.getKsqlTopic().getKeyFormat().getWindowType(),
         readQueries,
         writeQueries,
         EntityUtil.buildSourceSchemaEntity(dataSource.getSchema()),
@@ -54,7 +54,8 @@ public final class SourceDescriptionFactory {
             ? MetricCollectors.getAndFormatStatsFor(
             dataSource.getKafkaTopicName(), true) : ""),
         extended,
-        format,
+        dataSource.getKsqlTopic().getKeyFormat().getFormat().name(),
+        dataSource.getKsqlTopic().getValueFormat().getFormat().name(),
         dataSource.getKafkaTopicName(),
         topicDescription.map(td -> td.partitions().size()).orElse(0),
         topicDescription.map(td -> td.partitions().get(0).replicas().size()).orElse(0),

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutor.java
@@ -106,7 +106,6 @@ public final class DescribeConnectorExecutor {
           .map(source -> SourceDescriptionFactory.create(
               source,
               false,
-              source.getKsqlTopic().getValueFormat().getFormat().name(),
               ImmutableList.of(),
               ImmutableList.of(),
               Optional.empty()))

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutor.java
@@ -51,11 +51,12 @@ public final class ListQueriesExecutor {
         statement.getStatementText(),
         executionContext.getPersistentQueries()
             .stream()
-            .map(
-                q -> new RunningQuery(
+            .map(q -> new RunningQuery(
                     q.getStatementString(),
                     ImmutableSet.of(q.getSinkName().name()),
-                    q.getQueryId()))
+                    q.getQueryId(),
+                    Optional.of(q.getState())
+                ))
             .collect(Collectors.toList())));
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
@@ -205,7 +205,6 @@ public final class ListSourceExecutor {
         SourceDescriptionFactory.create(
             dataSource,
             extended,
-            dataSource.getKsqlTopic().getValueFormat().getFormat().name(),
             getQueries(ksqlEngine, q -> q.getSourceNames().contains(dataSource.getName())),
             getQueries(ksqlEngine, q -> q.getSinkName().equals(dataSource.getName())),
             topicDescription
@@ -223,7 +222,8 @@ public final class ListSourceExecutor {
         .map(q -> new RunningQuery(
             q.getStatementString(),
             ImmutableSet.of(q.getSinkName().name()),
-            q.getQueryId()
+            q.getQueryId(),
+            Optional.of(q.getState())
         ))
         .collect(Collectors.toList());
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
@@ -32,6 +32,9 @@ import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.SqlBaseType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatInfo;
+import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.PersistentQueryMetadata;
@@ -96,6 +99,8 @@ public class QueryDescriptionFactoryTest {
   public void setUp() {
     when(topology.describe()).thenReturn(topologyDescription);
     when(queryStreams.state()).thenReturn(State.RUNNING);
+
+    when(sinkTopic.getKeyFormat()).thenReturn(KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)));
 
     transientQuery = new TransientQueryMetadata(
         SQL_TEXT,

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionFactoryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionFactoryTest.java
@@ -118,7 +118,6 @@ public class SourceDescriptionFactoryTest {
     final SourceDescription sourceDescription = SourceDescriptionFactory.create(
         dataSource,
         true,
-        "json",
         Collections.emptyList(),
         Collections.emptyList(),
         Optional.empty());
@@ -142,7 +141,6 @@ public class SourceDescriptionFactoryTest {
     final SourceDescription sourceDescription = SourceDescriptionFactory.create(
         dataSource,
         true,
-        "json",
         Collections.emptyList(),
         Collections.emptyList(),
         Optional.empty());
@@ -165,7 +163,6 @@ public class SourceDescriptionFactoryTest {
     final SourceDescription sourceDescription = SourceDescriptionFactory.create(
         dataSource,
         true,
-        "json",
         Collections.emptyList(),
         Collections.emptyList(),
         Optional.empty());

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ExplainExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ExplainExecutorTest.java
@@ -26,11 +26,15 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.engine.KsqlEngine;
+import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.entity.QueryDescriptionEntity;
 import io.confluent.ksql.rest.entity.QueryDescriptionFactory;
 import io.confluent.ksql.rest.server.TemporaryEngine;
+import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatInfo;
+import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
@@ -54,7 +58,6 @@ public class ExplainExecutorTest {
     // Given:
     final ConfiguredStatement<?> explain = engine.configure("EXPLAIN id;");
     final PersistentQueryMetadata metadata = givenPersistentQuery("id");
-    when(metadata.getState()).thenReturn("Running");
 
     final KsqlEngine engine = mock(KsqlEngine.class);
     when(engine.getPersistentQuery(metadata.getQueryId())).thenReturn(Optional.of(metadata));
@@ -153,6 +156,14 @@ public class ExplainExecutorTest {
     when(metadata.getQueryId()).thenReturn(new QueryId(id));
     when(metadata.getSinkName()).thenReturn(SourceName.of(id));
     when(metadata.getLogicalSchema()).thenReturn(TemporaryEngine.SCHEMA);
+    when(metadata.getState()).thenReturn("Running");
+    when(metadata.getTopologyDescription()).thenReturn("topology");
+    when(metadata.getExecutionPlan()).thenReturn("plan");
+    when(metadata.getStatementString()).thenReturn("sql");
+
+    final KsqlTopic sinkTopic = mock(KsqlTopic.class);
+    when(sinkTopic.getKeyFormat()).thenReturn(KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)));
+    when(metadata.getResultTopic()).thenReturn(sinkTopic);
 
     return metadata;
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -473,11 +473,11 @@ public class KsqlResourceTest {
     assertThat(descriptionList.getSourceDescriptions(), containsInAnyOrder(
         SourceDescriptionFactory.create(
             ksqlEngine.getMetaStore().getSource(SourceName.of("TEST_STREAM")),
-            true, "JSON", Collections.emptyList(), Collections.emptyList(),
+            true, Collections.emptyList(), Collections.emptyList(),
             Optional.of(kafkaTopicClient.describeTopic("KAFKA_TOPIC_2"))),
         SourceDescriptionFactory.create(
             ksqlEngine.getMetaStore().getSource(SourceName.of("new_stream")),
-            true, "JSON", Collections.emptyList(), Collections.emptyList(),
+            true, Collections.emptyList(), Collections.emptyList(),
             Optional.of(kafkaTopicClient.describeTopic("new_topic"))))
     );
   }
@@ -502,11 +502,11 @@ public class KsqlResourceTest {
     assertThat(descriptionList.getSourceDescriptions(), containsInAnyOrder(
         SourceDescriptionFactory.create(
             ksqlEngine.getMetaStore().getSource(SourceName.of("TEST_TABLE")),
-            true, "JSON", Collections.emptyList(), Collections.emptyList(),
+            true, Collections.emptyList(), Collections.emptyList(),
             Optional.of(kafkaTopicClient.describeTopic("KAFKA_TOPIC_1"))),
         SourceDescriptionFactory.create(
             ksqlEngine.getMetaStore().getSource(SourceName.of("new_table")),
-            true, "JSON", Collections.emptyList(), Collections.emptyList(),
+            true, Collections.emptyList(), Collections.emptyList(),
             Optional.of(kafkaTopicClient.describeTopic("new_topic"))))
     );
   }
@@ -547,7 +547,6 @@ public class KsqlResourceTest {
     final SourceDescription expectedDescription = SourceDescriptionFactory.create(
         ksqlEngine.getMetaStore().getSource(SourceName.of("DESCRIBED_STREAM")),
         false,
-        "JSON",
         Collections.singletonList(queries.get(1)),
         Collections.singletonList(queries.get(0)),
         Optional.empty()
@@ -1959,7 +1958,9 @@ public class KsqlResourceTest {
         .map(md -> new RunningQuery(
             md.getStatementString(),
             ImmutableSet.of(md.getSinkName().toString(FormatOptions.noEscape())),
-            md.getQueryId()))
+            md.getQueryId(),
+            Optional.of(md.getState())
+        ))
         .collect(Collectors.toList());
   }
 

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryDescription.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryDescription.java
@@ -18,8 +18,11 @@ package io.confluent.ksql.rest.entity;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.confluent.ksql.model.WindowType;
 import io.confluent.ksql.query.QueryId;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -31,6 +34,7 @@ public class QueryDescription {
 
   private final QueryId id;
   private final String statementText;
+  private final Optional<WindowType> windowType;
   private final List<FieldInfo> fields;
   private final Set<String> sources;
   private final Set<String> sinks;
@@ -44,6 +48,7 @@ public class QueryDescription {
   public QueryDescription(
       @JsonProperty("id") final QueryId id,
       @JsonProperty("statementText") final String statementText,
+      @JsonProperty("windowType") final Optional<WindowType> windowType,
       @JsonProperty("fields") final List<FieldInfo> fields,
       @JsonProperty("sources") final Set<String> sources,
       @JsonProperty("sinks") final Set<String> sinks,
@@ -52,14 +57,16 @@ public class QueryDescription {
       @JsonProperty("overriddenProperties") final Map<String, Object> overriddenProperties,
       @JsonProperty("state") final Optional<String> state
   ) {
-    this.id = id;
-    this.statementText = statementText;
-    this.fields = Collections.unmodifiableList(fields);
-    this.sources = Collections.unmodifiableSet(sources);
-    this.sinks = Collections.unmodifiableSet(sinks);
-    this.topology = topology;
-    this.executionPlan = executionPlan;
-    this.overriddenProperties = Collections.unmodifiableMap(overriddenProperties);
+    this.id = Objects.requireNonNull(id, "id");
+    this.statementText = Objects.requireNonNull(statementText, "statementText");
+    this.windowType = Objects.requireNonNull(windowType, "windowType");
+    this.fields = ImmutableList.copyOf(Objects.requireNonNull(fields, "fields"));
+    this.sources = ImmutableSet.copyOf(Objects.requireNonNull(sources, "sources"));
+    this.sinks = ImmutableSet.copyOf(Objects.requireNonNull(sinks, "sinks"));
+    this.topology = Objects.requireNonNull(topology, "topology");
+    this.executionPlan = Objects.requireNonNull(executionPlan, "executionPlan");
+    this.overriddenProperties = ImmutableMap.copyOf(Objects
+        .requireNonNull(overriddenProperties, "overriddenProperties"));
     this.state = Objects.requireNonNull(state, "state");
   }
 
@@ -69,6 +76,10 @@ public class QueryDescription {
 
   public String getStatementText() {
     return statementText;
+  }
+
+  public Optional<WindowType> getWindowType() {
+    return windowType;
   }
 
   public List<FieldInfo> getFields() {
@@ -112,6 +123,7 @@ public class QueryDescription {
     final QueryDescription that = (QueryDescription) o;
     return Objects.equals(id, that.id)
         && Objects.equals(statementText, that.statementText)
+        && Objects.equals(windowType, that.windowType)
         && Objects.equals(fields, that.fields)
         && Objects.equals(topology, that.topology)
         && Objects.equals(executionPlan, that.executionPlan)
@@ -126,6 +138,7 @@ public class QueryDescription {
     return Objects.hash(
         id,
         statementText,
+        windowType,
         fields,
         topology,
         executionPlan,

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/RunningQuery.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/RunningQuery.java
@@ -16,31 +16,42 @@
 package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.confluent.ksql.query.QueryId;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RunningQuery {
+
   private final String queryString;
   private final Set<String> sinks;
   private final QueryId id;
+  private final Optional<String> state;
 
   @JsonCreator
   public RunningQuery(
-      @JsonProperty("statementText") final String queryString,
+      @JsonProperty("queryString") final String queryString,
       @JsonProperty("sinks") final Set<String> sinks,
-      @JsonProperty("id") final QueryId id
+      @JsonProperty("id") final QueryId id,
+      @JsonProperty("state") final Optional<String> state
   ) {
-    this.queryString = queryString;
-    this.sinks = sinks;
-    this.id = id;
+    this.queryString = Objects.requireNonNull(queryString, "queryString");
+    this.sinks = Objects.requireNonNull(sinks, "sinks");
+    this.id = Objects.requireNonNull(id, "id");
+    this.state = Objects.requireNonNull(state, "state");
   }
 
   public String getQueryString() {
     return queryString;
+  }
+
+  @JsonIgnore
+  public String getQuerySingleLine() {
+    return queryString.replaceAll(System.lineSeparator(), "");
   }
 
   public Set<String> getSinks() {
@@ -49,6 +60,10 @@ public class RunningQuery {
 
   public QueryId getId() {
     return id;
+  }
+
+  public Optional<String> getState() {
+    return state;
   }
 
   @Override
@@ -62,11 +77,12 @@ public class RunningQuery {
     final RunningQuery that = (RunningQuery) o;
     return Objects.equals(id, that.id)
         && Objects.equals(queryString, that.queryString)
-        && Objects.equals(sinks, that.sinks);
+        && Objects.equals(sinks, that.sinks)
+        && Objects.equals(state, that.state);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, queryString, id);
+    return Objects.hash(id, queryString, id, state);
   }
 }

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/SourceDescription.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/SourceDescription.java
@@ -20,9 +20,11 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.confluent.ksql.model.WindowType;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeName("description")
@@ -30,6 +32,7 @@ import java.util.Objects;
 public class SourceDescription {
 
   private final String name;
+  private final Optional<WindowType> windowType;
   private final List<RunningQuery> readQueries;
   private final List<RunningQuery> writeQueries;
   private final List<FieldInfo> fields;
@@ -39,7 +42,8 @@ public class SourceDescription {
   private final String statistics;
   private final String errorStats;
   private final boolean extended;
-  private final String format;
+  private final String keyFormat;
+  private final String valueFormat;
   private final String topic;
   private final int partitions;
   private final int replication;
@@ -49,6 +53,7 @@ public class SourceDescription {
   @JsonCreator
   public SourceDescription(
       @JsonProperty("name") final String name,
+      @JsonProperty("windowType") final Optional<WindowType> windowType,
       @JsonProperty("readQueries") final List<RunningQuery> readQueries,
       @JsonProperty("writeQueries") final List<RunningQuery> writeQueries,
       @JsonProperty("fields") final List<FieldInfo> fields,
@@ -58,7 +63,8 @@ public class SourceDescription {
       @JsonProperty("statistics") final String statistics,
       @JsonProperty("errorStats") final String errorStats,
       @JsonProperty("extended") final boolean extended,
-      @JsonProperty("format") final String format,
+      @JsonProperty("keyFormat") final String keyFormat,
+      @JsonProperty("valueFormat") final String valueFormat,
       @JsonProperty("topic") final String topic,
       @JsonProperty("partitions") final int partitions,
       @JsonProperty("replication") final int replication,
@@ -66,6 +72,7 @@ public class SourceDescription {
   ) {
     // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     this.name = Objects.requireNonNull(name, "name");
+    this.windowType = Objects.requireNonNull(windowType, "windowType");
     this.readQueries =
         Collections.unmodifiableList(Objects.requireNonNull(readQueries, "readQueries"));
     this.writeQueries =
@@ -77,8 +84,9 @@ public class SourceDescription {
     this.timestamp = Objects.requireNonNull(timestamp, "timestamp");
     this.statistics = Objects.requireNonNull(statistics, "statistics");
     this.errorStats = Objects.requireNonNull(errorStats, "errorStats");
-    this.extended = Objects.requireNonNull(extended, "extended");
-    this.format = Objects.requireNonNull(format, "format");
+    this.extended = extended;
+    this.keyFormat = Objects.requireNonNull(keyFormat, "keyFormat");
+    this.valueFormat = Objects.requireNonNull(valueFormat, "valueFormat");
     this.topic = Objects.requireNonNull(topic, "topic");
     this.partitions = partitions;
     this.replication = replication;
@@ -87,6 +95,10 @@ public class SourceDescription {
 
   public String getStatement() {
     return statement;
+  }
+
+  public Optional<WindowType> getWindowType() {
+    return windowType;
   }
 
   public int getPartitions() {
@@ -113,8 +125,12 @@ public class SourceDescription {
     return type;
   }
 
-  public String getFormat() {
-    return format;
+  public String getKeyFormat() {
+    return keyFormat;
+  }
+
+  public String getValueFormat() {
+    return valueFormat;
   }
 
   public String getTopic() {
@@ -145,62 +161,41 @@ public class SourceDescription {
     return errorStats;
   }
 
-  private boolean equals2(final SourceDescription that) {
-    if (!Objects.equals(topic, that.topic)) {
-      return false;
-    }
-    if (!Objects.equals(key, that.key)) {
-      return false;
-    }
-    if (!Objects.equals(writeQueries, that.writeQueries)) {
-      return false;
-    }
-    if (!Objects.equals(readQueries, that.readQueries)) {
-      return false;
-    }
-    if (!Objects.equals(timestamp, that.timestamp)) {
-      return false;
-    }
-    if (!Objects.equals(statistics, that.statistics)) {
-      return false;
-    }
-    if (!Objects.equals(errorStats, that.errorStats)) {
-      return false;
-    }
-    return Objects.equals(statement, that.statement);
-  }
-
+  // CHECKSTYLE_RULES.OFF: CyclomaticComplexity
   @Override
   public boolean equals(final Object o) {
+    // CHECKSTYLE_RULES.ON: CyclomaticComplexity
     if (this == o) {
       return true;
     }
-    if (!(o instanceof SourceDescription)) {
+    if (o == null || getClass() != o.getClass()) {
       return false;
     }
     final SourceDescription that = (SourceDescription) o;
-    if (!Objects.equals(name, that.name)) {
-      return false;
-    }
-    if (!Objects.equals(fields, that.fields)) {
-      return false;
-    }
-    if (!Objects.equals(extended, that.extended)) {
-      return false;
-    }
-    if (!Objects.equals(type, that.type)) {
-      return false;
-    }
-    if (!Objects.equals(format, that.format)) {
-      return false;
-    }
-    return equals2(that);
+    return extended == that.extended
+        && partitions == that.partitions
+        && replication == that.replication
+        && Objects.equals(name, that.name)
+        && Objects.equals(windowType, that.windowType)
+        && Objects.equals(readQueries, that.readQueries)
+        && Objects.equals(writeQueries, that.writeQueries)
+        && Objects.equals(fields, that.fields)
+        && Objects.equals(type, that.type)
+        && Objects.equals(key, that.key)
+        && Objects.equals(timestamp, that.timestamp)
+        && Objects.equals(statistics, that.statistics)
+        && Objects.equals(errorStats, that.errorStats)
+        && Objects.equals(keyFormat, that.keyFormat)
+        && Objects.equals(valueFormat, that.valueFormat)
+        && Objects.equals(topic, that.topic)
+        && Objects.equals(statement, that.statement);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
         name,
+        windowType,
         readQueries,
         writeQueries,
         fields,
@@ -210,7 +205,8 @@ public class SourceDescription {
         statistics,
         errorStats,
         extended,
-        format,
+        keyFormat,
+        valueFormat,
         topic,
         partitions,
         replication,

--- a/ksql-rest-model/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionTest.java
+++ b/ksql-rest-model/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionTest.java
@@ -15,8 +15,12 @@
 
 package io.confluent.ksql.rest.entity;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
+import io.confluent.ksql.model.WindowType;
 import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -28,26 +32,146 @@ public class SourceDescriptionTest {
     private static final String SOME_STRING = "some string";
     private static final int SOME_INT = 3;
     private static final boolean SOME_BOOL = true;
- 
-    @Mock
-    private RunningQuery runningQuery;
 
+    @Mock
+    private RunningQuery query1;
+    @Mock
+    private RunningQuery query2;
     @Mock
     private FieldInfo fieldInfo;
 
+    @SuppressWarnings("UnstableApiUsage")
     @Test
     public void shouldImplementHashCodeAndEqualsProperty() {
-      new EqualsTester()
-          .addEqualityGroup(
-              new SourceDescription(
-                  SOME_STRING, Collections.singletonList(runningQuery), Collections.singletonList(runningQuery),
-                  Collections.singletonList(fieldInfo), SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,
-                  SOME_STRING, SOME_BOOL, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT, SOME_STRING),
-              new SourceDescription(
-                  SOME_STRING, Collections.singletonList(runningQuery), Collections.singletonList(runningQuery),
-                  Collections.singletonList(fieldInfo), SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,
-                  SOME_STRING, SOME_BOOL, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT, SOME_STRING)
-          )
-          .testEquals();
+        final List<RunningQuery> readQueries = Collections.singletonList(query1);
+        final List<RunningQuery> writeQueries = Collections.singletonList(query2);
+        final List<FieldInfo> fields = Collections.singletonList(fieldInfo);
+
+        new EqualsTester()
+            .addEqualityGroup(
+                new SourceDescription(
+                    SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
+                    SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
+                    SOME_STRING),
+                new SourceDescription(
+                    SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
+                    SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
+                    SOME_STRING)
+            )
+            .addEqualityGroup(
+                new SourceDescription(
+                    "diff", Optional.of(WindowType.SESSION), readQueries, writeQueries, fields,
+                    SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
+                    SOME_STRING)
+            )
+            .addEqualityGroup(
+                new SourceDescription(
+                    SOME_STRING, Optional.empty(), ImmutableList.of(), writeQueries, fields,
+                    SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
+                    SOME_STRING)
+            )
+            .addEqualityGroup(
+                new SourceDescription(
+                    SOME_STRING, Optional.empty(), readQueries, ImmutableList.of(), fields,
+                    SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
+                    SOME_STRING)
+            )
+            .addEqualityGroup(
+                new SourceDescription(
+                    SOME_STRING, Optional.empty(), readQueries, writeQueries, ImmutableList.of(),
+                    SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
+                    SOME_STRING)
+            )
+            .addEqualityGroup(
+                new SourceDescription(
+                    SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, "diff",
+                    SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
+                    SOME_STRING)
+            )
+            .addEqualityGroup(
+                new SourceDescription(
+                    SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
+                    "diff", SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
+                    SOME_STRING)
+            )
+            .addEqualityGroup(
+                new SourceDescription(
+                    SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
+                    SOME_STRING, "diff", SOME_STRING, SOME_STRING,
+                    SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
+                    SOME_STRING)
+            )
+            .addEqualityGroup(
+                new SourceDescription(
+                    SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
+                    SOME_STRING, SOME_STRING, "diff", SOME_STRING,
+                    SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
+                    SOME_STRING)
+            )
+            .addEqualityGroup(
+                new SourceDescription(
+                    SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
+                    SOME_STRING, SOME_STRING, SOME_STRING, "diff",
+                    SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
+                    SOME_STRING)
+            )
+            .addEqualityGroup(
+                new SourceDescription(
+                    SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
+                    SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_BOOL, "diff", SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
+                    SOME_STRING)
+            )
+            .addEqualityGroup(
+                new SourceDescription(
+                    SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
+                    SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,
+                    !SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
+                    SOME_STRING)
+            )
+            .addEqualityGroup(
+                new SourceDescription(
+                    SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
+                    SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_BOOL, SOME_STRING, "diff", SOME_STRING, SOME_INT, SOME_INT,
+                    SOME_STRING)
+            )
+            .addEqualityGroup(
+                new SourceDescription(
+                    SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
+                    SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_BOOL, SOME_STRING, SOME_STRING, "diff", SOME_INT, SOME_INT,
+                    SOME_STRING)
+            )
+            .addEqualityGroup(
+                new SourceDescription(
+                    SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
+                    SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT + 1, SOME_INT,
+                    SOME_STRING)
+            )
+            .addEqualityGroup(
+                new SourceDescription(
+                    SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
+                    SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT + 1,
+                    SOME_STRING)
+            )
+            .addEqualityGroup(
+                new SourceDescription(
+                    SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
+                    SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
+                    "diff")
+            )
+            .testEquals();
     }
   }


### PR DESCRIPTION
### Description 

While testing the primitive keys stuff manually I can across a couple of issues, inconsistencies, poor UX and bugs, which this commit looks to fix.

This commit:
1. exposes the window type of the key of a query/source, i.e. `HOPPING`, `TUMBLING` `SESSION` or none.
2. makes the status of a query easier to find, so users can quickly know if a query has failed or is running.
3. fixes a bug that meant the statement text of a query was not displayed in the CLI.

BREAKING CHANGE: The response from the RESTful API has changed for some commands with this commit: the `SourceDescription` type no longer has a `format` field. Instead it has `keyFormat` and `valueFormat` fields.

## `SHOW QUERY` changes:

Response now includes a `state` property for each query that indicates the state of the query.

e.g.

```json
{
  "queryString" : "create table OUTPUT as select * from INPUT;",
  "sinks" : [ "OUTPUT" ],
  "id" : "CSAS_OUTPUT_0",
  "state" : "Running"
}
```

The CLI output was:

```
 ksql> show queries;

  Query ID                   | Kafka Topic         | Query String

   CSAS_OUTPUT_0              | OUTPUT              | CREATE STREAM OUTPUT WITH (KAFKA_TOPIC='OUTPUT', PARTITIONS=1, REPLICAS=1) AS SELECT *
 FROM INPUT INPUT
 EMIT CHANGES;
  CTAS_CLICK_USER_SESSIONS_5 | CLICK_USER_SESSIONS | CREATE TABLE CLICK_USER_SESSIONS WITH (KAFKA_TOPIC='CLICK_USER_SESSIONS', PARTITIONS=1, REPLICAS=1) AS SELECT
   CLICKSTREAM.USERID USERID,
   COUNT(*) COUNT
 FROM CLICKSTREAM CLICKSTREAM
 WINDOW SESSION ( 300 SECONDS )
 GROUP BY CLICKSTREAM.USERID
 EMIT CHANGES;

 For detailed information on a Query run: EXPLAIN <Query ID>;
```

and is now:

```
 Query ID                   | Status      | Kafka Topic         | Query String

 CSAS_OUTPUT_0              | RUNNING     | OUTPUT              | CREATE STREAM OUTPUT WITH (KAFKA_TOPIC='OUTPUT', PARTITIONS=1, REPLICAS=1) AS SELECT *FROM INPUT INPUTEMIT CHANGES;

For detailed information on a Query run: EXPLAIN <Query ID>;

```
Note the addition of the `Status` column and the fact that `Query String` is now longer being written across multiple lines.

## `DESCRIBE <source>;` changes:

old CLI output:

```
ksql> describe CLICK_USER_SESSIONS;

Name                 : CLICK_USER_SESSIONS
 Field   | Type

 ROWTIME | BIGINT           (system)
 ROWKEY  | INTEGER          (system)
 USERID  | INTEGER
 COUNT   | BIGINT

For runtime statistics and query details run: DESCRIBE EXTENDED <Stream,Table>;
```

New CLI output:

```
ksql> describe CLICK_USER_SESSIONS;

Name                 : CLICK_USER_SESSIONS
 Field   | Type

 ROWTIME | BIGINT           (system)
 ROWKEY  | INTEGER          (system) (Window type: SESSION)
 USERID  | INTEGER
 COUNT   | BIGINT

For runtime statistics and query details run: DESCRIBE EXTENDED <Stream,Table>;
```

Note the addition of the `Window Type` information.

## `DESCRIBE EXTENDED <source>;` changes:

Old output:

```
ksql> describe extended CLICK_USER_SESSIONS;

Name                 : CLICK_USER_SESSIONS
Type                 : TABLE
Key field            : USERID
Key format           : STRING
Timestamp field      : Not set - using <ROWTIME>
Value Format                : JSON
Kafka topic          : CLICK_USER_SESSIONS (partitions: 1, replication: 1)
Statement            : CREATE TABLE CLICK_USER_SESSIONS WITH (KAFKA_TOPIC='CLICK_USER_SESSIONS', PARTITIONS=1, REPLICAS=1) AS SELECT
  CLICKSTREAM.USERID USERID,
  COUNT(*) COUNT
FROM CLICKSTREAM CLICKSTREAM
WINDOW SESSION ( 300 SECONDS )
GROUP BY CLICKSTREAM.USERID
EMIT CHANGES;

 Field   | Type

 ROWTIME | BIGINT           (system)
 ROWKEY  | INTEGER          (system)
 USERID  | INTEGER
 COUNT   | BIGINT

Queries that write from this TABLE
-----------------------------------
CTAS_CLICK_USER_SESSIONS_5 (RUNNING) : CREATE TABLE CLICK_USER_SESSIONS WITH (KAFKA_TOPIC='CLICK_USER_SESSIONS', PARTITIONS=1, REPLICAS=1) AS SELECT
 CLICKSTREAM.USERID USERID,
 COUNT(*) COUNT
 FROM CLICKSTREAM CLICKSTREAM
 WINDOW SESSION ( 300 SECONDS )
 GROUP BY CLICKSTREAM.USERID
 EMIT CHANGES;

For query topology and execution plan please run: EXPLAIN <QueryId>

Local runtime statistics
------------------------

(Statistics of the local KSQL server interaction with the Kafka topic CLICK_USER_SESSIONS)
```

New output:

```
ksql> describe extended CLICK_USER_SESSIONS;

Name                 : CLICK_USER_SESSIONS
Type                 : TABLE
Key field            : USERID
Timestamp field      : Not set - using <ROWTIME>
Key format           : KAFKA
Value format         : JSON
Kafka topic          : CLICK_USER_SESSIONS (partitions: 1, replication: 1)
Statement            : CREATE TABLE CLICK_USER_SESSIONS WITH (KAFKA_TOPIC='CLICK_USER_SESSIONS', PARTITIONS=1, REPLICAS=1) AS SELECT
  CLICKSTREAM.USERID USERID,
  COUNT(*) COUNT
FROM CLICKSTREAM CLICKSTREAM
WINDOW SESSION ( 300 SECONDS )
GROUP BY CLICKSTREAM.USERID
EMIT CHANGES;

 Field   | Type

 ROWTIME | BIGINT           (system)
 ROWKEY  | INTEGER          (system) (Window type: SESSION)
 USERID  | INTEGER
 COUNT   | BIGINT

Queries that write from this TABLE
-----------------------------------
CTAS_CLICK_USER_SESSIONS_5 (RUNNING) : CREATE TABLE CLICK_USER_SESSIONS WITH (KAFKA_TOPIC='CLICK_USER_SESSIONS', PARTITIONS=1, REPLICAS=1) AS SELECT  CLICKSTREAM.USERID USERID,  COUNT(*) COUNTFROM CLICKSTREAM CLICKSTREAMWINDOW SESSION ( 300 SECONDS ) GROUP BY CLICKSTREAM.USERIDEMIT CHANGES;

For query topology and execution plan please run: EXPLAIN <QueryId>

Local runtime statistics
------------------------

(Statistics of the local KSQL server interaction with the Kafka topic CLICK_USER_SESSIONS)
```

 Note: the change from `Key format` of `STRING` to `KAFKA`.  The output of `Window Type` information for windowed schemas and outputing sql statements on a single line.


### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

