### PR TITLE
fix: pin the jetty client version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -379,6 +379,12 @@
                 <version>${clearspring-analytics.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-client</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+
             <!-- Required for running tests -->
             <dependency>
                 <groupId>junit</groupId>


### PR DESCRIPTION
### Description 

This patch pins the jetty client version to the jetty version specified
by confluent/common to fix the test failures in the `RestApiTest`
integration test. These tests are currently failing due to an issue
with the client version maven picks by default.