### PR TITLE
refactor: generalize FormatInfo in prepration for more formats

### DIFF
--- a/ksql-benchmark/src/main/java/io/confluent/ksql/benchmark/SerdeBenchmark.java
+++ b/ksql-benchmark/src/main/java/io/confluent/ksql/benchmark/SerdeBenchmark.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.benchmark;
 
+import com.google.common.collect.ImmutableMap;
 import io.confluent.avro.random.generator.Generator;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
@@ -31,7 +32,6 @@ import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
-import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -170,7 +170,8 @@ public class SerdeBenchmark {
       final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
 
       return getGenericRowSerde(
-          FormatInfo.of(Format.AVRO, Optional.of("benchmarkSchema"), Optional.empty()),
+          FormatInfo.of(
+              Format.AVRO, ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, "benchmarkSchema")),
           schema,
           () -> schemaRegistryClient
       );

--- a/ksql-common/src/main/java/io/confluent/ksql/serde/Format.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/serde/Format.java
@@ -15,23 +15,76 @@
 
 package io.confluent.ksql.serde;
 
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.google.common.collect.Sets.SetView;
 import io.confluent.ksql.util.KsqlException;
+import java.util.Map;
+import java.util.Set;
 
 public enum Format {
 
-  JSON(true),
-  AVRO(true),
-  DELIMITED(false),
-  KAFKA(false);
+  JSON(true, ImmutableSet.of(), ImmutableSet.of()),
+  AVRO(true, ImmutableSet.of(FormatInfo.FULL_SCHEMA_NAME), ImmutableSet.of()),
+  DELIMITED(false, ImmutableSet.of(FormatInfo.DELIMITER), ImmutableSet.of(FormatInfo.DELIMITER)),
+  KAFKA(false, ImmutableSet.of(), ImmutableSet.of());
 
   private final boolean supportsUnwrapping;
+  private final Set<String> validConfigs;
+  private final Set<String> inheritableProperties;
 
-  Format(final boolean supportsUnwrapping) {
+  Format(
+      final boolean supportsUnwrapping,
+      final Set<String> validConfigs,
+      final Set<String> inheritableProperties
+  ) {
     this.supportsUnwrapping = supportsUnwrapping;
+    this.validConfigs = validConfigs;
+    this.inheritableProperties = inheritableProperties;
   }
 
+  /**
+   * If this format supports unwrapping, primitive values can optionally
+   * be serialized anonymously (i.e. without a wrapping STRUCT and
+   * corresponding field name)
+   *
+   * @return whether or not this format supports unwrapping
+   */
   public boolean supportsUnwrapping() {
     return supportsUnwrapping;
+  }
+
+  /**
+   * @param properties the properties to validate
+   * @throws KsqlException if the properties are invalid for the given format
+   */
+  public void validateProperties(final Map<String, String> properties) {
+    final SetView<String> difference = Sets.difference(properties.keySet(), validConfigs);
+    if (!difference.isEmpty()) {
+      throw new KsqlException(name() + " does not support the following configs: " + difference);
+    }
+
+    properties.forEach((k, v) -> {
+      if (v.trim().isEmpty()) {
+        throw new KsqlException(k + " cannot be empty. Format configuration: " + properties);
+      }
+    });
+  }
+
+  /**
+   * Specifies the set of "inheritable" properties - these properties will
+   * persist across streams and tables if a sink is created from a source
+   * of the same type and does not explicitly overwrite the property.
+   *
+   * <p>For example, if a stream with format {@code DELIMITED} was created
+   * with {@code VALUE_DELIMITER='x'}, any {@code DELIMITED} sinks that are
+   * created with that stream as its source will also have the same delimiter
+   * value of {@code x}</p>
+   *
+   * @return the set of properties that are considered "inheritable"
+   */
+  public Set<String> getInheritableProperties() {
+    return inheritableProperties;
   }
 
   public static Format of(final String value) {

--- a/ksql-common/src/test/java/io/confluent/ksql/serde/FormatInfoTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/serde/FormatInfoTest.java
@@ -16,16 +16,14 @@
 package io.confluent.ksql.serde;
 
 import static io.confluent.ksql.serde.Format.AVRO;
-import static io.confluent.ksql.serde.Format.DELIMITED;
 import static io.confluent.ksql.serde.Format.KAFKA;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
-import com.google.common.testing.NullPointerTester;
 import io.confluent.ksql.util.KsqlException;
-import java.util.Optional;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -37,28 +35,22 @@ public class FormatInfoTest {
   public final ExpectedException expectedException = ExpectedException.none();
 
   @Test
-  public void shouldThrowNPEs() {
-    new NullPointerTester()
-        .testAllPublicStaticMethods(FormatInfo.class);
-  }
-
-  @Test
   public void shouldImplementEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            FormatInfo.of(Format.DELIMITED, Optional.empty(), Optional.of(Delimiter.of('x'))),
-            FormatInfo.of(Format.DELIMITED, Optional.empty(), Optional.of(Delimiter.of('x')))
+            FormatInfo.of(Format.DELIMITED, ImmutableMap.of(FormatInfo.DELIMITER, "x")),
+            FormatInfo.of(Format.DELIMITED, ImmutableMap.of(FormatInfo.DELIMITER, "x"))
         )
         .addEqualityGroup(
-            FormatInfo.of(Format.AVRO, Optional.of("something"), Optional.empty()),
-            FormatInfo.of(Format.AVRO, Optional.of("something"), Optional.empty())
+            FormatInfo.of(Format.AVRO, ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, "something")),
+            FormatInfo.of(Format.AVRO, ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, "something"))
         )
         .addEqualityGroup(
-            FormatInfo.of(Format.AVRO, Optional.empty(), Optional.empty()),
+            FormatInfo.of(Format.AVRO),
             FormatInfo.of(Format.AVRO)
         )
         .addEqualityGroup(
-            FormatInfo.of(Format.JSON, Optional.empty(), Optional.empty()),
+            FormatInfo.of(Format.JSON),
             FormatInfo.of(Format.JSON)
         )
         .testEquals();
@@ -67,7 +59,7 @@ public class FormatInfoTest {
   @Test
   public void shouldImplementToStringAvro() {
     // Given:
-    final FormatInfo info = FormatInfo.of(AVRO, Optional.of("something"), Optional.empty());
+    final FormatInfo info = FormatInfo.of(AVRO, ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, "something"));
 
     // When:
     final String result = info.toString();
@@ -78,69 +70,45 @@ public class FormatInfoTest {
   }
 
   @Test
-  public void shouldImplementToStringDelimited() {
-    // Given:
-    final FormatInfo info = FormatInfo.of(DELIMITED, Optional.empty(), Optional.of(Delimiter.parse("~")));
-
-    // When:
-    final String result = info.toString();
-
-    // Then:
-    assertThat(result, containsString("DELIMITED"));
-    assertThat(result, containsString("~"));
-  }
-
-  @Test
-  public void shouldThrowOnNonAvroWithAvroSchemName() {
+  public void shouldThrowOnNonAvroWithAvroSchemaName() {
     // Then:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Full schema name only supported with AVRO format");
+    expectedException.expectMessage("JSON does not support the following configs: [fullSchemaName]");
 
     // When:
-    FormatInfo.of(Format.JSON, Optional.of("thing"), Optional.empty());
+    FormatInfo.of(Format.JSON, ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, "foo"));
   }
 
   @Test
   public void shouldThrowOnEmptyAvroSchemaName() {
     // Then:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Schema name cannot be empty");
+    expectedException.expectMessage("fullSchemaName cannot be empty. Format configuration: {fullSchemaName= }");
 
     // When:
-    FormatInfo.of(Format.AVRO, Optional.of(""), Optional.empty());
+    FormatInfo.of(Format.AVRO, ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, " "));
   }
 
   @Test
   public void shouldGetFormat() {
-    assertThat(FormatInfo.of(KAFKA, Optional.empty(), Optional.empty()).getFormat(), is(KAFKA));
+    assertThat(FormatInfo.of(KAFKA).getFormat(), is(KAFKA));
   }
 
   @Test
   public void shouldGetAvroSchemaName() {
-    assertThat(FormatInfo.of(AVRO, Optional.of("Something"), Optional.empty()).getFullSchemaName(),
-        is(Optional.of("Something")));
+    assertThat(FormatInfo.of(AVRO, ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, "Something")).getProperties(),
+        is(ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, "Something")));
 
