### PR TITLE
feat: support implicit casting in UDFs

### DIFF
--- a/ksql-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
@@ -35,6 +35,8 @@ public class UdfIndexTest {
   private static final ParamType STRING = ParamTypes.STRING;
   private static final ParamType DECIMAL = ParamTypes.DECIMAL;
   private static final ParamType INT = ParamTypes.INTEGER;
+  private static final ParamType LONG = ParamTypes.LONG;
+  private static final ParamType DOUBLE = ParamTypes.DOUBLE;
   private static final ParamType STRUCT1 = StructType.builder().field("a", STRING).build();
   private static final ParamType STRUCT2 = StructType.builder().field("b", INT).build();
   private static final ParamType MAP1 = MapType.of(STRING);
@@ -83,6 +85,37 @@ public class UdfIndexTest {
 
     // When:
     final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlTypes.STRING));
+
+    // Then:
+    assertThat(fun.name(), equalTo(EXPECTED));
+  }
+
+  @Test
+  public void shouldFindOneArgWithCast() {
+    // Given:
+    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
+        function(EXPECTED, false, LONG)};
+    Arrays.stream(functions).forEach(udfIndex::addFunction);
+
+    // When:
+    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlTypes.INTEGER));
+
+    // Then:
+    assertThat(fun.name(), equalTo(EXPECTED));
+  }
+
+  @Test
+  public void shouldFindPreferredOneArgWithCast() {
+    // Given:
+    final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
+        function(OTHER, false, LONG),
+        function(EXPECTED, false, INT),
+        function(OTHER, false, DOUBLE)
+    };
+    Arrays.stream(functions).forEach(udfIndex::addFunction);
+
+    // When:
+    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlTypes.INTEGER));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));

--- a/ksql-common/src/test/java/io/confluent/ksql/util/SchemaUtilTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/SchemaUtilTest.java
@@ -302,7 +302,27 @@ public class SchemaUtilTest {
         SqlTypes.map(SqlTypes.decimal(1, 1)),
         MapType.of(ParamTypes.DECIMAL)),
         is(true));
+  }
 
