### PR TITLE
fix: reserve `WINDOWSTART` and `WINDOWEND` as system column names

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
@@ -120,6 +120,18 @@ public final class LogicalSchema {
   }
 
   /**
+   * Checks to see if value namespace contain any of the supplied names.
+   *
+   * @param names the names to check for.
+   * @return {@code true} if <i>any</i> of the supplied names exist in the value namespace.
+   */
+  public boolean valueContainsAny(final Set<ColumnName> names) {
+    return value().stream()
+        .map(Column::name)
+        .anyMatch(names::contains);
+  }
+
+  /**
    * Copies metadata and key columns to the value schema.
    *
    * <p>If the columns already exist in the value schema the function returns the same schema.

--- a/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
@@ -45,8 +45,14 @@ public final class SchemaUtil {
   public static final ColumnName ROWKEY_NAME = ColumnName.of("ROWKEY");
   public static final ColumnName ROWTIME_NAME = ColumnName.of("ROWTIME");
   public static final ColumnName WINDOWSTART_NAME = ColumnName.of("WINDOWSTART");
+  public static final ColumnName WINDOWEND_NAME = ColumnName.of("WINDOWEND");
 
-  public static final int ROWKEY_INDEX = 1;
+  private static final Set<ColumnName> SYSTEM_COLUMN_NAMES = ImmutableSet.of(
+      ROWKEY_NAME,
+      ROWTIME_NAME,
+      WINDOWSTART_NAME,
+      WINDOWEND_NAME
+  );
 
   private static final Set<Schema.Type> ARITHMETIC_TYPES = ImmutableSet.of(
       Type.INT8,
@@ -60,6 +66,10 @@ public final class SchemaUtil {
   private static final char FIELD_NAME_DELIMITER = '.';
 
   private SchemaUtil() {
+  }
+
+  public static Set<ColumnName> systemColumnNames() {
+    return SYSTEM_COLUMN_NAMES;
   }
 
   // Do Not use in new code - use `SchemaConverters` directly.

--- a/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
@@ -32,6 +32,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.Column.Namespace;
@@ -630,6 +631,33 @@ public class LogicalSchemaTest {
         valueColumn(ROWTIME_NAME, BIGINT),
         valueColumn(K0, BIGINT)
     ));
+  }
+
+  @Test
+  public void shouldMatchAnyValueSchema() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueColumn(F0, STRING)
+        .keyColumn(K0, BIGINT)
+        .valueColumn(F1, BIGINT)
+        .build();
+
+    // Then:
+    assertThat(schema.valueContainsAny(ImmutableSet.of(F0)), is(true));
+    assertThat(schema.valueContainsAny(ImmutableSet.of(V0, F0, F1, V1)), is(true));
+  }
+
+  @Test
+  public void shouldOnlyMatchValueSchema() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueColumn(F0, STRING)
+        .keyColumn(K0, BIGINT)
+        .valueColumn(F1, BIGINT)
+        .build();
+
+    // Then:
+    assertThat(schema.valueContainsAny(ImmutableSet.of(K0, V0, ROWTIME_NAME)), is(false));
   }
 
   private static org.apache.kafka.connect.data.Field connectField(

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -569,8 +569,7 @@ class Analyzer {
 
     private void addSelectItem(final Expression exp, final ColumnName columnName) {
       if (persistent) {
-        if (SchemaUtil.ROWTIME_NAME.equals(columnName)
-            || SchemaUtil.ROWKEY_NAME.equals(columnName)) {
+        if (SchemaUtil.systemColumnNames().contains(columnName)) {
           throw new KsqlException("Reserved column name in select: " + columnName + ". "
               + "Please remove or alias the column.");
         }

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
@@ -171,11 +171,11 @@ public final class CreateSourceFactory {
     }
 
     tableElements.forEach(e -> {
-      if (e.getName().equals(SchemaUtil.ROWTIME_NAME)) {
+      final boolean isRowKey = e.getName().equals(SchemaUtil.ROWKEY_NAME);
+
+      if (!isRowKey && SchemaUtil.systemColumnNames().contains(e.getName())) {
         throw new KsqlException("'" + e.getName().name() + "' is a reserved column name.");
       }
-
-      final boolean isRowKey = e.getName().equals(SchemaUtil.ROWKEY_NAME);
 
       if (e.getNamespace() == Namespace.KEY) {
         if (!isRowKey) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -175,9 +175,7 @@ public class LogicalPlanner {
         : null;
 
     final Optional<ColumnName> keyFieldName = getSelectAliasMatching((expression, alias) ->
-            expression.equals(groupBy)
-                && !SchemaUtil.isFieldName(alias.name(), SchemaUtil.ROWTIME_NAME.name())
-                && !SchemaUtil.isFieldName(alias.name(), SchemaUtil.ROWKEY_NAME.name()),
+            expression.equals(groupBy) && !SchemaUtil.systemColumnNames().contains(alias),
         sourcePlanNode.getSelectExpressions());
 
     return new AggregateNode(

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -326,12 +326,12 @@ public class SchemaKStream<K> {
       final Expression keyExpression,
       final QueryContext.Stacker contextStacker
   ) {
-    if (keyFormat.isWindowed()) {
-      throw new UnsupportedOperationException("Can not selectKey of windowed stream");
-    }
-
     if (!needsRepartition(keyExpression)) {
       return (SchemaKStream<Struct>) this;
+    }
+
+    if (keyFormat.isWindowed()) {
+      throw new UnsupportedOperationException("Can not selectKey of windowed stream");
     }
 
     final StreamSelectKey step = ExecutionStepFactory.streamSelectKey(

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -188,8 +188,8 @@ public class SchemaKStream<K> {
     }
 
     final Optional<ColumnRef> filtered = found
-        .filter(f -> !SchemaUtil.isFieldName(f.name().name(), SchemaUtil.ROWTIME_NAME.name()))
-        .filter(f -> !SchemaUtil.isFieldName(f.name().name(), SchemaUtil.ROWKEY_NAME.name()))
+        // System columns can not be key fields:
+        .filter(f -> !SchemaUtil.systemColumnNames().contains(f.name()))
         .map(Column::ref);
 
     return KeyField.of(filtered);

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateSourceCommand.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateSourceCommand.java
@@ -92,9 +92,8 @@ public abstract class CreateSourceCommand implements DdlCommand {
   }
 
   private static void validate(final LogicalSchema schema, final Optional<ColumnName> keyField) {
-    if (schema.findValueColumn(ColumnRef.of(SchemaUtil.ROWKEY_NAME)).isPresent()
-        || schema.findValueColumn(ColumnRef.of(SchemaUtil.ROWTIME_NAME)).isPresent()) {
-      throw new IllegalArgumentException("Schema contains implicit columns in value schema");
+    if (schema.valueContainsAny(SchemaUtil.systemColumnNames())) {
+      throw new IllegalArgumentException("Schema contains system columns in value schema");
     }
 
     if (schema.key().size() != 1) {

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/elements.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/elements.json
@@ -426,8 +426,8 @@
         "CREATE STREAM INPUT (F0 INT) WITH (kafka_topic='input', value_format='JSON');",
         "CREATE STREAM OUTPUT AS SELECT F0, ROWTIME AS TIME, ROWKEY AS KEY FROM INPUT;"
       ],
-      "inputs": [{"topic": "input", "key": "k", "value": {"F0": 4}, "timestamp": 1, "window": {"start": 12, "end": 465, "type": "session"}}],
-      "outputs": [{"topic": "OUTPUT", "key": "k", "value": {"F0": 4, "TIME": 1, "WSTART": 12, "WEND": 465, "KEY": "k"}, "timestamp": 1, "window": {"start": 12, "end": 465, "type": "session"}}]
+      "inputs": [{"topic": "input", "key": "k", "value": {"F0": 4}, "timestamp": 1}],
+      "outputs": [{"topic": "OUTPUT", "key": "k", "value": {"F0": 4, "TIME": 1, "KEY": "k"}, "timestamp": 1}]
     },
     {
       "name": "join should reject ROWTIME in projection",
@@ -488,7 +488,7 @@
         {"topic": "left", "key": "k", "value": {"F0": 4}, "timestamp": 1, "window": {"start": 0, "end": 1000, "type": "time"}},
         {"topic": "right", "key": "k", "value": {"F1": 6}, "timestamp": 2, "window": {"start": 0, "end": 1000, "type": "time"}}
       ],
-      "outputs": [{"topic": "OUTPUT", "key": "k", "value": {"F0": 4, "F1": 6, "TIME": 1, "WSTART": 0, "WEND": 1000, "KEY": "k"}, "timestamp": 2, "window": {"start": 0, "end": 1000, "type": "time"}}]
+      "outputs": [{"topic": "OUTPUT", "key": "k", "value": {"F0": 4, "F1": 6, "TIME": 1, "KEY": "k : Window{start=0 end=-}"}, "timestamp": 2, "window": {"start": 0, "end": 1000, "type": "time"}}]
     },
     {
       "name": "group-by rejects ROWKEY in projection",

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/elements.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/elements.json
@@ -399,13 +399,35 @@
       }
     },
     {
-      "name": "non-join leaves aliased ROWKEY and ROWTIME in output's value schema",
+      "name": "non-join should reject WINDOWSTART in projection",
+      "statements": [
+        "CREATE STREAM INPUT (F0 INT) WITH (kafka_topic='input', value_format='JSON', window_type='session');",
+        "CREATE STREAM OUTPUT AS SELECT WINDOWSTART FROM INPUT;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Reserved column name in select: `WINDOWSTART`. Please remove or alias the column."
+      }
+    },
+    {
+      "name": "non-join should reject WINDOWEND in projection",
+      "statements": [
+        "CREATE STREAM INPUT (F0 INT) WITH (kafka_topic='input', value_format='JSON', window_type='session');",
+        "CREATE STREAM OUTPUT AS SELECT WINDOWEND FROM INPUT;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Reserved column name in select: `WINDOWEND`. Please remove or alias the column."
+      }
+    },
+    {
+      "name": "non-join leaves aliased system columns in output's value schema",
       "statements": [
         "CREATE STREAM INPUT (F0 INT) WITH (kafka_topic='input', value_format='JSON');",
         "CREATE STREAM OUTPUT AS SELECT F0, ROWTIME AS TIME, ROWKEY AS KEY FROM INPUT;"
       ],
-      "inputs": [{"topic": "input", "key": "k", "value": {"F0": 4}, "timestamp": 1}],
-      "outputs": [{"topic": "OUTPUT", "key": "k", "value": {"F0": 4, "TIME": 1, "KEY": "k"}, "timestamp": 1}]
+      "inputs": [{"topic": "input", "key": "k", "value": {"F0": 4}, "timestamp": 1, "window": {"start": 12, "end": 465, "type": "session"}}],
+      "outputs": [{"topic": "OUTPUT", "key": "k", "value": {"F0": 4, "TIME": 1, "WSTART": 12, "WEND": 465, "KEY": "k"}, "timestamp": 1, "window": {"start": 12, "end": 465, "type": "session"}}]
     },
     {
       "name": "join should reject ROWTIME in projection",
@@ -432,17 +454,41 @@
       }
     },
     {
-      "name": "join leaves aliased ROWKEY and ROWTIME in output's value schema",
+      "name": "join should reject WINDOWSTART in projection",
       "statements": [
-        "CREATE STREAM LEFT_STREAM (F0 INT) WITH (kafka_topic='left', value_format='JSON');",
-        "CREATE STREAM RIGHT_STREAM (F1 INT) WITH (kafka_topic='right', value_format='JSON');",
+        "CREATE STREAM LEFT_STREAM (F0 INT) WITH (kafka_topic='left', value_format='JSON', window_type='tumbling', window_size='1 second');",
+        "CREATE STREAM RIGHT_STREAM (F1 INT) WITH (kafka_topic='right', value_format='JSON', window_type='tumbling', window_size='1 second');",
+        "CREATE STREAM OUTPUT as SELECT l.WINDOWSTART AS WINDOWSTART, f0 FROM left_stream l join right_stream r WITHIN 1 seconds ON l.rowkey = r.rowkey;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Reserved column name in select: `WINDOWSTART`. Please remove or alias the column."
+      }
+    },
+    {
+      "name": "join should reject WINDOWEND in projection",
+      "statements": [
+        "CREATE STREAM LEFT_STREAM (F0 INT) WITH (kafka_topic='left', value_format='JSON', window_type='tumbling', window_size='1 second');",
+        "CREATE STREAM RIGHT_STREAM (F1 INT) WITH (kafka_topic='right', value_format='JSON', window_type='tumbling', window_size='1 second');",
+        "CREATE STREAM OUTPUT as SELECT l.WINDOWEND AS WINDOWEND, f0 FROM left_stream l join right_stream r WITHIN 1 seconds ON l.rowkey = r.rowkey;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Reserved column name in select: `WINDOWEND`. Please remove or alias the column."
+      }
+    },
+    {
+      "name": "join leaves aliased system columns in output's value schema",
+      "statements": [
+        "CREATE STREAM LEFT_STREAM (F0 INT) WITH (kafka_topic='left', value_format='JSON', window_type='tumbling', window_size='1 second');",
+        "CREATE STREAM RIGHT_STREAM (F1 INT) WITH (kafka_topic='right', value_format='JSON', window_type='tumbling', window_size='1 second');",
         "CREATE STREAM OUTPUT as SELECT l.ROWTIME AS TIME, l.ROWKEY AS KEY, f0, f1 FROM left_stream l join right_stream r WITHIN 1 seconds ON l.rowkey = r.rowkey;"
       ],
       "inputs": [
-        {"topic": "left", "key": "k", "value": {"F0": 4}, "timestamp": 1},
-        {"topic": "right", "key": "k", "value": {"F1": 6}, "timestamp": 1}
+        {"topic": "left", "key": "k", "value": {"F0": 4}, "timestamp": 1, "window": {"start": 0, "end": 1000, "type": "time"}},
+        {"topic": "right", "key": "k", "value": {"F1": 6}, "timestamp": 2, "window": {"start": 0, "end": 1000, "type": "time"}}
       ],
-      "outputs": [{"topic": "OUTPUT", "key": "k", "value": {"F0": 4, "F1": 6, "TIME": 1, "KEY": "k"}, "timestamp": 1}]
+      "outputs": [{"topic": "OUTPUT", "key": "k", "value": {"F0": 4, "F1": 6, "TIME": 1, "WSTART": 0, "WEND": 1000, "KEY": "k"}, "timestamp": 2, "window": {"start": 0, "end": 1000, "type": "time"}}]
     },
     {
       "name": "group-by rejects ROWKEY in projection",
@@ -453,6 +499,17 @@
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlException",
         "message": "Reserved column name in select: `ROWKEY`. Please remove or alias the column."
+      }
+    },
+    {
+      "name": "group-by rejects window bounds in projection",
+      "statements": [
+        "CREATE STREAM INPUT (F0 INT) WITH (kafka_topic='input', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT WINDOWSTART, COUNT(*) AS COUNT FROM INPUT GROUP BY WINDOWSTART;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Reserved column name in select: `WINDOWSTART`. Please remove or alias the column."
       }
     },
     {

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/StructuredDataSource.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/StructuredDataSource.java
@@ -22,7 +22,6 @@ import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.execution.timestamp.TimestampColumn;
 import io.confluent.ksql.name.SourceName;
-import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.util.SchemaUtil;
@@ -64,9 +63,8 @@ abstract class StructuredDataSource<K> implements DataSource<K> {
     this.serdeOptions = ImmutableSet.copyOf(requireNonNull(serdeOptions, "serdeOptions"));
     this.casTarget = casTarget;
 
-    if (schema.findValueColumn(ColumnRef.of(SchemaUtil.ROWKEY_NAME)).isPresent()
-        || schema.findValueColumn(ColumnRef.of(SchemaUtil.ROWTIME_NAME)).isPresent()) {
-      throw new IllegalArgumentException("Schema contains implicit columns in value schema");
+    if (schema.valueContainsAny(SchemaUtil.systemColumnNames())) {
+      throw new IllegalArgumentException("Schema contains system columns in value schema");
     }
   }
 

--- a/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/StructuredDataSourceTest.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/StructuredDataSourceTest.java
@@ -83,6 +83,36 @@ public class StructuredDataSourceTest {
     );
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldThrowIfSchemaContainsWindowStart() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueColumn(SchemaUtil.WINDOWSTART_NAME, SqlTypes.STRING)
+        .valueColumn(ColumnName.of("f0"), SqlTypes.BIGINT)
+        .build();
+
+    // When:
+    new TestStructuredDataSource(
+        schema,
+        keyField
+    );
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldThrowIfSchemaContainsWindowEnd() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueColumn(SchemaUtil.WINDOWEND_NAME, SqlTypes.STRING)
+        .valueColumn(ColumnName.of("f0"), SqlTypes.BIGINT)
+        .build();
+
+    // When:
+    new TestStructuredDataSource(
+        schema,
+        keyField
+    );
+  }
+
   /**
    * Test class to allow the abstract base class to be instantiated.
    */

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SingleColumn.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SingleColumn.java
@@ -46,8 +46,8 @@ public class SingleColumn extends SelectItem {
   ) {
     super(location);
 
-    checkForReservedToken(expression, alias, SchemaUtil.ROWTIME_NAME);
-    checkForReservedToken(expression, alias, SchemaUtil.ROWKEY_NAME);
+    SchemaUtil.systemColumnNames()
+        .forEach(columnName -> checkForReservedToken(expression, alias, columnName));
 
     this.expression = requireNonNull(expression, "expression");
     this.alias = requireNonNull(alias, "alias");

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/SingleColumnTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/SingleColumnTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser.tree;
+
+import io.confluent.ksql.execution.expression.tree.Expression;
+import io.confluent.ksql.execution.expression.tree.StringLiteral;
+import io.confluent.ksql.parser.NodeLocation;
+import io.confluent.ksql.parser.exception.ParseFailedException;
+import io.confluent.ksql.util.SchemaUtil;
+import java.util.Optional;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class SingleColumnTest {
+
+  private static final Optional<NodeLocation> A_LOCATION = Optional.empty();
+  private static final Expression AN_EXPRESSION = new StringLiteral("foo");
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void shouldThrowIfAliasIsSystemColumnName() {
+    // Expect:
+    expectedException.expect(ParseFailedException.class);
+    expectedException.expectMessage("is a reserved token for implicit column.");
+
+    // When:
+    new SingleColumn(A_LOCATION, AN_EXPRESSION, Optional.of(SchemaUtil.WINDOWSTART_NAME));
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/TableRowsEntityFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/TableRowsEntityFactory.java
@@ -18,10 +18,10 @@ package io.confluent.ksql.rest.entity;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.execution.streams.materialization.TableRow;
 import io.confluent.ksql.model.WindowType;
-import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.util.SchemaUtil;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -37,12 +37,12 @@ public final class TableRowsEntityFactory {
 
   @SuppressWarnings("deprecation")
   private static final List<Column> TIME_WINDOW_COLUMNS = ImmutableList
-      .of(Column.legacySystemWindowColumn(ColumnName.of("WINDOWSTART"), SqlTypes.BIGINT));
+      .of(Column.legacySystemWindowColumn(SchemaUtil.WINDOWSTART_NAME, SqlTypes.BIGINT));
 
   @SuppressWarnings("deprecation")
   private static final List<Column> SESSION_WINDOW_COLUMNS = ImmutableList.<Column>builder()
       .addAll(TIME_WINDOW_COLUMNS)
-      .add(Column.legacySystemWindowColumn(ColumnName.of("WINDOWEND"), SqlTypes.BIGINT))
+      .add(Column.legacySystemWindowColumn(SchemaUtil.WINDOWEND_NAME, SqlTypes.BIGINT))
       .build();
 
   private TableRowsEntityFactory() {


### PR DESCRIPTION
### Description 

BREAKING CHANGE: `WINDOWSTART` and `WINDOWEND` are now reserved system column names. Any query that previously used those names will need to be changed: for example, alias the columns to a different name.

These column names are being reserved for use as system columns when dealing with streams and tables that have a windowed key.

In the fullness of time we may allow custom names for these columns. However, in the short term we're going to be using hardcoded names.

### Testing done 

Suitable test unit / QTT tests added.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

