### PR TITLE
test: add ImmutabilityTest to api module

### DIFF
--- a/ksql-api/src/test/java/io/confluent/ksql/api/ImmutabilityTest.java
+++ b/ksql-api/src/test/java/io/confluent/ksql/api/ImmutabilityTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api;
+
+import io.confluent.ksql.test.util.ImmutableTester;
+import java.util.Collection;
+import java.util.Objects;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.connect.data.ConnectSchema;
+import org.apache.kafka.streams.kstream.JoinWindows;
+import org.apache.kafka.streams.kstream.KGroupedStream;
+import org.apache.kafka.streams.kstream.KGroupedTable;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Windows;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+/**
+ * Test that any type annotated as immutable _is_ immutable
+ *
+ * <p>Note: there are multiple copies of this test to ensure all types are tested.
+ * However, this does mean some times are tested multiple types.
+ */
+@RunWith(Parameterized.class)
+public class ImmutabilityTest {
+
+  private final Class<?> modelClass;
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<Class<?>> data() {
+    return ImmutableTester
+        .classesMarkedImmutable("io.confluent.ksql");
+  }
+
+  public ImmutabilityTest(final Class<?> modelClass) {
+    this.modelClass = Objects.requireNonNull(modelClass, "modelClass");
+  }
+
+  @Test
+  public void shouldBeImmutable() {
+    new ImmutableTester()
+        .withKnownImmutableType(JoinWindows.class)
+        .withKnownImmutableType(ConnectSchema.class)
+        .withKnownImmutableType(KStream.class)
+        .withKnownImmutableType(KTable.class)
+        .withKnownImmutableType(KGroupedStream.class)
+        .withKnownImmutableType(KGroupedTable.class)
+        .withKnownImmutableType(Serde.class)
+        .withKnownImmutableType(Windows.class)
+        .test(modelClass);
+  }
+}


### PR DESCRIPTION
### Description 

Adds a copy of the `ImmutabilityTest` to the new leaf `ksql-api` module to ensure types in this class are checked for valid `@Immutability` annotations.

### Testing done 

Manually locally.  Test fails.  Raising PR to highlight issues.


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