+  @Test
+  public void shouldPassCompatibleSchemasWithImplicitCasting() {
+    assertThat(SchemaUtil.areCompatible(SqlTypes.INTEGER, ParamTypes.LONG, true), is(true));
+    assertThat(SchemaUtil.areCompatible(SqlTypes.INTEGER, ParamTypes.DOUBLE, true), is(true));
+    assertThat(SchemaUtil.areCompatible(SqlTypes.INTEGER, ParamTypes.DECIMAL, true), is(true));
+
+    assertThat(SchemaUtil.areCompatible(SqlTypes.BIGINT, ParamTypes.DOUBLE, true), is(true));
+    assertThat(SchemaUtil.areCompatible(SqlTypes.BIGINT, ParamTypes.DECIMAL, true), is(true));
+
+    assertThat(SchemaUtil.areCompatible(SqlTypes.decimal(2, 1), ParamTypes.DOUBLE, true), is(true));
+  }
+
+  @Test
+  public void shouldNotPassInCompatibleSchemasWithImplicitCasting() {
+    assertThat(SchemaUtil.areCompatible(SqlTypes.BIGINT, ParamTypes.INTEGER, true), is(false));
+
+    assertThat(SchemaUtil.areCompatible(SqlTypes.DOUBLE, ParamTypes.LONG, true), is(false));
+
+    assertThat(SchemaUtil.areCompatible(SqlTypes.DOUBLE, ParamTypes.DECIMAL, true), is(false));
   }
 
   @Test

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/udf-implicit-cast.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/udf-implicit-cast.json
@@ -1,0 +1,93 @@
+{
+  "tests": [
+    {
+      "name": "int literal -> double",
+      "statements": [
+        "CREATE STREAM TEST (ID bigint, LAT1 double, LON1 double) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM DISTANCE_STREAM AS select ID, geo_distance(LAT1, LON1, 51, 0) as CALCULATED_DISTANCE from test;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "value": {"ID": 1, "LAT1": 37.4439, "LON1": -122.1663}}
+      ],
+      "outputs": [
+        {"topic": "DISTANCE_STREAM", "value": {"ID": 1, "CALCULATED_DISTANCE": 8682.459061368269}}
+      ]
+    },
+    {
+      "name": "int field -> double",
+      "statements": [
+        "CREATE STREAM TEST (ID bigint, LAT1 double, LON1 double, LAT2 int) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM DISTANCE_STREAM AS select ID, geo_distance(LAT1, LON1, LAT2, 0) as CALCULATED_DISTANCE from test;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "value": {"ID": 1, "LAT1": 37.4439, "LON1": -122.1663, "LAT2": 51}}
+      ],
+      "outputs": [
+        {"topic": "DISTANCE_STREAM", "value": {"ID": 1, "CALCULATED_DISTANCE": 8682.459061368269}}
+      ]
+    },
+    {
+      "name": "long field -> double",
+      "statements": [
+        "CREATE STREAM TEST (ID bigint, LAT1 double, LON1 double, LAT2 bigint) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM DISTANCE_STREAM AS select ID, geo_distance(LAT1, LON1, LAT2, 0) as CALCULATED_DISTANCE from test;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "value": {"ID": 1, "LAT1": 37.4439, "LON1": -122.1663, "LAT2": 51}}
+      ],
+      "outputs": [
+        {"topic": "DISTANCE_STREAM", "value": {"ID": 1, "CALCULATED_DISTANCE": 8682.459061368269}}
+      ]
+    },
+    {
+      "name": "decimal literal -> double",
+      "statements": [
+        "CREATE STREAM TEST (ID bigint, LAT1 double, LON1 double) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM DISTANCE_STREAM AS select ID, geo_distance(LAT1, LON1, 51.0, 0) as CALCULATED_DISTANCE from test;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "value": {"ID": 1, "LAT1": 37.4439, "LON1": -122.1663}}
+      ],
+      "outputs": [
+        {"topic": "DISTANCE_STREAM", "value": {"ID": 1, "CALCULATED_DISTANCE": 8682.459061368269}}
+      ]
+    },
+    {
+      "name": "decimal field -> double",
+      "statements": [
+        "CREATE STREAM TEST (ID bigint, LAT1 double, LON1 double, LAT2 decimal(3, 1)) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM DISTANCE_STREAM AS select ID, geo_distance(LAT1, LON1, LAT2, 0) as CALCULATED_DISTANCE from test;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "value": {"ID": 1, "LAT1": 37.4439, "LON1": -122.1663, "LAT2": 51.0}}
+      ],
+      "outputs": [
+        {"topic": "DISTANCE_STREAM", "value": {"ID": 1, "CALCULATED_DISTANCE": 8682.459061368269}}
+      ]
+    },
+    {
+      "name": "choose the exact match first",
+      "statements": [
+        "CREATE STREAM TEST (ID int) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS select ID, test_udf(ID, 'foo') as foo from test;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "value": {"ID": 1}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"ID": 1, "FOO": "doStuffIntString"}}
+      ]
+    },
+    {
+      "name": "string literal -> double",
+      "statements": [
+        "CREATE STREAM TEST (ID bigint, LAT1 double, LON1 double) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM DISTANCE_STREAM AS select ID, geo_distance(LAT1, LON1, 'foo', 0) as CALCULATED_DISTANCE from test;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Function 'geo_distance' does not accept parameters"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
fixes #4400 
fixes #3791 

### Description 
This PR adds functionality to automagically cast parameters when calling into a user defined function.

**Review Guide**:
1. Look at `SchemaUtil#areCompatible` which now supports implicit casting to determine whether or not a sqltype and param type are compatible
2. Look at `UdfIndex` which now first checks the strict compatibility, and if it finds nothing will check the implicit cast compatibility
3. Look at `SqlToJavaVisitor`, which will perform the implicit casts when the arguments are not the exact types

### Testing done 

- unit tests
- QTT tests
- ran the scenario described in #4400 to make sure that it works

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

