### PR TITLE
refactor: supress warnings for metadataForKey

### DIFF
--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocator.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocator.java
@@ -51,6 +51,7 @@ final class KsLocator implements Locator {
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public Optional<KsqlNode> locate(final Struct key) {
     final StreamsMetadata metadata = kafkaStreams
         .metadataForKey(stateStoreName, key, keySerializer);

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocatorTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocatorTest.java
@@ -77,6 +77,7 @@ public class KsLocatorTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void shouldRequestMetadata() {
     // When:
     locator.locate(SOME_KEY);
@@ -183,7 +184,7 @@ public class KsLocatorTest {
     assertThat(result.map(KsqlNode::isLocal), is(Optional.of(false)));
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "deprecation"})
   private void givenOwnerMetadata(final Optional<HostInfo> hostInfo) {
     final StreamsMetadata metadata = hostInfo
         .map(hi -> {


### PR DESCRIPTION
### Description 
 - apache/kafka trunk Streams code has deprecated this already
 - This change prevents an upcoming ksql build break

### Testing done 
Build locally with a cherry-picked AK trunk and build seems to pass 


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

