### PR TITLE
chore: add *.class to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ logs/
 .DS_Store
 .dumbjump
 *classes
+*.class
 *~
 *#
 .#*


### PR DESCRIPTION
### Description 
I recently re-cloned my fork of the repo and after building, noticed all these untracked files full of compiled class files.

```
testing:ksql stevenz$ git status
On branch master
Your branch is up to date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        ksql-benchmark/bin/
        ksql-cli/bin/
        ksql-common/bin/
        ksql-engine/bin/
        ksql-examples/bin/
        ksql-functional-tests/bin/
        ksql-parser/bin/
        ksql-rest-app/bin/
        ksql-test-util/bin/
```
Not sure why they started showing up, but wanted to add `*.class` to .gitignore to not have them show up
### Testing done 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

