### PR TITLE
test: missed requested change (trivial)

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -281,14 +281,13 @@ public class ConsoleTest {
           + "-------------------------------------------------------\n"));
     }
   }
-
   @Test
   public void testPrintQueries() {
     // Given:
     final List<RunningQuery> queries = new ArrayList<>();
     queries.add(
         new RunningQuery(
-            "select * from t1", Collections.singleton("Test"), new QueryId("0"), Optional.of("Running")));
+            "select * from t1", Collections.singleton("Test"), new QueryId("0"), Optional.of("Foobar")));
 
     final KsqlEntityList entityList = new KsqlEntityList(ImmutableList.of(
         new Queries("e", queries)
@@ -307,16 +306,16 @@ public class ConsoleTest {
           + "    \"queryString\" : \"select * from t1\",\n"
           + "    \"sinks\" : [ \"Test\" ],\n"
           + "    \"id\" : \"0\",\n"
-          + "    \"state\" : \"Running\"\n"
+          + "    \"state\" : \"Foobar\"\n"
           + "  } ],\n"
           + "  \"warnings\" : [ ]\n"
           + "} ]\n"));
     } else {
       assertThat(output, is("\n"
-          + " Query ID | Status  | Kafka Topic | Query String     \n"
-          + "-----------------------------------------------------\n"
-          + " 0        | Running | Test        | select * from t1 \n"
-          + "-----------------------------------------------------\n"
+          + " Query ID | Status | Kafka Topic | Query String     \n"
+          + "----------------------------------------------------\n"
+          + " 0        | Foobar | Test        | select * from t1 \n"
+          + "----------------------------------------------------\n"
           + "For detailed information on a Query run: EXPLAIN <Query ID>;\n"));
     }
   }


### PR DESCRIPTION
### Description 

Trivial PR to apply some requested feedback I missed on PR https://github.com/confluentinc/ksql/pull/4313, as I merged it before submitting the change.


### Testing done 

Also requested was manual testing of the new single-line SQL in the tables.  This has been done.  I can report that the terminal handles wrapping the text perfectly, (well, iTerm2 on mac does anyway!). Resizing the window allows the user to choose how much wrapping they want or don't want, dynamically. 


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

