### PR TITLE
chore: rename `AbstractStreamSource` to `SourceStep`

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKSourceFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKSourceFactory.java
@@ -18,11 +18,11 @@ package io.confluent.ksql.structured;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.context.QueryContext.Stacker;
-import io.confluent.ksql.execution.plan.AbstractStreamSource;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.plan.KStreamHolder;
 import io.confluent.ksql.execution.plan.KTableHolder;
+import io.confluent.ksql.execution.plan.SourceStep;
 import io.confluent.ksql.execution.plan.StreamSource;
 import io.confluent.ksql.execution.plan.TableSource;
 import io.confluent.ksql.execution.plan.WindowedStreamSource;
@@ -210,7 +210,7 @@ public final class SchemaKSourceFactory {
       final KsqlQueryBuilder builder,
       final LogicalSchema schema,
       final KeyFormat keyFormat,
-      final AbstractStreamSource<KStreamHolder<K>> streamSource,
+      final SourceStep<KStreamHolder<K>> streamSource,
       final KeyField keyField
   ) {
     return new SchemaKStream<>(
@@ -227,7 +227,7 @@ public final class SchemaKSourceFactory {
       final KsqlQueryBuilder builder,
       final LogicalSchema schema,
       final KeyFormat keyFormat,
-      final AbstractStreamSource<KTableHolder<K>> tableSource,
+      final SourceStep<KTableHolder<K>> tableSource,
       final KeyField keyField
   ) {
     return new SchemaKTable<>(

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/PlanSummary.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/PlanSummary.java
@@ -18,8 +18,8 @@ package io.confluent.ksql.util;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.execution.context.QueryLoggerUtil;
-import io.confluent.ksql.execution.plan.AbstractStreamSource;
 import io.confluent.ksql.execution.plan.ExecutionStep;
+import io.confluent.ksql.execution.plan.SourceStep;
 import io.confluent.ksql.execution.plan.StreamAggregate;
 import io.confluent.ksql.execution.plan.StreamFilter;
 import io.confluent.ksql.execution.plan.StreamFlatMap;
@@ -137,7 +137,7 @@ public class PlanSummary {
       case 0: break;
       default: throw new IllegalStateException();
     }
-    return schemaResolver.resolve(step, ((AbstractStreamSource) step).getSourceSchema());
+    return schemaResolver.resolve(step, ((SourceStep) step).getSourceSchema());
   }
 
   private static final class StepSummary {

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/SourceStep.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/SourceStep.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 @Immutable
-public abstract class AbstractStreamSource<K> implements ExecutionStep<K> {
+public abstract class SourceStep<K> implements ExecutionStep<K> {
 
   final ExecutionStepPropertiesV1 properties;
   final String topicName;
@@ -36,13 +36,14 @@ public abstract class AbstractStreamSource<K> implements ExecutionStep<K> {
   final SourceName alias;
 
   @VisibleForTesting
-  public AbstractStreamSource(
+  public SourceStep(
       final ExecutionStepPropertiesV1 properties,
       final String topicName,
       final Formats formats,
       final Optional<TimestampColumn> timestampColumn,
       final LogicalSchema sourceSchema,
-      final SourceName alias) {
+      final SourceName alias
+  ) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.topicName = Objects.requireNonNull(topicName, "topicName");
     this.formats = Objects.requireNonNull(formats, "formats");

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSource.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSource.java
@@ -24,7 +24,8 @@ import java.util.Optional;
 import org.apache.kafka.connect.data.Struct;
 
 @Immutable
-public final class StreamSource extends AbstractStreamSource<KStreamHolder<Struct>> {
+public final class StreamSource extends SourceStep<KStreamHolder<Struct>> {
+
   public StreamSource(
       @JsonProperty(value = "properties", required = true) final ExecutionStepPropertiesV1 props,
       @JsonProperty(value = "topicName", required = true) final String topicName,

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableSource.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableSource.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 import org.apache.kafka.connect.data.Struct;
 
 @Immutable
-public final class TableSource extends AbstractStreamSource<KTableHolder<Struct>> {
+public final class TableSource extends SourceStep<KTableHolder<Struct>> {
 
   public TableSource(
       @JsonProperty(value = "properties", required = true)

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/WindowedStreamSource.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/WindowedStreamSource.java
@@ -27,8 +27,7 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.kstream.Windowed;
 
 @Immutable
-public final class WindowedStreamSource
-    extends AbstractStreamSource<KStreamHolder<Windowed<Struct>>> {
+public final class WindowedStreamSource extends SourceStep<KStreamHolder<Windowed<Struct>>> {
 
   private final WindowInfo windowInfo;
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/WindowedTableSource.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/WindowedTableSource.java
@@ -25,8 +25,7 @@ import java.util.Optional;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.kstream.Windowed;
 
-public final class WindowedTableSource
-    extends AbstractStreamSource<KTableHolder<Windowed<Struct>>> {
+public final class WindowedTableSource extends SourceStep<KTableHolder<Windowed<Struct>>> {
 
   private final WindowInfo windowInfo;
 

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
@@ -19,11 +19,11 @@ import static java.util.Objects.requireNonNull;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext.Stacker;
-import io.confluent.ksql.execution.plan.AbstractStreamSource;
 import io.confluent.ksql.execution.plan.ExecutionStepPropertiesV1;
 import io.confluent.ksql.execution.plan.KStreamHolder;
 import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.KeySerdeFactory;
+import io.confluent.ksql.execution.plan.SourceStep;
 import io.confluent.ksql.execution.plan.StreamSource;
 import io.confluent.ksql.execution.plan.TableSource;
 import io.confluent.ksql.execution.plan.WindowedStreamSource;
@@ -239,7 +239,7 @@ public final class SourceBuilder {
   }
 
   private static LogicalSchema buildSchema(
-      final AbstractStreamSource<?> source,
+      final SourceStep<?> source,
       final boolean windowed
   ) {
     return source
@@ -249,7 +249,7 @@ public final class SourceBuilder {
 
   private static Serde<GenericRow> getValueSerde(
       final KsqlQueryBuilder queryBuilder,
-      final AbstractStreamSource<?> streamSource,
+      final SourceStep<?> streamSource,
       final PhysicalSchema physicalSchema) {
     return queryBuilder.buildValueSerde(
         streamSource.getFormats().getValueFormat(),
@@ -258,7 +258,7 @@ public final class SourceBuilder {
     );
   }
 
-  private static PhysicalSchema getPhysicalSchema(final AbstractStreamSource<?> streamSource) {
+  private static PhysicalSchema getPhysicalSchema(final SourceStep<?> streamSource) {
     return PhysicalSchema.from(
         streamSource.getSourceSchema(),
         streamSource.getFormats().getOptions()
@@ -266,7 +266,7 @@ public final class SourceBuilder {
   }
 
   private static <K> KStream<K, GenericRow> buildKStream(
-      final AbstractStreamSource<?> streamSource,
+      final SourceStep<?> streamSource,
       final KsqlQueryBuilder queryBuilder,
       final Consumed<K, GenericRow> consumed,
       final Function<K, Object> rowKeyGenerator
@@ -279,7 +279,7 @@ public final class SourceBuilder {
   }
 
   private static <K> KTable<K, GenericRow> buildKTable(
-      final AbstractStreamSource<?> streamSource,
+      final SourceStep<?> streamSource,
       final KsqlQueryBuilder queryBuilder,
       final Consumed<K, GenericRow> consumed,
       final Function<K, Object> rowKeyGenerator,
@@ -312,7 +312,7 @@ public final class SourceBuilder {
   }
 
   private static <K> Consumed<K, GenericRow> buildSourceConsumed(
-      final AbstractStreamSource<?> streamSource,
+      final SourceStep<?> streamSource,
       final Serde<K> keySerde,
       final Serde<GenericRow> valueSerde,
       final Topology.AutoOffsetReset defaultReset,

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StepSchemaResolver.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StepSchemaResolver.java
@@ -18,9 +18,9 @@ package io.confluent.ksql.execution.streams;
 import io.confluent.ksql.execution.codegen.CodeGenRunner;
 import io.confluent.ksql.execution.codegen.ExpressionMetadata;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
-import io.confluent.ksql.execution.plan.AbstractStreamSource;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.SelectExpression;
+import io.confluent.ksql.execution.plan.SourceStep;
 import io.confluent.ksql.execution.plan.StreamAggregate;
 import io.confluent.ksql.execution.plan.StreamFilter;
 import io.confluent.ksql.execution.plan.StreamFlatMap;
@@ -221,17 +221,11 @@ public final class StepSchemaResolver {
         .build();
   }
 
-  private LogicalSchema handleSource(
-      final LogicalSchema schema,
-      final AbstractStreamSource<?> step
-  ) {
+  private LogicalSchema handleSource(final LogicalSchema schema, final SourceStep<?> step) {
     return buildSourceSchema(schema, false);
   }
 
-  private LogicalSchema handleWindowedSource(
-      final LogicalSchema schema,
-      final AbstractStreamSource<?> step
-  ) {
+  private LogicalSchema handleWindowedSource(final LogicalSchema schema, final SourceStep<?> step) {
     return buildSourceSchema(schema, true);
   }
 

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/SourceBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/SourceBuilderTest.java
@@ -35,12 +35,12 @@ import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.context.QueryContext.Stacker;
-import io.confluent.ksql.execution.plan.AbstractStreamSource;
 import io.confluent.ksql.execution.plan.ExecutionStepPropertiesV1;
 import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.plan.KStreamHolder;
 import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.PlanBuilder;
+import io.confluent.ksql.execution.plan.SourceStep;
 import io.confluent.ksql.execution.plan.StreamSource;
 import io.confluent.ksql.execution.plan.TableSource;
 import io.confluent.ksql.execution.plan.WindowedStreamSource;
@@ -637,7 +637,7 @@ public class SourceBuilderTest {
 
   @SuppressWarnings("unchecked")
   private <K> ValueTransformerWithKey<K, GenericRow, GenericRow> getTransformerFromStreamSource(
-      final AbstractStreamSource<?> streamSource
+      final SourceStep<?> streamSource
   ) {
     streamSource.build(planBuilder);
     verify(kStream).transformValues(transformSupplierCaptor.capture());
@@ -648,7 +648,7 @@ public class SourceBuilderTest {
 
   @SuppressWarnings("unchecked")
   private <K> ValueTransformerWithKey<K, GenericRow, GenericRow> getTransformerFromTableSource(
-      final AbstractStreamSource<?> streamSource
+      final SourceStep<?> streamSource
   ) {
     streamSource.build(planBuilder);
     verify(kTable).transformValues(transformSupplierCaptor.capture());


### PR DESCRIPTION
### Description 

why?
* Removed `Abstract`: while the class is abstract that does not mean it needs `Abstract` in the class name. We wouldn't put `Final` in the name of a `final` class. Names should describe what things are, not what attributes they have.  This makes code that uses the type easier to read.
* Remove `Stream`: as it is also the base class for tables, not just streams.
* Add `Step`: to more clearly disambiguate from `DataSource`, which is the source in the metastore.

### Testing done 

Non-functional change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

