### PR TITLE
fix: include valid alternative UDF signatures in error message (MINOR)

### DIFF
--- a/ksql-common/src/test/java/io/confluent/ksql/function/UdfFactoryTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/function/UdfFactoryTest.java
@@ -39,7 +39,7 @@ public class UdfFactoryTest {
   @Test
   public void shouldThrowIfNoVariantFoundThatAcceptsSuppliedParamTypes() {
     expectedException.expect(KafkaException.class);
-    expectedException.expectMessage("Function 'TestFunc' does not accept parameters of types:[STRING, BIGINT]");
+    expectedException.expectMessage("Function 'TestFunc' does not accept parameters (STRING, BIGINT)");
 
     factory.getFunction(ImmutableList.of(SqlTypes.STRING, SqlTypes.BIGINT));
   }

--- a/ksql-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
@@ -3,7 +3,6 @@ package io.confluent.ksql.function;
 import static io.confluent.ksql.function.KsqlScalarFunction.INTERNAL_PATH;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.function.types.ArrayType;
@@ -55,7 +54,7 @@ public class UdfIndexTest {
 
   @Before
   public void setUp() {
-    udfIndex = new UdfIndex<KsqlScalarFunction>("name");
+    udfIndex = new UdfIndex<>("name");
   }
 
   @Rule
@@ -64,8 +63,9 @@ public class UdfIndexTest {
   @Test
   public void shouldFindNoArgs() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{function(EXPECTED, false)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+    givenFunctions(
+        function(EXPECTED, false)
+    );
 
     // When:
     final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of());
@@ -77,9 +77,9 @@ public class UdfIndexTest {
   @Test
   public void shouldFindOneArg() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
-        function(EXPECTED, false, STRING)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+    givenFunctions(
+        function(EXPECTED, false, STRING)
+    );
 
     // When:
     final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlTypes.STRING));
@@ -91,12 +91,13 @@ public class UdfIndexTest {
   @Test
   public void shouldFindTwoDifferentArgs() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
-        function(EXPECTED, false, STRING, INT)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+    givenFunctions(
+        function(EXPECTED, false, STRING, INT)
+    );
 
     // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlTypes.STRING, SqlTypes.INTEGER));
+    final KsqlScalarFunction fun = udfIndex
+        .getFunction(ImmutableList.of(SqlTypes.STRING, SqlTypes.INTEGER));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -105,12 +106,13 @@ public class UdfIndexTest {
   @Test
   public void shouldFindTwoSameArgs() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
-        function(EXPECTED, false, STRING, STRING)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+    givenFunctions(
+        function(EXPECTED, false, STRING, STRING)
+    );
 
     // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlTypes.STRING, SqlTypes.STRING));
+    final KsqlScalarFunction fun = udfIndex
+        .getFunction(ImmutableList.of(SqlTypes.STRING, SqlTypes.STRING));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -119,10 +121,10 @@ public class UdfIndexTest {
   @Test
   public void shouldFindOneArgConflict() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
+    givenFunctions(
         function(EXPECTED, false, STRING),
-        function(OTHER, false, INT)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+        function(OTHER, false, INT)
+    );
 
     // When:
     final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlTypes.STRING));
@@ -134,10 +136,10 @@ public class UdfIndexTest {
   @Test
   public void shouldFindTwoArgSameFirstConflict() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
+    givenFunctions(
         function(EXPECTED, false, STRING, STRING),
-        function(OTHER, false, STRING, INT)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+        function(OTHER, false, STRING, INT)
+    );
 
     // When:
     final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlTypes.STRING, SqlTypes.STRING));
@@ -149,9 +151,10 @@ public class UdfIndexTest {
   @Test
   public void shouldChooseCorrectStruct() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{function(OTHER, false, STRUCT2),
-        function(EXPECTED, false, STRUCT1)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+    givenFunctions(
+        function(OTHER, false, STRUCT2),
+        function(EXPECTED, false, STRUCT1)
+    );
 
     // When:
     final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(STRUCT1_ARG));
@@ -163,9 +166,10 @@ public class UdfIndexTest {
   @Test
   public void shouldChooseCorrectMap() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{function(OTHER, false, MAP2),
-        function(EXPECTED, false, MAP1)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+    givenFunctions(
+        function(OTHER, false, MAP2),
+        function(EXPECTED, false, MAP1)
+    );
 
     // When:
     final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(MAP1_ARG));
@@ -177,9 +181,9 @@ public class UdfIndexTest {
   @Test
   public void shouldAllowAnyDecimal() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
-        function(EXPECTED, false, DECIMAL)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+    givenFunctions(
+        function(EXPECTED, false, DECIMAL)
+    );
 
     // When:
     final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(DECIMAL1_ARG));
@@ -191,9 +195,9 @@ public class UdfIndexTest {
   @Test
   public void shouldFindVarargsEmpty() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
-        function(EXPECTED, true, STRING_VARARGS)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+    givenFunctions(
+        function(EXPECTED, true, STRING_VARARGS)
+    );
 
     // When:
     final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of());
@@ -205,9 +209,9 @@ public class UdfIndexTest {
   @Test
   public void shouldFindVarargsOne() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
-        function(EXPECTED, true, STRING_VARARGS)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+    givenFunctions(
+        function(EXPECTED, true, STRING_VARARGS)
+    );
 
     // When:
     final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlTypes.STRING));
@@ -219,12 +223,13 @@ public class UdfIndexTest {
   @Test
   public void shouldFindVarargsTwo() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
-        function(EXPECTED, true, STRING_VARARGS)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+    givenFunctions(
+        function(EXPECTED, true, STRING_VARARGS)
+    );
 
     // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlTypes.STRING, SqlTypes.STRING));
+    final KsqlScalarFunction fun = udfIndex
+        .getFunction(ImmutableList.of(SqlTypes.STRING, SqlTypes.STRING));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -233,9 +238,9 @@ public class UdfIndexTest {
   @Test
   public void shouldFindVarargWithStruct() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
-        function(EXPECTED, true, ArrayType.of(STRUCT1))};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+    givenFunctions(
+        function(EXPECTED, true, ArrayType.of(STRUCT1))
+    );
 
     // When:
     final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(STRUCT1_ARG, STRUCT1_ARG));
@@ -247,12 +252,13 @@ public class UdfIndexTest {
   @Test
   public void shouldFindVarargWithList() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
-        function(EXPECTED, true, STRING_VARARGS)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+    givenFunctions(
+        function(EXPECTED, true, STRING_VARARGS)
+    );
 
     // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlArray.of(SqlTypes.STRING)));
+    final KsqlScalarFunction fun = udfIndex
+        .getFunction(ImmutableList.of(SqlArray.of(SqlTypes.STRING)));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -261,10 +267,10 @@ public class UdfIndexTest {
   @Test
   public void shouldChooseSpecificOverVarArgs() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
+    givenFunctions(
         function(EXPECTED, false, STRING),
-        function(OTHER, true, STRING_VARARGS)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+        function(OTHER, true, STRING_VARARGS)
+    );
 
     // When:
     final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlTypes.STRING));
@@ -276,11 +282,11 @@ public class UdfIndexTest {
   @Test
   public void shouldChooseSpecificOverMultipleVarArgs() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
+    givenFunctions(
         function(EXPECTED, false, STRING),
         function(OTHER, true, STRING_VARARGS),
-        function("two", true, STRING, STRING_VARARGS)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+        function("two", true, STRING, STRING_VARARGS)
+    );
 
     // When:
     final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlTypes.STRING));
@@ -292,12 +298,14 @@ public class UdfIndexTest {
   @Test
   public void shouldChooseVarArgsIfSpecificDoesntMatch() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{function(OTHER, false, STRING),
-        function(EXPECTED, true, STRING_VARARGS)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+    givenFunctions(
+        function(OTHER, false, STRING),
+        function(EXPECTED, true, STRING_VARARGS)
+    );
 
     // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlTypes.STRING, SqlTypes.STRING));
+    final KsqlScalarFunction fun = udfIndex
+        .getFunction(ImmutableList.of(SqlTypes.STRING, SqlTypes.STRING));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -306,9 +314,9 @@ public class UdfIndexTest {
   @Test
   public void shouldFindNonVarargWithNullValues() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
-        function(EXPECTED, false, STRING)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+    givenFunctions(
+        function(EXPECTED, false, STRING)
+    );
 
     // When:
     final KsqlScalarFunction fun = udfIndex.getFunction(Collections.singletonList(null));
@@ -320,9 +328,9 @@ public class UdfIndexTest {
   @Test
   public void shouldFindNonVarargWithPartialNullValues() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
-        function(EXPECTED, false, STRING, STRING)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+    givenFunctions(
+        function(EXPECTED, false, STRING, STRING)
+    );
 
     // When:
     final KsqlScalarFunction fun = udfIndex.getFunction(Arrays.asList(null, SqlTypes.STRING));
@@ -334,10 +342,10 @@ public class UdfIndexTest {
   @Test
   public void shouldChooseFirstAddedWithNullValues() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
+    givenFunctions(
         function(EXPECTED, false, STRING),
-        function(OTHER, false, INT)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+        function(OTHER, false, INT)
+    );
 
     // When:
     final KsqlScalarFunction fun = udfIndex.getFunction(Collections.singletonList(null));
@@ -349,9 +357,9 @@ public class UdfIndexTest {
   @Test
   public void shouldFindVarargWithNullValues() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
-        function(EXPECTED, true, STRING_VARARGS)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+    givenFunctions(
+        function(EXPECTED, true, STRING_VARARGS)
+    );
 
     // When:
     final KsqlScalarFunction fun = udfIndex.getFunction(Arrays.asList(new SqlType[]{null}));
@@ -363,9 +371,9 @@ public class UdfIndexTest {
   @Test
   public void shouldFindVarargWithSomeNullValues() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
-        function(EXPECTED, true, STRING_VARARGS)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+    givenFunctions(
+        function(EXPECTED, true, STRING_VARARGS)
+    );
 
     // When:
     final KsqlScalarFunction fun = udfIndex.getFunction(Arrays.asList(null, SqlTypes.STRING, null));
@@ -377,10 +385,10 @@ public class UdfIndexTest {
   @Test
   public void shouldChooseNonVarargWithNullValues() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
+    givenFunctions(
         function(EXPECTED, false, STRING),
-        function(OTHER, true, STRING_VARARGS)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+        function(OTHER, true, STRING_VARARGS)
+    );
 
     // When:
     final KsqlScalarFunction fun = udfIndex.getFunction(Collections.singletonList(null));
@@ -392,10 +400,10 @@ public class UdfIndexTest {
   @Test
   public void shouldChooseNonVarargWithNullValuesOfDifferingSchemas() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
+    givenFunctions(
         function(EXPECTED, false, STRING, INT),
-        function(OTHER, true, STRING_VARARGS)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+        function(OTHER, true, STRING_VARARGS)
+    );
 
     // When:
     final KsqlScalarFunction fun = udfIndex.getFunction(Arrays.asList(new SqlType[]{null, null}));
@@ -407,10 +415,10 @@ public class UdfIndexTest {
   @Test
   public void shouldChooseNonVarargWithNullValuesOfSameSchemas() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
+    givenFunctions(
         function(EXPECTED, false, STRING, STRING),
-        function(OTHER, true, STRING_VARARGS)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+        function(OTHER, true, STRING_VARARGS)
+    );
 
     // When:
     final KsqlScalarFunction fun = udfIndex.getFunction(Arrays.asList(new SqlType[]{null, null}));
@@ -422,10 +430,10 @@ public class UdfIndexTest {
   @Test
   public void shouldChooseNonVarargWithNullValuesOfPartialNulls() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
+    givenFunctions(
         function(EXPECTED, false, STRING, INT),
-        function(OTHER, true, STRING_VARARGS)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+        function(OTHER, true, STRING_VARARGS)
+    );
 
     // When:
     final KsqlScalarFunction fun = udfIndex.getFunction(Arrays.asList(SqlTypes.STRING, null));
@@ -437,13 +445,13 @@ public class UdfIndexTest {
   @Test
   public void shouldChooseCorrectlyInComplicatedTopology() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
+    givenFunctions(
         function(EXPECTED, false, STRING, INT, STRING, INT), function(OTHER, true, STRING_VARARGS),
         function("two", true, STRING, STRING_VARARGS),
         function("three", true, STRING, INT, STRING_VARARGS),
         function("four", true, STRING, INT, STRING, INT, STRING_VARARGS),
-        function("five", true, INT, INT, STRING, INT, STRING_VARARGS)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+        function("five", true, INT, INT, STRING, INT, STRING_VARARGS)
+    );
 
     // When:
     final KsqlScalarFunction fun = udfIndex.getFunction(Arrays.asList(SqlTypes.STRING, SqlTypes.INTEGER, null, SqlTypes.INTEGER));
@@ -455,10 +463,9 @@ public class UdfIndexTest {
   @Test
   public void shouldFindGenericMethodWithIntParam() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
+    givenFunctions(
         function(EXPECTED, false, GENERIC_LIST)
-    };
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+    );
 
     // When:
     final KsqlScalarFunction fun = udfIndex.getFunction(Collections.singletonList(SqlArray.of(SqlTypes.INTEGER)));
@@ -470,10 +477,9 @@ public class UdfIndexTest {
   @Test
   public void shouldFindGenericMethodWithStringParam() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
+    givenFunctions(
         function(EXPECTED, false, GENERIC_LIST)
-    };
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+    );
 
     // When:
     final KsqlScalarFunction fun = udfIndex.getFunction(Collections.singletonList(SqlArray.of(SqlTypes.STRING)));
@@ -486,10 +492,9 @@ public class UdfIndexTest {
   public void shouldMatchGenericMethodWithMultipleIdenticalGenerics() {
     // Given:
     final GenericType generic = GenericType.of("A");
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
+    givenFunctions(
         function(EXPECTED, false, generic, generic)
-    };
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+    );
 
     // When:
     final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlTypes.INTEGER, SqlTypes.INTEGER));
@@ -503,10 +508,9 @@ public class UdfIndexTest {
     // Given:
     final GenericType genericA = GenericType.of("A");
     final GenericType genericB = GenericType.of("B");
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
+    givenFunctions(
         function(EXPECTED, false, genericA, genericB)
-    };
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+    );
 
     // When:
     final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlTypes.INTEGER, SqlTypes.STRING));
@@ -519,10 +523,9 @@ public class UdfIndexTest {
   public void shouldMatchNestedGenericMethodWithMultipleGenerics() {
     // Given:
     final ArrayType generic = ArrayType.of(GenericType.of("A"));
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
+    givenFunctions(
         function(EXPECTED, false, generic, generic)
-    };
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+    );
 
     // When:
     final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlArray.of(SqlTypes.INTEGER), SqlArray.of(SqlTypes.INTEGER)));
@@ -534,13 +537,14 @@ public class UdfIndexTest {
   @Test
   public void shouldNotMatchIfParamLengthDiffers() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{function(OTHER, false, STRING)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+    givenFunctions(
+        function(OTHER, false, STRING)
+    );
 
     // Expect:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage(is("Function 'name' does not accept parameters of types:"
-        + "[STRING, STRING]"));
+    expectedException.expectMessage("Function 'name' does not accept parameters "
+        + "(STRING, STRING)");
 
     // When:
     udfIndex.getFunction(ImmutableList.of(SqlTypes.STRING, SqlTypes.STRING));
@@ -549,81 +553,79 @@ public class UdfIndexTest {
   @Test
   public void shouldNotMatchIfNoneFound() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{function(OTHER, false, STRING)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+    givenFunctions(
+        function(OTHER, false, STRING)
+    );
 
     // Expect:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage(is("Function 'name' does not accept parameters of types:"
-        + "[INTEGER]"));
+    expectedException.expectMessage("Function 'name' does not accept parameters "
+        + "(INTEGER)");
 
     // When:
     udfIndex.getFunction(ImmutableList.of(SqlTypes.INTEGER));
-
   }
 
   @Test
   public void shouldNotMatchIfNoneFoundWithNull() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
-        function(OTHER, false, STRING, INT)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+    givenFunctions(
+        function(OTHER, false, STRING, INT)
+    );
 
     // Expect:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage(is("Function 'name' does not accept parameters of types:"
-        + "[INTEGER, null]"));
+    expectedException.expectMessage("Function 'name' does not accept parameters "
+        + "(INTEGER, null)");
 
     // When:
     udfIndex.getFunction(Arrays.asList(SqlTypes.INTEGER, null));
-
   }
 
   @Test
   public void shouldNotChooseSpecificWhenTrickyVarArgLoop() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
+    givenFunctions(
         function(OTHER, false, STRING, INT),
-        function("two", true, STRING_VARARGS)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+        function("two", true, STRING_VARARGS)
+    );
 
     // Expect:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage(is("Function 'name' does not accept parameters of types:"
-        + "[STRING, INTEGER, STRING]"));
+    expectedException.expectMessage("Function 'name' does not accept parameters "
+        + "(STRING, INTEGER, STRING)");
 
     // When:
     udfIndex.getFunction(ImmutableList.of(SqlTypes.STRING, SqlTypes.INTEGER, SqlTypes.STRING));
-
   }
 
   @Test
   public void shouldNotMatchWhenNullTypeInArgsIfParamLengthDiffers() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{function(OTHER, false, STRING)};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+    givenFunctions(
+        function(OTHER, false, STRING)
+    );
 
     // Expect:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage(is("Function 'name' does not accept parameters of types:"
-        + "[STRING, null]"));
+    expectedException.expectMessage("Function 'name' does not accept parameters "
+        + "(STRING, null)");
 
     // When:
     udfIndex.getFunction(Arrays.asList(SqlTypes.STRING, null));
-
   }
 
   @Test
   public void shouldNotMatchVarargDifferentStructs() {
     // Given:
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
-        function(OTHER, true, ArrayType.of(STRUCT1))};
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+    givenFunctions(
+        function(OTHER, true, ArrayType.of(STRUCT1))
+    );
 
     // Expect:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage(is("Function 'name' does not accept parameters of types:"
