### PR TITLE
refactor: make decimal literals actual decimals

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
@@ -430,7 +430,7 @@ public class InsertValuesExecutorTest {
             new DoubleLiteral(3.0),
             new BooleanLiteral("TRUE"),
             new StringLiteral("str"),
-            new DecimalLiteral("1.2"))
+            new DecimalLiteral(new BigDecimal("1.2")))
     );
 
     // When:

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/rewrite/ExpressionTreeRewriterTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/rewrite/ExpressionTreeRewriterTest.java
@@ -75,6 +75,7 @@ import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.types.SqlPrimitiveType;
 import io.confluent.ksql.util.KsqlParserTestUtil;
 import io.confluent.ksql.util.MetaStoreFixture;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -95,7 +96,7 @@ public class ExpressionTreeRewriterTest {
       new BooleanLiteral("true"),
       new StringLiteral("abcd"),
       new NullLiteral(),
-      new DecimalLiteral("1.0"),
+      new DecimalLiteral(BigDecimal.ONE),
       new TimeLiteral("00:00:00"),
       new TimestampLiteral("00:00:00")
   );

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
@@ -287,7 +287,7 @@ public class SqlToJavaVisitor {
     ) {
       return new Pair<>(
           "new BigDecimal(\"" + decimalLiteral.getValue() + "\")",
-          DecimalUtil.fromValue(new BigDecimal(decimalLiteral.getValue()))
+          DecimalUtil.fromValue(decimalLiteral.getValue())
       );
     }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