-    assertThat(FormatInfo.of(AVRO, Optional.empty(), Optional.empty()).getFullSchemaName(),
-        is(Optional.empty()));
-  }
-
-  @Test
-  public void shouldThrowWhenAttemptingToUseValueDelimiterWithAvroFormat() {
-    // Then:
-    expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Delimiter only supported with DELIMITED format");
-
-    // When:
-    FormatInfo.of(Format.AVRO, Optional.of("something"), Optional.of(Delimiter.of('x')));
+    assertThat(FormatInfo.of(AVRO).getProperties(), is(ImmutableMap.of()));
   }
 
   @Test
   public void shouldThrowWhenAttemptingToUseValueDelimiterWithJsonFormat() {
     // Then:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Delimiter only supported with DELIMITED format");
+    expectedException.expectMessage("JSON does not support the following configs: [delimiter]");
 
     // When:
-    FormatInfo.of(Format.JSON, Optional.empty(), Optional.of(Delimiter.of('x')));
+    FormatInfo.of(Format.JSON, ImmutableMap.of("delimiter", "x"));
   }
 }

--- a/ksql-common/src/test/java/io/confluent/ksql/serde/KeyFormatTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/serde/KeyFormatTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
 import com.google.common.testing.NullPointerTester;
 import java.time.Duration;
