### PR TITLE
(WIP) feat: add transient query to show queries command

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/QueriesTableBuilder.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/QueriesTableBuilder.java
@@ -25,7 +25,13 @@ import java.util.stream.Stream;
 public class QueriesTableBuilder implements TableBuilder<Queries> {
 
   private static final List<String> HEADERS =
-      ImmutableList.of("Query ID", "Status", "Sink Name", "Sink Kafka Topic", "Query String");
+      ImmutableList.of(
+          "Query ID",
+          "Status",
+          "Query Type",
+          "Sink Name",
+          "Sink Kafka Topic",
+          "Query String");
 
   @Override
   public Table buildTable(final Queries entity) {
@@ -33,6 +39,7 @@ public class QueriesTableBuilder implements TableBuilder<Queries> {
         .map(r -> ImmutableList.of(
             r.getId().getId(),
             r.getState().orElse("N/A"),
+            r.getQueryType().toString(),
             String.join(",", r.getSinks()),
             String.join(",", r.getSinkKafkaTopics()),
             r.getQuerySingleLine()

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlExecutionContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlExecutionContext.java
@@ -78,6 +78,21 @@ public interface KsqlExecutionContext {
   List<PersistentQueryMetadata> getPersistentQueries();
 
   /**
+   * Retrieves the list of all running transient queries.
+   *
+   * @return the list of all transient queries
+   */
+  List<TransientQueryMetadata> getTransientQueries();
+
+  /**
+   * Retrieve the details of a transient query.
+   *
+   * @param queryId the string id of the query to retrieve.
+   * @return the query's details or else {@code Optional.empty()} if no found.
+   */
+  Optional<TransientQueryMetadata> getTransientQuery(String queryId);
+
+  /**
    * Parse the statement(s) in supplied {@code sql}.
    *
    * <p>Note: the state of the execution context will not be changed.

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -123,7 +123,8 @@ final class EngineExecutor {
         overriddenProperties,
         serviceContext
     );
-    return executor.buildTransientQuery(
+
+    final TransientQueryMetadata queryMetadata = executor.buildTransientQuery(
         statement.getStatementText(),
         plans.physicalPlan.getQueryId(),
         getSourceNames(outputNode),
@@ -134,6 +135,9 @@ final class EngineExecutor {
         outputNode.getSchema(),
         outputNode.getLimit()
     );
+
+    engineContext.registerQuery(queryMetadata);
+    return queryMetadata;
   }
 
   @SuppressWarnings("OptionalGetWithoutIsPresent") // Known to be non-empty

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -130,6 +130,15 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
     return ImmutableList.copyOf(primaryContext.getPersistentQueries().values());
   }
 
+  @Override
+  public Optional<TransientQueryMetadata> getTransientQuery(final String queryId) {
+    return primaryContext.getTransientQuery(queryId);
+  }
+  
+  public List<TransientQueryMetadata> getTransientQueries() {
+    return ImmutableList.copyOf(primaryContext.getTransientQueries().values());
+  }
+
   public boolean hasActiveQueries() {
     return !primaryContext.getPersistentQueries().isEmpty();
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
@@ -80,6 +80,16 @@ final class SandboxedExecutionContext implements KsqlExecutionContext {
   }
 
   @Override
+  public Optional<TransientQueryMetadata> getTransientQuery(final String queryId) {
+    return engineContext.getTransientQuery(queryId);
+  }
+
+  @Override
+  public List<TransientQueryMetadata> getTransientQueries() {
+    return ImmutableList.copyOf(engineContext.getTransientQueries().values());
+  }
+
+  @Override
   public List<ParsedStatement> parse(final String sql) {
     return engineContext.parse(sql);
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -153,11 +153,12 @@ public final class QueryExecutor {
   ) {
     final BlockingRowQueue queue = buildTransientQueryQueue(queryId, physicalPlan, limit);
 
-    final String applicationId = addTimeSuffix(getQueryApplicationId(
+    final QueryId queryIdWithTimeSuffix = new QueryId(addTimeSuffix(queryId.getId()));
+    final String applicationId = getQueryApplicationId(
         getServiceId(),
         ksqlConfig.getString(KsqlConfig.KSQL_TRANSIENT_QUERY_NAME_PREFIX_CONFIG),
         queryId
-    ));
+    );
 
     final Map<String, Object> streamsProperties = buildStreamsProperties(applicationId, queryId);
 
@@ -178,7 +179,8 @@ public final class QueryExecutor {
         streamsProperties,
         overrides,
         queryCloseCallback,
-        ksqlConfig.getLong(KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG)
+        ksqlConfig.getLong(KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG),
+        queryIdWithTimeSuffix
     );
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -38,7 +38,6 @@ import org.apache.kafka.streams.Topology;
  */
 public class PersistentQueryMetadata extends QueryMetadata {
 
-  private final QueryId id;
   private final KsqlTopic resultTopic;
   private final SourceName sinkName;
   private final QuerySchemas schemas;
@@ -77,9 +76,9 @@ public class PersistentQueryMetadata extends QueryMetadata {
         streamsProperties,
         overriddenProperties,
         closeCallback,
-        closeTimeout);
+        closeTimeout,
+        id);
 
-    this.id = requireNonNull(id, "id");
     this.resultTopic = requireNonNull(resultTopic, "resultTopic");
     this.sinkName = Objects.requireNonNull(sinkName, "sinkName");
     this.schemas = requireNonNull(schemas, "schemas");
@@ -94,7 +93,6 @@ public class PersistentQueryMetadata extends QueryMetadata {
       final Consumer<QueryMetadata> closeCallback
   ) {
     super(other, closeCallback);
-    this.id = other.id;
     this.resultTopic = other.resultTopic;
     this.sinkName = other.sinkName;
     this.schemas = other.schemas;
@@ -109,10 +107,6 @@ public class PersistentQueryMetadata extends QueryMetadata {
 
   public DataSourceType getDataSourceType() {
     return dataSourceType;
-  }
-
-  public QueryId getQueryId() {
-    return id;
   }
 
   public KsqlTopic getResultTopic() {

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.internal.QueryStateListener;
 import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.time.Duration;
@@ -51,6 +52,7 @@ public class QueryMetadata {
   private final Set<SourceName> sourceNames;
   private final LogicalSchema logicalSchema;
   private final Long closeTimeout;
+  private final QueryId queryId;
 
   private Optional<QueryStateListener> queryStateListener = Optional.empty();
   private boolean everStarted = false;
@@ -67,7 +69,8 @@ public class QueryMetadata {
       final Map<String, Object> streamsProperties,
       final Map<String, Object> overriddenProperties,
       final Consumer<QueryMetadata> closeCallback,
-      final long closeTimeout
+      final long closeTimeout,
+      final QueryId queryId
   ) {
     // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     this.statementString = Objects.requireNonNull(statementString, "statementString");
@@ -85,6 +88,7 @@ public class QueryMetadata {
     this.sourceNames = Objects.requireNonNull(sourceNames, "sourceNames");
     this.logicalSchema = Objects.requireNonNull(logicalSchema, "logicalSchema");
     this.closeTimeout = closeTimeout;
+    this.queryId = Objects.requireNonNull(queryId, "queryId");
   }
 
   protected QueryMetadata(final QueryMetadata other, final Consumer<QueryMetadata> closeCallback) {
@@ -99,6 +103,7 @@ public class QueryMetadata {
     this.logicalSchema = other.logicalSchema;
     this.closeCallback = Objects.requireNonNull(closeCallback, "closeCallback");
     this.closeTimeout = other.closeTimeout;
+    this.queryId = other.queryId;
   }
 
   public void registerQueryStateListener(final QueryStateListener queryStateListener) {
@@ -167,6 +172,10 @@ public class QueryMetadata {
 
   public boolean hasEverBeenStarted() {
     return everStarted;
+  }
+
+  public QueryId getQueryId() {
+    return queryId;
   }
 
   public void close() {

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.util;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.BlockingRowQueue;
 import io.confluent.ksql.query.LimitHandler;
+import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.Map;
 import java.util.Objects;
@@ -48,7 +49,8 @@ public class TransientQueryMetadata extends QueryMetadata {
       final Map<String, Object> streamsProperties,
       final Map<String, Object> overriddenProperties,
       final Consumer<QueryMetadata> closeCallback,
-      final long closeTimeout) {
+      final long closeTimeout,
+      final QueryId queryId) {
     // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     super(
         statementString,
@@ -61,7 +63,8 @@ public class TransientQueryMetadata extends QueryMetadata {
         streamsProperties,
         overriddenProperties,
         closeCallback,
-        closeTimeout
+        closeTimeout,
+        queryId
     );
     this.rowQueue = Objects.requireNonNull(rowQueue, "rowQueue");
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.internal.QueryStateListener;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.time.Duration;
@@ -45,6 +46,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class QueryMetadataTest {
 
   private static final String QUERY_APPLICATION_ID = "Query1";
+  private static final QueryId QUERY_ID = new QueryId(QUERY_APPLICATION_ID);
   private static final LogicalSchema SOME_SCHEMA = LogicalSchema.builder()
       .valueColumn(ColumnName.of("f0"), SqlTypes.STRING)
       .build();
@@ -74,7 +76,8 @@ public class QueryMetadataTest {
         Collections.emptyMap(),
         Collections.emptyMap(),
         closeCallback,
-        closeTimeout);
+        closeTimeout,
+        QUERY_ID);
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/TransientQueryMetadataTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/TransientQueryMetadataTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.inOrder;
 
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.BlockingRowQueue;
+import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.Map;
 import java.util.Set;
@@ -36,7 +37,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class TransientQueryMetadataTest {
 
-  private static final String QUERY_ID = "queryId";
+  private static final String QUERY_APPLICATION_ID = "queryApplicationId";
+  private static final QueryId QUERY_ID = new QueryId("queryId");
   private static final String EXECUTION_PLAN = "execution plan";
   private static final String SQL = "sql";
   private static final long CLOSE_TIMEOUT = 10L;
@@ -68,12 +70,13 @@ public class TransientQueryMetadataTest {
         sourceNames,
         EXECUTION_PLAN,
         rowQueue,
-        QUERY_ID,
+        QUERY_APPLICATION_ID,
         topology,
         props,
         overrides,
         closeCallback,
-        CLOSE_TIMEOUT
+        CLOSE_TIMEOUT,
+        QUERY_ID
     );
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescriptionFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescriptionFactory.java
@@ -45,11 +45,11 @@ public final class QueryDescriptionFactory {
     }
 
     return create(
-        new QueryId(""),
+        queryMetadata.getQueryId(),
         queryMetadata,
         Optional.empty(),
         Collections.emptySet(),
-        Optional.empty()
+        Optional.of(queryMetadata.getState())
     );
   }
 
@@ -70,7 +70,8 @@ public final class QueryDescriptionFactory {
         queryMetadata.getTopologyDescription(),
         queryMetadata.getExecutionPlan(),
         queryMetadata.getOverriddenProperties(),
-        state
+        state,
+        sinks.isEmpty() ? RunningQuery.QueryType.TRANSIENT : RunningQuery.QueryType.PUSH
     );
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ExplainExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ExplainExecutor.java
@@ -128,7 +128,7 @@ public final class ExplainExecutor {
     final PersistentQueryMetadata metadata = executionContext
         .getPersistentQuery(new QueryId(queryId))
         .orElseThrow(() -> new KsqlException(
-            "Query with id:" + queryId + " does not exist, "
+            "Persistent Query with id:" + queryId + " does not exist, "
                 + "use SHOW QUERIES to view the full set of queries."));
 
     return QueryDescriptionFactory.forQueryMetadata(metadata);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
@@ -224,8 +224,9 @@ public final class ListSourceExecutor {
             ImmutableSet.of(q.getSinkName().name()),
             ImmutableSet.of(q.getResultTopic().getKafkaTopicName()),
             q.getQueryId(),
-            Optional.of(q.getState())
-        ))
+            Optional.of(q.getState()),
+            RunningQuery.QueryType.PUSH)
+        )
         .collect(Collectors.toList());
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
@@ -114,7 +114,8 @@ public class QueryDescriptionFactoryTest {
         STREAMS_PROPS,
         PROP_OVERRIDES,
         queryCloseCallback,
-        closeTimeout);
+        closeTimeout,
+        QUERY_ID);
 
     transientQueryDescription = QueryDescriptionFactory.forQueryMetadata(transientQuery);
 
@@ -141,13 +142,9 @@ public class QueryDescriptionFactoryTest {
   }
 
   @Test
-  public void shouldHaveEmptyQueryIdFromTransientQuery() {
-    assertThat(transientQueryDescription.getId().getId(), is(isEmptyString()));
-  }
-
-  @Test
-  public void shouldHaveQueryIdForPersistentQuery() {
+  public void shouldHaveQueryIdForQueries() {
     assertThat(persistentQueryDescription.getId().getId(), is(QUERY_ID.getId()));
+    assertThat(transientQueryDescription.getId().getId(), is(QUERY_ID.getId()));
   }
 
   @Test
@@ -197,13 +194,9 @@ public class QueryDescriptionFactoryTest {
   }
 
   @Test
-  public void shouldReportPersistentQueriesStatus() {
+  public void shouldReportQueriesStatus() {
     assertThat(persistentQueryDescription.getState(), is(Optional.of("RUNNING")));
-  }
-
-  @Test
-  public void shouldNotReportTransientQueriesStatus() {
-    assertThat(transientQueryDescription.getState(), is(Optional.empty()));
+    assertThat(transientQueryDescription.getState(), is(Optional.of("RUNNING")));
   }
 
   @Test
@@ -228,7 +221,8 @@ public class QueryDescriptionFactoryTest {
         STREAMS_PROPS,
         PROP_OVERRIDES,
         queryCloseCallback,
-        closeTimeout);
+        closeTimeout,
+        QUERY_ID);
 
     // When:
     transientQueryDescription = QueryDescriptionFactory.forQueryMetadata(transientQuery);
@@ -262,7 +256,8 @@ public class QueryDescriptionFactoryTest {
         STREAMS_PROPS,
         PROP_OVERRIDES,
         queryCloseCallback,
-        closeTimeout);
+        closeTimeout,
+        QUERY_ID);
 
     // When:
     transientQueryDescription = QueryDescriptionFactory.forQueryMetadata(transientQuery);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
@@ -259,7 +259,8 @@ public class ListSourceExecutorTest {
                 ImmutableSet.of(metadata.getSinkName().toString(FormatOptions.noEscape())),
                 ImmutableSet.of(metadata.getResultTopic().getKafkaTopicName()),
                 metadata.getQueryId(),
-                Optional.of(metadata.getState())
+                Optional.of(metadata.getState()),
+                RunningQuery.QueryType.PUSH
             )),
             Optional.empty())));
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -1960,7 +1960,8 @@ public class KsqlResourceTest {
             ImmutableSet.of(md.getSinkName().toString(FormatOptions.noEscape())),
             ImmutableSet.of(md.getResultTopic().getKafkaTopicName()),
             md.getQueryId(),
-            Optional.of(md.getState())
+            Optional.of(md.getState()),
+            RunningQuery.QueryType.PUSH
         ))
         .collect(Collectors.toList());
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -50,6 +50,7 @@ import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.query.BlockingRowQueue;
 import io.confluent.ksql.query.LimitHandler;
+import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.Errors;
 import io.confluent.ksql.rest.entity.KsqlErrorMessage;
 import io.confluent.ksql.rest.entity.KsqlRequest;
@@ -386,7 +387,8 @@ public class StreamedQueryResourceTest {
             Collections.emptyMap(),
             Collections.emptyMap(),
             queryCloseCallback,
-            closeTimeout);
+            closeTimeout,
+            new QueryId(""));
 
     when(mockKsqlEngine.executeQuery(serviceContext,
         ConfiguredStatement.of(query, requestStreamsProperties, VALID_CONFIG)))

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryDescription.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryDescription.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.model.WindowType;
 import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.rest.entity.RunningQuery.QueryType;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -42,8 +43,9 @@ public class QueryDescription {
   private final String executionPlan;
   private final Map<String, Object> overriddenProperties;
   private final Optional<String> state;
+  private final QueryType queryType;
 
-  @SuppressWarnings("WeakerAccess") // Invoked via reflection
+  @SuppressWarnings({"WeakerAccess", "checkstyle:ParameterNumber"}) // Invoked via reflection
   @JsonCreator
   public QueryDescription(
       @JsonProperty("id") final QueryId id,
@@ -55,7 +57,8 @@ public class QueryDescription {
       @JsonProperty("topology") final String topology,
       @JsonProperty("executionPlan") final String executionPlan,
       @JsonProperty("overriddenProperties") final Map<String, Object> overriddenProperties,
-      @JsonProperty("state") final Optional<String> state
+      @JsonProperty("state") final Optional<String> state,
+      @JsonProperty("queryType") final QueryType queryType
   ) {
     this.id = Objects.requireNonNull(id, "id");
     this.statementText = Objects.requireNonNull(statementText, "statementText");
@@ -68,6 +71,7 @@ public class QueryDescription {
     this.overriddenProperties = ImmutableMap.copyOf(Objects
         .requireNonNull(overriddenProperties, "overriddenProperties"));
     this.state = Objects.requireNonNull(state, "state");
+    this.queryType = Objects.requireNonNull(queryType, "queryType");
   }
 
   public QueryId getId() {
@@ -108,6 +112,10 @@ public class QueryDescription {
 
   public Optional<String> getState() {
     return state;
+  }
+
+  public QueryType getQueryType() {
+    return queryType;
   }
 
   // CHECKSTYLE_RULES.OFF: CyclomaticComplexity

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/RunningQuery.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/RunningQuery.java
@@ -27,11 +27,17 @@ import java.util.Set;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RunningQuery {
 
+  public enum QueryType {
+    PUSH,
+    TRANSIENT
+  }
+
   private final String queryString;
   private final Set<String> sinks;
   private final Set<String> sinkKafkaTopics;
   private final QueryId id;
   private final Optional<String> state;
+  private final QueryType queryType;
 
   @JsonCreator
   public RunningQuery(
@@ -39,13 +45,15 @@ public class RunningQuery {
       @JsonProperty("sinks") final Set<String> sinks,
       @JsonProperty("sinkKafkaTopics") final Set<String> sinkKafkaTopics,
       @JsonProperty("id") final QueryId id,
-      @JsonProperty("state") final Optional<String> state
+      @JsonProperty("state") final Optional<String> state,
+      @JsonProperty("queryType") final QueryType queryType
   ) {
     this.queryString = Objects.requireNonNull(queryString, "queryString");
     this.sinkKafkaTopics = Objects.requireNonNull(sinkKafkaTopics, "sinkKafkaTopics");
     this.sinks = Objects.requireNonNull(sinks, "sinks");
     this.id = Objects.requireNonNull(id, "id");
     this.state = Objects.requireNonNull(state, "state");
+    this.queryType = Objects.requireNonNull(queryType, "queryType");
   }
 
   public String getQueryString() {
@@ -67,6 +75,10 @@ public class RunningQuery {
 
   public QueryId getId() {
     return id;
+  }
+
+  public QueryType getQueryType() {
+    return queryType;
   }
 
   public Optional<String> getState() {


### PR DESCRIPTION
### Description 
https://github.com/confluentinc/ksql/issues/4308
Adds transient queries to the show queries commands.

```
ksql> show queries;

 Query ID                          | Status  | Query Type | Kafka Topic    | Query String                                                                                                                                
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 CSAS_PAGEVIEWS_COPY_0             | RUNNING | PUSH       | PAGEVIEWS_COPY | CREATE STREAM PAGEVIEWS_COPY WITH (KAFKA_TOPIC='PAGEVIEWS_COPY', PARTITIONS=2, REPLICAS=1) AS SELECT *FROM PAGEVIEWS PAGEVIEWSEMIT CHANGES; 
 8477777122193757219_1579645875188 | RUNNING | TRANSIENT  |                | select * from pageviews_copy emit changes;                                                                                                  
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
For detailed information on a Query run: EXPLAIN <Query ID>;

```

Extended:
```
ID                   : 177547265110114872_1579648250519
SQL                  : select * from pageviews_copy emit changes;

 Field   | Type                      
-------------------------------------
 ROWTIME | BIGINT           (system) 
 ROWKEY  | VARCHAR(STRING)  (system) 
 AGE     | BIGINT                    
-------------------------------------

Sources that this query reads from: 
-----------------------------------
PAGEVIEWS_COPY

For source description please run: DESCRIBE [EXTENDED] <SourceId>

Execution plan      
--------------      
 > [ PROJECT ] | Schema: ROWKEY STRING KEY, ROWTIME BIGINT, ROWKEY STRING, AGE BIGINT | Logger: 177547265110114872.Project
                 > [ SOURCE ] | Schema: PAGEVIEWS_COPY.ROWKEY STRING KEY, PAGEVIEWS_COPY.ROWTIME BIGINT, PAGEVIEWS_COPY.ROWKEY STRING, PAGEVIEWS_COPY.AGE BIGINT | Logger: 177547265110114872.KsqlTopic.Source


Processing topology 
------------------- 
Topologies:
   Sub-topology: 0
    Source: KSTREAM-SOURCE-0000000000 (topics: [PAGEVIEWS_COPY])
      --> KSTREAM-TRANSFORMVALUES-0000000001
    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
      --> Project
      <-- KSTREAM-SOURCE-0000000000
    Processor: Project (stores: [])
      --> KSTREAM-FOREACH-0000000003
      <-- KSTREAM-TRANSFORMVALUES-0000000001
    Processor: KSTREAM-FOREACH-0000000003 (stores: [])
      --> none
      <-- Project
```
### Testing done 
Update console output tests
Update unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