-        + "[STRUCT<a STRING>, STRUCT<b INTEGER>]"));
+    expectedException.expectMessage("Function 'name' does not accept parameters "
+        + "(STRUCT<a STRING>, STRUCT<b INTEGER>)");
 
     // When:
     udfIndex.getFunction(ImmutableList.of(STRUCT1_ARG, STRUCT2_ARG));
@@ -633,15 +635,14 @@ public class UdfIndexTest {
   public void shouldNotMatchGenericMethodWithAlreadyReservedTypes() {
     // Given:
     final GenericType generic = GenericType.of("A");
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
+    givenFunctions(
         function(EXPECTED, false, generic, generic)
-    };
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+    );
 
     // Expect:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage(is("Function 'name' does not accept parameters of types:"
-        + "[INTEGER, STRING]"));
+    expectedException.expectMessage("Function 'name' does not accept parameters "
+        + "(INTEGER, STRING)");
 
     // When:
     udfIndex.getFunction(ImmutableList.of(SqlTypes.INTEGER, SqlTypes.STRING));
@@ -651,18 +652,46 @@ public class UdfIndexTest {
   public void shouldNotMatchNestedGenericMethodWithAlreadyReservedTypes() {
     // Given:
     final ArrayType generic = ArrayType.of(GenericType.of("A"));
-    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
+    givenFunctions(
         function(EXPECTED, false, generic, generic)
-    };
-    Arrays.stream(functions).forEach(udfIndex::addFunction);
+    );
 
     // Expect:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage(is("Function 'name' does not accept parameters of types:"
-        + "[ARRAY<INTEGER>, ARRAY<STRING>]"));
+    expectedException.expectMessage("Function 'name' does not accept parameters "
+        + "(ARRAY<INTEGER>, ARRAY<STRING>)");
 
     // When:
