### PR TITLE
fix: remove jar plugin to fix broken maven deploy for cp-snapshots

### DIFF
--- a/ksql-docker/pom.xml
+++ b/ksql-docker/pom.xml
@@ -90,17 +90,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>test-jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
### Description 
Jenkins building cp-snapshots is broken due to #4274 

Error is here:
https://jenkins.confluent.io/job/confluentinc/job/confluent-snapshots/job/master/3416/consoleText

This is an unsuccessful attempt at fixing it.
