### PR TITLE
chore: migrate to ClassGraph (speed up UDF loading time)

### DIFF
--- a/ksql-engine/pom.xml
+++ b/ksql-engine/pom.xml
@@ -119,9 +119,9 @@
         </dependency>
 
         <dependency>
-            <groupId>io.github.lukehutch</groupId>
-            <artifactId>fast-classpath-scanner</artifactId>
-            <version>3.1.6</version>
+            <groupId>io.github.classgraph</groupId>
+            <artifactId>classgraph</artifactId>
+            <version>4.8.59</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
fixes #1788

### Description 

FastClasspathScanner has been EOL'd, ClassGraph is the new and improved shiny alternative. Migrating to it improves the speed of class-scanning slightly.

### Testing done 

- `mvn clean install`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

