### PR TITLE
test: increase timeouts to avoid flaky tests

### DIFF
--- a/ksql-api/src/test/java/io/confluent/ksql/api/tck/BufferedPublisherVerificationTest.java
+++ b/ksql-api/src/test/java/io/confluent/ksql/api/tck/BufferedPublisherVerificationTest.java
@@ -32,7 +32,7 @@ public class BufferedPublisherVerificationTest extends PublisherVerification<Jso
   public BufferedPublisherVerificationTest() {
     // We need to increase the default timeouts as they are a bit low and can lead to
     // non deterministic runs
-    super(new TestEnvironment(500), 1000);
+    super(new TestEnvironment(1000), 1000);
     this.vertx = Vertx.vertx();
   }
 

--- a/ksql-api/src/test/java/io/confluent/ksql/api/tck/ReactiveSubscriberBlackboxVerificationTest.java
+++ b/ksql-api/src/test/java/io/confluent/ksql/api/tck/ReactiveSubscriberBlackboxVerificationTest.java
@@ -30,7 +30,7 @@ public class ReactiveSubscriberBlackboxVerificationTest extends
   private final Vertx vertx;
 
   public ReactiveSubscriberBlackboxVerificationTest() {
-    super(new TestEnvironment(500));
+    super(new TestEnvironment(1000));
     this.vertx = Vertx.vertx();
   }
 

--- a/ksql-api/src/test/java/io/confluent/ksql/api/tck/ReactiveSubscriberWhiteboxVerificationTest.java
+++ b/ksql-api/src/test/java/io/confluent/ksql/api/tck/ReactiveSubscriberWhiteboxVerificationTest.java
@@ -32,7 +32,7 @@ public class ReactiveSubscriberWhiteboxVerificationTest extends
   private final Vertx vertx;
 
   public ReactiveSubscriberWhiteboxVerificationTest() {
-    super(new TestEnvironment(500));
+    super(new TestEnvironment(1000));
     this.vertx = Vertx.vertx();
   }
 


### PR DESCRIPTION
### Description 

Following some local failures in `ReactiveSubscriberWhiteboxVerificationTest` on loaded local machine.

### Testing done 

Test only change

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

