### PR TITLE
docs: add note re. logs folder for server output

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,8 @@ $ ./bin/ksql
 ```
 
 This will start the KSQL server in the background and the KSQL CLI in the
-foreground.
+foreground. Check the `logs` folder for the log files that the server writes 
+including any errors.
 
 If you would rather have the KSQL server logs spool to the console, then
 drop the `-daemon` switch, and start the CLI in a second console.


### PR DESCRIPTION
I followed the instructions to build and run locally, and fatal errors weren't written to stdout - took me a while to realise why the process was just exiting :) Found the error in the `ksql.log` log in the logs folder.