@@ -44,8 +45,8 @@ public class KeyFormatTest {
   @Test
   public void shouldImplementEquals() {
 
-    final FormatInfo format1 = FormatInfo.of(AVRO, Optional.empty(), Optional.empty());
-    final FormatInfo format2 = FormatInfo.of(JSON, Optional.empty(), Optional.empty());
+    final FormatInfo format1 = FormatInfo.of(AVRO);
+    final FormatInfo format2 = FormatInfo.of(JSON);
 
     final WindowInfo window1 = WindowInfo.of(SESSION, Optional.empty());
     final WindowInfo window2 = WindowInfo.of(HOPPING, Optional.of(Duration.ofMillis(1000)));
@@ -74,7 +75,7 @@ public class KeyFormatTest {
   @Test
   public void shouldImplementToString() {
     // Given:
-    final FormatInfo formatInfo = FormatInfo.of(AVRO, Optional.of("something"), Optional.empty());
+    final FormatInfo formatInfo = FormatInfo.of(AVRO, ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, "something"));
     final WindowInfo windowInfo = WindowInfo.of(HOPPING, Optional.of(Duration.ofMillis(10101)));
 
     final KeyFormat keyFormat = KeyFormat.windowed(formatInfo, windowInfo);
@@ -90,7 +91,7 @@ public class KeyFormatTest {
   @Test
   public void shouldGetFormat() {
     // Given:
-    final FormatInfo format = FormatInfo.of(DELIMITED, Optional.empty(), Optional.empty());
+    final FormatInfo format = FormatInfo.of(DELIMITED);
     final KeyFormat keyFormat = KeyFormat.nonWindowed(format);
 
     // When:
@@ -103,7 +104,7 @@ public class KeyFormatTest {
   @Test
   public void shouldGetFormatInfo() {
     // Given:
-    final FormatInfo format = FormatInfo.of(AVRO, Optional.of("something"), Optional.empty());
+    final FormatInfo format = FormatInfo.of(AVRO, ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, "something"));
     final KeyFormat keyFormat = KeyFormat.nonWindowed(format);
 
     // When:
@@ -116,8 +117,7 @@ public class KeyFormatTest {
   @Test
   public void shouldHandleNoneWindowedFunctionsForNonWindowed() {
     // Given:
-    final KeyFormat keyFormat = KeyFormat.nonWindowed(FormatInfo.of(JSON, Optional.empty(),
-        Optional.empty()));
+    final KeyFormat keyFormat = KeyFormat.nonWindowed(FormatInfo.of(JSON));
 
     // Then:
     assertThat(keyFormat.isWindowed(), is(false));
@@ -143,13 +143,12 @@ public class KeyFormatTest {
   public void shouldHandleWindowedWithAvroSchemaName() {
     // Given:
     final KeyFormat keyFormat = KeyFormat.windowed(
-        FormatInfo.of(AVRO, Optional.of("something"), Optional.empty()),
+        FormatInfo.of(AVRO, ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, "something")),
         WindowInfo.of(HOPPING, Optional.of(Duration.ofMinutes(4)))
     );
 
     // Then:
-    assertThat(keyFormat.getFormatInfo(), is(FormatInfo.of(AVRO, Optional.of("something"),
-        Optional.empty())));
+    assertThat(keyFormat.getFormatInfo(), is(FormatInfo.of(AVRO, ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, "something"))));
   }
 
   @Test

--- a/ksql-common/src/test/java/io/confluent/ksql/serde/ValueFormatTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/serde/ValueFormatTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
 import com.google.common.testing.NullPointerTester;
 import java.util.Optional;
@@ -31,8 +32,7 @@ public class ValueFormatTest {
   private static final FormatInfo FORMAT_INFO =
       FormatInfo.of(
           AVRO,
-          Optional.of("something"),
-          Optional.empty()
+          ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, "something")
       );
 
   @Test
@@ -49,7 +49,7 @@ public class ValueFormatTest {
             ValueFormat.of(FORMAT_INFO)
         )
         .addEqualityGroup(
-            ValueFormat.of(FormatInfo.of(JSON, Optional.empty(), Optional.empty()))
+            ValueFormat.of(FormatInfo.of(JSON))
         )
         .testEquals();
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicFactory.java
@@ -45,8 +45,7 @@ public final class TopicFactory {
 
     final ValueFormat valueFormat = ValueFormat.of(FormatInfo.of(
         properties.getValueFormat(),
-        properties.getValueAvroSchemaName(),
-        properties.getValueDelimiter()
+        properties.getFormatProperties()
     ));
 
     return new KsqlTopic(

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/AvroUtil.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/AvroUtil.java
@@ -49,7 +49,8 @@ public final class AvroUtil {
     );
     final org.apache.avro.Schema avroSchema = AvroSchemas.getAvroSchema(
         physicalSchema.valueSchema(),
-        format.getFullSchemaName().orElse(KsqlConstants.DEFAULT_AVRO_SCHEMA_FULL_NAME),
+        format.getProperties()
+            .getOrDefault(FormatInfo.FULL_SCHEMA_NAME, KsqlConstants.DEFAULT_AVRO_SCHEMA_FULL_NAME),
         ksqlConfig
     );
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerFunctionalTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerFunctionalTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import io.confluent.ksql.analyzer.Analysis.Into;
@@ -314,8 +315,7 @@ public class AnalyzerFunctionalTest {
 
     assertThat(analysis.getInto(), is(not(Optional.empty())));
     assertThat(analysis.getInto().get().getKsqlTopic().getValueFormat(),
-        is(ValueFormat.of(FormatInfo.of(Format.AVRO, Optional.of("com.custom.schema"),
-            Optional.empty()))));
+        is(ValueFormat.of(FormatInfo.of(Format.AVRO, ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, "com.custom.schema")))));
   }
 
   @Test
@@ -346,7 +346,8 @@ public class AnalyzerFunctionalTest {
 
     assertThat(analysis.getInto(), is(not(Optional.empty())));
       assertThat(analysis.getInto().get().getKsqlTopic().getValueFormat(),
-          is(ValueFormat.of(FormatInfo.of(Format.AVRO, Optional.of("org.ac.s1"), Optional.empty()))));
+          is(ValueFormat.of(FormatInfo.of(Format.AVRO, ImmutableMap
+              .of(FormatInfo.FULL_SCHEMA_NAME, "org.ac.s1")))));
   }
 
   @Test
@@ -358,7 +359,7 @@ public class AnalyzerFunctionalTest {
     final KsqlTopic ksqlTopic = new KsqlTopic(
         "s0",
         KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
-        ValueFormat.of(FormatInfo.of(Format.AVRO, Optional.of("org.ac.s1"), Optional.empty()))
+        ValueFormat.of(FormatInfo.of(Format.AVRO, ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, "org.ac.s1")))
     );
 
     final LogicalSchema schema = LogicalSchema.builder()
@@ -416,7 +417,7 @@ public class AnalyzerFunctionalTest {
     final Analyzer analyzer = new Analyzer(jsonMetaStore, "", DEFAULT_SERDE_OPTIONS);
 
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Full schema name only supported with AVRO format");
+    expectedException.expectMessage("JSON does not support the following configs: [fullSchemaName]");
 
     analyzer.analyze(query, Optional.of(createStreamAsSelect.getSink()));
   }
@@ -433,7 +434,7 @@ public class AnalyzerFunctionalTest {
     final Analyzer analyzer = new Analyzer(jsonMetaStore, "", DEFAULT_SERDE_OPTIONS);
 
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Schema name cannot be empty");
+    expectedException.expectMessage("fullSchemaName cannot be empty. Format configuration: {fullSchemaName=}");
 
     analyzer.analyze(query, Optional.of(createStreamAsSelect.getSink()));
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceFactoryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceFactoryTest.java
@@ -594,7 +594,7 @@ public class CreateSourceFactoryTest {
         withProperties);
 
     when(keySerdeFactory.create(
-        FormatInfo.of(KAFKA, Optional.empty(), Optional.empty()),
+        FormatInfo.of(KAFKA),
         PersistenceSchema.from(EXPECTED_SCHEMA.keyConnectSchema(), false),
         ksqlConfig,
         serviceContext.getSchemaRegistryClientFactory(),
@@ -617,7 +617,7 @@ public class CreateSourceFactoryTest {
         withProperties);
 
     when(valueSerdeFactory.create(
-        FormatInfo.of(JSON, Optional.empty(), Optional.empty()),
+        FormatInfo.of(JSON),
         PersistenceSchema.from(EXPECTED_SCHEMA.valueConnectSchema(), false),
         ksqlConfig,
         serviceContext.getSchemaRegistryClientFactory(),
@@ -664,7 +664,7 @@ public class CreateSourceFactoryTest {
     // Then:
     assertThat(
         cmd.getFormats().getValueFormat(),
-        is(FormatInfo.of(AVRO, Optional.of("full.schema.name"), Optional.empty())));
+        is(FormatInfo.of(AVRO, ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, "full.schema.name"))));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
@@ -807,7 +807,7 @@ public class InsertValuesExecutorTest {
 
     // Then:
     verify(keySerdeFactory).create(
-        FormatInfo.of(Format.KAFKA, Optional.empty(), Optional.empty()),
+        FormatInfo.of(Format.KAFKA),
         PersistenceSchema.from(SCHEMA.keyConnectSchema(), false),
         new KsqlConfig(ImmutableMap.of()),
         srClientFactory,
@@ -816,7 +816,7 @@ public class InsertValuesExecutorTest {
     );
 
     verify(valueSerdeFactory).create(
-        FormatInfo.of(Format.JSON, Optional.empty(), Optional.empty()),
+        FormatInfo.of(Format.JSON),
         PersistenceSchema.from(SCHEMA.valueConnectSchema(), false),
         new KsqlConfig(ImmutableMap.of()),
         srClientFactory,

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
@@ -48,7 +48,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -589,7 +588,7 @@ public final class IntegrationTestHarness extends ExternalResource {
       final PhysicalSchema schema
   ) {
     return GenericRowSerDe.from(
-        FormatInfo.of(format, Optional.empty(), Optional.empty()),
+        FormatInfo.of(format),
         schema.valueSchema(),
         new KsqlConfig(Collections.emptyMap()),
         serviceContext.get().getSchemaRegistryClientFactory(),
@@ -612,7 +611,7 @@ public final class IntegrationTestHarness extends ExternalResource {
       final PhysicalSchema schema
   ) {
     return GenericRowSerDe.from(
-        FormatInfo.of(format, Optional.empty(), Optional.empty()),
+        FormatInfo.of(format),
         schema.valueSchema(),
         new KsqlConfig(Collections.emptyMap()),
         serviceContext.get().getSchemaRegistryClientFactory(),

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
@@ -179,8 +180,8 @@ public class KsqlStructuredDataOutputNodeTest {
     // Given:
     givenInsertIntoNode();
 
-    final ValueFormat valueFormat = ValueFormat.of(FormatInfo.of(Format.AVRO, Optional.of("name"),
-        Optional.empty()));
+    final ValueFormat valueFormat = ValueFormat.of(FormatInfo.of(Format.AVRO, ImmutableMap
+        .of(FormatInfo.FULL_SCHEMA_NAME, "name")));
 
     when(ksqlTopic.getValueFormat()).thenReturn(valueFormat);
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicDeleteInjectorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicDeleteInjectorTest.java
@@ -245,7 +245,7 @@ public class TopicDeleteInjectorTest {
   public void shouldNotThrowIfSchemaIsMissing() throws IOException, RestClientException {
     // Given:
     when(topic.getValueFormat())
-        .thenReturn(ValueFormat.of(FormatInfo.of(Format.AVRO, Optional.of("foo"), Optional.empty())));
+        .thenReturn(ValueFormat.of(FormatInfo.of(Format.AVRO, ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, "foo"))));
 
     doThrow(new RestClientException("Subject not found.", 404, 40401))
             .when(registryClient).deleteSubject("something" + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX);

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/AvroUtilTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/AvroUtilTest.java
@@ -23,6 +23,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.connect.avro.AvroData;
 import io.confluent.connect.avro.AvroDataConfig;
@@ -104,7 +105,8 @@ public class AvroUtilTest {
 
   private static final Formats FORMATS = Formats.of(
       KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
-      ValueFormat.of(FormatInfo.of(Format.AVRO, Optional.of(SCHEMA_NAME), Optional.empty())),
+      ValueFormat.of(FormatInfo.of(Format.AVRO, ImmutableMap
+          .of(FormatInfo.FULL_SCHEMA_NAME, SCHEMA_NAME))),
       SerdeOption.none()
   );
 

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/builder/KsqlQueryBuilderTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/builder/KsqlQueryBuilderTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.NullPointerTester;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.GenericRow;
@@ -71,7 +72,7 @@ public class KsqlQueryBuilderTest {
   private static final QueryId QUERY_ID = new QueryId("fred");
 
   private static final FormatInfo FORMAT_INFO = FormatInfo
-      .of(Format.AVRO, Optional.of("io.confluent.ksql"), Optional.empty());
+      .of(Format.AVRO, ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, "io.confluent.ksql"));
 
   private static final WindowInfo WINDOW_INFO = WindowInfo
       .of(WindowType.TUMBLING, Optional.of(Duration.ofMillis(1000)));

--- a/ksql-functional-tests/src/test/resources/historical_plans/average_-_calculate_average_in_select/5.5.0_1579766275923/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/average_-_calculate_average_in_select/5.5.0_1579766275923/spec.json
@@ -14,13 +14,11 @@
       "formats" : {
         "keyFormat" : {
           "format" : "KAFKA",
-          "fullSchemaName" : null,
-          "delimiter" : null
+          "properties": null
         },
         "valueFormat" : {
           "format" : "DELIMITED",
-          "fullSchemaName" : null,
-          "delimiter" : null
+          "properties": null
         },
         "options" : [ ]
       },
@@ -39,14 +37,11 @@
       "topicName" : "AVG",
       "formats" : {
         "keyFormat" : {
-          "format" : "KAFKA",
-          "fullSchemaName" : null,
-          "delimiter" : null
+          "format" : "KAFKA"
         },
         "valueFormat" : {
           "format" : "DELIMITED",
-          "fullSchemaName" : null,
-          "delimiter" : null
+          "properties": null
         },
         "options" : [ ]
       },
@@ -89,13 +84,11 @@
                   "formats" : {
                     "keyFormat" : {
                       "format" : "KAFKA",
-                      "fullSchemaName" : null,
-                      "delimiter" : null
+                      "properties": null
                     },
                     "valueFormat" : {
                       "format" : "DELIMITED",
-                      "fullSchemaName" : null,
-                      "delimiter" : null
+                      "properties": null
                     },
                     "options" : [ ]
                   },
@@ -108,13 +101,11 @@
               "internalFormats" : {
                 "keyFormat" : {
                   "format" : "KAFKA",
-                  "fullSchemaName" : null,
-                  "delimiter" : null
+                  "properties": null
                 },
                 "valueFormat" : {
                   "format" : "DELIMITED",
-                  "fullSchemaName" : null,
-                  "delimiter" : null
+                  "properties": null
                 },
                 "options" : [ ]
               }
@@ -122,13 +113,11 @@
             "internalFormats" : {
               "keyFormat" : {
                 "format" : "KAFKA",
-                "fullSchemaName" : null,
-                "delimiter" : null
+                "properties": null
               },
               "valueFormat" : {
                 "format" : "DELIMITED",
-                "fullSchemaName" : null,
-                "delimiter" : null
+                "properties": null
               },
               "options" : [ ]
             },
@@ -140,13 +129,11 @@
         "formats" : {
           "keyFormat" : {
             "format" : "KAFKA",
-            "fullSchemaName" : null,
-            "delimiter" : null
+            "properties": null
           },
           "valueFormat" : {
             "format" : "DELIMITED",
-            "fullSchemaName" : null,
-            "delimiter" : null
+            "properties": null
           },
           "options" : [ ]
         },

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/delimited.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/delimited.json
@@ -179,7 +179,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Delimiter only supported with DELIMITED format"
+        "message": "JSON does not support the following configs: [delimiter]"
       },
       "inputs": [],
       "outputs": []

--- a/ksql-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
+++ b/ksql-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
@@ -256,7 +256,7 @@
       "statements": [
         "CREATE STREAM INPUT (IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE TABLE AGGREGATE AS SELECT COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ROWKEY;",
-        "SELECT TIMESTAMPTOSTRING(WINDOWSTART, 'yyyy-MM-dd HH:mm:ss Z') AS WSTART, TIMESTAMPTOSTRING(WINDOWEND, 'yyyy-MM-dd HH:mm:ss Z') AS WEND, COUNT FROM AGGREGATE EMIT CHANGES LIMIT 2;"
+        "SELECT TIMESTAMPTOSTRING(WINDOWSTART, 'yyyy-MM-dd HH:mm:ss Z', 'UTC') AS WSTART, TIMESTAMPTOSTRING(WINDOWEND, 'yyyy-MM-dd HH:mm:ss Z', 'UTC') AS WEND, COUNT FROM AGGREGATE EMIT CHANGES LIMIT 2;"
       ],
       "inputs": [
         {"topic": "test_topic", "timestamp": 1580223282123, "key": "11", "value": {"id": 100}},

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceAsProperties.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceAsProperties.java
@@ -24,8 +24,8 @@ import io.confluent.ksql.parser.ColumnReferenceParser;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
 import io.confluent.ksql.properties.with.CreateAsConfigs;
 import io.confluent.ksql.schema.ksql.ColumnRef;
-import io.confluent.ksql.serde.Delimiter;
 import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Map;
 import java.util.Objects;
@@ -91,17 +91,24 @@ public final class CreateSourceAsProperties {
     return Optional.ofNullable(props.getString(CommonCreateConfigs.TIMESTAMP_FORMAT_PROPERTY));
   }
 
-  public Optional<String> getValueAvroSchemaName() {
-    return Optional.ofNullable(props.getString(CommonCreateConfigs.VALUE_AVRO_SCHEMA_FULL_NAME));
-  }
-
   public Optional<Boolean> getWrapSingleValues() {
     return Optional.ofNullable(props.getBoolean(CommonCreateConfigs.WRAP_SINGLE_VALUE));
   }
 
-  public Optional<Delimiter> getValueDelimiter() {
-    final String val = props.getString(CommonCreateConfigs.VALUE_DELIMITER_PROPERTY);
-    return val == null ? Optional.empty() : Optional.of(Delimiter.parse(val));
+  public Map<String, String> getFormatProperties() {
+    final ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+
+    final String schemaName = props.getString(CommonCreateConfigs.VALUE_AVRO_SCHEMA_FULL_NAME);
+    if (schemaName != null) {
+      builder.put(FormatInfo.FULL_SCHEMA_NAME, schemaName);
+    }
+
+    final String delimiter = props.getString(CommonCreateConfigs.VALUE_DELIMITER_PROPERTY);
+    if (delimiter != null) {
+      builder.put(FormatInfo.DELIMITER, delimiter);
+    }
+
+    return builder.build();
   }
 
   public CreateSourceAsProperties withTopic(

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceProperties.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceProperties.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.parser.properties.with;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
 import io.confluent.ksql.execution.expression.tree.Literal;
@@ -25,8 +26,8 @@ import io.confluent.ksql.parser.DurationParser;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
 import io.confluent.ksql.properties.with.CreateConfigs;
 import io.confluent.ksql.schema.ksql.ColumnRef;
-import io.confluent.ksql.serde.Delimiter;
 import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.testing.EffectivelyImmutable;
 import io.confluent.ksql.util.KsqlException;
 import java.time.Duration;
@@ -129,17 +130,24 @@ public final class CreateSourceProperties {
     return Optional.ofNullable(props.getInt(CreateConfigs.AVRO_SCHEMA_ID));
   }
 
-  public Optional<String> getValueAvroSchemaName() {
-    return Optional.ofNullable(props.getString(CommonCreateConfigs.VALUE_AVRO_SCHEMA_FULL_NAME));
+  public Map<String, String> getFormatProperties() {
+    final ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+
+    final String schemaName = props.getString(CommonCreateConfigs.VALUE_AVRO_SCHEMA_FULL_NAME);
+    if (schemaName != null) {
+      builder.put(FormatInfo.FULL_SCHEMA_NAME, schemaName);
+    }
+
+    final String delimiter = props.getString(CommonCreateConfigs.VALUE_DELIMITER_PROPERTY);
+    if (delimiter != null) {
+      builder.put(FormatInfo.DELIMITER, delimiter);
+    }
+
+    return builder.build();
   }
 
   public Optional<Boolean> getWrapSingleValues() {
     return Optional.ofNullable(props.getBoolean(CommonCreateConfigs.WRAP_SINGLE_VALUE));
-  }
-
-  public Optional<Delimiter> getValueDelimiter() {
-    final String val = props.getString(CommonCreateConfigs.VALUE_DELIMITER_PROPERTY);
-    return val == null ? Optional.empty() : Optional.of(Delimiter.parse(val));
   }
 
   public CreateSourceProperties withSchemaId(final int id) {

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourceAsPropertiesTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourceAsPropertiesTest.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.execution.expression.tree.StringLiteral;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
 import io.confluent.ksql.schema.ksql.ColumnRef;
+import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Optional;
 import org.junit.Rule;
@@ -55,7 +56,7 @@ public class CreateSourceAsPropertiesTest {
     assertThat(properties.getValueFormat(), is(Optional.empty()));
     assertThat(properties.getTimestampColumnName(), is(Optional.empty()));
     assertThat(properties.getTimestampFormat(), is(Optional.empty()));
-    assertThat(properties.getValueAvroSchemaName(), is(Optional.empty()));
+    assertThat(properties.getFormatProperties(), is(ImmutableMap.of()));
     assertThat(properties.getReplicas(), is(Optional.empty()));
     assertThat(properties.getPartitions(), is(Optional.empty()));
     assertThat(properties.getWrapSingleValues(), is(Optional.empty()));
@@ -114,7 +115,7 @@ public class CreateSourceAsPropertiesTest {
         ImmutableMap.of(CommonCreateConfigs.VALUE_AVRO_SCHEMA_FULL_NAME, new StringLiteral("schema")));
 
     // Then:
-    assertThat(properties.getValueAvroSchemaName(), is(Optional.of("schema")));
+    assertThat(properties.getFormatProperties().get(FormatInfo.FULL_SCHEMA_NAME), is("schema"));
   }
 
   @Test

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourcePropertiesTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourcePropertiesTest.java
@@ -33,6 +33,7 @@ import io.confluent.ksql.properties.with.CommonCreateConfigs;
 import io.confluent.ksql.properties.with.CreateConfigs;
 import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.util.KsqlException;
 import java.time.Duration;
 import java.util.HashMap;
@@ -81,7 +82,7 @@ public class CreateSourcePropertiesTest {
     assertThat(properties.getTimestampFormat(), is(Optional.empty()));
     assertThat(properties.getWindowType(), is(Optional.empty()));
     assertThat(properties.getAvroSchemaId(), is(Optional.empty()));
-    assertThat(properties.getValueAvroSchemaName(), is(Optional.empty()));
+    assertThat(properties.getFormatProperties(), is(ImmutableMap.of()));
     assertThat(properties.getReplicas(), is(Optional.empty()));
     assertThat(properties.getPartitions(), is(Optional.empty()));
     assertThat(properties.getWrapSingleValues(), is(Optional.empty()));
@@ -295,7 +296,7 @@ public class CreateSourcePropertiesTest {
             .build());
 
     // Then:
-    assertThat(properties.getValueAvroSchemaName(), is(Optional.of("schema")));
+    assertThat(properties.getFormatProperties().get(FormatInfo.FULL_SCHEMA_NAME), is("schema"));
   }
 
   @Test

--- a/ksql-rest-app/src/test/resources/ksql-plan-schema/schema.json
+++ b/ksql-rest-app/src/test/resources/ksql-plan-schema/schema.json
@@ -112,11 +112,9 @@
           "type" : "string",
           "enum" : [ "JSON", "AVRO", "DELIMITED", "KAFKA" ]
         },
-        "fullSchemaName" : {
-          "type" : "string"
-        },
-        "delimiter" : {
-          "type" : "string"
+        "properties" : {
+          "type" : "object",
+          "additionalProperties": {"type": "string"}
         }
       },
       "required" : [ "format" ]

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/GenericRowSerDeTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/GenericRowSerDeTest.java
@@ -35,7 +35,6 @@ import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.util.KsqlConfig;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -59,7 +58,7 @@ public class GenericRowSerDeTest {
   private static final String LOGGER_PREFIX = "bob";
 
   private static final FormatInfo FORMAT =
-      FormatInfo.of(Format.JSON, Optional.empty(), Optional.empty());
+      FormatInfo.of(Format.JSON);
 
   private static final PersistenceSchema MUTLI_FIELD_SCHEMA =
       PersistenceSchema.from(

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/KsqlSerdeFactoriesTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/KsqlSerdeFactoriesTest.java
@@ -34,7 +34,6 @@ import io.confluent.ksql.serde.delimited.KsqlDelimitedSerdeFactory;
 import io.confluent.ksql.serde.json.KsqlJsonSerdeFactory;
 import io.confluent.ksql.serde.kafka.KafkaSerdeFactory;
 import io.confluent.ksql.util.KsqlConfig;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.apache.kafka.common.serialization.Serde;
@@ -159,7 +158,7 @@ public class KsqlSerdeFactoriesTest {
   public void shouldHandleAvro() {
     // When:
     final KsqlSerdeFactory result = KsqlSerdeFactories
-        .create(FormatInfo.of(AVRO, Optional.empty(), Optional.empty()));
+        .create(FormatInfo.of(AVRO));
 
     // Then:
     assertThat(result, instanceOf(KsqlAvroSerdeFactory.class));
@@ -169,7 +168,7 @@ public class KsqlSerdeFactoriesTest {
   public void shouldHandleJson() {
     // When:
     final KsqlSerdeFactory result = KsqlSerdeFactories
-        .create(FormatInfo.of(JSON, Optional.empty(), Optional.empty()));
+        .create(FormatInfo.of(JSON));
 
     // Then:
     assertThat(result, instanceOf(KsqlJsonSerdeFactory.class));
@@ -179,7 +178,7 @@ public class KsqlSerdeFactoriesTest {
   public void shouldHandleDelimited() {
     // When:
     final KsqlSerdeFactory result = KsqlSerdeFactories
-        .create(FormatInfo.of(DELIMITED, Optional.empty(), Optional.empty()));
+        .create(FormatInfo.of(DELIMITED));
 
     // Then:
     assertThat(result, instanceOf(KsqlDelimitedSerdeFactory.class));
@@ -189,7 +188,7 @@ public class KsqlSerdeFactoriesTest {
   public void shouldHandleKafka() {
     // When:
     final KsqlSerdeFactory result = KsqlSerdeFactories
-        .create(FormatInfo.of(KAFKA, Optional.empty(), Optional.empty()));
+        .create(FormatInfo.of(KAFKA));
 
     // Then:
     assertThat(result, instanceOf(KafkaSerdeFactory.class));


### PR DESCRIPTION
### Description 

The `FormatInfo` class is serialized as part of the execution plan and contains one-off fields that are specific to a given format (e.g. `delimiter` for the DELIMITED format). This PR instead changes it to use a map of properties that is more flexible to use for any format going forward.

Reviewing note: almost all of the changes in this PR are test changes, look at `FormatInfo` and `schema.json` to see the important changes.

### Testing done 

- updated corresponding unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

