### PR TITLE
feat: add a DefaultSchemaRegistryClient and remove default for SR url in KsqlConfig

### DIFF
--- a/config/ksql-production-server.properties
+++ b/config/ksql-production-server.properties
@@ -58,6 +58,9 @@ ksql.logging.processing.stream.auto.create=true
 # The set of Kafka brokers to bootstrap Kafka cluster information from:
 bootstrap.servers=localhost:9092
 
+# uncomment the below to point to a Schema Registry cluster
+# ksql.schema.registry.url=http://localhost:8081
+
 # uncomment the below to start an embedded Connect worker
 # ksql.connect.worker.config=config/connect.properties
 # ksql.connect.configs.topic=ksql-connect-configs

--- a/config/ksql-server.properties
+++ b/config/ksql-server.properties
@@ -58,6 +58,9 @@ ksql.logging.processing.stream.auto.create=true
 # The set of Kafka brokers to bootstrap Kafka cluster information from:
 bootstrap.servers=localhost:9092
 
+# uncomment the below to point to a Schema Registry cluster
+# ksql.schema.registry.url=http://localhost:8081
+
 # uncomment the below to start an embedded Connect worker
 # ksql.connect.worker.config=config/connect.properties
 

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -361,9 +361,9 @@ public class KsqlConfig extends AbstractConfig {
         ).define(
             SCHEMA_REGISTRY_URL_PROPERTY,
             ConfigDef.Type.STRING,
-            DEFAULT_SCHEMA_REGISTRY_URL,
+            "",
             ConfigDef.Importance.MEDIUM,
-            "The URL for the schema registry, defaults to http://localhost:8081"
+            "The URL for the schema registry"
         ).define(
             CONNECT_URL_PROPERTY,
             ConfigDef.Type.STRING,

--- a/ksql-engine/src/main/java/io/confluent/ksql/schema/registry/DefaultSchemaRegistryClient.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/schema/registry/DefaultSchemaRegistryClient.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.schema.registry;
+
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+
+import io.confluent.ksql.rest.ErrorMessages;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.kafka.common.config.ConfigException;
+
+/** 
+ * Implements the SchemaRegistryClient interface. Used as default when the Schema Registry URL isn't
+ * specified in {@link io.confluent.ksql.util.KsqlConfig}
+ */
+public class DefaultSchemaRegistryClient implements SchemaRegistryClient {
+
+  private final ConfigException configException;
+
+  public DefaultSchemaRegistryClient(final ErrorMessages errorMessages) {
+    configException = new ConfigException(errorMessages.schemaRegistryUnconfiguredErrorMessage());
+  }
+
+  @Override
+  public Optional<ParsedSchema> parseSchema(
+      final String var1, final String var2,
+      final List<SchemaReference> var3
+  ) {
+    throw configException;
+  }
+
+  @Override
+  public int register(final String s, final ParsedSchema parsedSchema) {
+    throw configException;
+  }
+
+  @Override
+  public int register(final String s, final ParsedSchema parsedSchema, final int i, final int i1) {
+    throw configException;
+  }
+
+  @Override
+  public ParsedSchema getSchemaById(final int i) {
+    throw configException;
+  }
+
+  @Override
+  public ParsedSchema getSchemaBySubjectAndId(final String s, final int i) {
+    throw configException;
+  }
+
+  @Override
+  public Collection<String> getAllSubjectsById(final int i) {
+    throw configException;
+  }
+
+  @Override
+  public SchemaMetadata getLatestSchemaMetadata(final String s) {
+    throw configException;
+  }
+
+  @Override
+  public SchemaMetadata getSchemaMetadata(final String s, final int i) {
+    throw configException;
+  }
+
+  @Override
+  public int getVersion(final String s, final ParsedSchema parsedSchema) {
+    throw configException;
+  }
+
+  @Override
+  public List<Integer> getAllVersions(final String s) {
+    throw configException;
+  }
+
+  @Override
+  public boolean testCompatibility(final String s, final ParsedSchema parsedSchema) {
+    throw configException;
+  }
+
+  @Override
+  public String updateCompatibility(final String s, final String s1) {
+    throw configException;
+  }
+
+  @Override
+  public String getCompatibility(final String s) {
+    throw configException;
+  }
+
+  @Override
+  public String setMode(final String s) {
+    throw configException;
+  }
+
+  @Override
+  public String setMode(final String s, final String s1) {
+    throw configException;
+  }
+
+  @Override
+  public String getMode() {
+    throw configException;
+  }
+
+  @Override
+  public String getMode(final String s) {
+    throw configException;
+  }
+
+  @Override
+  public Collection<String> getAllSubjects() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public int getId(final String s, final ParsedSchema parsedSchema) {
+    throw configException;
+  }
+
+  @Override
+  public List<Integer> deleteSubject(final String s) {
+    throw configException;
+  }
+
+  @Override
+  public List<Integer> deleteSubject(final Map<String, String> map, final String s) {
+    throw configException;
+  }
+
+  @Override
+  public Integer deleteSchemaVersion(final String s, final String s1) {
+    throw configException;
+  }
+
+  @Override
+  public Integer deleteSchemaVersion(
+      final Map<String, String> map, 
+      final String s, 
+      final String s1
+  ) {
+    throw configException;
+  }
+
+  @Override
+  public void reset() {
+    throw configException;
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/ServiceContextFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/ServiceContextFactory.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.services;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.ksql.rest.DefaultErrorMessages;
 import io.confluent.ksql.schema.registry.KsqlSchemaRegistryClientFactory;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.Collections;
@@ -35,7 +36,10 @@ public final class ServiceContextFactory {
     return create(
         ksqlConfig,
         new DefaultKafkaClientSupplier(),
-        new KsqlSchemaRegistryClientFactory(ksqlConfig, Collections.emptyMap())::get,
+        new KsqlSchemaRegistryClientFactory(
+            ksqlConfig,
+            new DefaultErrorMessages(),
+            Collections.emptyMap())::get,
         () -> new DefaultConnectClient(ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY),
                                        Optional.empty()),
         ksqlClientSupplier

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -465,7 +465,10 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
   ) {
     final KsqlConfig ksqlConfig = new KsqlConfig(restConfig.getKsqlConfigProperties());
     final Supplier<SchemaRegistryClient> schemaRegistryClientFactory =
-        new KsqlSchemaRegistryClientFactory(ksqlConfig, Collections.emptyMap())::get;
+        new KsqlSchemaRegistryClientFactory(ksqlConfig, restConfig.getConfiguredInstance(
+                KsqlRestConfig.KSQL_SERVER_ERROR_MESSAGES,
+                ErrorMessages.class
+        ),Collections.emptyMap())::get;
     final ServiceContext serviceContext = new LazyServiceContext(() ->
         RestServiceContextFactory.create(ksqlConfig, Optional.empty(),
             schemaRegistryClientFactory));

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -27,6 +27,7 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.json.JsonMapper;
 import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.rest.DefaultErrorMessages;
 import io.confluent.ksql.rest.client.BasicCredentials;
 import io.confluent.ksql.rest.client.KsqlRestClient;
 import io.confluent.ksql.rest.client.RestResponse;
@@ -445,7 +446,7 @@ public class TestKsqlRestApp extends ExternalResource {
           () -> defaultServiceContext(bootstrapServers, buildBaseConfig(additionalProps));
       this.securityContextBinder = (config, securityExtension) ->
         new KsqlSecurityContextBinder(config, securityExtension,
-            new KsqlSchemaRegistryClientFactory(config, Collections.emptyMap())::get);
+            new KsqlSchemaRegistryClientFactory(config, new DefaultErrorMessages(), Collections.emptyMap())::get);
     }
 
     @SuppressWarnings("unused") // Part of public API

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/DefaultErrorMessages.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/DefaultErrorMessages.java
@@ -15,10 +15,18 @@
 
 package io.confluent.ksql.rest;
 
+import io.confluent.ksql.util.KsqlConfig;
+
 public class DefaultErrorMessages implements ErrorMessages {
 
   @Override
   public String kafkaAuthorizationErrorMessage(final Exception e) {
     return e.getMessage();
+  }
+
+  @Override
+  public String schemaRegistryUnconfiguredErrorMessage() {
+    return "KSQL is not configured to use a schema registry. To enable it, please set "
+        + KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY;
   }
 }

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/ErrorMessages.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/ErrorMessages.java
@@ -18,4 +18,6 @@ package io.confluent.ksql.rest;
 public interface ErrorMessages {
   
   String kafkaAuthorizationErrorMessage(Exception e);
+
+  String schemaRegistryUnconfiguredErrorMessage();
 }


### PR DESCRIPTION
### Description 
Fixes #4319 

Removed default URL for SR from KsqlConfig
Implemented a new `DefaultSchemaRegistryClient` that's used when the URL is `""`

```
ksql> CREATE STREAM pageviews_avro WITH (KAFKA_TOPIC='pageviews', VALUE_FORMAT='AVRO');
Schema registry fetch for topic pageviews request failed.
Caused by: KSQL is not configured to use a schema registry. To enable it, please
        set ksql.schema.registry.url

```

### Testing done 
Unit test
Verified logs weren't being spammed when closing queries

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