-    udfIndex.getFunction(ImmutableList.of(SqlArray.of(SqlTypes.INTEGER), SqlArray.of(SqlTypes.STRING)));
+    udfIndex
+        .getFunction(ImmutableList.of(SqlArray.of(SqlTypes.INTEGER), SqlArray.of(SqlTypes.STRING)));
+  }
+
+  @Test
+  public void shouldIncludeAvailableSignaturesIfNotMatchFound() {
+    // Given:
+    final ArrayType generic = ArrayType.of(GenericType.of("A"));
+    givenFunctions(
+        function(OTHER, true, false, STRING, INT),
+        function(OTHER, true, STRING_VARARGS),
+        function(OTHER, false, generic)
+    );
+
+    // Expect:
+    expectedException.expectMessage("Valid alternatives are:"
+        + System.lineSeparator()
+        + "other(VARCHAR...)"
+        + System.lineSeparator()
+        + "other(ARRAY<A>)"
+        + System.lineSeparator()
+        + "other(VARCHAR paramName, INT paramName)"
+    );
+
+    // When:
+    udfIndex.getFunction(ImmutableList.of(SqlTypes.STRING, SqlTypes.INTEGER, SqlTypes.STRING));
+  }
+
+  private void givenFunctions(final KsqlScalarFunction... functions) {
+    Arrays.stream(functions).forEach(udfIndex::addFunction);
   }
 
   private static KsqlScalarFunction function(
@@ -678,6 +707,15 @@ public class UdfIndexTest {
       final boolean isVarArgs,
       final ParamType... args
   ) {
+    return function(name, false, isVarArgs, args);
+  }
+
+  private static KsqlScalarFunction function(
+      final FunctionName name,
+      final boolean namedParams,
+      final boolean isVarArgs,
+      final ParamType... args
+  ) {
     final Function<KsqlConfig, Kudf> udfFactory = ksqlConfig -> {
       try {
         return new MyUdf();
@@ -688,7 +726,7 @@ public class UdfIndexTest {
     };
 
     final List<ParameterInfo> paramInfos = Arrays.stream(args)
-        .map(type -> new ParameterInfo("", type, "", false))
+        .map(type -> new ParameterInfo(namedParams ? "paramName" : "", type, "", false))
         .collect(Collectors.toList());
 
     return KsqlScalarFunction.create(

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/explode.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/explode.json
@@ -50,7 +50,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Function 'explode' does not accept parameters of types:[MAP<STRING, INTEGER>]"
+        "message": "Function 'explode' does not accept parameters (MAP<STRING, INTEGER>).\nValid alternatives are:\nexplode(ARRAY<DECIMAL> input)\nexplode(ARRAY<T> list)"
       }
     },
     {


### PR DESCRIPTION
### Description 

When a UDF/UDAF/UDTF is called with incorrect parameters the user is informed by the error:

```
Function 'Foo' does not accept parameters of types:[STRING, STRING]
```

This is all well and good, but KSQL could be more helpful!  The message is now:

```
Function 'Foo' does not accept parameters (STRING, STRING).
Valid alternatives are:
FOO(STRING)
FOO(STRING text, INT len)
FOO(STRING text, INT start, INT len)
For detailed information on a function run: DESCRIBE FUNCTION <Function-Name>;
```

### Testing done 

`mvn test` and manual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

