### PR TITLE
fix: do not throw error if VALUE_DELIMITER is set on non-DELIMITED topic

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/serde/FormatInfo.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/serde/FormatInfo.java
@@ -62,11 +62,6 @@ public final class FormatInfo {
     }
 
     this.delimiter = Objects.requireNonNull(delimiter, "delimiter");
-
-    if (format != Format.DELIMITED && delimiter.isPresent()) {
-      throw new KsqlException("Delimeter only supported with DELIMITED format");
-    }
-
   }
 
   public Format getFormat() {

--- a/ksql-common/src/test/java/io/confluent/ksql/serde/FormatInfoTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/serde/FormatInfoTest.java
@@ -123,24 +123,4 @@ public class FormatInfoTest {
     assertThat(FormatInfo.of(AVRO, Optional.empty(), Optional.empty()).getFullSchemaName(),
         is(Optional.empty()));
   }
-
-  @Test
-  public void shouldThrowWhenAttemptingToUseValueDelimeterWithAvroFormat() {
-    // Then:
-    expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Delimeter only supported with DELIMITED format");
-
-    // When:
-    FormatInfo.of(Format.AVRO, Optional.of("something"), Optional.of(Delimiter.of('x')));
-  }
-
-  @Test
-  public void shouldThrowWhenAttemptingToUseValueDelimeterWithJsonFormat() {
-    // Then:
-    expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Delimeter only supported with DELIMITED format");
-
-    // When:
-    FormatInfo.of(Format.JSON, Optional.empty(), Optional.of(Delimiter.of('x')));
-  }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -261,6 +261,7 @@ class Analyzer {
       if (sink.getProperties().getValueDelimiter().isPresent()) {
         return sink.getProperties().getValueDelimiter();
       }
+
       return analysis
           .getFromDataSources()
           .get(0)

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/delimited.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/delimited.json
@@ -23,6 +23,20 @@
       ]
     },
     {
+      "name": "select delimited value_format into another format",
+      "format": ["JSON", "AVRO"],
+      "statements": [
+        "CREATE STREAM TEST (ID bigint, NAME varchar, VALUE integer) WITH (kafka_topic='test_topic', value_format='DELIMITED', value_delimiter=',');",
+        "CREATE STREAM S2 WITH(value_format='{FORMAT}') as SELECT id, name, value FROM test;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "0", "value": "0,zero,0", "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": "0", "value": {"ID": 0, "NAME": "zero", "VALUE": 0}, "timestamp": 0}
+      ]
+    },
+    {
       "name": "validate value_delimiter to be single character",
       "statements": [
         "CREATE STREAM TEST WITH (kafka_topic='test_topic', value_format='DELIMITED', value_delimiter='<~>');"
@@ -35,7 +49,7 @@
       "outputs": []
     },
     {
-      "name": "validate delimeter is not empty",
+      "name": "validate delimiter is not empty",
       "statements": [
         "CREATE STREAM TEST WITH (kafka_topic='test_topic', value_format='DELIMITED', value_delimiter='');"
       ],
@@ -53,7 +67,7 @@
       "outputs": []
     },
     {
-      "name": "validate delimeter is not a space",
+      "name": "validate delimiter is not a space",
       "statements": [
         "CREATE STREAM TEST WITH (kafka_topic='test_topic', value_format='DELIMITED', value_delimiter=' ');"
       ],
@@ -65,7 +79,7 @@
       "outputs": []
     },
     {
-      "name": "validate delimeter is not a tab character",
+      "name": "validate delimiter is not a tab character",
       "statements": [
         "CREATE STREAM TEST WITH (kafka_topic='test_topic', value_format='DELIMITED', value_delimiter='\t');"
       ],
@@ -151,24 +165,6 @@
         {"topic": "S2", "key": "100", "value": "100\t100\t500", "timestamp": 0},
         {"topic": "S2", "key": "100", "value": "100\t100\t100", "timestamp": 0}
       ]
-    },
-    {
-      "name": "validate cannot specify delimeter with json format",
-      "statements": [
-        "CREATE STREAM TEST WITH (kafka_topic='test_topic', value_format='JSON', value_delimiter='|');"
-      ],
-      "topics": [
-        {
-          "name": "test_topic",
-          "format": "JSON"
-        }
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Delimeter only supported with DELIMITED format"
-      },
-      "inputs": [],
-      "outputs": []
     }
   ]
 }

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerializerTest.java
@@ -217,16 +217,16 @@ public class KsqlDelimitedSerializerTest {
   }
 
   @Test
-  public void shouldSerializeRowCorrectlyWithTabDelimeter() {
-    shouldSerializeRowCorrectlyWithNonDefaultDelimeter('\t');
+  public void shouldSerializeRowCorrectlyWithTabDelimiter() {
+    shouldSerializeRowCorrectlyWithNonDefaultDelimiter('\t');
   }
 
   @Test
-  public void shouldSerializeRowCorrectlyWithBarDelimeter() {
-    shouldSerializeRowCorrectlyWithNonDefaultDelimeter('|');
+  public void shouldSerializeRowCorrectlyWithBarDelimiter() {
+    shouldSerializeRowCorrectlyWithNonDefaultDelimiter('|');
   }
 
-  private void shouldSerializeRowCorrectlyWithNonDefaultDelimeter(final char delimiter) {
+  private void shouldSerializeRowCorrectlyWithNonDefaultDelimiter(final char delimiter) {
     // Given:
     final Struct data = new Struct(SCHEMA)
         .put("ORDERTIME", 1511897796092L)


### PR DESCRIPTION
fixes #4200

### Description 

The `VALUE_DELIMITER` only makes sense in the context of `DELIMITED` format and today we throw an error if it is set in any other format. This PR removes that error and just ignores it if it is set on a non-delimited stream. This way:

1. users can issue commands that take a delimited topic and turn it into another format
2. if they go back to delimited (e.g. delimited->json->delimited) it will maintain the original source delimiter

Alternatively, we can just not pipe the delimiter and use the default if going from a non-delimited format back to delimited.

### Testing done 

- updated unit tests
- updated qtt
- local end-to-end testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

