### PR TITLE
feat: hide internal/system topics from SHOW TOPICS

### DIFF
--- a/docs-md/developer-guide/ksqldb-reference/show-topics.md
+++ b/docs-md/developer-guide/ksqldb-reference/show-topics.md
@@ -25,17 +25,17 @@ configured to connect to (default setting for `bootstrap.servers`:
 and their active consumer counts.
 
 SHOW TOPICS does not display topics considered internal, such as:
-* KSQL internal topics (i.e. the KSQL command topic)
-* Topics found in the `system.internal.topics` configuration
+* KSQL internal topics, like the KSQL command topic
+* Topics found in the `ksql.internal.hidden.topics` configuration
 
-SHOW ALL TOPICS will list all topics including those considered as
-internal or found in the `system.internal.topics` configuration.
+SHOW ALL TOPICS lists all topics, including those considered to be
+internal or found in the `ksql.internal.hidden.topics` configuration.
 
 Example
 -------
 
 ```sql
-ksql> SHOW TOPICS
+ksql> SHOW TOPICS;
 
  Kafka Topic                            | Partitions | Partition Replicas
 -------------------------------------------------------------------------
@@ -47,7 +47,7 @@ ksql> SHOW TOPICS
 
 
 ```sql
-ksql> SHOW ALL TOPICS
+ksql> SHOW ALL TOPICS;
 
  Kafka Topic                            | Partitions | Partition Replicas
 -------------------------------------------------------------------------

--- a/docs-md/developer-guide/ksqldb-reference/show-topics.md
+++ b/docs-md/developer-guide/ksqldb-reference/show-topics.md
@@ -24,12 +24,11 @@ configured to connect to (default setting for `bootstrap.servers`:
 `localhost:9092`). SHOW TOPICS EXTENDED also displays consumer groups
 and their active consumer counts.
 
-SHOW TOPICS does not display topics considered internal, such as:
-* KSQL internal topics, like the KSQL command topic
-* Topics found in the `ksql.internal.hidden.topics` configuration
+`SHOW TOPICS` does not display hidden topics by default, such as:
+* KSQL internal topics, like the KSQL command topic or changelog & repartition topics.
+* Topics that match any pattern in the `ksql.hidden.topics` configuration.
 
-SHOW ALL TOPICS lists all topics, including those considered to be
-internal or found in the `ksql.internal.hidden.topics` configuration.
+`SHOW ALL TOPICS` lists all topics, including hidden topics.
 
 Example
 -------
@@ -37,23 +36,25 @@ Example
 ```sql
 ksql> SHOW TOPICS;
 
- Kafka Topic                            | Partitions | Partition Replicas
--------------------------------------------------------------------------
- default_ksql-processing-log            | 1          | 1
- pageviews                              | 1          | 1
- users                                  | 1          | 1
--------------------------------------------------------------------------
+ Kafka Topic                                                                           | Partitions | Partition Replicas
+--------------------------------------------------------------------------------------------------------
+ default_ksql_processing_log                                                           | 1          | 1
+ pageviews                                                                             | 1          | 1
+ users                                                                                 | 1          | 1
+--------------------------------------------------------------------------------------------------------
 ```
 
 
 ```sql
 ksql> SHOW ALL TOPICS;
 
- Kafka Topic                            | Partitions | Partition Replicas
--------------------------------------------------------------------------
- _confluent-ksql-default_command_topic  | 1          | 1
- default_ksql-processing-log            | 1          | 1
- pageviews                              | 1          | 1
- users                                  | 1          | 1
--------------------------------------------------------------------------
+ Kafka Topic                                                                           | Partitions | Partition Replicas
+--------------------------------------------------------------------------------------------------------
+ _confluent-ksql-default__command_topic                                                | 1          | 1
+ _confluent-ksql-default_query_CTAS_USERS_0-Aggregate-Aggregate-Materialize-changelog  | 1          | 1
+ _confluent-ksql-default_query_CTAS_USERS_0-Aggregate-GroupBy-repartition              | 1          | 1
+ default_ksql_processing_log                                                           | 1          | 1
+ pageviews                                                                             | 1          | 1
+ users                                                                                 | 1          | 1
+--------------------------------------------------------------------------------------------------------
 ```

--- a/docs-md/developer-guide/ksqldb-reference/show-topics.md
+++ b/docs-md/developer-guide/ksqldb-reference/show-topics.md
@@ -13,7 +13,7 @@ Synopsis
 --------
 
 ```sql
-SHOW | LIST TOPICS [EXTENDED];
+SHOW | LIST [ALL] TOPICS [EXTENDED];
 ```
 
 Description
@@ -24,10 +24,36 @@ configured to connect to (default setting for `bootstrap.servers`:
 `localhost:9092`). SHOW TOPICS EXTENDED also displays consumer groups
 and their active consumer counts.
 
+SHOW TOPICS does not display topics considered internal, such as:
+* KSQL internal topics (i.e. the KSQL command topic)
+* Topics found in the `system.internal.topics` configuration
+
+SHOW ALL TOPICS will list all topics including those considered as
+internal or found in the `system.internal.topics` configuration.
+
 Example
 -------
 
-TODO: example
+```sql
+ksql> SHOW TOPICS
+
+ Kafka Topic                            | Partitions | Partition Replicas
+-------------------------------------------------------------------------
+ default_ksql-processing-log            | 1          | 1
+ pageviews                              | 1          | 1
+ users                                  | 1          | 1
+-------------------------------------------------------------------------
+```
 
 
-Page last revised on: {{ git_revision_date }}
+```sql
+ksql> SHOW ALL TOPICS
+
+ Kafka Topic                            | Partitions | Partition Replicas
+-------------------------------------------------------------------------
+ _confluent-ksql-default_command_topic  | 1          | 1
+ default_ksql-processing-log            | 1          | 1
+ pageviews                              | 1          | 1
+ users                                  | 1          | 1
+-------------------------------------------------------------------------
+```

--- a/docs-md/developer-guide/ksqldb-reference/show-topics.md
+++ b/docs-md/developer-guide/ksqldb-reference/show-topics.md
@@ -25,8 +25,8 @@ configured to connect to (default setting for `bootstrap.servers`:
 and their active consumer counts.
 
 `SHOW TOPICS` does not display hidden topics by default, such as:
-* KSQL internal topics, like the KSQL command topic or changelog & repartition topics.
-* Topics that match any pattern in the `ksql.hidden.topics` configuration.
+* KSQL internal topics, like the KSQL command topic or changelog & repartition topics, or
+  topics that match any pattern in the `ksql.hidden.topics` configuration.
 
 `SHOW ALL TOPICS` lists all topics, including hidden topics.
 

--- a/ksql-common/src/main/java/io/confluent/ksql/config/ImmutableProperties.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/config/ImmutableProperties.java
@@ -30,6 +30,8 @@ public final class ImmutableProperties {
       .add(KsqlConfig.KSQL_EXT_DIR)
       .add(KsqlConfig.KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_CONFIG)
       .add(KsqlConfig.KSQL_PULL_QUERIES_ENABLE_CONFIG)
+      .add(KsqlConfig.KSQL_HIDDEN_TOPICS_CONFIG)
+      .add(KsqlConfig.KSQL_READONLY_TOPICS_CONFIG)
       .addAll(KsqlConfig.SSL_CONFIG_NAMES)
       .build();
 

--- a/ksql-common/src/main/java/io/confluent/ksql/configdef/ConfigValidators.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/configdef/ConfigValidators.java
@@ -95,15 +95,27 @@ public final class ConfigValidators {
 
   public static Validator validRegex() {
     return (name, val) -> {
-      if (!(val instanceof String)) {
-        throw new IllegalArgumentException("validator should only be used with STRING defs");
+      if (!(val instanceof List)) {
+        throw new IllegalArgumentException("validator should only be used with "
+            + "LIST of STRING defs");
       }
 
-      final String regex = Arrays.stream(((String) val).split(","))
-          .collect(Collectors.joining("|"));
+      final StringBuilder regexBuilder = new StringBuilder();
+      for (Object item : (List)val) {
+        if (!(item instanceof String)) {
+          throw new IllegalArgumentException("validator should only be used with "
+              + "LIST of STRING defs");
+        }
+
+        if (regexBuilder.length() > 0) {
+          regexBuilder.append("|");
+        }
+
+        regexBuilder.append((String)item);
+      }
 
       try {
-        Pattern.compile(regex);
+        Pattern.compile(regexBuilder.toString());
       } catch (final Exception e) {
         throw new ConfigException(name, val, "Not valid regular expression: " + e.getMessage());
       }

--- a/ksql-common/src/main/java/io/confluent/ksql/configdef/ConfigValidators.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/configdef/ConfigValidators.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.config.ConfigDef.Validator;
 import org.apache.kafka.common.config.ConfigException;
@@ -88,6 +89,23 @@ public final class ConfigValidators {
         new URL((String)val);
       } catch (final Exception e) {
         throw new ConfigException(name, val, "Not valid URL: " + e.getMessage());
+      }
+    };
+  }
+
+  public static Validator validRegex() {
+    return (name, val) -> {
+      if (!(val instanceof String)) {
+        throw new IllegalArgumentException("validator should only be used with STRING defs");
+      }
+
+      final String regex = Arrays.stream(((String) val).split(","))
+          .collect(Collectors.joining("|"));
+
+      try {
+        Pattern.compile(regex);
+      } catch (final Exception e) {
+        throw new ConfigException(name, val, "Not valid regular expression: " + e.getMessage());
       }
     };
   }

--- a/ksql-common/src/main/java/io/confluent/ksql/logging/processing/ProcessingLogConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/logging/processing/ProcessingLogConfig.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.logging.processing;
 
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.Map;
+import java.util.Set;
+
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
@@ -124,6 +126,10 @@ public class ProcessingLogConfig extends AbstractConfig {
           Importance.HIGH,
           INCLUDE_ROWS_DOC
       );
+
+  public static Set<String> configNames() {
+    return CONFIG_DEF.names();
+  }
 
   public ProcessingLogConfig(final Map<?, ?> properties) {
     super(CONFIG_DEF, properties);

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -566,14 +566,14 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_AUTH_CACHE_MAX_ENTRIES_DOC
         ).define(
             KSQL_HIDDEN_TOPICS_CONFIG,
-            Type.STRING,
+            Type.LIST,
             KSQL_HIDDEN_TOPICS_DEFAULT,
             ConfigValidators.validRegex(),
             Importance.LOW,
             KSQL_HIDDEN_TOPICS_DOC
         ).define(
             KSQL_READONLY_TOPICS_CONFIG,
-            Type.STRING,
+            Type.LIST,
             KSQL_READONLY_TOPICS_DEFAULT,
             ConfigValidators.validRegex(),
             Importance.LOW,

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -23,6 +23,7 @@ import io.confluent.ksql.config.KsqlConfigResolver;
 import io.confluent.ksql.configdef.ConfigValidators;
 import io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler;
 import io.confluent.ksql.errors.ProductionExceptionHandlerUtil;
+import io.confluent.ksql.logging.processing.ProcessingLogConfig;
 import io.confluent.ksql.model.SemanticVersion;
 import io.confluent.ksql.testing.EffectivelyImmutable;
 import java.util.Collection;
@@ -712,6 +713,10 @@ public class KsqlConfig extends AbstractConfig {
 
   public Map<String, Object> getProducerClientConfigProps() {
     return getConfigsFor(ProducerConfig.configNames());
+  }
+
+  public Map<String, Object> getProcessingLogConfigProps() {
+    return getConfigsFor(ProcessingLogConfig.configNames());
   }
 
   private Map<String, Object> getConfigsFor(final Set<String> configs) {

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.config.ConfigItem;
 import io.confluent.ksql.config.KsqlConfigResolver;
+import io.confluent.ksql.configdef.ConfigValidators;
 import io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler;
 import io.confluent.ksql.errors.ProductionExceptionHandlerUtil;
 import io.confluent.ksql.model.SemanticVersion;
@@ -202,23 +203,35 @@ public class KsqlConfig extends AbstractConfig {
   public static final String KSQL_AUTH_CACHE_MAX_ENTRIES_DOC = "Controls the size of the cache "
       + "to a maximum number of KSQL authorization responses entries.";
 
-  public static final String KSQL_INTERNAL_HIDDEN_TOPICS_CONFIG = "ksql.internal.hidden.topics";
-  public static final String KSQL_INTERNAL_HIDDEN_TOPICS_DEFAULT = "_confluent.*,__confluent.*"
+  public static final String KSQL_HIDDEN_TOPICS_CONFIG = "ksql.hidden.topics";
+  public static final String KSQL_HIDDEN_TOPICS_DEFAULT = "_confluent.*,__confluent.*"
       + ",_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,"
       + "connect-status,connect-statuses";
-  public static final String KSQL_INTERNAL_HIDDEN_TOPICS_DOC = "List of topics that will not be "
-      + "visible when running the SHOW TOPICS command unless SHOW ALL TOPICS is used. This list "
-      + "is comma separated and may use Java regular expressions to specify each topic (i.e. "
-      + " _confluent.* accepts any topic that starts with the _confluent prefix).";
+  public static final String KSQL_HIDDEN_TOPICS_DOC = "Comma-separated list of topics that will "
+      + "be hidden. Entries in the list may be literal topic names or "
+      + "[Java regular expressions](https://docs.oracle.com/javase/8/docs/api/java/util/regex/"
+      + "Pattern.html). "
+      + "For example, `_confluent.*` will match any topic whose name starts with the `_confluent`)."
+      + "\nHidden topics will not visible when running the `SHOW TOPICS` command unless "
+      + "`SHOW ALL TOPICS` is used."
+      + "\nThe default value hides known system topics from Kafka and Confluent products."
+      + "\nKSQL also marks its own internal topics as hidden. This is not controlled by this "
+      + "config.";
 
-  public static final String KSQL_INTERNAL_READONLY_TOPICS_CONFIG = "ksql.internal.readonly.topics";
-  public static final String KSQL_INTERNAL_READONLY_TOPICS_DEFAULT = "_confluent.*,__confluent.*"
+  public static final String KSQL_READONLY_TOPICS_CONFIG = "ksql.readonly.topics";
+  public static final String KSQL_READONLY_TOPICS_DEFAULT = "_confluent.*,__confluent.*"
       + ",_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,"
       + "connect-status,connect-statuses";
-  public static final String KSQL_INTERNAL_READONLY_TOPICS_DOC = "List of topics that KSQL will "
-      + " handle as read-only. These topics cannot be modified by any KSQL command. This list "
-      + "is comma separated and may use Java regular expressions to specify each topic (i.e. "
-      + " _confluent.* accepts any topic that starts with the _confluent prefix).";
+  public static final String KSQL_READONLY_TOPICS_DOC = "Comma-separated list of topics that "
+      + "should be marked as read-only. Entries in the list may be literal topic names or "
+      + "[Java regular expressions](https://docs.oracle.com/javase/8/docs/api/java/util/regex/"
+      + "Pattern.html). "
+      + "For example, `_confluent.*` will match any topic whose name starts with the `_confluent`)."
+      + "\nRead-only topics cannot be modified by any KSQL command."
+      + "\nThe default value marks known system topics from Kafka and Confluent products as "
+      + "read-only."
+      + "\nKSQL also marks its own internal topics as read-only. This is not controlled by this "
+      + "config.";
 
   private enum ConfigGeneration {
     LEGACY,
@@ -551,17 +564,19 @@ public class KsqlConfig extends AbstractConfig {
             Importance.LOW,
             KSQL_AUTH_CACHE_MAX_ENTRIES_DOC
         ).define(
-            KSQL_INTERNAL_HIDDEN_TOPICS_CONFIG,
-            Type.LIST,
-            KSQL_INTERNAL_HIDDEN_TOPICS_DEFAULT,
+            KSQL_HIDDEN_TOPICS_CONFIG,
+            Type.STRING,
+            KSQL_HIDDEN_TOPICS_DEFAULT,
+            ConfigValidators.validRegex(),
             Importance.LOW,
-            KSQL_INTERNAL_HIDDEN_TOPICS_DOC
+            KSQL_HIDDEN_TOPICS_DOC
         ).define(
-            KSQL_INTERNAL_READONLY_TOPICS_CONFIG,
-            Type.LIST,
-            KSQL_INTERNAL_READONLY_TOPICS_DEFAULT,
+            KSQL_READONLY_TOPICS_CONFIG,
+            Type.STRING,
+            KSQL_READONLY_TOPICS_DEFAULT,
+            ConfigValidators.validRegex(),
             Importance.LOW,
-            KSQL_INTERNAL_READONLY_TOPICS_DOC
+            KSQL_READONLY_TOPICS_DOC
         )
         .withClientSslSupport();
 

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -202,6 +202,16 @@ public class KsqlConfig extends AbstractConfig {
   public static final String KSQL_AUTH_CACHE_MAX_ENTRIES_DOC = "Controls the size of the cache "
       + "to a maximum number of KSQL authorization responses entries.";
 
+  public static final String SYSTEM_INTERNAL_TOPICS_CONFIG = "system.internal.topics";
+  public static final String SYSTEM_INTERNAL_TOPICS_DEFAULT = "_confluent.*,__confluent.*,_schemas,"
+      + "__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,"
+      + "connect-statuses";
+  public static final String SYSTEM_INTERNAL_TOPICS_DOC = "List of topics considered part of "
+      + "system internals which KSQL should not allow users to write data on them. This list will "
+      + "not be displayed from the SHOW TOPICS command unless SHOW ALL TOPICS is used. The list "
+      + "is separated by comma and may use regular expressions based on Java Patterns "
+      + "(i.e. _confluent.* accepts any topic that starts with _confluent prefix).";
+
   private enum ConfigGeneration {
     LEGACY,
     CURRENT
@@ -532,6 +542,12 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_AUTH_CACHE_MAX_ENTRIES_DEFAULT,
             Importance.LOW,
             KSQL_AUTH_CACHE_MAX_ENTRIES_DOC
+        ).define(
+            SYSTEM_INTERNAL_TOPICS_CONFIG,
+            Type.LIST,
+            SYSTEM_INTERNAL_TOPICS_DEFAULT,
+            Importance.LOW,
+            SYSTEM_INTERNAL_TOPICS_DOC
         )
         .withClientSslSupport();
 

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -202,15 +202,23 @@ public class KsqlConfig extends AbstractConfig {
   public static final String KSQL_AUTH_CACHE_MAX_ENTRIES_DOC = "Controls the size of the cache "
       + "to a maximum number of KSQL authorization responses entries.";
 
-  public static final String SYSTEM_INTERNAL_TOPICS_CONFIG = "system.internal.topics";
-  public static final String SYSTEM_INTERNAL_TOPICS_DEFAULT = "_confluent.*,__confluent.*,_schemas,"
-      + "__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,"
-      + "connect-statuses";
-  public static final String SYSTEM_INTERNAL_TOPICS_DOC = "List of topics considered part of "
-      + "system internals which KSQL should not allow users to write data on them. This list will "
-      + "not be displayed from the SHOW TOPICS command unless SHOW ALL TOPICS is used. The list "
-      + "is separated by comma and may use regular expressions based on Java Patterns "
-      + "(i.e. _confluent.* accepts any topic that starts with _confluent prefix).";
+  public static final String KSQL_INTERNAL_HIDDEN_TOPICS_CONFIG = "ksql.internal.hidden.topics";
+  public static final String KSQL_INTERNAL_HIDDEN_TOPICS_DEFAULT = "_confluent.*,__confluent.*"
+      + ",_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,"
+      + "connect-status,connect-statuses";
+  public static final String KSQL_INTERNAL_HIDDEN_TOPICS_DOC = "List of topics that will not be "
+      + "visible when running the SHOW TOPICS command unless SHOW ALL TOPICS is used. This list "
+      + "is comma separated and may use Java regular expressions to specify each topic (i.e. "
+      + " _confluent.* accepts any topic that starts with the _confluent prefix).";
+
+  public static final String KSQL_INTERNAL_READONLY_TOPICS_CONFIG = "ksql.internal.readonly.topics";
+  public static final String KSQL_INTERNAL_READONLY_TOPICS_DEFAULT = "_confluent.*,__confluent.*"
+      + ",_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,"
+      + "connect-status,connect-statuses";
+  public static final String KSQL_INTERNAL_READONLY_TOPICS_DOC = "List of topics that KSQL will "
+      + " handle as read-only. These topics cannot be modified by any KSQL command. This list "
+      + "is comma separated and may use Java regular expressions to specify each topic (i.e. "
+      + " _confluent.* accepts any topic that starts with the _confluent prefix).";
 
   private enum ConfigGeneration {
     LEGACY,
@@ -543,11 +551,17 @@ public class KsqlConfig extends AbstractConfig {
             Importance.LOW,
             KSQL_AUTH_CACHE_MAX_ENTRIES_DOC
         ).define(
-            SYSTEM_INTERNAL_TOPICS_CONFIG,
+            KSQL_INTERNAL_HIDDEN_TOPICS_CONFIG,
             Type.LIST,
-            SYSTEM_INTERNAL_TOPICS_DEFAULT,
+            KSQL_INTERNAL_HIDDEN_TOPICS_DEFAULT,
             Importance.LOW,
-            SYSTEM_INTERNAL_TOPICS_DOC
+            KSQL_INTERNAL_HIDDEN_TOPICS_DOC
+        ).define(
+            KSQL_INTERNAL_READONLY_TOPICS_CONFIG,
+            Type.LIST,
+            KSQL_INTERNAL_READONLY_TOPICS_DEFAULT,
+            Importance.LOW,
+            KSQL_INTERNAL_READONLY_TOPICS_DOC
         )
         .withClientSslSupport();
 

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
@@ -23,7 +23,6 @@ public final class KsqlConstants {
   public static final String CONFLUENT_AUTHOR = "Confluent";
 
   public static final String KSQL_INTERNAL_TOPIC_PREFIX = "_confluent-ksql-";
-  public static final String CONFLUENT_INTERNAL_TOPIC_PREFIX = "__confluent";
 
   public static final String STREAMS_CHANGELOG_TOPIC_SUFFIX = "-changelog";
   public static final String STREAMS_REPARTITION_TOPIC_SUFFIX = "-repartition";

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
@@ -22,8 +22,6 @@ public final class KsqlConstants {
 
   public static final String CONFLUENT_AUTHOR = "Confluent";
 
-  public static final String KSQL_INTERNAL_TOPIC_PREFIX = "_confluent-ksql-";
-
   public static final String STREAMS_CHANGELOG_TOPIC_SUFFIX = "-changelog";
   public static final String STREAMS_REPARTITION_TOPIC_SUFFIX = "-repartition";
 

--- a/ksql-common/src/main/java/io/confluent/ksql/util/ReservedInternalTopics.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/ReservedInternalTopics.java
@@ -20,6 +20,8 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 
 public final class ReservedInternalTopics {
+  public static final String KSQL_INTERNAL_TOPIC_PREFIX = "_confluent-ksql-";
+
   private static final Set<String> ALL_INTERNAL_TOPICS_PREFIXES = ImmutableSet.of(
       // Confluent
       "_confluent",
@@ -52,10 +54,11 @@ public final class ReservedInternalTopics {
   }
 
   private static boolean isPrefix(final String topicName) {
-    return ALL_INTERNAL_TOPICS_PREFIXES.stream()
-        .filter(topicName::startsWith)
-        .findAny()
-        .isPresent();
+    return topicName.startsWith(KSQL_INTERNAL_TOPIC_PREFIX)
+        || ALL_INTERNAL_TOPICS_PREFIXES.stream()
+            .filter(topicName::startsWith)
+            .findAny()
+            .isPresent();
   }
 
   private static boolean isLiteral(final String topicName) {

--- a/ksql-common/src/main/java/io/confluent/ksql/util/ReservedInternalTopics.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/ReservedInternalTopics.java
@@ -105,7 +105,7 @@ public final class ReservedInternalTopics {
 
   public ReservedInternalTopics(final KsqlConfig ksqlConfig) {
     final ProcessingLogConfig processingLogConfig =
-        new ProcessingLogConfig(ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
+        new ProcessingLogConfig(ksqlConfig.getProcessingLogConfigProps());
 
     this.hiddenTopicsPattern = Pattern.compile(
         Streams.concat(

--- a/ksql-common/src/main/java/io/confluent/ksql/util/ReservedInternalTopics.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/ReservedInternalTopics.java
@@ -21,9 +21,47 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public final class ReservedInternalTopics {
-  // This constant should not be part of KsqlConfig.SYSTEM_INTERNAL_TOPICS_CONFIG because it is
-  // not configurable. KSQL must always hide its own internal topics.
+  // These constant should not be part of KsqlConfig.SYSTEM_INTERNAL_TOPICS_CONFIG because they're
+  // not configurable.
   public static final String KSQL_INTERNAL_TOPIC_PREFIX = "_confluent-ksql-";
+  public static final String KSQL_COMMAND_TOPIC_SUFFIX = "command_topic";
+  public static final String KSQL_CONFIGS_TOPIC_SUFFIX = "configs";
+
+  /**
+   * Returns the internal KSQL command topic.
+   *
+   * @param ksqlConfig The KSQL config, which is used to extract the internal topic prefix.
+   * @return The command topic name.
+   */
+  public static String commandTopic(final KsqlConfig ksqlConfig) {
+    return toKsqlInternalTopic(ksqlConfig, KSQL_COMMAND_TOPIC_SUFFIX);
+  }
+
+  /**
+   * Returns the internal KSQL configs topic (used for KSQL standalone)
+   *
+   * @param ksqlConfig The KSQL config, which is used to extract the internal topic prefix.
+   * @return The configurations topic name.
+   */
+  public static String configsTopic(final KsqlConfig ksqlConfig) {
+    return toKsqlInternalTopic(ksqlConfig, KSQL_CONFIGS_TOPIC_SUFFIX);
+  }
+
+  /**
+   * Compute a name for a KSQL internal topic.
+   *
+   * @param ksqlConfig The KSQL config, which is used to extract the internal topic prefix.
+   * @param topicSuffix A suffix that is appended to the topic name.
+   * @return The computed topic name.
+   */
+  public static String toKsqlInternalTopic(final KsqlConfig ksqlConfig, final String topicSuffix) {
+    return String.format(
+        "%s%s_%s",
+        KSQL_INTERNAL_TOPIC_PREFIX,
+        ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG),
+        topicSuffix
+    );
+  }
 
   private final List<Pattern> systemInternalTopics;
 

--- a/ksql-common/src/main/java/io/confluent/ksql/util/ReservedInternalTopics.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/ReservedInternalTopics.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
+
+public final class ReservedInternalTopics {
+  private static final Set<String> ALL_INTERNAL_TOPICS_PREFIXES = ImmutableSet.of(
+      // Confluent
+      "_confluent",
+      "__confluent"
+  );
+
+  private static final Set<String> ALL_INTERNAL_TOPICS_LITERALS = ImmutableSet.of(
+      // Security
+      "_secrets",
+
+      // Kafka
+      "__consumer_offsets",
+      "__transaction_state",
+
+      // Replicator
+      "__consumer_timestamps",
+
+      // Schema Registry
+      "_schemas",
+
+      // Connect
+      "connect-configs",
+      "connect-offsets",
+      "connect-status",
+      "connect-statuses"
+  );
+
+  public static boolean isInternalTopic(final String topicName) {
+    return isLiteral(topicName) || isPrefix(topicName);
+  }
+
+  private static boolean isPrefix(final String topicName) {
+    return ALL_INTERNAL_TOPICS_PREFIXES.stream()
+        .filter(topicName::startsWith)
+        .findAny()
+        .isPresent();
+  }
+
+  private static boolean isLiteral(final String topicName) {
+    return ALL_INTERNAL_TOPICS_LITERALS.contains(topicName);
+  }
+
+  private ReservedInternalTopics() {
+  }
+}

--- a/ksql-common/src/main/java/io/confluent/ksql/util/ReservedInternalTopics.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/ReservedInternalTopics.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.util;
 import com.google.common.collect.Streams;
 import io.confluent.ksql.logging.processing.ProcessingLogConfig;
 
-import java.util.Arrays;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -110,7 +109,7 @@ public final class ReservedInternalTopics {
     this.hiddenTopicsPattern = Pattern.compile(
         Streams.concat(
             Stream.of(KSQL_INTERNAL_TOPIC_PREFIX + ".*"),
-            toStream(ksqlConfig.getString(KsqlConfig.KSQL_HIDDEN_TOPICS_CONFIG))
+            ksqlConfig.getList(KsqlConfig.KSQL_HIDDEN_TOPICS_CONFIG).stream()
         ).collect(Collectors.joining("|"))
     );
 
@@ -118,7 +117,7 @@ public final class ReservedInternalTopics {
         Streams.concat(
             Stream.of(processingLogTopic(processingLogConfig, ksqlConfig)),
             Stream.of(KSQL_INTERNAL_TOPIC_PREFIX + ".*"),
-            toStream(ksqlConfig.getString(KsqlConfig.KSQL_READONLY_TOPICS_CONFIG))
+            ksqlConfig.getList(KsqlConfig.KSQL_READONLY_TOPICS_CONFIG).stream()
         ).collect(Collectors.joining("|"))
     );
   }
@@ -135,9 +134,5 @@ public final class ReservedInternalTopics {
 
   public boolean isReadOnly(final String topicName) {
     return readOnlyTopicsPattern.matcher(topicName).matches();
-  }
-
-  private Stream<String> toStream(final String s) {
-    return Arrays.stream(s.split(","));
   }
 }

--- a/ksql-common/src/test/java/io/confluent/ksql/configdef/ConfigValidatorsTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/configdef/ConfigValidatorsTest.java
@@ -207,6 +207,19 @@ public class ConfigValidatorsTest {
     // Then: did not throw.
   }
 
+  @Test
+  public void shouldThrowOnInvalidRegex() {
+    // Given:
+    final Validator validator = ConfigValidators.validRegex();
+
+    // Then:
+    expectedException.expect(ConfigException.class);
+    expectedException.expectMessage("Not valid regular expression: ");
+
+    // When:
+    validator.ensureValid("propName", "*_suffix");
+  }
+
   private enum TestEnum {
     FOO, BAR
   }

--- a/ksql-common/src/test/java/io/confluent/ksql/configdef/ConfigValidatorsTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/configdef/ConfigValidatorsTest.java
@@ -19,6 +19,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
 import java.util.function.Function;
 import org.apache.kafka.common.config.ConfigDef.Validator;
 import org.apache.kafka.common.config.ConfigException;
@@ -208,6 +209,17 @@ public class ConfigValidatorsTest {
   }
 
   @Test
+  public void shouldNotThrowOnValidRegex() {
+    // Given
+    final Validator validator = ConfigValidators.validRegex();
+
+    // When:
+    validator.ensureValid("propName", Collections.singletonList("prefix_.*"));
+
+    // Then: did not throw.
+  }
+
+  @Test
   public void shouldThrowOnInvalidRegex() {
     // Given:
     final Validator validator = ConfigValidators.validRegex();
@@ -217,7 +229,33 @@ public class ConfigValidatorsTest {
     expectedException.expectMessage("Not valid regular expression: ");
 
     // When:
-    validator.ensureValid("propName", "*_suffix");
+    validator.ensureValid("propName", Collections.singletonList("*_suffix"));
+  }
+
+  @Test
+  public void shouldThrowOnNoRegexList() {
+    // Given:
+    final Validator validator = ConfigValidators.validRegex();
+
+    // Then:
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("validator should only be used with LIST of STRING defs");
+
+    // When:
+    validator.ensureValid("propName", "*.*");
+  }
+
+  @Test
+  public void shouldThrowOnNoStringRegexList() {
+    // Given:
+    final Validator validator = ConfigValidators.validRegex();
+
+    // Then:
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("validator should only be used with LIST of STRING defs");
+
+    // When:
+    validator.ensureValid("propName", Collections.singletonList(1));
   }
 
   private enum TestEnum {

--- a/ksql-common/src/test/java/io/confluent/ksql/util/ReservedInternalTopicsTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/ReservedInternalTopicsTest.java
@@ -86,4 +86,16 @@ public class ReservedInternalTopicsTest {
       assertThat(isReserved, is(false));
     });
   }
+
+  @Test
+  public void shouldReturnTrueOnKsqlInternalTopics() {
+    // Given
+    final String ksqlInternalTopic = ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX + "_test";
+
+    // When
+    final boolean isReserved = ReservedInternalTopics.isInternalTopic(ksqlInternalTopic);
+
+    // Then
+    assertThat(isReserved, is(true));
+  }
 }

--- a/ksql-common/src/test/java/io/confluent/ksql/util/ReservedInternalTopicsTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/ReservedInternalTopicsTest.java
@@ -43,8 +43,8 @@ public class ReservedInternalTopicsTest {
   @Before
   public void setUp() {
     ksqlConfig = new KsqlConfig(ImmutableMap.of(
-        KsqlConfig.KSQL_INTERNAL_HIDDEN_TOPICS_CONFIG, "prefix_.*,literal,.*_suffix",
-        KsqlConfig.KSQL_INTERNAL_READONLY_TOPICS_CONFIG, "ro_prefix_.*,ro_literal,.*_suffix_ro"
+        KsqlConfig.KSQL_HIDDEN_TOPICS_CONFIG, "prefix_.*,literal,.*_suffix",
+        KsqlConfig.KSQL_READONLY_TOPICS_CONFIG, "ro_prefix_.*,ro_literal,.*_suffix_ro"
     ));
 
     internalTopics = new ReservedInternalTopics(ksqlConfig);
@@ -137,38 +137,6 @@ public class ReservedInternalTopicsTest {
 
     // Then
     assertThat(filteredTopics, is(ImmutableSet.of("tt", "name1", "suffix")));
-  }
-
-  @Test
-  public void shouldThrowWhenInvalidInternalHiddenTopicsListIsUsed() {
-    // Given
-    final KsqlConfig givenConfig = new KsqlConfig(ImmutableMap.of(
-        KsqlConfig.KSQL_INTERNAL_HIDDEN_TOPICS_CONFIG, "*_suffix"
-    ));
-
-    // Then
-    expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Invalid pattern list in '"
-        + KsqlConfig.KSQL_INTERNAL_HIDDEN_TOPICS_CONFIG + "'");
-
-    // When
-    new ReservedInternalTopics(givenConfig);
-  }
-
-  @Test
-  public void shouldThrowWhenInvalidInternalReadOnlyTopicsListIsUsed() {
-    // Given
-    final KsqlConfig givenConfig = new KsqlConfig(ImmutableMap.of(
-        KsqlConfig.KSQL_INTERNAL_READONLY_TOPICS_CONFIG, "*_suffix"
-    ));
-
-    // Then
-    expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Invalid pattern list in '"
-        + KsqlConfig.KSQL_INTERNAL_READONLY_TOPICS_CONFIG + "'");
-
-    // When
-    new ReservedInternalTopics(givenConfig);
   }
 
   @Test

--- a/ksql-common/src/test/java/io/confluent/ksql/util/ReservedInternalTopicsTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/ReservedInternalTopicsTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+
+import java.util.Set;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class ReservedInternalTopicsTest {
+  private static final Set<String> ALL_INTERNAL_TOPICS_PREFIXES = ImmutableSet.of(
+      // Confluent
+      "_confluent",
+      "__confluent"
+  );
+
+  private static final Set<String> ALL_INTERNAL_TOPICS_LITERALS = ImmutableSet.of(
+      // Confluent
+      "_secrets",
+
+      // Kafka
+      "__consumer_offsets",
+      "__transaction_state",
+
+      // Replicator
+      "__consumer_timestamps",
+
+      // Schema Registry
+      "_schemas",
+
+      // Connect
+      "connect-configs",
+      "connect-offsets",
+      "connect-status",
+      "connect-statuses"
+  );
+
+  @Test
+  public void shouldReturnTrueOnAllInternalTopicsPrefixes() {
+    // Given
+    ALL_INTERNAL_TOPICS_PREFIXES.forEach(topic -> {
+      // When
+      final boolean isReserved = ReservedInternalTopics.isInternalTopic(topic + "_any_name");
+
+      // Then
+      assertThat(isReserved, is(true));
+    });
+  }
+
+  @Test
+  public void shouldReturnTrueOnAllInternalTopicsLiterals() {
+    // Given
+    ALL_INTERNAL_TOPICS_LITERALS.forEach(topic -> {
+      // When
+      final boolean isReserved = ReservedInternalTopics.isInternalTopic(topic);
+
+      // Then
+      assertThat(isReserved, is(true));
+    });
+  }
+
+  @Test
+  public void shouldReturnFalseOnAnyNonInternalTopic() {
+    // Given
+    ALL_INTERNAL_TOPICS_PREFIXES.forEach(topic -> {
+      // When
+      final boolean isReserved = ReservedInternalTopics.isInternalTopic("any_name_" + topic);
+
+      // Then
+      assertThat(isReserved, is(false));
+    });
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.VisitParentExpressionVisitor;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.logging.processing.NoopProcessingLogContext;
+import io.confluent.ksql.logging.processing.ProcessingLogConfig;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
@@ -191,6 +192,15 @@ public class InsertValuesExecutor {
     final ReservedInternalTopics internalTopics = new ReservedInternalTopics(ksqlConfig);
     if (internalTopics.isInternalTopic(dataSource.getKafkaTopicName())) {
       throw new KsqlException("Cannot insert values into the reserved internal topic: "
+          + dataSource.getKafkaTopicName());
+    }
+
+    final ProcessingLogConfig processingLogConfig =
+        new ProcessingLogConfig(ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
+    final String processingLogTopic =
+        ReservedInternalTopics.processingLogTopic(processingLogConfig, ksqlConfig);
+    if (dataSource.getKafkaTopicName().equals(processingLogTopic)) {
+      throw new KsqlException("Cannot insert into the processing log topic: "
           + dataSource.getKafkaTopicName());
     }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
@@ -28,7 +28,6 @@ import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.VisitParentExpressionVisitor;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.logging.processing.NoopProcessingLogContext;
-import io.confluent.ksql.logging.processing.ProcessingLogConfig;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
@@ -190,17 +189,8 @@ public class InsertValuesExecutor {
     }
 
     final ReservedInternalTopics internalTopics = new ReservedInternalTopics(ksqlConfig);
-    if (internalTopics.isInternalTopic(dataSource.getKafkaTopicName())) {
-      throw new KsqlException("Cannot insert values into the reserved internal topic: "
-          + dataSource.getKafkaTopicName());
-    }
-
-    final ProcessingLogConfig processingLogConfig =
-        new ProcessingLogConfig(ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
-    final String processingLogTopic =
-        ReservedInternalTopics.processingLogTopic(processingLogConfig, ksqlConfig);
-    if (dataSource.getKafkaTopicName().equals(processingLogTopic)) {
-      throw new KsqlException("Cannot insert into the processing log topic: "
+    if (internalTopics.isReadOnly(dataSource.getKafkaTopicName())) {
+      throw new KsqlException("Cannot insert values into read-only topic: "
           + dataSource.getKafkaTopicName());
     }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
@@ -17,8 +17,8 @@ package io.confluent.ksql.internal;
 
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.metrics.MetricCollectors;
-import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.QueryMetadata;
+import io.confluent.ksql.util.ReservedInternalTopics;
 import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -88,7 +88,8 @@ public class KsqlEngineMetrics implements Closeable {
       final Optional<KsqlMetricsExtension> metricsExtension
   ) {
     this.ksqlEngine = ksqlEngine;
-    this.ksqlServiceId = KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX + ksqlEngine.getServiceId();
+    this.ksqlServiceId = ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX
+        + ksqlEngine.getServiceId();
     this.sensors = new ArrayList<>();
     this.countMetrics = new ArrayList<>();
     this.metricGroupPrefix = Objects.requireNonNull(metricGroupPrefix, "metricGroupPrefix");

--- a/ksql-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -46,10 +46,10 @@ import io.confluent.ksql.serde.GenericKeySerDe;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
+import io.confluent.ksql.util.ReservedInternalTopics;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -274,7 +274,7 @@ public final class QueryExecutor {
   }
 
   private String getServiceId() {
-    return KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX
+    return ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX
         + ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG);
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -25,7 +25,6 @@ import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlServerException;
 import io.confluent.ksql.util.Pair;
-import io.confluent.ksql.util.ReservedInternalTopics;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -174,13 +173,6 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
     } catch (final Exception e) {
       throw new KafkaResponseGetFailedException("Failed to retrieve Kafka Topic names", e);
     }
-  }
-
-  @Override
-  public Set<String> listNonInternalTopicNames() {
-    return listTopicNames().stream()
-        .filter(topic -> !ReservedInternalTopics.isInternalTopic(topic))
-        .collect(Collectors.toSet());
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -25,6 +25,7 @@ import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlServerException;
 import io.confluent.ksql.util.Pair;
+import io.confluent.ksql.util.ReservedInternalTopics;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -178,8 +179,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
   @Override
   public Set<String> listNonInternalTopicNames() {
     return listTopicNames().stream()
-        .filter((topic) -> !(topic.startsWith(KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX)
-            || topic.startsWith(KsqlConstants.CONFLUENT_INTERNAL_TOPIC_PREFIX)))
+        .filter(topic -> !ReservedInternalTopics.isInternalTopic(topic))
         .collect(Collectors.toSet());
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
@@ -562,7 +562,7 @@ public class InsertValuesExecutorTest {
     // Expect:
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage(
-        "Cannot insert values into the reserved internal topic: _confluent-ksql-default__command-topic");
+        "Cannot insert values into read-only topic: _confluent-ksql-default__command-topic");
 
     // When:
     executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
@@ -592,7 +592,7 @@ public class InsertValuesExecutorTest {
     // Expect:
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage(
-        "Cannot insert into the processing log topic: default_ksql_processing_log");
+        "Cannot insert values into read-only topic: default_ksql_processing_log");
 
     // When:
     executor.execute(statement, ImmutableMap.of(), engine, serviceContext);

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
@@ -569,6 +569,36 @@ public class InsertValuesExecutorTest {
   }
 
   @Test
+  public void shouldThrowWhenInsertValuesOnProcessingLogTopic() {
+    // Given
+    givenDataSourceWithSchema("default_ksql_processing_log", SCHEMA,
+        SerdeOption.none(), Optional.of(COL0), false);
+
+    final ConfiguredStatement<InsertValues> statement = ConfiguredStatement.of(
+        PreparedStatement.of(
+            "",
+            new InsertValues(SourceName.of("TOPIC"),
+                allFieldNames(SCHEMA),
+                ImmutableList.of(
+                    new LongLiteral(1L),
+                    new StringLiteral("str"),
+                    new StringLiteral("str"),
+                    new LongLiteral(2L)
+                ))),
+        ImmutableMap.of(),
+        new KsqlConfig(ImmutableMap.of())
+    );
+
+    // Expect:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage(
+        "Cannot insert into the processing log topic: default_ksql_processing_log");
+
+    // When:
+    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+  }
+
+  @Test
   public void shouldThrowOnProducerSendError() throws ExecutionException, InterruptedException {
     // Given:
     final ConfiguredStatement<InsertValues> statement = givenInsertValues(

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
@@ -539,6 +539,36 @@ public class InsertValuesExecutorTest {
   }
 
   @Test
+  public void shouldThrowWhenInsertValuesOnReservedInternalTopic() {
+    // Given
+    givenDataSourceWithSchema("_confluent-ksql-default__command-topic", SCHEMA,
+        SerdeOption.none(), Optional.of(COL0), false);
+
+    final ConfiguredStatement<InsertValues> statement = ConfiguredStatement.of(
+        PreparedStatement.of(
+            "",
+            new InsertValues(SourceName.of("TOPIC"),
+                allFieldNames(SCHEMA),
+                ImmutableList.of(
+                    new LongLiteral(1L),
+                    new StringLiteral("str"),
+                    new StringLiteral("str"),
+                    new LongLiteral(2L)
+                ))),
+        ImmutableMap.of(),
+        new KsqlConfig(ImmutableMap.of())
+    );
+
+    // Expect:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage(
+        "Cannot insert values into the reserved internal topic: _confluent-ksql-default__command-topic");
+
+    // When:
+    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+  }
+
+  @Test
   public void shouldThrowOnProducerSendError() throws ExecutionException, InterruptedException {
     // Given:
     final ConfiguredStatement<InsertValues> statement = givenInsertValues(
@@ -850,24 +880,25 @@ public class InsertValuesExecutorTest {
       final Set<SerdeOption> serdeOptions,
       final Optional<ColumnName> keyField
   ) {
-    givenDataSourceWithSchema(schema, serdeOptions, keyField, false);
+    givenDataSourceWithSchema(TOPIC_NAME, schema, serdeOptions, keyField, false);
   }
 
   private void givenSourceTableWithSchema(
       final Set<SerdeOption> serdeOptions,
       final Optional<ColumnName> keyField
   ) {
-    givenDataSourceWithSchema(SCHEMA, serdeOptions, keyField, true);
+    givenDataSourceWithSchema(TOPIC_NAME, SCHEMA, serdeOptions, keyField, true);
   }
 
   private void givenDataSourceWithSchema(
+      final String topicName,
       final LogicalSchema schema,
       final Set<SerdeOption> serdeOptions,
       final Optional<ColumnName> keyField,
       final boolean table
   ) {
     final KsqlTopic topic = new KsqlTopic(
-        TOPIC_NAME,
+        topicName,
         KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
         ValueFormat.of(FormatInfo.of(Format.JSON))
     );

--- a/ksql-engine/src/test/java/io/confluent/ksql/internal/KsqlEngineMetricsTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/internal/KsqlEngineMetricsTest.java
@@ -40,6 +40,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
+
+import io.confluent.ksql.util.ReservedInternalTopics;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -66,7 +68,8 @@ public class KsqlEngineMetricsTest {
   private static final String METRIC_GROUP = "testGroup";
   private KsqlEngineMetrics engineMetrics;
   private static final String KSQL_SERVICE_ID = "test-ksql-service-id";
-  private static final String metricNamePrefix = KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX + KSQL_SERVICE_ID;
+  private static final String metricNamePrefix = ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX
+      + KSQL_SERVICE_ID;
   private static final Map<String, String> CUSTOM_TAGS = ImmutableMap.of("tag1", "value1", "tag2", "value2");
 
   @Mock

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/FakeKafkaTopicClient.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/FakeKafkaTopicClient.java
@@ -20,7 +20,7 @@ import static org.apache.kafka.common.config.TopicConfig.CLEANUP_POLICY_CONFIG;
 
 import com.google.common.collect.Sets;
 import io.confluent.ksql.topic.TopicProperties;
-import io.confluent.ksql.util.KsqlConstants;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -31,6 +31,8 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import io.confluent.ksql.util.ReservedInternalTopics;
 import org.apache.kafka.clients.admin.CreateTopicsOptions;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.Node;
@@ -158,8 +160,7 @@ public class FakeKafkaTopicClient implements KafkaTopicClient {
   @Override
   public Set<String> listNonInternalTopicNames() {
     return topicMap.keySet().stream()
-        .filter((topic) -> (!topic.startsWith(KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX)
-            || !topic.startsWith(KsqlConstants.CONFLUENT_INTERNAL_TOPIC_PREFIX)))
+        .filter(topic -> !ReservedInternalTopics.isInternalTopic(topic))
         .collect(Collectors.toSet());
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/FakeKafkaTopicClient.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/FakeKafkaTopicClient.java
@@ -32,7 +32,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import io.confluent.ksql.util.ReservedInternalTopics;
 import org.apache.kafka.clients.admin.CreateTopicsOptions;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.Node;
@@ -155,13 +154,6 @@ public class FakeKafkaTopicClient implements KafkaTopicClient {
   @Override
   public Set<String> listTopicNames() {
     return topicMap.keySet();
-  }
-
-  @Override
-  public Set<String> listNonInternalTopicNames() {
-    return topicMap.keySet().stream()
-        .filter(topic -> !ReservedInternalTopics.isInternalTopic(topic))
-        .collect(Collectors.toSet());
   }
 
   @Override

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
@@ -47,6 +47,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
+
+import io.confluent.ksql.util.ReservedInternalTopics;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType;
@@ -95,12 +97,12 @@ public class KafkaTopicClientImplTest {
   private static final String topicName2 = "topic2";
   private static final String topicName3 = "topic3";
   private static final String internalTopic1 = String.format("%s%s_%s",
-      KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX,
+      ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX,
       "default",
       "query_CTAS_USERS_BY_CITY-KSTREAM-AGGREGATE"
           + "-STATE-STORE-0000000006-repartition");
   private static final String internalTopic2 = String.format("%s%s_%s",
-      KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX,
+      ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX,
       "default",
       "query_CTAS_USERS_BY_CITY-KSTREAM-AGGREGATE"
           + "-STATE-STORE-0000000006-changelog");
@@ -324,7 +326,7 @@ public class KafkaTopicClientImplTest {
     replay(adminClient);
     final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
     final String applicationId = String.format("%s%s",
-        KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX,
+        ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX,
         "default_query_CTAS_USERS_BY_CITY");
     kafkaTopicClient.deleteInternalTopics(applicationId);
     verify(adminClient);

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
@@ -105,7 +105,8 @@ public class KafkaTopicClientImplTest {
       "default",
       "query_CTAS_USERS_BY_CITY-KSTREAM-AGGREGATE"
           + "-STATE-STORE-0000000006-changelog");
-  private static final String confluentInternalTopic = "_confluent-confluent-control-center";
+  private static final String internalTopic = String.format("%s_internal",
+      ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX);
   private Node node;
   @Mock
   private AdminClient adminClient;
@@ -645,7 +646,7 @@ public class KafkaTopicClientImplTest {
     final ListTopicsResult listTopicsResult = mock(ListTopicsResult.class);
     final List<String> topicNamesList = Arrays.asList(topicName1, topicName2, topicName3,
         internalTopic1, internalTopic2,
-        confluentInternalTopic);
+        internalTopic);
     expect(listTopicsResult.names())
         .andReturn(KafkaFuture.completedFuture(new HashSet<>(topicNamesList)));
     replay(listTopicsResult);

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
@@ -33,7 +33,6 @@ import io.confluent.ksql.exception.KafkaDeleteTopicsException;
 import io.confluent.ksql.exception.KafkaResponseGetFailedException;
 import io.confluent.ksql.exception.KafkaTopicExistsException;
 import io.confluent.ksql.exception.KsqlTopicAuthorizationException;
-import io.confluent.ksql.util.KsqlConstants;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -272,16 +271,6 @@ public class KafkaTopicClientImplTest {
     replay(adminClient);
     final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
     final Set<String> names = kafkaTopicClient.listTopicNames();
-    assertThat(names, equalTo(Utils.mkSet(topicName1, topicName2, topicName3)));
-    verify(adminClient);
-  }
-
-  @Test
-  public void shouldFilterInternalTopics() {
-    expect(adminClient.listTopics()).andReturn(getListTopicsResultWithInternalTopics());
-    replay(adminClient);
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
-    final Set<String> names = kafkaTopicClient.listNonInternalTopicNames();
     assertThat(names, equalTo(Utils.mkSet(topicName1, topicName2, topicName3)));
     verify(adminClient);
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
@@ -104,9 +104,7 @@ public class KafkaTopicClientImplTest {
       "default",
       "query_CTAS_USERS_BY_CITY-KSTREAM-AGGREGATE"
           + "-STATE-STORE-0000000006-changelog");
-  private static final String confluentInternalTopic =
-      String.format("%s-%s", KsqlConstants.CONFLUENT_INTERNAL_TOPIC_PREFIX,
-          "confluent-control-center");
+  private static final String confluentInternalTopic = "_confluent-confluent-control-center";
   private Node node;
   @Mock
   private AdminClient adminClient;

--- a/ksql-execution/src/main/java/io/confluent/ksql/services/KafkaTopicClient.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/services/KafkaTopicClient.java
@@ -141,13 +141,6 @@ public interface KafkaTopicClient {
   Set<String> listTopicNames();
 
   /**
-   * Call to retrieve list of internal topics
-   *
-   * @return set of all non-internal topics
-   */
-  Set<String> listNonInternalTopicNames();
-
-  /**
    * Call to get a one or more topic's description.
    *
    * @param topicNames topicNames to describe

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/stubs/StubKafkaTopicClient.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/stubs/StubKafkaTopicClient.java
@@ -22,7 +22,6 @@ import com.google.common.collect.Sets;
 import io.confluent.ksql.exception.KafkaTopicExistsException;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.topic.TopicProperties;
-import io.confluent.ksql.util.ReservedInternalTopics;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -135,13 +134,6 @@ public class StubKafkaTopicClient implements KafkaTopicClient {
   @Override
   public Set<String> listTopicNames() {
     return topicMap.keySet();
-  }
-
-  @Override
-  public Set<String> listNonInternalTopicNames() {
-    return topicMap.keySet().stream()
-        .filter(topic -> !ReservedInternalTopics.isInternalTopic(topic))
-        .collect(Collectors.toSet());
   }
 
   @Override

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/stubs/StubKafkaTopicClient.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/stubs/StubKafkaTopicClient.java
@@ -22,7 +22,7 @@ import com.google.common.collect.Sets;
 import io.confluent.ksql.exception.KafkaTopicExistsException;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.topic.TopicProperties;
-import io.confluent.ksql.util.KsqlConstants;
+import io.confluent.ksql.util.ReservedInternalTopics;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -140,8 +140,7 @@ public class StubKafkaTopicClient implements KafkaTopicClient {
   @Override
   public Set<String> listNonInternalTopicNames() {
     return topicMap.keySet().stream()
-        .filter((topic) -> (!topic.startsWith(KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX)
-            || !topic.startsWith(KsqlConstants.CONFLUENT_INTERNAL_TOPIC_PREFIX)))
+        .filter(topic -> !ReservedInternalTopics.isInternalTopic(topic))
         .collect(Collectors.toSet());
   }
 

--- a/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -34,7 +34,7 @@ singleExpression
 statement
     : query                                                                 #queryStatement
     | (LIST | SHOW) PROPERTIES                                              #listProperties
-    | (LIST | SHOW) TOPICS EXTENDED?                                        #listTopics
+    | (LIST | SHOW) ALL? TOPICS EXTENDED?                                   #listTopics
     | (LIST | SHOW) STREAMS EXTENDED?                                       #listStreams
     | (LIST | SHOW) TABLES EXTENDED?                                        #listTables
     | (LIST | SHOW) FUNCTIONS                                               #listFunctions

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -579,7 +579,8 @@ public class AstBuilder {
 
     @Override
     public Node visitListTopics(final SqlBaseParser.ListTopicsContext context) {
-      return new ListTopics(getLocation(context), context.EXTENDED() != null);
+      return new ListTopics(getLocation(context),
+          context.ALL() != null, context.EXTENDED() != null);
     }
 
     @Override

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListTopics.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListTopics.java
@@ -23,11 +23,21 @@ import java.util.Optional;
 
 public class ListTopics extends Statement {
 
+  private final boolean showAll;
   private final boolean showExtended;
 
-  public ListTopics(final Optional<NodeLocation> location, final boolean showExtended) {
+  public ListTopics(
+      final Optional<NodeLocation> location,
+      final boolean showAll,
+      final boolean showExtended
+  ) {
     super(location);
+    this.showAll = showAll;
     this.showExtended = showExtended;
+  }
+
+  public boolean getShowAll() {
+    return showAll;
   }
 
   public boolean getShowExtended() {
@@ -43,17 +53,18 @@ public class ListTopics extends Statement {
       return false;
     }
     final ListTopics that = (ListTopics) o;
-    return showExtended == that.showExtended;
+    return showAll == that.showAll && showExtended == that.showExtended;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(showExtended);
+    return Objects.hash(showAll, showExtended);
   }
 
   @Override
   public String toString() {
     return toStringHelper(this)
+        .add("showAll", showAll)
         .add("showExtended", showExtended)
         .toString();
   }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -692,7 +692,7 @@ public class KsqlParserTest {
 
     // Then:
     Assert.assertTrue(statement instanceof ListTopics);
-    Assert.assertThat(listTopics.toString(), is("ListTopics{showExtended=false}"));
+    Assert.assertThat(listTopics.toString(), is("ListTopics{showAll=false, showExtended=false}"));
     Assert.assertThat(listTopics.getShowExtended(), is(false));
   }
 

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/ListTopicsTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/ListTopicsTest.java
@@ -34,8 +34,10 @@ public class ListTopicsTest {
             new ListTopics(Optional.of(OTHER_LOCATION), true, true)
         )
         .addEqualityGroup(
-            new ListTopics(Optional.of(SOME_LOCATION), false, false),
-            new ListTopics(Optional.of(OTHER_LOCATION), false,false)
+            new ListTopics(Optional.of(SOME_LOCATION), false, true)
+        )
+        .addEqualityGroup(
+            new ListTopics(Optional.of(SOME_LOCATION), true,false)
         )
         .testEquals();
   }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/ListTopicsTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/ListTopicsTest.java
@@ -30,12 +30,12 @@ public class ListTopicsTest {
     // Note: At the moment location does not take part in equality testing
     new EqualsTester()
         .addEqualityGroup(
-            new ListTopics(Optional.of(SOME_LOCATION), true),
-            new ListTopics(Optional.of(OTHER_LOCATION), true)
+            new ListTopics(Optional.of(SOME_LOCATION), true, true),
+            new ListTopics(Optional.of(OTHER_LOCATION), true, true)
         )
         .addEqualityGroup(
-            new ListTopics(Optional.of(SOME_LOCATION), false),
-            new ListTopics(Optional.of(OTHER_LOCATION), false)
+            new ListTopics(Optional.of(SOME_LOCATION), false, false),
+            new ListTopics(Optional.of(OTHER_LOCATION), false,false)
         )
         .testEquals();
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -86,6 +86,7 @@ import io.confluent.ksql.services.SimpleKsqlClient;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlServerException;
+import io.confluent.ksql.util.ReservedInternalTopics;
 import io.confluent.ksql.util.RetryUtil;
 import io.confluent.ksql.util.Version;
 import io.confluent.ksql.util.WelcomeMsgUtils;
@@ -565,8 +566,7 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
 
     UserFunctionLoader.newInstance(ksqlConfig, functionRegistry, ksqlInstallDir).load();
 
-    final String commandTopicName = KsqlInternalTopicUtils.getTopicName(
-        ksqlConfig, KsqlRestConfig.COMMAND_TOPIC_SUFFIX);
+    final String commandTopicName = ReservedInternalTopics.commandTopic(ksqlConfig);
 
     final CommandStore commandStore = CommandStore.Factory.create(
         commandTopicName,

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -77,8 +77,6 @@ public class KsqlRestConfig extends RestConfig {
   private static final String INSTALL_DIR_DOC
       = "The directory that ksql is installed in. This is set in the ksql-server-start script.";
 
-  static final String COMMAND_TOPIC_SUFFIX = "command_topic";
-
   static final String KSQL_WEBSOCKETS_NUM_THREADS =
       KSQL_CONFIG_PREFIX + "server.websockets.num.threads";
   private static final String KSQL_WEBSOCKETS_NUM_THREADS_DOC =

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutorFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutorFactory.java
@@ -34,6 +34,7 @@ import io.confluent.ksql.services.ServiceContextFactory;
 import io.confluent.ksql.statement.Injector;
 import io.confluent.ksql.statement.Injectors;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.ReservedInternalTopics;
 import io.confluent.ksql.version.metrics.KsqlVersionCheckerAgent;
 import io.confluent.ksql.version.metrics.VersionCheckerAgent;
 import java.util.Map;
@@ -42,8 +43,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 public final class StandaloneExecutorFactory {
-
-  static final String CONFIG_TOPIC_SUFFIX = "configs";
 
   private StandaloneExecutorFactory(){
   }
@@ -93,8 +92,7 @@ public final class StandaloneExecutorFactory {
 
     final ServiceContext serviceContext = serviceContextFactory.apply(baseConfig);
 
-    final String configTopicName
-        = KsqlInternalTopicUtils.getTopicName(baseConfig, CONFIG_TOPIC_SUFFIX);
+    final String configTopicName = ReservedInternalTopics.configsTopic(baseConfig);
     KsqlInternalTopicUtils.ensureTopic(
         configTopicName,
         baseConfig,

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunnerStatusMetric.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunnerStatusMetric.java
@@ -17,7 +17,7 @@ package io.confluent.ksql.rest.server.computation;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.metrics.MetricCollectors;
-import io.confluent.ksql.util.KsqlConstants;
+import io.confluent.ksql.util.ReservedInternalTopics;
 
 import java.io.Closeable;
 import java.util.Collections;
@@ -63,7 +63,7 @@ public class CommandRunnerStatusMetric implements Closeable {
     this.metricGroupName = metricsGroupPrefix + METRIC_GROUP_POST_FIX;
     this.metricName = metrics.metricName(
         "status",
-        KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX + ksqlServiceId + metricGroupName,
+        ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX + ksqlServiceId + metricGroupName,
        "The status of the commandRunner thread as it processes the command topic.",
         Collections.emptyMap()
     );

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/DistributingExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/DistributingExecutor.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.security.KsqlSecurityContext;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.statement.Injector;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlServerException;
 import io.confluent.ksql.util.ReservedInternalTopics;
@@ -95,6 +96,7 @@ public class DistributingExecutor {
 
     if (injected.getStatement() instanceof InsertInto) {
       throwIfInsertOnInternalTopic(
+          statement.getConfig(),
           executionContext.getMetaStore(),
           (InsertInto)injected.getStatement()
       );
@@ -172,6 +174,7 @@ public class DistributingExecutor {
   }
 
   private void throwIfInsertOnInternalTopic(
+      final KsqlConfig ksqlConfig,
       final MetaStore metaStore,
       final InsertInto insertInto
   ) {
@@ -181,7 +184,8 @@ public class DistributingExecutor {
           + insertInto.getTarget());
     }
 
-    if (ReservedInternalTopics.isInternalTopic(dataSource.getKafkaTopicName())) {
+    final ReservedInternalTopics internalTopics = new ReservedInternalTopics(ksqlConfig);
+    if (internalTopics.isInternalTopic(dataSource.getKafkaTopicName())) {
       throw new KsqlException("Cannot insert into the reserved internal topic: "
           + dataSource.getKafkaTopicName());
     }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/DistributingExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/DistributingExecutor.java
@@ -48,7 +48,6 @@ import org.apache.kafka.common.errors.ProducerFencedException;
  * {@code distributedCmdResponseTimeout}.
  */
 public class DistributingExecutor {
-  private final KsqlConfig ksqlConfig;
   private final CommandQueue commandQueue;
   private final Duration distributedCmdResponseTimeout;
   private final BiFunction<KsqlExecutionContext, ServiceContext, Injector> injectorFactory;
@@ -65,7 +64,6 @@ public class DistributingExecutor {
       final Optional<KsqlAuthorizationValidator> authorizationValidator,
       final ValidatedCommandFactory validatedCommandFactory
   ) {
-    this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig");
     this.commandQueue = Objects.requireNonNull(commandQueue, "commandQueue");
     this.distributedCmdResponseTimeout =
         Objects.requireNonNull(distributedCmdResponseTimeout, "distributedCmdResponseTimeout");
@@ -77,7 +75,8 @@ public class DistributingExecutor {
         "validatedCommandFactory"
     );
     this.commandIdAssigner = new CommandIdAssigner();
-    this.internalTopics = new ReservedInternalTopics(ksqlConfig);
+    this.internalTopics =
+        new ReservedInternalTopics(Objects.requireNonNull(ksqlConfig, "ksqlConfig"));
   }
 
   /**

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/DistributingExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/DistributingExecutor.java
@@ -180,7 +180,7 @@ public class DistributingExecutor {
       final MetaStore metaStore,
       final InsertInto insertInto
   ) {
-    final DataSource<?> dataSource = metaStore.getSource(insertInto.getTarget());
+    final DataSource dataSource = metaStore.getSource(insertInto.getTarget());
     if (dataSource == null) {
       throw new KsqlException("Cannot insert into an unknown stream/table: "
           + insertInto.getTarget());

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/DistributingExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/DistributingExecutor.java
@@ -15,6 +15,7 @@
 package io.confluent.ksql.rest.server.computation;
 
 import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.logging.processing.ProcessingLogConfig;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.parser.tree.InsertInto;
@@ -187,6 +188,15 @@ public class DistributingExecutor {
     final ReservedInternalTopics internalTopics = new ReservedInternalTopics(ksqlConfig);
     if (internalTopics.isInternalTopic(dataSource.getKafkaTopicName())) {
       throw new KsqlException("Cannot insert into the reserved internal topic: "
+          + dataSource.getKafkaTopicName());
+    }
+
+    final ProcessingLogConfig processingLogConfig =
+        new ProcessingLogConfig(ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
+    final String processingLogTopic =
+        ReservedInternalTopics.processingLogTopic(processingLogConfig, ksqlConfig);
+    if (dataSource.getKafkaTopicName().equals(processingLogTopic)) {
+      throw new KsqlException("Cannot insert into the processing log topic: "
           + dataSource.getKafkaTopicName());
     }
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutor.java
@@ -29,7 +29,7 @@ import io.confluent.ksql.util.KafkaConsumerGroupClient;
 import io.confluent.ksql.util.KafkaConsumerGroupClient.ConsumerSummary;
 import io.confluent.ksql.util.KafkaConsumerGroupClientImpl;
 import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.KsqlConstants;
+import io.confluent.ksql.util.ReservedInternalTopics;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -119,7 +119,7 @@ public final class ListTopicsExecutor {
       final KsqlConfig ksqlConfig
   ) {
     final Map<String, TopicDescription> filteredKafkaTopics = new HashMap<>();
-    final String serviceId = KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX
+    final String serviceId = ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX
         + ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG);
     final String persistentQueryPrefix = ksqlConfig.getString(
         KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutor.java
@@ -90,7 +90,7 @@ public final class ListTopicsExecutor {
 
     final Set<String> topics = statement.getStatement().getShowAll()
         ? topicClient.listTopicNames()
-        : internalTopics.filterInternalTopics(topicClient.listTopicNames());
+        : internalTopics.removeHiddenTopics(topicClient.listTopicNames());
 
     return new TreeMap<>(
         filterKsqlInternalTopics(topicClient.describeTopics(topics), statement.getConfig())

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutor.java
@@ -59,8 +59,12 @@ public final class ListTopicsExecutor {
   ) {
     final KafkaTopicClient client = serviceContext.getTopicClient();
 
-    final Map<String, TopicDescription> kafkaTopicDescriptions
-        = client.describeTopics(client.listNonInternalTopicNames());
+    final Map<String, TopicDescription> kafkaTopicDescriptions;
+    if (statement.getStatement().getShowAll()) {
+      kafkaTopicDescriptions = client.describeTopics(client.listTopicNames());
+    } else {
+      kafkaTopicDescriptions = client.describeTopics(client.listNonInternalTopicNames());
+    }
 
     final Map<String, TopicDescription> filteredDescriptions = new TreeMap<>(
         filterKsqlInternalTopics(kafkaTopicDescriptions, statement.getConfig()));

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -162,6 +162,7 @@ public class KsqlResource implements KsqlConfigurable {
     this.handler = new RequestHandler(
         CustomExecutors.EXECUTOR_MAP,
         new DistributingExecutor(
+            config,
             commandQueue,
             distributedCmdResponseTimeout,
             injectorFactory,

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtils.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtils.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.rest.util;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.ReservedInternalTopics;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.config.TopicConfig;
 import org.slf4j.Logger;
@@ -37,22 +36,6 @@ public final class KsqlInternalTopicUtils {
   private static final int NPARTITIONS = 1;
 
   private KsqlInternalTopicUtils() {
-  }
-
-  /**
-   * Compute a name for an internal topic.
-   *
-   * @param ksqlConfig The KSQL config, which is used to extract the internal topic prefix.
-   * @param topicSuffix A suffix that is appended to the topic name.
-   * @return The computed topic name.
-   */
-  public static String getTopicName(final KsqlConfig ksqlConfig, final String topicSuffix) {
-    return String.format(
-        "%s%s_%s",
-        ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX,
-        ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG),
-        topicSuffix
-    );
   }
 
   /**

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtils.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtils.java
@@ -18,7 +18,7 @@ package io.confluent.ksql.rest.util;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.KsqlConstants;
+import io.confluent.ksql.util.ReservedInternalTopics;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.config.TopicConfig;
 import org.slf4j.Logger;
@@ -49,7 +49,7 @@ public final class KsqlInternalTopicUtils {
   public static String getTopicName(final KsqlConfig ksqlConfig, final String topicSuffix) {
     return String.format(
         "%s%s_%s",
-        KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX,
+        ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX,
         ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG),
         topicSuffix
     );

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ProcessingLogServerUtils.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ProcessingLogServerUtils.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.schema.connect.SqlSchemaFormatter.Option;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.util.IdentifierUtil;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.ReservedInternalTopics;
 import java.util.Optional;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
@@ -50,16 +51,7 @@ public final class ProcessingLogServerUtils {
   public static String getTopicName(
       final ProcessingLogConfig config,
       final KsqlConfig ksqlConfig) {
-    final String topicNameConfig = config.getString(ProcessingLogConfig.TOPIC_NAME);
-    if (topicNameConfig.equals(ProcessingLogConfig.TOPIC_NAME_NOT_SET)) {
-      return String.format(
-          "%s%s",
-          ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG),
-          ProcessingLogConfig.TOPIC_NAME_DEFAULT_SUFFIX
-      );
-    } else {
-      return topicNameConfig;
-    }
+    return ReservedInternalTopics.processingLogTopic(config, ksqlConfig);
   }
 
   public static Optional<String> maybeCreateProcessingLogTopic(

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorFactoryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorFactoryTest.java
@@ -16,10 +16,10 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.rest.server.StandaloneExecutorFactory.StandaloneExecutorConstructor;
 import io.confluent.ksql.rest.server.computation.ConfigStore;
-import io.confluent.ksql.rest.util.KsqlInternalTopicUtils;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.ReservedInternalTopics;
 import io.confluent.ksql.version.metrics.VersionCheckerAgent;
 import java.util.Collections;
 import java.util.Map;
@@ -47,10 +47,7 @@ public class StandaloneExecutorFactoryTest {
   private final Map<String, String> properties = Collections.emptyMap();
   private final KsqlConfig baseConfig = new KsqlConfig(properties);
   private final KsqlConfig mergedConfig = new KsqlConfig(Collections.emptyMap());
-  private final String configTopicName = KsqlInternalTopicUtils.getTopicName(
-      baseConfig,
-      StandaloneExecutorFactory.CONFIG_TOPIC_SUFFIX
-  );
+  private final String configTopicName = ReservedInternalTopics.configsTopic(baseConfig);
 
   @Mock
   private Function<KsqlConfig, ServiceContext> serviceContextFactory;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -48,6 +48,7 @@ import io.confluent.ksql.services.ServiceContextFactory;
 import io.confluent.ksql.services.SimpleKsqlClient;
 import io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.ReservedInternalTopics;
 import io.confluent.ksql.version.metrics.VersionCheckerAgent;
 import io.confluent.rest.ApplicationServer;
 import io.confluent.rest.validation.JacksonMessageBodyProvider;
@@ -192,10 +193,7 @@ public class TestKsqlRestApp extends ExternalResource {
   }
 
   public static String getCommandTopicName() {
-    return KsqlInternalTopicUtils.getTopicName(
-        new KsqlConfig(ImmutableMap.of()),
-        KsqlRestConfig.COMMAND_TOPIC_SUFFIX
-    );
+    return ReservedInternalTopics.commandTopic(new KsqlConfig(ImmutableMap.of()));
   }
 
   public Set<String> getPersistentQueries() {

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/DistributingExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/DistributingExecutorTest.java
@@ -313,7 +313,7 @@ public class DistributingExecutorTest {
         PreparedStatement.of("", new InsertInto(SourceName.of("s1"), mock(Query.class)));
     final ConfiguredStatement<Statement> configured =
         ConfiguredStatement.of(preparedStatement, ImmutableMap.of(), KSQL_CONFIG);
-    final DataSource<?> dataSource = mock(DataSource.class);
+    final DataSource dataSource = mock(DataSource.class);
     doReturn(dataSource).when(metaStore).getSource(SourceName.of("s1"));
     when(dataSource.getKafkaTopicName()).thenReturn("_confluent-ksql-default__command-topic");
 
@@ -333,7 +333,7 @@ public class DistributingExecutorTest {
         PreparedStatement.of("", new InsertInto(SourceName.of("s1"), mock(Query.class)));
     final ConfiguredStatement<Statement> configured =
         ConfiguredStatement.of(preparedStatement, ImmutableMap.of(), KSQL_CONFIG);
-    final DataSource<?> dataSource = mock(DataSource.class);
+    final DataSource dataSource = mock(DataSource.class);
     doReturn(dataSource).when(metaStore).getSource(SourceName.of("s1"));
     when(dataSource.getKafkaTopicName()).thenReturn("default_ksql_processing_log");
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/DistributingExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/DistributingExecutorTest.java
@@ -325,4 +325,24 @@ public class DistributingExecutorTest {
     // When:
     distributor.execute(configured, executionContext, mock(KsqlSecurityContext.class));
   }
+
+  @Test
+  public void shouldThrowExceptionWhenInsertIntoProcessingLogTopic() {
+    // Given
+    final PreparedStatement<Statement> preparedStatement =
+        PreparedStatement.of("", new InsertInto(SourceName.of("s1"), mock(Query.class)));
+    final ConfiguredStatement<Statement> configured =
+        ConfiguredStatement.of(preparedStatement, ImmutableMap.of(), KSQL_CONFIG);
+    final DataSource<?> dataSource = mock(DataSource.class);
+    doReturn(dataSource).when(metaStore).getSource(SourceName.of("s1"));
+    when(dataSource.getKafkaTopicName()).thenReturn("default_ksql_processing_log");
+
+    // Expect:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("Cannot insert into the processing log topic: "
+        + "default_ksql_processing_log");
+
+    // When:
+    distributor.execute(configured, executionContext, mock(KsqlSecurityContext.class));
+  }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/DistributingExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/DistributingExecutorTest.java
@@ -153,6 +153,7 @@ public class DistributingExecutorTest {
     securityContext = new KsqlSecurityContext(Optional.empty(), serviceContext);
 
     distributor = new DistributingExecutor(
+        KSQL_CONFIG,
         queue,
         DURATION_10_MS,
         (ec, sc) -> InjectorChain.of(schemaInjector, topicInjector),
@@ -307,7 +308,7 @@ public class DistributingExecutorTest {
   }
 
   @Test
-  public void shouldThrowExceptionWhenInsertIntoReservedInternalTopic() {
+  public void shouldThrowExceptionWhenInsertIntoReadOnlyTopic() {
     // Given
     final PreparedStatement<Statement> preparedStatement =
         PreparedStatement.of("", new InsertInto(SourceName.of("s1"), mock(Query.class)));
@@ -319,7 +320,7 @@ public class DistributingExecutorTest {
 
     // Expect:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Cannot insert into the reserved internal topic: "
+    expectedException.expectMessage("Cannot insert into read-only topic: "
         + "_confluent-ksql-default__command-topic");
 
     // When:
@@ -339,7 +340,7 @@ public class DistributingExecutorTest {
 
     // Expect:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Cannot insert into the processing log topic: "
+    expectedException.expectMessage("Cannot insert into read-only topic: "
         + "default_ksql_processing_log");
 
     // When:

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/DistributingExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/DistributingExecutorTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -32,11 +33,15 @@ import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.exception.KsqlTopicAuthorizationException;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
 import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.metastore.model.DataSource;
+import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.properties.with.CreateSourceProperties;
 import io.confluent.ksql.parser.tree.CreateStream;
+import io.confluent.ksql.parser.tree.InsertInto;
 import io.confluent.ksql.parser.tree.ListProperties;
+import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.TableElements;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
@@ -281,5 +286,43 @@ public class DistributingExecutorTest {
 
     // When:
     distributor.execute(configured, executionContext, userSecurityContext);
+  }
+
+  @Test
+  public void shouldThrowExceptionWhenInsertIntoUnknownStream() {
+    // Given
+    final PreparedStatement<Statement> preparedStatement =
+        PreparedStatement.of("", new InsertInto(SourceName.of("s1"), mock(Query.class)));
+    final ConfiguredStatement<Statement> configured =
+        ConfiguredStatement.of(preparedStatement, ImmutableMap.of(), KSQL_CONFIG);
+    final DataSource<?> dataSource = mock(DataSource.class);
+    doReturn(null).when(metaStore).getSource(SourceName.of("s1"));
+
+    // Expect:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("Cannot insert into an unknown stream/table: `s1`");
+
+    // When:
+    distributor.execute(configured, executionContext, mock(KsqlSecurityContext.class));
+  }
+
+  @Test
+  public void shouldThrowExceptionWhenInsertIntoReservedInternalTopic() {
+    // Given
+    final PreparedStatement<Statement> preparedStatement =
+        PreparedStatement.of("", new InsertInto(SourceName.of("s1"), mock(Query.class)));
+    final ConfiguredStatement<Statement> configured =
+        ConfiguredStatement.of(preparedStatement, ImmutableMap.of(), KSQL_CONFIG);
+    final DataSource<?> dataSource = mock(DataSource.class);
+    doReturn(dataSource).when(metaStore).getSource(SourceName.of("s1"));
+    when(dataSource.getKafkaTopicName()).thenReturn("_confluent-ksql-default__command-topic");
+
+    // Expect:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("Cannot insert into the reserved internal topic: "
+        + "_confluent-ksql-default__command-topic");
+
+    // When:
+    distributor.execute(configured, executionContext, mock(KsqlSecurityContext.class));
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/DistributingExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/DistributingExecutorTest.java
@@ -296,7 +296,6 @@ public class DistributingExecutorTest {
         PreparedStatement.of("", new InsertInto(SourceName.of("s1"), mock(Query.class)));
     final ConfiguredStatement<Statement> configured =
         ConfiguredStatement.of(preparedStatement, ImmutableMap.of(), KSQL_CONFIG);
-    final DataSource<?> dataSource = mock(DataSource.class);
     doReturn(null).when(metaStore).getSource(SourceName.of("s1"));
 
     // Expect:

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutorTest.java
@@ -62,10 +62,11 @@ public class ListTopicsExecutorTest {
   }
 
   @Test
-  public void shouldListKafkaTopics() {
+  public void shouldListKafkaTopicsWithoutInternalTopics() {
     // Given:
     engine.givenKafkaTopic("topic1");
     engine.givenKafkaTopic("topic2");
+    engine.givenKafkaTopic("_confluent_any_topic");
 
     // When:
     final KafkaTopicsList topicsList =
@@ -80,6 +81,30 @@ public class ListTopicsExecutorTest {
     assertThat(topicsList.getTopics(), containsInAnyOrder(
         new KafkaTopicInfo("topic1", ImmutableList.of(1)),
         new KafkaTopicInfo("topic2", ImmutableList.of(1))
+    ));
+  }
+
+  @Test
+  public void shouldListKafkaTopicsIncludingInternalTopics() {
+    // Given:
+    engine.givenKafkaTopic("topic1");
+    engine.givenKafkaTopic("topic2");
+    engine.givenKafkaTopic("_confluent_any_topic");
+
+    // When:
+    final KafkaTopicsList topicsList =
+        (KafkaTopicsList) CustomExecutors.LIST_TOPICS.execute(
+            engine.configure("LIST ALL TOPICS;"),
+            ImmutableMap.of(),
+            engine.getEngine(),
+            serviceContext
+        ).orElseThrow(IllegalStateException::new);
+
+    // Then:
+    assertThat(topicsList.getTopics(), containsInAnyOrder(
+        new KafkaTopicInfo("topic1", ImmutableList.of(1)),
+        new KafkaTopicInfo("topic2", ImmutableList.of(1)),
+        new KafkaTopicInfo("_confluent_any_topic", ImmutableList.of(1))
     ));
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockKafkaTopicClient.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockKafkaTopicClient.java
@@ -48,11 +48,6 @@ public class MockKafkaTopicClient implements KafkaTopicClient {
   }
 
   @Override
-  public Set<String> listNonInternalTopicNames() {
-    return Collections.EMPTY_SET;
-  }
-
-  @Override
   public Map<String, TopicDescription> describeTopics(final Collection<String> topicNames) {
     return Collections.emptyMap();
   }


### PR DESCRIPTION
### Description 
Fixes https://github.com/confluentinc/ksql/issues/2952
Fixes https://github.com/confluentinc/ksql/issues/3134

Hide all KSQL, Confluent, Kafka, SR and Connect internal or system topics from the `SHOW TOPICS` command and prevents writing on streams/tables that are based on an internal/system topic. 

Also, it adds the `SHOW ALL TOPICS` syntax in case users want to list all topics including internal/system topics.

### Testing done 
Uni tests
Verified manually

```
ksql> insert into t1(id) values (1);
Cannot insert values into the reserved internal topic: _confluent-ksql-default__command_topic
```

```
ksql> show topics extended;

ksql> show topics;

 Kafka Topic                 | Partitions | Partition Replicas 
---------------------------------------------------------------
 default_ksql_processing_log | 1          | 1                  
---------------------------------------------------------------
```

```
ksql> show all topics;
sql> show all topics;

 Kafka Topic                                                                                   | Partitions | Partition Replicas 
---------------------------------------------------------------------------------------------------------------------------------
 __confluent.support.metrics                                                                   | 1          | 1                  
 _confluent-command
...
default_ksql_processing_log                                                                   | 1          | 1                  
---------------------------------------------------------------------------------------------------------------------------------
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

