### PR TITLE
chore: change RUNNING to WARNING when all connector tasks fail (MINOR)

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListConnectorsExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListConnectorsExecutor.java
@@ -129,7 +129,11 @@ public final class ListConnectorsExecutor {
         .filter(State.RUNNING.name()::equals)
         .count();
 
-    return String.format("RUNNING (%s/%s tasks RUNNING)",
+    final String status = connectorState.tasks().size() > 0 && numRunningTasks == 0
+        ? "WARNING"
+        : "RUNNING";
+    return String.format("%s (%s/%s tasks RUNNING)",
+        status,
         numRunningTasks,
         connectorState.tasks().size());
   }


### PR DESCRIPTION
fixes #4321

### Description 
If no tasks of a connector are running, make sure that the status is `WARNING` instead of `RUNNING`

### Testing done 
added a unit test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

