### PR TITLE
refactor: move custom schema registry not configured error messages to rest endpoints

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlSchemaRegistryNotConfiguredException.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlSchemaRegistryNotConfiguredException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Confluent Inc.
+ * Copyright 2020 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the
@@ -13,11 +13,13 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.rest;
+package io.confluent.ksql.util;
 
-public interface ErrorMessages {
-  
-  String kafkaAuthorizationErrorMessage(Exception e);
+import org.apache.kafka.common.config.ConfigException;
 
-  String schemaRegistryUnconfiguredErrorMessage(Exception e);
+public class KsqlSchemaRegistryNotConfiguredException extends ConfigException {
+
+  public KsqlSchemaRegistryNotConfiguredException(final String message) {
+    super(message);
+  }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/schema/registry/DefaultSchemaRegistryClient.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/schema/registry/DefaultSchemaRegistryClient.java
@@ -19,25 +19,29 @@ import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
-
-import io.confluent.ksql.rest.ErrorMessages;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlSchemaRegistryNotConfiguredException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.apache.kafka.common.config.ConfigException;
 
 /** 
  * Implements the SchemaRegistryClient interface. Used as default when the Schema Registry URL isn't
  * specified in {@link io.confluent.ksql.util.KsqlConfig}
  */
 public class DefaultSchemaRegistryClient implements SchemaRegistryClient {
+  
+  public static final String SCHEMA_REGISTRY_CONFIG_NOT_SET =
+      "KSQL is not configured to use a schema registry. To enable it, please set "
+          + KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY;
+  
+  private final KsqlSchemaRegistryNotConfiguredException configException;
 
-  private final ConfigException configException;
-
-  public DefaultSchemaRegistryClient(final ErrorMessages errorMessages) {
-    configException = new ConfigException(errorMessages.schemaRegistryUnconfiguredErrorMessage());
+  public DefaultSchemaRegistryClient() {
+    configException =
+        new KsqlSchemaRegistryNotConfiguredException(SCHEMA_REGISTRY_CONFIG_NOT_SET);
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/ServiceContextFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/ServiceContextFactory.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.services;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.ksql.rest.DefaultErrorMessages;
 import io.confluent.ksql.schema.registry.KsqlSchemaRegistryClientFactory;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.Collections;
@@ -38,7 +37,6 @@ public final class ServiceContextFactory {
         new DefaultKafkaClientSupplier(),
         new KsqlSchemaRegistryClientFactory(
             ksqlConfig,
-            new DefaultErrorMessages(),
             Collections.emptyMap())::get,
         () -> new DefaultConnectClient(ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY),
                                        Optional.empty()),

--- a/ksql-engine/src/test/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactoryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactoryTest.java
@@ -30,7 +30,6 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.RestService;
-import io.confluent.ksql.rest.ErrorMessages;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.Collections;
 import java.util.Map;
@@ -61,8 +60,6 @@ public class KsqlSchemaRegistryClientFactoryTest {
   private SslFactory sslFactory;
   @Mock
   private SslEngineBuilder sslEngineBuilder;
-  @Mock
-  private ErrorMessages errorMessages;
 
   @Mock
   private KsqlSchemaRegistryClientFactory.SchemaRegistryClientFactory srClientFactory;
@@ -139,9 +136,9 @@ public class KsqlSchemaRegistryClientFactoryTest {
 
     // When:
     SchemaRegistryClient client1 = new KsqlSchemaRegistryClientFactory(
-        config1, errorMessages, restServiceSupplier, sslFactory, srClientFactory, Collections.emptyMap()).get();
+        config1, restServiceSupplier, sslFactory, srClientFactory, Collections.emptyMap()).get();
     SchemaRegistryClient client2 = new KsqlSchemaRegistryClientFactory(
-        config2, errorMessages, restServiceSupplier, sslFactory, srClientFactory, Collections.emptyMap()).get();
+        config2, restServiceSupplier, sslFactory, srClientFactory, Collections.emptyMap()).get();
 
     // Then:
     assertThat(client1, instanceOf(DefaultSchemaRegistryClient.class));
@@ -165,7 +162,7 @@ public class KsqlSchemaRegistryClientFactoryTest {
 
     // When:
     new KsqlSchemaRegistryClientFactory(
-        config, errorMessages, restServiceSupplier, sslFactory, srClientFactory, Collections.emptyMap()).get();
+        config, restServiceSupplier, sslFactory, srClientFactory, Collections.emptyMap()).get();
 
     // Then:
     verify(restService).setSslSocketFactory(isA(SSL_CONTEXT.getSocketFactory().getClass()));

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -489,10 +489,7 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
   ) {
     final KsqlConfig ksqlConfig = new KsqlConfig(restConfig.getKsqlConfigProperties());
     final Supplier<SchemaRegistryClient> schemaRegistryClientFactory =
-        new KsqlSchemaRegistryClientFactory(ksqlConfig, restConfig.getConfiguredInstance(
-                KsqlRestConfig.KSQL_SERVER_ERROR_MESSAGES,
-                ErrorMessages.class
-        ),Collections.emptyMap())::get;
+        new KsqlSchemaRegistryClientFactory(ksqlConfig, Collections.emptyMap())::get;
     final ServiceContext serviceContext = new LazyServiceContext(() ->
         RestServiceContextFactory.create(ksqlConfig, Optional.empty(),
             schemaRegistryClientFactory));

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -23,11 +23,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.json.JsonMapper;
 import io.confluent.ksql.query.QueryId;
-import io.confluent.ksql.rest.DefaultErrorMessages;
 import io.confluent.ksql.rest.client.BasicCredentials;
 import io.confluent.ksql.rest.client.KsqlRestClient;
 import io.confluent.ksql.rest.client.RestResponse;
@@ -39,7 +37,6 @@ import io.confluent.ksql.rest.entity.SourceInfo;
 import io.confluent.ksql.rest.entity.StreamsList;
 import io.confluent.ksql.rest.entity.TablesList;
 import io.confluent.ksql.rest.server.context.KsqlSecurityContextBinder;
-import io.confluent.ksql.rest.server.services.RestServiceContextFactory;
 import io.confluent.ksql.rest.util.KsqlInternalTopicUtils;
 import io.confluent.ksql.schema.registry.KsqlSchemaRegistryClientFactory;
 import io.confluent.ksql.security.KsqlSecurityContext;
@@ -446,7 +443,7 @@ public class TestKsqlRestApp extends ExternalResource {
           () -> defaultServiceContext(bootstrapServers, buildBaseConfig(additionalProps));
       this.securityContextBinder = (config, securityExtension) ->
         new KsqlSecurityContextBinder(config, securityExtension,
-            new KsqlSchemaRegistryClientFactory(config, new DefaultErrorMessages(), Collections.emptyMap())::get);
+            new KsqlSchemaRegistryClientFactory(config, Collections.emptyMap())::get);
     }
 
     @SuppressWarnings("unused") // Part of public API

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/DefaultErrorMessages.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/DefaultErrorMessages.java
@@ -15,18 +15,17 @@
 
 package io.confluent.ksql.rest;
 
-import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.ErrorMessageUtil;
 
 public class DefaultErrorMessages implements ErrorMessages {
 
   @Override
   public String kafkaAuthorizationErrorMessage(final Exception e) {
-    return e.getMessage();
+    return ErrorMessageUtil.buildErrorMessage(e);
   }
 
   @Override
-  public String schemaRegistryUnconfiguredErrorMessage() {
-    return "KSQL is not configured to use a schema registry. To enable it, please set "
-        + KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY;
+  public String schemaRegistryUnconfiguredErrorMessage(final Exception e) {
+    return ErrorMessageUtil.buildErrorMessage(e);
   }
 }


### PR DESCRIPTION
### Description 
Previous PR to add a default SR client broke some downstream builds. This refactors the change in order to keep the old interface for `KsqlSchemaRegistryClientFactory`. Custom error messages moved to being handled only in rest endpoint

### Testing done 
Spun up a server
```
ksql> CREATE STREAM pageviews_avro WITH (KAFKA_TOPIC='pageviews', VALUE_FORMAT='AVRO');
Schema registry fetch for topic pageviews request failed.
Caused by: KSQL is not configured to use a schema registry. To enable it, please
        set ksql.schema.registry.url
ksql> 
```
unit test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