@@ -178,7 +178,7 @@ public final class ExpressionFormatter {
 
     @Override
     public String visitDecimalLiteral(final DecimalLiteral node, final Context context) {
-      return node.getValue();
+      return node.getValue().toString();
     }
 
     @Override

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/DecimalLiteral.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/DecimalLiteral.java
@@ -19,25 +19,26 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
+import java.math.BigDecimal;
 import java.util.Objects;
 import java.util.Optional;
 
 @Immutable
 public class DecimalLiteral extends Literal {
 
-  private final String value;
+  private final BigDecimal value;
 
-  public DecimalLiteral(final String value) {
+  public DecimalLiteral(final BigDecimal value) {
     this(Optional.empty(), value);
   }
 
-  public DecimalLiteral(final Optional<NodeLocation> location, final String value) {
+  public DecimalLiteral(final Optional<NodeLocation> location, final BigDecimal value) {
     super(location);
     this.value = requireNonNull(value, "value");
   }
 
   @Override
-  public String getValue() {
+  public BigDecimal getValue() {
     return value;
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
@@ -71,7 +71,6 @@ import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.VisitorUtil;
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -544,8 +543,7 @@ public class ExpressionTypeManager {
     public Void visitDecimalLiteral(
         final DecimalLiteral decimalLiteral, final ExpressionTypeContext expressionTypeContext
     ) {
-      expressionTypeContext.setSqlType(
-          DecimalUtil.fromValue(new BigDecimal(decimalLiteral.getValue())));
+      expressionTypeContext.setSqlType(DecimalUtil.fromValue(decimalLiteral.getValue()));
 
       return null;
     }

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatterTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatterTest.java
@@ -67,6 +67,7 @@ import io.confluent.ksql.schema.ksql.types.SqlArray;
 import io.confluent.ksql.schema.ksql.types.SqlMap;
 import io.confluent.ksql.schema.ksql.types.SqlStruct;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.Optional;
 import org.junit.Test;
@@ -159,7 +160,7 @@ public class ExpressionFormatterTest {
 
   @Test
   public void shouldFormatDecimalLiteral() {
-    assertThat(ExpressionFormatter.formatExpression(new DecimalLiteral("3.5")), equalTo("3.5"));
+    assertThat(ExpressionFormatter.formatExpression(new DecimalLiteral(new BigDecimal("3.5"))), equalTo("3.5"));
   }
 
   @Test

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/floating-point.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/floating-point.json
@@ -21,6 +21,25 @@
         {"topic": "OUTPUT", "key": 0.10001, "value": {"ID": 3}},
         {"topic": "OUTPUT", "key": 0.2, "value": {"ID": 4}}
       ]
+    },
+    {
+      "name": "with exponent",
+      "statements": [
+        "CREATE STREAM INPUT (ROWKEY DOUBLE KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT WHERE ROWKEY > 1e-1;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0.0, "value": {"ID": 0}},
+        {"topic": "test_topic", "key": 0.099, "value": {"ID": 1}},
+        {"topic": "test_topic", "key": 0.1, "value": {"ID": 2}},
+        {"topic": "test_topic", "key": 0.10001, "value": {"ID": 3}},
+        {"topic": "test_topic", "key": 0.2, "value": {"ID": 4}},
+        {"topic": "test_topic", "key": null, "value": {"ID": 5}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0.10001, "value": {"ID": 3}},
+        {"topic": "OUTPUT", "key": 0.2, "value": {"ID": 4}}
+      ]
     }
   ]
 }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -138,6 +138,7 @@ import io.confluent.ksql.schema.ksql.SqlTypeParser;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.Pair;
 import io.confluent.ksql.util.ParserUtil;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -1082,7 +1083,7 @@ public class AstBuilder {
         return new TimestampLiteral(location, value);
       }
       if (type.equals("DECIMAL")) {
-        return new DecimalLiteral(location, value);
+        return new DecimalLiteral(location, new BigDecimal(value));
       }
 
       throw new KsqlException("Unknown type: " + type + ", location:" + location);

--- a/ksql-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
@@ -133,10 +133,8 @@ public final class ParserUtil {
     final Optional<NodeLocation> location = getLocation(context);
 
     try {
-      // check that we can parse the literal but just pass in the text directly
       final String value = context.getText();
-      new BigDecimal(value);
-      return new DecimalLiteral(location, value);
+      return new DecimalLiteral(location, new BigDecimal(value));
     } catch (final NumberFormatException e) {
       throw new ParsingException("Invalid numeric literal: " + context.getText(), location);
     }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -35,7 +35,9 @@ import com.google.common.collect.Iterables;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.execution.expression.tree.ArithmeticUnaryExpression;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
+import io.confluent.ksql.execution.expression.tree.DecimalLiteral;
 import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
+import io.confluent.ksql.execution.expression.tree.DoubleLiteral;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
 import io.confluent.ksql.execution.expression.tree.Literal;
@@ -93,6 +95,7 @@ import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.util.MetaStoreFixture;
 import io.confluent.ksql.util.SchemaUtil;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -1276,6 +1279,31 @@ public class KsqlParserTest {
 
     final TableElement element = elements.iterator().next();
     assertThat(element.getType().getSqlType(), is(cookie));
+  }
+
+  @Test
+  public void shouldParseFloatingPointNumbers() {
+    assertThat(parseDouble("1.23E-1"), is(new DoubleLiteral(0.123)));
+    assertThat(parseDouble("1.230E+1"), is(new DoubleLiteral(12.3)));
+    assertThat(parseDouble("01.23e1"), is(new DoubleLiteral(12.3)));
+  }
+
+  @Test
+  public void shouldParseDecimals() {
+    assertThat(parseDouble("0.1"), is(new DecimalLiteral(new BigDecimal("0.1"))));
+    assertThat(parseDouble("0.123"), is(new DecimalLiteral(new BigDecimal("0.123"))));
+    assertThat(parseDouble("00123.000"), is(new DecimalLiteral(new BigDecimal("123.000"))));
+  }
+
+  private Literal parseDouble(final String literalText) {
+    final PreparedStatement<Query> query = KsqlParserTestUtil
+        .buildSingleAst(
+            "SELECT * FROM TEST1 WHERE COL3 > " + literalText + ";",
+            metaStore
+        );
+
+    final ComparisonExpression where = (ComparisonExpression) query.getStatement().getWhere().get();
+    return (Literal) where.getRight();
   }
 
   private static SearchedCaseExpression getSearchedCaseExpressionFromCsas(final Statement statement) {


### PR DESCRIPTION
### Description 

Fixes build failures in https://github.com/confluentinc/ksql/pull/4364.

Previously, `DecimalLiteral` was the only literal type where the contained java type did not reflect the literal type. `DoubleLiteral` has a `double` field, `StringLiteral` a `String` field, `IntegerLiteral` an `int` field, etc.  But `DecimalLiteral` contained a `String` field.

While this works with the legacy code for persistent and push queries, (which tend to 'toString' everything), this is actually causing issues with pull queries, which pass the result of `Literal.getValue` to the `SqlValueCoercer`.  The coercer will happily coerce an `INT`, `BIGINT` or `DECIMAL` to a `DOUBLE`. But it won't convert a `STRING` to a `DOUBLE`. Because `DecimalLiteral.getValue` was returning a `String` the coercion failed.  This issue only comes to light now that we can have `ROWKEY` of type `DOUBLE`.  This issue causes the following RQTT pull query test to fail:

```json
{
      "name": "windowed single key lookup - DOUBLE",
      "statements": [
        "CREATE STREAM INPUT (ROWKEY DOUBLE KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
        "CREATE TABLE AGGREGATE AS SELECT COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ROWKEY;",
        "SELECT * FROM AGGREGATE WHERE ROWKEY=10.1;",
        "SELECT * FROM AGGREGATE WHERE ROWKEY=0;"
      ],
      "inputs": [
        {"topic": "test_topic", "timestamp": 12346, "key": 11.1, "value": {"val": 1}}
      ],
      "responses": [
        {"admin": {"@type": "currentStatus"}},
        {"admin": {"@type": "currentStatus"}},
        {"query": [
          {"header":{"schema":"`ROWKEY` DOUBLE KEY, `WINDOWSTART` BIGINT KEY, `ROWTIME` BIGINT, `COUNT` BIGINT"}},
          {"row":{"columns":[10.1, 12000, 12345, 1]}}
        ]}
      ]
    }
```

It fails with an error complaining the value `"10.1"` can not be coerced to the type of `ROWKEY`, which is `DOUBLE`.

Switching `DecimalLiteral` to actually contain a `BigDecimal` fixes this issue.

### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

