### PR TITLE
fix: Remove unncecessary @AfterClass cleanup in LagReportingAgentFunctionalTest which is causing flakiness

### DIFF
--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/LagReportingAgentFunctionalTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/LagReportingAgentFunctionalTest.java
@@ -135,12 +135,6 @@ public class LagReportingAgentFunctionalTest {
     );
   }
 
-  @AfterClass
-  public static void tearDownClass() {
-    REST_APP_0.closePersistentQueries();
-    REST_APP_0.dropSourcesExcept();
-  }
-
   @Test(timeout = 60000)
   public void shouldExchangeLags() {
     // Given:

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/LagReportingAgentFunctionalTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/LagReportingAgentFunctionalTest.java
@@ -68,8 +68,6 @@ public class LagReportingAgentFunctionalTest {
 
   private static final KsqlHostEntity HOST0 = new KsqlHostEntity("localhost", 8088);
   private static final KsqlHostEntity HOST1 = new KsqlHostEntity("localhost", 8089);
-  private static final String HOST0_STR = "localhost:8088";
-  private static final String HOST1_STR = "localhost:8089";
   private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
   private static final TestKsqlRestApp REST_APP_0 = TestKsqlRestApp
       .builder(TEST_HARNESS::kafkaBootstrapServers)
@@ -86,7 +84,6 @@ public class LagReportingAgentFunctionalTest {
       // Lag Reporting
       .withProperty(KsqlRestConfig.KSQL_LAG_REPORTING_ENABLE_CONFIG, true)
       .withProperty(KsqlRestConfig.KSQL_LAG_REPORTING_SEND_INTERVAL_MS_CONFIG, 3000)
-      .withProperties(ClientTrustStore.trustStoreProps())
       .build();
   private static final TestKsqlRestApp REST_APP_1 = TestKsqlRestApp
       .builder(TEST_HARNESS::kafkaBootstrapServers)
@@ -103,7 +100,6 @@ public class LagReportingAgentFunctionalTest {
       // Lag Reporting
       .withProperty(KsqlRestConfig.KSQL_LAG_REPORTING_ENABLE_CONFIG, true)
       .withProperty(KsqlRestConfig.KSQL_LAG_REPORTING_SEND_INTERVAL_MS_CONFIG, 3000)
-      .withProperties(ClientTrustStore.trustStoreProps())
       .build();
 
   @ClassRule


### PR DESCRIPTION
### Description 
Removes unnecessary @AfterClass cleanup since this is setup across tests.  This was the source of flakiness.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

