### PR TITLE
docs: migrate new struct content to md docs (DOCS-3240)

### DIFF
--- a/docs-md/developer-guide/syntax-reference.md
+++ b/docs-md/developer-guide/syntax-reference.md
@@ -84,9 +84,19 @@ SELECT address->city, address->zip FROM orders;
 
 For more info, see [Operators](#operators).
 
-!!! note
-      You can't create new nested `STRUCT` data as the result of a query, but
-      you can copy existing `STRUCT` fields as-is.
+You can create a `STRUCT` in a query by specifying the names of the columns
+and expressions that construct the values, separated by commas. The following
+example SELECT statement creates a schema that has a `STRUCT`.
+
+```sql
+SELECT STRUCT(name := col0, ageInDogYears := col1*7) AS dogs FROM animals
+```
+
+If `col0` is a string and `col1` is an integer, the resulting schema is:
+
+```sql
+col0 STRUCT<name VARCHAR, ageInDogYears INTEGER>
+```
 
 ### ksqlDB Time Units
 

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -71,13 +71,6 @@ encapsulate a street address and a postal code:
      orderId BIGINT,
      address STRUCT<street VARCHAR, zip INTEGER>) WITH (...);
 
-
-You can create a struct in a query by specifying the names of the columns
-and expressions that construct the values, separated by ``,`` and wrapped with
-curly braces. For example: ``SELECT STRUCT(name := col0, ageInDogYears := col1*7) AS dogs FROM animals``
-creates a schema ``col0 STRUCT<name VARCHAR, ageInDogYears INTEGER>``, assuming ``col0`` was a string and
-``col1`` was an integer.
-
 Access the fields in a ``STRUCT`` by using the dereference operator (``->``):
 
 .. code:: sql
@@ -86,8 +79,20 @@ Access the fields in a ``STRUCT`` by using the dereference operator (``->``):
 
 For more info, see :ref:`operators`.
 
-.. note:: You can’t create new nested ``STRUCT`` data as the result of a query,
-   but you can copy existing ``STRUCT`` fields as-is.
+You can create a ``STRUCT`` in a query by specifying the names of the columns
+and expressions that construct the values, separated by commas. The following
+example SELECT statement creates a schema that has a ``STRUCT``.
+
+.. code:: sql
+
+   SELECT STRUCT(name := col0, ageInDogYears := col1*7) AS dogs FROM animals
+
+If ``col0`` is a string and ``col1`` is an integer, the resulting schema is:
+
+.. code:: sql
+
+   col0 STRUCT<name VARCHAR, ageInDogYears INTEGER>
+
 
 .. _ksql-time-units:
 

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -79,8 +79,19 @@ Access the fields in a ``STRUCT`` by using the dereference operator (``->``):
 
 For more info, see :ref:`operators`.
 
-.. note:: You can’t create new nested ``STRUCT`` data as the result of a query,
-   but you can copy existing ``STRUCT`` fields as-is.
+You can create a ``STRUCT`` in a query by specifying the names of the columns
+and expressions that construct the values, separated by commas. The following
+example SELECT statement creates a schema that has a ``STRUCT``.
+
+.. code:: sql
+
+   SELECT STRUCT(name := col0, ageInDogYears := col1*7) AS dogs FROM animals
+
+If ``col0`` is a string and ``col1`` is an integer, the resulting schema is:
+
+.. code:: sql
+
+   col0 STRUCT<name VARCHAR, ageInDogYears INTEGER>
 
 .. _ksql-time-units:
 

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -79,20 +79,8 @@ Access the fields in a ``STRUCT`` by using the dereference operator (``->``):
 
 For more info, see :ref:`operators`.
 
-You can create a ``STRUCT`` in a query by specifying the names of the columns
-and expressions that construct the values, separated by commas. The following
-example SELECT statement creates a schema that has a ``STRUCT``.
-
-.. code:: sql
-
-   SELECT STRUCT(name := col0, ageInDogYears := col1*7) AS dogs FROM animals
-
-If ``col0`` is a string and ``col1`` is an integer, the resulting schema is:
-
-.. code:: sql
-
-   col0 STRUCT<name VARCHAR, ageInDogYears INTEGER>
-
+.. note:: You can’t create new nested ``STRUCT`` data as the result of a query,
+   but you can copy existing ``STRUCT`` fields as-is.
 
 .. _ksql-time-units:
 


### PR DESCRIPTION
Migrate the new inline struct content from the rst docs to the markdown docs. Remove the obsolete note about not being able to create structs inline. Also, edit and re-arrange a bit.