### PR TITLE
refactor: introduce Format interface

### DIFF
--- a/ksql-benchmark/src/main/java/io/confluent/ksql/benchmark/SerdeBenchmark.java
+++ b/ksql-benchmark/src/main/java/io/confluent/ksql/benchmark/SerdeBenchmark.java
@@ -23,9 +23,10 @@ import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.datagen.RowGenerator;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.GenericRowSerDe;
+import io.confluent.ksql.serde.avro.AvroFormat;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.Pair;
 import java.io.InputStream;
@@ -158,7 +159,7 @@ public class SerdeBenchmark {
         final org.apache.kafka.connect.data.Schema schema
     ) {
       return getGenericRowSerde(
-          FormatInfo.of(Format.JSON.name()),
+          FormatInfo.of(FormatFactory.JSON.name()),
           schema,
           () -> null
       );
@@ -171,7 +172,8 @@ public class SerdeBenchmark {
 
       return getGenericRowSerde(
           FormatInfo.of(
-              Format.AVRO.name(), ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, "benchmarkSchema")),
+              FormatFactory.AVRO.name(),
+              ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "benchmarkSchema")),
           schema,
           () -> schemaRegistryClient
       );

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -63,7 +63,7 @@ import io.confluent.ksql.rest.server.TestKsqlRestApp;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.test.util.KsqlIdentifierTestUtil;
 import io.confluent.ksql.util.KsqlConfig;
@@ -179,7 +179,7 @@ public class CliTest {
     orderDataProvider = new OrderDataProvider();
     TEST_HARNESS.getKafkaCluster().createTopic(orderDataProvider.topicName());
 
-    TEST_HARNESS.produceRows(orderDataProvider.topicName(), orderDataProvider, Format.JSON);
+    TEST_HARNESS.produceRows(orderDataProvider.topicName(), orderDataProvider, FormatFactory.JSON);
 
     try (Cli cli = Cli.build(1L, 1000L, OutputFormat.JSON, restClient)) {
       createKStream(orderDataProvider, cli);
@@ -270,7 +270,7 @@ public class CliTest {
     final Map<Long, GenericRow> results = TEST_HARNESS.verifyAvailableUniqueRows(
         streamName,
         expectedResults.size(),
-        Format.JSON,
+        FormatFactory.JSON,
         resultSchema
     );
 

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/SslFunctionalTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/SslFunctionalTest.java
@@ -15,7 +15,7 @@
 
 package io.confluent.ksql.cli;
 
-import static io.confluent.ksql.serde.Format.JSON;
+import static io.confluent.ksql.serde.FormatFactory.JSON;
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.both;

--- a/ksql-common/src/main/java/io/confluent/ksql/serde/FormatInfo.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/serde/FormatInfo.java
@@ -29,9 +29,6 @@ import java.util.Optional;
 @Immutable
 public final class FormatInfo {
 
-  public static final String FULL_SCHEMA_NAME = "fullSchemaName";
-  public static final String DELIMITER = "delimiter";
-
   private final String format;
   private final ImmutableMap<String, String> properties;
 

--- a/ksql-common/src/test/java/io/confluent/ksql/serde/FormatInfoTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/serde/FormatInfoTest.java
@@ -21,7 +21,6 @@ import static org.hamcrest.Matchers.is;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
-import io.confluent.ksql.util.KsqlException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -36,8 +35,8 @@ public class FormatInfoTest {
   public void shouldImplementEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            FormatInfo.of("DELIMITED", ImmutableMap.of(FormatInfo.DELIMITER, "x")),
-            FormatInfo.of("DELIMITED", ImmutableMap.of(FormatInfo.DELIMITER, "x"))
+            FormatInfo.of("DELIMITED", ImmutableMap.of("prop", "x")),
+            FormatInfo.of("DELIMITED", ImmutableMap.of("prop", "x"))
         )
         .addEqualityGroup(
             FormatInfo.of("DELIMITED"),
@@ -47,7 +46,7 @@ public class FormatInfoTest {
             FormatInfo.of("AVRO")
         )
         .addEqualityGroup(
-            FormatInfo.of("DELIMITED", ImmutableMap.of(FormatInfo.DELIMITER, "|"))
+            FormatInfo.of("DELIMITED", ImmutableMap.of("prop", "|"))
         )
         .testEquals();
   }
@@ -55,7 +54,7 @@ public class FormatInfoTest {
   @Test
   public void shouldImplementToStringAvro() {
     // Given:
-    final FormatInfo info = FormatInfo.of("AVRO", ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, "something"));
+    final FormatInfo info = FormatInfo.of("AVRO", ImmutableMap.of("property", "something"));
 
     // When:
     final String result = info.toString();

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -60,6 +60,7 @@ import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.FormatOptions;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
@@ -232,7 +233,8 @@ class Analyzer {
           .map(WindowExpression::getKsqlWindowExpression);
 
       return ksqlWindow
-          .map(w -> KeyFormat.windowed(FormatInfo.of(Format.KAFKA.name()), w.getWindowInfo()))
+          .map(w -> KeyFormat.windowed(
+              FormatInfo.of(FormatFactory.KAFKA.name()), w.getWindowInfo()))
           .orElseGet(() -> analysis
               .getFromDataSources()
               .get(0)
@@ -264,7 +266,7 @@ class Analyzer {
 
     private Format getValueFormat(final Sink sink) {
       return sink.getProperties().getValueFormat()
-          .orElseGet(() -> Format.of(getSourceInfo()));
+          .orElseGet(() -> FormatFactory.of(getSourceInfo()));
     }
 
     private FormatInfo getSourceInfo() {
@@ -612,7 +614,7 @@ class Analyzer {
     public void validate() {
       final String kafkaSources = analysis.getFromDataSources().stream()
           .filter(s -> s.getDataSource().getKsqlTopic().getValueFormat().getFormat()
-              == Format.KAFKA)
+              == FormatFactory.KAFKA)
           .map(AliasedDataSource::getAlias)
           .map(SourceName::name)
           .collect(Collectors.joining(", "));

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
@@ -20,7 +20,6 @@ import com.google.common.collect.Iterables;
 import io.confluent.ksql.execution.ddl.commands.CreateStreamCommand;
 import io.confluent.ksql.execution.ddl.commands.CreateTableCommand;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
-import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.streams.timestamp.TimestampExtractionPolicyFactory;
 import io.confluent.ksql.execution.timestamp.TimestampColumn;
 import io.confluent.ksql.logging.processing.NoopProcessingLogContext;
@@ -110,7 +109,8 @@ public final class CreateSourceFactory {
         keyFieldName,
         timestampColumn,
         topic.getKafkaTopicName(),
-        Formats.of(topic.getKeyFormat(), topic.getValueFormat(), serdeOptions),
+        io.confluent.ksql.execution.plan.Formats
+            .of(topic.getKeyFormat(), topic.getValueFormat(), serdeOptions),
         topic.getKeyFormat().getWindowInfo()
     );
   }
@@ -143,7 +143,8 @@ public final class CreateSourceFactory {
         keyFieldName,
         timestampColumn,
         topic.getKafkaTopicName(),
-        Formats.of(topic.getKeyFormat(), topic.getValueFormat(), serdeOptions),
+        io.confluent.ksql.execution.plan.Formats
+            .of(topic.getKeyFormat(), topic.getValueFormat(), serdeOptions),
         topic.getKeyFormat().getWindowInfo()
     );
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
@@ -43,7 +43,7 @@ import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.schema.ksql.SqlBaseType;
 import io.confluent.ksql.schema.ksql.SqlValueCoercer;
 import io.confluent.ksql.schema.ksql.types.SqlType;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.GenericKeySerDe;
 import io.confluent.ksql.serde.GenericRowSerDe;
 import io.confluent.ksql.serde.KeySerdeFactory;
@@ -437,7 +437,7 @@ public class InsertValuesExecutor {
     try {
       return valueSerde.serializer().serialize(topicName, row);
     } catch (final Exception e) {
-      if (dataSource.getKsqlTopic().getValueFormat().getFormat() == Format.AVRO) {
+      if (dataSource.getKsqlTopic().getValueFormat().getFormat() == FormatFactory.AVRO) {
         final Throwable rootCause = ExceptionUtils.getRootCause(e);
         if (rootCause instanceof RestClientException) {
           switch (((RestClientException) rootCause).getStatus()) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/serde/SerdeOptions.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/serde/SerdeOptions.java
@@ -101,10 +101,10 @@ public final class SerdeOptions {
           : SerdeOption.none();
     }
 
-    if (!valueFormat.supportsUnwrapping()) {
+    if (!valueFormat.supportsWrapping()) {
       throw new KsqlException("'" + CommonCreateConfigs.WRAP_SINGLE_VALUE
           + "' can not be used with format '"
-          + valueFormat + "' as it does not support wrapping");
+          + valueFormat.name() + "' as it does not support wrapping");
     }
 
     if (!singleField) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedStream.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.structured;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
 import io.confluent.ksql.execution.plan.ExecutionStep;
-import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.plan.KGroupedStreamHolder;
 import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.streams.ExecutionStepFactory;
@@ -28,7 +27,7 @@ import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.parser.tree.WindowExpression;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
@@ -87,7 +86,7 @@ public class SchemaKGroupedStream {
       step = ExecutionStepFactory.streamWindowedAggregate(
           contextStacker,
           sourceStep,
-          Formats.of(keyFormat, valueFormat, SerdeOption.none()),
+          io.confluent.ksql.execution.plan.Formats.of(keyFormat, valueFormat, SerdeOption.none()),
           nonAggregateColumns,
           aggregations,
           windowExpression.get().getKsqlWindowExpression()
@@ -97,7 +96,7 @@ public class SchemaKGroupedStream {
       step = ExecutionStepFactory.streamAggregate(
           contextStacker,
           sourceStep,
-          Formats.of(keyFormat, valueFormat, SerdeOption.none()),
+          io.confluent.ksql.execution.plan.Formats.of(keyFormat, valueFormat, SerdeOption.none()),
           nonAggregateColumns,
           aggregations
       );
@@ -115,7 +114,7 @@ public class SchemaKGroupedStream {
 
   private static KeyFormat getKeyFormat(final WindowExpression windowExpression) {
     return KeyFormat.windowed(
-        FormatInfo.of(Format.KAFKA.name()),
+        FormatInfo.of(FormatFactory.KAFKA.name()),
         windowExpression.getKsqlWindowExpression().getWindowInfo()
     );
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicDeleteInjector.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicDeleteInjector.java
@@ -27,7 +27,7 @@ import io.confluent.ksql.parser.SqlFormatter;
 import io.confluent.ksql.parser.tree.DropStatement;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.schema.registry.SchemaRegistryUtil;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
@@ -45,7 +45,7 @@ import java.util.stream.Collectors;
  * passed through. Furthermore, it will remove the DELETE TOPIC clause from
  * the statement, indicating that the operation has already been done.
  *
- * <p>If the topic being deleted is {@link Format#AVRO},
+ * <p>If the topic being deleted is {@link FormatFactory#AVRO},
  * this injector will also clean up the corresponding schema in the schema
  * registry.
  */
@@ -108,7 +108,7 @@ public class TopicDeleteInjector implements Injector {
       }
 
       try {
-        if (source.getKsqlTopic().getValueFormat().getFormat() == Format.AVRO) {
+        if (source.getKsqlTopic().getValueFormat().getFormat() == FormatFactory.AVRO) {
           SchemaRegistryUtil.deleteSubjectWithRetries(
                   schemaRegistryClient,
                   source.getKafkaTopicName() + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX);

--- a/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicFactory.java
@@ -18,7 +18,7 @@ package io.confluent.ksql.topic;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.model.WindowType;
 import io.confluent.ksql.parser.properties.with.CreateSourceProperties;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.ValueFormat;
@@ -39,9 +39,9 @@ public final class TopicFactory {
 
     final KeyFormat keyFormat = windowType
         .map(type -> KeyFormat
-            .windowed(FormatInfo.of(Format.KAFKA.name()), WindowInfo.of(type, windowSize)))
+            .windowed(FormatInfo.of(FormatFactory.KAFKA.name()), WindowInfo.of(type, windowSize)))
         .orElseGet(() -> KeyFormat
-            .nonWindowed(FormatInfo.of(Format.KAFKA.name())));
+            .nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())));
 
     final ValueFormat valueFormat = ValueFormat.of(properties.getFormatInfo());
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/AvroUtil.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/AvroUtil.java
@@ -18,10 +18,10 @@ package io.confluent.ksql.util;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.ksql.execution.ddl.commands.CreateSourceCommand;
-import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
+import io.confluent.ksql.serde.avro.AvroFormat;
 import io.confluent.ksql.serde.avro.AvroSchemas;
 import java.io.IOException;
 import org.apache.http.HttpStatus;
@@ -37,9 +37,9 @@ public final class AvroUtil {
       final SchemaRegistryClient schemaRegistryClient,
       final KsqlConfig ksqlConfig
   ) {
-    final Formats formats = ddl.getFormats();
+    final io.confluent.ksql.execution.plan.Formats formats = ddl.getFormats();
     final FormatInfo format = formats.getValueFormat();
-    if (Format.valueOf(format.getFormat()) != Format.AVRO) {
+    if (FormatFactory.of(format) != FormatFactory.AVRO) {
       return;
     }
 
@@ -50,7 +50,7 @@ public final class AvroUtil {
     final org.apache.avro.Schema avroSchema = AvroSchemas.getAvroSchema(
         physicalSchema.valueSchema(),
         format.getProperties()
-            .getOrDefault(FormatInfo.FULL_SCHEMA_NAME, KsqlConstants.DEFAULT_AVRO_SCHEMA_FULL_NAME),
+            .getOrDefault(AvroFormat.FULL_SCHEMA_NAME, KsqlConstants.DEFAULT_AVRO_SCHEMA_FULL_NAME),
         ksqlConfig
     );
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerFunctionalTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerFunctionalTest.java
@@ -62,10 +62,12 @@ import io.confluent.ksql.planner.plan.JoinNode.JoinType;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.ValueFormat;
+import io.confluent.ksql.serde.avro.AvroFormat;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlParserTestUtil;
 import io.confluent.ksql.util.MetaStoreFixture;
@@ -123,7 +125,7 @@ public class AnalyzerFunctionalTest {
     jsonMetaStore = MetaStoreFixture.getNewMetaStore(new InternalFunctionRegistry());
     avroMetaStore = MetaStoreFixture.getNewMetaStore(
         new InternalFunctionRegistry(),
-        ValueFormat.of(FormatInfo.of(Format.AVRO.name()))
+        ValueFormat.of(FormatInfo.of(FormatFactory.AVRO.name()))
     );
 
     analyzer = new Analyzer(
@@ -314,7 +316,8 @@ public class AnalyzerFunctionalTest {
 
     assertThat(analysis.getInto(), is(not(Optional.empty())));
     assertThat(analysis.getInto().get().getKsqlTopic().getValueFormat(),
-        is(ValueFormat.of(FormatInfo.of(Format.AVRO.name(), ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, "com.custom.schema")))));
+        is(ValueFormat.of(FormatInfo.of(
+            FormatFactory.AVRO.name(), ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "com.custom.schema")))));
   }
 
   @Test
@@ -329,7 +332,7 @@ public class AnalyzerFunctionalTest {
 
     assertThat(analysis.getInto(), is(not(Optional.empty())));
     assertThat(analysis.getInto().get().getKsqlTopic().getValueFormat(),
-        is(ValueFormat.of(FormatInfo.of(Format.AVRO.name()))));
+        is(ValueFormat.of(FormatInfo.of(FormatFactory.AVRO.name()))));
   }
 
     @Test
@@ -345,8 +348,8 @@ public class AnalyzerFunctionalTest {
 
     assertThat(analysis.getInto(), is(not(Optional.empty())));
       assertThat(analysis.getInto().get().getKsqlTopic().getValueFormat(),
-          is(ValueFormat.of(FormatInfo.of(Format.AVRO.name(), ImmutableMap
-              .of(FormatInfo.FULL_SCHEMA_NAME, "org.ac.s1")))));
+          is(ValueFormat.of(FormatInfo.of(FormatFactory.AVRO.name(), ImmutableMap
+              .of(AvroFormat.FULL_SCHEMA_NAME, "org.ac.s1")))));
   }
 
   @Test
@@ -357,8 +360,9 @@ public class AnalyzerFunctionalTest {
 
     final KsqlTopic ksqlTopic = new KsqlTopic(
         "s0",
-        KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA.name())),
-        ValueFormat.of(FormatInfo.of(Format.AVRO.name(), ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, "org.ac.s1")))
+        KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())),
+        ValueFormat.of(FormatInfo.of(
+            FormatFactory.AVRO.name(), ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "org.ac.s1")))
     );
 
     final LogicalSchema schema = LogicalSchema.builder()
@@ -387,7 +391,7 @@ public class AnalyzerFunctionalTest {
 
     assertThat(analysis.getInto(), is(not(Optional.empty())));
     assertThat(analysis.getInto().get().getKsqlTopic().getValueFormat(),
-        is(ValueFormat.of(FormatInfo.of(Format.AVRO.name()))));
+        is(ValueFormat.of(FormatInfo.of(FormatFactory.AVRO.name()))));
   }
 
   @Test
@@ -403,7 +407,7 @@ public class AnalyzerFunctionalTest {
 
     assertThat(analysis.getInto(), is(not(Optional.empty())));
     assertThat(analysis.getInto().get().getKsqlTopic().getValueFormat(),
-        is(ValueFormat.of(FormatInfo.of(Format.AVRO.name()))));
+        is(ValueFormat.of(FormatInfo.of(FormatFactory.AVRO.name()))));
   }
 
   @Test
@@ -444,7 +448,7 @@ public class AnalyzerFunctionalTest {
     final Set<SerdeOption> serdeOptions = ImmutableSet.of(SerdeOption.UNWRAP_SINGLE_VALUES);
     when(serdeOptionsSupplier.build(any(), any(), any(), any())).thenReturn(serdeOptions);
 
-    givenSinkValueFormat(Format.AVRO);
+    givenSinkValueFormat(FormatFactory.AVRO);
     givenWrapSingleValues(true);
 
     // When:
@@ -453,7 +457,7 @@ public class AnalyzerFunctionalTest {
     // Then:
     verify(serdeOptionsSupplier).build(
         ImmutableList.of("COL0", "COL1").stream().map(ColumnName::of).collect(Collectors.toList()),
-        Format.AVRO,
+        FormatFactory.AVRO,
         Optional.of(true),
         DEFAULT_SERDE_OPTIONS);
 
@@ -465,7 +469,7 @@ public class AnalyzerFunctionalTest {
     // Given:
     query = parseSingle("Select COL0 from KAFKA_SOURCE GROUP BY COL0;");
 
-    givenSinkValueFormat(Format.KAFKA);
+    givenSinkValueFormat(FormatFactory.KAFKA);
 
     // Then:
     expectedException.expect(KsqlException.class);
@@ -483,7 +487,7 @@ public class AnalyzerFunctionalTest {
         + "WITHIN 1 SECOND ON "
         + "TEST1.COL0 = KAFKA_SOURCE.COL0;");
 
-    givenSinkValueFormat(Format.KAFKA);
+    givenSinkValueFormat(FormatFactory.KAFKA);
 
     // Then:
     expectedException.expect(KsqlException.class);
@@ -644,7 +648,7 @@ public class AnalyzerFunctionalTest {
 
   private void buildProps() {
     final Map<String, Literal> props = new HashMap<>();
-    sinkFormat.ifPresent(f -> props.put("VALUE_FORMAT", new StringLiteral(f.toString())));
+    sinkFormat.ifPresent(f -> props.put("VALUE_FORMAT", new StringLiteral(f.name())));
     sinkWrapSingleValues.ifPresent(b -> props.put("WRAP_SINGLE_VALUE", new BooleanLiteral(Boolean.toString(b))));
 
     final CreateSourceAsProperties properties = CreateSourceAsProperties.from(props);
@@ -660,8 +664,8 @@ public class AnalyzerFunctionalTest {
 
     final KsqlTopic topic = new KsqlTopic(
         "ks",
-        KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA.name())),
-        ValueFormat.of(FormatInfo.of(Format.KAFKA.name()))
+        KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())),
+        ValueFormat.of(FormatInfo.of(FormatFactory.KAFKA.name()))
     );
 
     final KsqlStream<?> stream = new KsqlStream<>(

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/QueryAnalyzerFunctionalTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/QueryAnalyzerFunctionalTest.java
@@ -48,7 +48,7 @@ import io.confluent.ksql.parser.tree.CreateTableAsSelect;
 import io.confluent.ksql.parser.tree.InsertInto;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Sink;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlParserTestUtil;
@@ -524,7 +524,7 @@ public class QueryAnalyzerFunctionalTest {
 
     // Then:
     assertThat(analysis.getInto().get().getKsqlTopic().getValueFormat().getFormat(),
-        is(Format.DELIMITED));
+        is(FormatFactory.DELIMITED));
   }
 
   private Query givenQuery(final String sql) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
@@ -57,7 +57,7 @@ import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
@@ -180,8 +180,8 @@ public class CodeGenRunnerTest {
 
         final KsqlTopic ksqlTopic = new KsqlTopic(
             "codegen_test",
-            KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA.name())),
-            ValueFormat.of(FormatInfo.of(Format.JSON.name()))
+            KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())),
+            ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name()))
         );
 
         final KsqlStream<?> ksqlStream = new KsqlStream<>(

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceFactoryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceFactoryTest.java
@@ -22,9 +22,9 @@ import static io.confluent.ksql.parser.tree.TableElement.Namespace.KEY;
 import static io.confluent.ksql.parser.tree.TableElement.Namespace.VALUE;
 import static io.confluent.ksql.schema.ksql.ColumnMatchers.keyColumn;
 import static io.confluent.ksql.schema.ksql.types.SqlTypes.BIGINT;
-import static io.confluent.ksql.serde.Format.AVRO;
-import static io.confluent.ksql.serde.Format.JSON;
-import static io.confluent.ksql.serde.Format.KAFKA;
+import static io.confluent.ksql.serde.FormatFactory.AVRO;
+import static io.confluent.ksql.serde.FormatFactory.JSON;
+import static io.confluent.ksql.serde.FormatFactory.KAFKA;
 import static io.confluent.ksql.util.SchemaUtil.ROWKEY_NAME;
 import static io.confluent.ksql.util.SchemaUtil.ROWTIME_NAME;
 import static io.confluent.ksql.util.SchemaUtil.WINDOWEND_NAME;
@@ -69,6 +69,7 @@ import io.confluent.ksql.serde.KeySerdeFactory;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.ValueSerdeFactory;
 import io.confluent.ksql.serde.WindowInfo;
+import io.confluent.ksql.serde.avro.AvroFormat;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
@@ -663,7 +664,7 @@ public class CreateSourceFactoryTest {
     // Then:
     assertThat(
         cmd.getFormats().getValueFormat(),
-        is(FormatInfo.of(AVRO.name(), ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, "full.schema.name"))));
+        is(FormatInfo.of(AVRO.name(), ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "full.schema.name"))));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/DdlCommandExecTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/DdlCommandExecTest.java
@@ -12,7 +12,6 @@ import io.confluent.ksql.execution.ddl.commands.DdlCommandResult;
 import io.confluent.ksql.execution.ddl.commands.DropSourceCommand;
 import io.confluent.ksql.execution.ddl.commands.DropTypeCommand;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
-import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.timestamp.TimestampColumn;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.MutableMetaStore;
@@ -22,7 +21,7 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
@@ -51,8 +50,8 @@ public class DdlCommandExecTest {
       .valueColumn(ColumnName.of("F1"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("F2"), SqlTypes.STRING)
       .build();
-  private static final ValueFormat VALUE_FORMAT = ValueFormat.of(FormatInfo.of(Format.JSON.name()));
-  private static final KeyFormat KEY_FORMAT = KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA.name()));
+  private static final ValueFormat VALUE_FORMAT = ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name()));
+  private static final KeyFormat KEY_FORMAT = KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name()));
   private static final Set<SerdeOption> SERDE_OPTIONS = SerdeOption.none();
 
   private CreateStreamCommand createStream;
@@ -313,7 +312,7 @@ public class DdlCommandExecTest {
         keyField.map(ColumnName::of),
         Optional.of(timestampColumn),
         "topic",
-        Formats.of(
+        io.confluent.ksql.execution.plan.Formats.of(
             KEY_FORMAT,
             VALUE_FORMAT,
             SERDE_OPTIONS),
@@ -328,7 +327,7 @@ public class DdlCommandExecTest {
         Optional.empty(),
         Optional.of(timestampColumn),
         "topic",
-        Formats.of(
+        io.confluent.ksql.execution.plan.Formats.of(
             KEY_FORMAT,
             VALUE_FORMAT,
             SERDE_OPTIONS),
@@ -343,7 +342,7 @@ public class DdlCommandExecTest {
         Optional.empty(),
         Optional.of(timestampColumn),
         TOPIC_NAME,
-        Formats.of(
+        io.confluent.ksql.execution.plan.Formats.of(
             KEY_FORMAT,
             VALUE_FORMAT,
             SERDE_OPTIONS
@@ -359,7 +358,7 @@ public class DdlCommandExecTest {
         keyField.map(ColumnName::of),
         Optional.of(timestampColumn),
         TOPIC_NAME,
-        Formats.of(
+        io.confluent.ksql.execution.plan.Formats.of(
             KEY_FORMAT,
             VALUE_FORMAT,
             SERDE_OPTIONS

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
@@ -55,7 +55,7 @@ import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.KeySerdeFactory;
@@ -855,7 +855,7 @@ public class InsertValuesExecutorTest {
 
     // Then:
     verify(keySerdeFactory).create(
-        FormatInfo.of(Format.KAFKA.name()),
+        FormatInfo.of(FormatFactory.KAFKA.name()),
         PersistenceSchema.from(SCHEMA.keyConnectSchema(), false),
         new KsqlConfig(ImmutableMap.of()),
         srClientFactory,
@@ -864,7 +864,7 @@ public class InsertValuesExecutorTest {
     );
 
     verify(valueSerdeFactory).create(
-        FormatInfo.of(Format.JSON.name()),
+        FormatInfo.of(FormatFactory.JSON.name()),
         PersistenceSchema.from(SCHEMA.valueConnectSchema(), false),
         new KsqlConfig(ImmutableMap.of()),
         srClientFactory,
@@ -917,8 +917,8 @@ public class InsertValuesExecutorTest {
   ) {
     final KsqlTopic topic = new KsqlTopic(
         topicName,
-        KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA.name())),
-        ValueFormat.of(FormatInfo.of(Format.JSON.name()))
+        KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())),
+        ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name()))
     );
 
     final KeyField valueKeyField = keyField

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
@@ -14,7 +14,7 @@
  */
 package io.confluent.ksql.integration;
 
-import static io.confluent.ksql.serde.Format.JSON;
+import static io.confluent.ksql.serde.FormatFactory.JSON;
 import static io.confluent.ksql.util.KsqlConfig.KSQL_FUNCTIONS_PROPERTY_PREFIX;
 import static java.lang.String.format;
 import static org.hamcrest.Matchers.either;

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/JoinIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/JoinIntTest.java
@@ -16,8 +16,8 @@
 package io.confluent.ksql.integration;
 
 import static io.confluent.ksql.GenericRow.genericRow;
-import static io.confluent.ksql.serde.Format.AVRO;
-import static io.confluent.ksql.serde.Format.JSON;
+import static io.confluent.ksql.serde.FormatFactory.AVRO;
+import static io.confluent.ksql.serde.FormatFactory.JSON;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.common.utils.IntegrationTest;
@@ -26,6 +26,7 @@ import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.test.util.TopicTestUtil;
 import io.confluent.ksql.util.ItemDataProvider;
 import io.confluent.ksql.util.OrderDataProvider;
@@ -217,7 +218,7 @@ public class JoinIntTest {
         orderStreamTopicJson,
         ORDER_STREAM_NAME_JSON,
         ITEM_TABLE_NAME_JSON,
-        Format.JSON);
+        FormatFactory.JSON);
 
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.integration;
 
 import static io.confluent.ksql.GenericRow.genericRow;
-import static io.confluent.ksql.serde.Format.JSON;
+import static io.confluent.ksql.serde.FormatFactory.JSON;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
@@ -15,7 +15,7 @@
 
 package io.confluent.ksql.integration;
 
-import static io.confluent.ksql.serde.Format.JSON;
+import static io.confluent.ksql.serde.FormatFactory.JSON;
 import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/SecureIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/SecureIntegrationTest.java
@@ -15,7 +15,7 @@
 
 package io.confluent.ksql.integration;
 
-import static io.confluent.ksql.serde.Format.JSON;
+import static io.confluent.ksql.serde.FormatFactory.JSON;
 import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 import static io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster.VALID_USER1;
 import static io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster.VALID_USER2;

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/StreamsSelectAndProjectIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/StreamsSelectAndProjectIntTest.java
@@ -16,8 +16,8 @@
 package io.confluent.ksql.integration;
 
 import static io.confluent.ksql.GenericRow.genericRow;
-import static io.confluent.ksql.serde.Format.AVRO;
-import static io.confluent.ksql.serde.Format.JSON;
+import static io.confluent.ksql.serde.FormatFactory.AVRO;
+import static io.confluent.ksql.serde.FormatFactory.JSON;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java
@@ -16,9 +16,9 @@
 package io.confluent.ksql.integration;
 
 import static io.confluent.ksql.GenericRow.genericRow;
-import static io.confluent.ksql.serde.Format.AVRO;
-import static io.confluent.ksql.serde.Format.DELIMITED;
-import static io.confluent.ksql.serde.Format.JSON;
+import static io.confluent.ksql.serde.FormatFactory.AVRO;
+import static io.confluent.ksql.serde.FormatFactory.DELIMITED;
+import static io.confluent.ksql.serde.FormatFactory.JSON;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -32,6 +32,8 @@ import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.avro.AvroFormat;
+import io.confluent.ksql.serde.json.JsonFormat;
 import io.confluent.ksql.test.util.KsqlIdentifierTestUtil;
 import io.confluent.ksql.util.ItemDataProvider;
 import io.confluent.ksql.util.OrderDataProvider;
@@ -104,12 +106,12 @@ public class UdfIntTest {
   }
 
   public UdfIntTest(final Format format) {
-    switch (format) {
-      case AVRO:
+    switch (format.name()) {
+      case AvroFormat.NAME:
         this.testData =
             new TestData(format, AVRO_TOPIC_NAME, AVRO_STREAM_NAME, avroRecordMetadataMap);
         break;
-      case JSON:
+      case JsonFormat.NAME:
         this.testData =
             new TestData(format, JSON_TOPIC_NAME, JSON_STREAM_NAME, jsonRecordMetadataMap);
         break;

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.integration;
 
 import static io.confluent.ksql.GenericRow.genericRow;
-import static io.confluent.ksql.serde.Format.JSON;
+import static io.confluent.ksql.serde.FormatFactory.JSON;
 import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 import static io.confluent.ksql.test.util.ConsumerTestUtil.hasUniqueRecords;
 import static io.confluent.ksql.test.util.MapMatchers.mapHasItems;

--- a/ksql-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
@@ -15,7 +15,7 @@
 
 package io.confluent.ksql.materialization.ks;
 
-import static io.confluent.ksql.serde.Format.JSON;
+import static io.confluent.ksql.serde.FormatFactory.JSON;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
@@ -582,7 +582,7 @@ public class KsMaterializationFunctionalTest {
         + " (" + USER_DATA_PROVIDER.ksqlSchemaString() + ")"
         + " WITH ("
         + "    kafka_topic='" + USERS_TOPIC + "', "
-        + "    value_format='" + VALUE_FORMAT + "', "
+        + "    value_format='" + VALUE_FORMAT.name() + "', "
         + "    key = '" + USER_DATA_PROVIDER.key() + "'"
         + ");"
     );
@@ -591,7 +591,7 @@ public class KsMaterializationFunctionalTest {
         + " (" + USER_DATA_PROVIDER.ksqlSchemaString() + ")"
         + " WITH ("
         + "    kafka_topic='" + USERS_TOPIC + "', "
-        + "    value_format='" + VALUE_FORMAT + "', "
+        + "    value_format='" + VALUE_FORMAT.name() + "', "
         + "    key = '" + USER_DATA_PROVIDER.key() + "'"
         + ");"
     );

--- a/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -37,7 +37,7 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.services.FakeKafkaTopicClient;
 import io.confluent.ksql.services.KafkaTopicClient;
@@ -256,7 +256,7 @@ public class PhysicalPlanBuilderTest {
     final PersistentQueryMetadata persistentQuery = (PersistentQueryMetadata)
         queryMetadataList.get(1);
     assertThat(persistentQuery.getResultTopic().getValueFormat().getFormat(),
-        equalTo(Format.DELIMITED));
+        equalTo(FormatFactory.DELIMITED));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
@@ -45,7 +45,7 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
@@ -116,8 +116,8 @@ public class DataSourceNodeTest {
         false,
       new KsqlTopic(
           "topic",
-          KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA.name())),
-          ValueFormat.of(FormatInfo.of(Format.JSON.name()))
+          KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())),
+          ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name()))
       )
   );
 
@@ -235,8 +235,8 @@ public class DataSourceNodeTest {
         false,
         new KsqlTopic(
             "topic2",
-            KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA.name())),
-            ValueFormat.of(FormatInfo.of(Format.JSON.name()))
+            KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())),
+            ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name()))
         )
     );
 
@@ -381,7 +381,7 @@ public class DataSourceNodeTest {
   }
 
   private void givenWindowedSource(final boolean windowed) {
-    final FormatInfo format = FormatInfo.of(Format.KAFKA.name());
+    final FormatInfo format = FormatInfo.of(FormatFactory.KAFKA.name());
 
     final KeyFormat keyFormat = windowed
         ? KeyFormat.windowed(format, WindowInfo.of(WindowType.SESSION, Optional.empty()))

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
@@ -50,7 +50,7 @@ import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.services.KafkaTopicClient;
@@ -112,8 +112,8 @@ public class JoinNodeTest {
       RIGHT_ALIAS, RIGHT_SOURCE_SCHEMA.withMetaAndKeyColsInValue(false)
   );
 
-  private static final ValueFormat VALUE_FORMAT = ValueFormat.of(FormatInfo.of(Format.JSON.name()));
-  private static final ValueFormat OTHER_FORMAT = ValueFormat.of(FormatInfo.of(Format.DELIMITED.name()));
+  private static final ValueFormat VALUE_FORMAT = ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name()));
+  private static final ValueFormat OTHER_FORMAT = ValueFormat.of(FormatInfo.of(FormatFactory.DELIMITED.name()));
   private final KsqlConfig ksqlConfig = new KsqlConfig(new HashMap<>());
   private StreamsBuilder builder;
   private JoinNode joinNode;

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -37,10 +37,11 @@ import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.query.id.QueryIdGenerator;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.ValueFormat;
+import io.confluent.ksql.serde.avro.AvroFormat;
 import io.confluent.ksql.structured.SchemaKStream;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -75,7 +76,7 @@ public class KsqlStructuredDataOutputNodeTest {
       .of(ColumnName.of("key"));
 
   private static final PlanNodeId PLAN_NODE_ID = new PlanNodeId("0");
-  private static final ValueFormat JSON_FORMAT = ValueFormat.of(FormatInfo.of(Format.JSON.name()));
+  private static final ValueFormat JSON_FORMAT = ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name()));
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
@@ -179,8 +180,8 @@ public class KsqlStructuredDataOutputNodeTest {
     // Given:
     givenInsertIntoNode();
 
-    final ValueFormat valueFormat = ValueFormat.of(FormatInfo.of(Format.AVRO.name(), ImmutableMap
-        .of(FormatInfo.FULL_SCHEMA_NAME, "name")));
+    final ValueFormat valueFormat = ValueFormat.of(FormatInfo.of(FormatFactory.AVRO.name(), ImmutableMap
+        .of(AvroFormat.FULL_SCHEMA_NAME, "name")));
 
     when(ksqlTopic.getValueFormat()).thenReturn(valueFormat);
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
@@ -40,7 +40,7 @@ import io.confluent.ksql.query.KafkaStreamsBuilder.BuildResult;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
@@ -93,7 +93,7 @@ public class QueryExecutorTest {
       .valueColumn(ColumnName.of("col0"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("col1"), SqlTypes.STRING)
       .build();
-  private static final KeyFormat KEY_FORMAT = KeyFormat.nonWindowed(FormatInfo.of(Format.JSON.name()));
+  private static final KeyFormat KEY_FORMAT = KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.JSON.name()));
   private static final PhysicalSchema SINK_PHYSICAL_SCHEMA = PhysicalSchema.from(
       SINK_SCHEMA,
       SerdeOption.none()

--- a/ksql-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorTest.java
@@ -446,7 +446,6 @@ public class DefaultSchemaInjectorTest {
 
     // Then:
     expectedException.expect(KsqlException.class);
-    expectedException.expect(not(instanceOf(KsqlStatementException.class)));
     expectedException.expectMessage("Oh no");
 
     // When:

--- a/ksql-engine/src/test/java/io/confluent/ksql/security/KsqlAuthorizationValidatorImplTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/security/KsqlAuthorizationValidatorImplTest.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.security;
 
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.when;
 
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.engine.KsqlEngineTestUtil;
@@ -32,12 +31,11 @@ import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.ValueFormat;
-import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
 import java.util.Collections;
 import java.util.Optional;
@@ -361,8 +359,8 @@ public class KsqlAuthorizationValidatorImplTest {
   ) {
     final KsqlTopic sourceTopic = new KsqlTopic(
         topicName,
-        KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA.name())),
-        ValueFormat.of(FormatInfo.of(Format.JSON.name()))
+        KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())),
+        ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name()))
     );
 
     final KsqlStream<?> streamSource = new KsqlStream<>(

--- a/ksql-engine/src/test/java/io/confluent/ksql/serde/SerdeOptionsTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/serde/SerdeOptionsTest.java
@@ -111,7 +111,7 @@ public class SerdeOptionsTest {
     // When:
     final Set<SerdeOption> result = SerdeOptions.buildForCreateStatement(
         SINGLE_FIELD_SCHEMA,
-        Format.JSON,
+        FormatFactory.JSON,
         Optional.of(false),
         ksqlConfig
     );
@@ -130,7 +130,7 @@ public class SerdeOptionsTest {
     // When:
     final Set<SerdeOption> result = SerdeOptions.buildForCreateStatement(
         SINGLE_FIELD_SCHEMA,
-        Format.JSON,
+        FormatFactory.JSON,
         Optional.empty(),
         ksqlConfig
     );
@@ -144,7 +144,7 @@ public class SerdeOptionsTest {
     // When:
     final Set<SerdeOption> result = SerdeOptions.buildForCreateStatement(
         SINGLE_FIELD_SCHEMA,
-        Format.JSON,
+        FormatFactory.JSON,
         Optional.empty(),
         ksqlConfig
     );
@@ -163,7 +163,7 @@ public class SerdeOptionsTest {
     // When:
     final Set<SerdeOption> result = SerdeOptions.buildForCreateStatement(
         MULTI_FIELD_SCHEMA,
-        Format.JSON,
+        FormatFactory.JSON,
         Optional.empty(),
         ksqlConfig
     );
@@ -182,7 +182,7 @@ public class SerdeOptionsTest {
     // When:
     SerdeOptions.buildForCreateStatement(
         MULTI_FIELD_SCHEMA,
-        Format.JSON,
+        FormatFactory.JSON,
         Optional.of(true),
         ksqlConfig
     );
@@ -198,7 +198,7 @@ public class SerdeOptionsTest {
     // When:
     SerdeOptions.buildForCreateStatement(
         SINGLE_FIELD_SCHEMA,
-        Format.DELIMITED,
+        FormatFactory.DELIMITED,
         Optional.of(false),
         ksqlConfig
     );
@@ -211,7 +211,7 @@ public class SerdeOptionsTest {
 
     // When:
     final Set<SerdeOption> result = SerdeOptions.buildForCreateAsStatement(
-        SINGLE_COLUMN_NAME, Format.AVRO, Optional.of(true), singleFieldDefaults);
+        SINGLE_COLUMN_NAME, FormatFactory.AVRO, Optional.of(true), singleFieldDefaults);
 
     // Then:
     assertThat(result, not(hasItem(SerdeOption.UNWRAP_SINGLE_VALUES)));
@@ -224,7 +224,7 @@ public class SerdeOptionsTest {
 
     // When:
     final Set<SerdeOption> result = SerdeOptions.buildForCreateAsStatement(
-        SINGLE_COLUMN_NAME, Format.JSON, Optional.empty(), singleFieldDefaults);
+        SINGLE_COLUMN_NAME, FormatFactory.JSON, Optional.empty(), singleFieldDefaults);
 
     // Then:
     assertThat(result, hasItem(SerdeOption.UNWRAP_SINGLE_VALUES));
@@ -237,7 +237,7 @@ public class SerdeOptionsTest {
 
     // When:
     final Set<SerdeOption> result = SerdeOptions.buildForCreateAsStatement(
-        MULTI_FIELD_NAMES, Format.AVRO, Optional.empty(), singleFieldDefaults);
+        MULTI_FIELD_NAMES, FormatFactory.AVRO, Optional.empty(), singleFieldDefaults);
 
     // Then:
     assertThat(result, not(hasItem(SerdeOption.UNWRAP_SINGLE_VALUES)));
@@ -253,7 +253,7 @@ public class SerdeOptionsTest {
     // When:
     SerdeOptions.buildForCreateAsStatement(
         MULTI_FIELD_NAMES,
-        Format.JSON,
+        FormatFactory.JSON,
         Optional.of(true),
         singleFieldDefaults
     );
@@ -269,7 +269,7 @@ public class SerdeOptionsTest {
     // When:
     SerdeOptions.buildForCreateAsStatement(
         SINGLE_COLUMN_NAME,
-        Format.DELIMITED,
+        FormatFactory.DELIMITED,
         Optional.of(true),
         singleFieldDefaults
     );

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedStreamTest.java
@@ -25,7 +25,6 @@ import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
 import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
 import io.confluent.ksql.execution.plan.ExecutionStep;
-import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.streams.ExecutionStepFactory;
 import io.confluent.ksql.execution.windows.KsqlWindowExpression;
 import io.confluent.ksql.execution.windows.SessionWindowExpression;
@@ -38,7 +37,7 @@ import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.parser.tree.WindowExpression;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
@@ -147,7 +146,7 @@ public class SchemaKGroupedStreamTest {
             ExecutionStepFactory.streamAggregate(
                 queryContext,
                 schemaGroupedStream.getSourceStep(),
-                Formats.of(keyFormat, valueFormat, SerdeOption.none()),
+                io.confluent.ksql.execution.plan.Formats.of(keyFormat, valueFormat, SerdeOption.none()),
                 NON_AGGREGATE_COLUMNS,
                 ImmutableList.of(AGG)
             )
@@ -168,7 +167,7 @@ public class SchemaKGroupedStreamTest {
 
     // Then:
     final KeyFormat expected = KeyFormat.windowed(
-        FormatInfo.of(Format.KAFKA.name()),
+        FormatInfo.of(FormatFactory.KAFKA.name()),
         WindowInfo.of(WindowType.SESSION, Optional.empty())
     );
     assertThat(
@@ -177,7 +176,7 @@ public class SchemaKGroupedStreamTest {
             ExecutionStepFactory.streamWindowedAggregate(
                 queryContext,
                 schemaGroupedStream.getSourceStep(),
-                Formats.of(expected, valueFormat, SerdeOption.none()),
+                io.confluent.ksql.execution.plan.Formats.of(expected, valueFormat, SerdeOption.none()),
                 NON_AGGREGATE_COLUMNS,
                 ImmutableList.of(AGG),
                 KSQL_WINDOW_EXP

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
@@ -25,7 +25,6 @@ import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
 import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
 import io.confluent.ksql.execution.plan.ExecutionStep;
-import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.streams.ExecutionStepFactory;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.model.KeyField;
@@ -34,7 +33,7 @@ import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.parser.tree.WindowExpression;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
@@ -74,8 +73,8 @@ public class SchemaKGroupedTableTest {
   private final InternalFunctionRegistry functionRegistry = new InternalFunctionRegistry();
   private final QueryContext.Stacker queryContext
       = new QueryContext.Stacker().push("node");
-  private final ValueFormat valueFormat = ValueFormat.of(FormatInfo.of(Format.JSON.name()));
-  private final KeyFormat keyFormat = KeyFormat.nonWindowed(FormatInfo.of(Format.JSON.name()));
+  private final ValueFormat valueFormat = ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name()));
+  private final KeyFormat keyFormat = KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.JSON.name()));
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
@@ -152,7 +151,7 @@ public class SchemaKGroupedTableTest {
             ExecutionStepFactory.tableAggregate(
                 queryContext,
                 kGroupedTable.getSourceTableStep(),
-                Formats.of(keyFormat, valueFormat, SerdeOption.none()),
+                io.confluent.ksql.execution.plan.Formats.of(keyFormat, valueFormat, SerdeOption.none()),
                 NON_AGG_COLUMNS,
                 ImmutableList.of(SUM, COUNT)
             )

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
@@ -30,7 +30,6 @@ import io.confluent.ksql.execution.expression.tree.FunctionCall;
 import io.confluent.ksql.execution.expression.tree.LongLiteral;
 import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
 import io.confluent.ksql.execution.plan.ExecutionStep;
-import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.plan.JoinType;
 import io.confluent.ksql.execution.plan.SelectExpression;
 import io.confluent.ksql.execution.plan.StreamFilter;
@@ -52,7 +51,7 @@ import io.confluent.ksql.planner.plan.RepartitionNode;
 import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
@@ -84,9 +83,9 @@ public class SchemaKStreamTest {
   private final MetaStore metaStore = MetaStoreFixture.getNewMetaStore(new InternalFunctionRegistry());
   private final KeyField validJoinKeyField = KeyField
       .of(Optional.of(ColumnName.of("COL0")));
-  private final KeyFormat keyFormat = KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA.name()));
-  private final ValueFormat valueFormat = ValueFormat.of(FormatInfo.of(Format.JSON.name()));
-  private final ValueFormat rightFormat = ValueFormat.of(FormatInfo.of(Format.DELIMITED.name()));
+  private final KeyFormat keyFormat = KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name()));
+  private final ValueFormat valueFormat = ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name()));
+  private final ValueFormat rightFormat = ValueFormat.of(FormatInfo.of(FormatFactory.DELIMITED.name()));
   private final QueryContext.Stacker queryContext
       = new QueryContext.Stacker().push("node");
   private final QueryContext.Stacker childContextStacker = queryContext.push("child");
@@ -594,7 +593,8 @@ public class SchemaKStreamTest {
             ExecutionStepFactory.streamGroupByKey(
                 childContextStacker,
                 initialSchemaKStream.getSourceStep(),
-                Formats.of(expectedKeyFormat, valueFormat, SerdeOption.none())
+                io.confluent.ksql.execution.plan.Formats
+                    .of(expectedKeyFormat, valueFormat, SerdeOption.none())
             )
         )
     );
@@ -646,7 +646,8 @@ public class SchemaKStreamTest {
             ExecutionStepFactory.streamGroupBy(
                 childContextStacker,
                 initialSchemaKStream.getSourceStep(),
-                Formats.of(expectedKeyFormat, valueFormat, SerdeOption.none()),
+                io.confluent.ksql.execution.plan.Formats
+                    .of(expectedKeyFormat, valueFormat, SerdeOption.none()),
                 groupBy
             )
         )
@@ -760,7 +761,7 @@ public class SchemaKStreamTest {
               ExecutionStepFactory.streamTableJoin(
                   childContextStacker,
                   testcase.left,
-                  Formats.of(keyFormat, valueFormat, SerdeOption.none()),
+                  io.confluent.ksql.execution.plan.Formats.of(keyFormat, valueFormat, SerdeOption.none()),
                   initialSchemaKStream.getSourceStep(),
                   schemaKTable.getSourceTableStep()
               )

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
@@ -44,7 +44,6 @@ import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.LongLiteral;
 import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
 import io.confluent.ksql.execution.plan.ExecutionStep;
-import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.plan.JoinType;
 import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.KeySerdeFactory;
@@ -81,7 +80,7 @@ import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.GenericRowSerDe;
 import io.confluent.ksql.serde.KeyFormat;
@@ -148,8 +147,8 @@ public class SchemaKTableTest {
       new UnqualifiedColumnReferenceExp(ColumnName.of("COL1"));
   private static final Expression TEST_2_COL_2 =
       new UnqualifiedColumnReferenceExp(ColumnName.of("COL2"));
-  private static final KeyFormat keyFormat = KeyFormat.nonWindowed(FormatInfo.of(Format.JSON.name()));
-  private static final ValueFormat valueFormat = ValueFormat.of(FormatInfo.of(Format.JSON.name()));
+  private static final KeyFormat keyFormat = KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.JSON.name()));
+  private static final ValueFormat valueFormat = ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name()));
 
   private PlanBuilder planBuilder;
 
@@ -497,7 +496,8 @@ public class SchemaKTableTest {
             ExecutionStepFactory.tableGroupBy(
                 childContextStacker,
                 initialSchemaKTable.getSourceTableStep(),
-                Formats.of(initialSchemaKTable.keyFormat, valueFormat, SerdeOption.none()),
+                io.confluent.ksql.execution.plan.Formats
+                    .of(initialSchemaKTable.keyFormat, valueFormat, SerdeOption.none()),
                 groupByExpressions
             )
         )

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/SourceTopicsExtractorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/SourceTopicsExtractorTest.java
@@ -33,7 +33,7 @@ import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
@@ -160,8 +160,8 @@ public class SourceTopicsExtractorTest {
   ) {
     final KsqlTopic sourceTopic = new KsqlTopic(
         topicDescription.name(),
-        KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA.name())),
-        ValueFormat.of(FormatInfo.of(Format.JSON.name()))
+        KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())),
+        ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name()))
     );
 
     final KsqlStream<?> streamSource = new KsqlStream<>(

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
@@ -43,7 +43,7 @@ import io.confluent.ksql.parser.tree.CreateAsSelect;
 import io.confluent.ksql.parser.tree.CreateSource;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
@@ -103,8 +103,8 @@ public class TopicCreateInjectorTest {
 
     final KsqlTopic sourceTopic = new KsqlTopic(
         "source",
-        KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA.name())),
-        ValueFormat.of(FormatInfo.of(Format.JSON.name()))
+        KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())),
+        ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name()))
     );
 
     final KsqlStream source = new KsqlStream<>(
@@ -121,8 +121,8 @@ public class TopicCreateInjectorTest {
 
     final KsqlTopic joinTopic = new KsqlTopic(
         "jSource",
-        KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA.name())),
-        ValueFormat.of(FormatInfo.of(Format.JSON.name()))
+        KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())),
+        ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name()))
     );
 
     final KsqlStream joinSource = new KsqlStream<>(

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicDeleteInjectorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicDeleteInjectorTest.java
@@ -38,9 +38,10 @@ import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.DropStream;
 import io.confluent.ksql.parser.tree.ListProperties;
 import io.confluent.ksql.parser.tree.Statement;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.ValueFormat;
+import io.confluent.ksql.serde.avro.AvroFormat;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
@@ -93,7 +94,7 @@ public class TopicDeleteInjectorTest {
     when(source.getName()).thenReturn(SOURCE_NAME);
     when(source.getKafkaTopicName()).thenReturn(TOPIC_NAME);
     when(source.getKsqlTopic()).thenReturn(topic);
-    when(topic.getValueFormat()).thenReturn(ValueFormat.of(FormatInfo.of(Format.JSON.name())));
+    when(topic.getValueFormat()).thenReturn(ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name())));
   }
 
   @Test
@@ -141,7 +142,7 @@ public class TopicDeleteInjectorTest {
   @Test
   public void shouldDeleteSchemaInSR() throws IOException, RestClientException {
     // Given:
-    when(topic.getValueFormat()).thenReturn(ValueFormat.of(FormatInfo.of(Format.AVRO.name())));
+    when(topic.getValueFormat()).thenReturn(ValueFormat.of(FormatInfo.of(FormatFactory.AVRO.name())));
 
     // When:
     deleteInjector.inject(DROP_WITH_DELETE_TOPIC);
@@ -245,7 +246,8 @@ public class TopicDeleteInjectorTest {
   public void shouldNotThrowIfSchemaIsMissing() throws IOException, RestClientException {
     // Given:
     when(topic.getValueFormat())
-        .thenReturn(ValueFormat.of(FormatInfo.of(Format.AVRO.name(), ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, "foo"))));
+        .thenReturn(ValueFormat.of(FormatInfo.of(
+            FormatFactory.AVRO.name(), ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "foo"))));
 
     doThrow(new RestClientException("Subject not found.", 404, 40401))
             .when(registryClient).deleteSubject("something" + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX);

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/AvroUtilTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/AvroUtilTest.java
@@ -30,7 +30,6 @@ import io.confluent.connect.avro.AvroDataConfig;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.ksql.execution.ddl.commands.CreateSourceCommand;
-import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
@@ -39,11 +38,12 @@ import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.schema.ksql.SchemaConverters.ConnectToSqlTypeConverter;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.ValueFormat;
+import io.confluent.ksql.serde.avro.AvroFormat;
 import io.confluent.ksql.serde.avro.AvroSchemas;
 import io.confluent.ksql.serde.connect.ConnectSchemaTranslator;
 import java.io.IOException;
@@ -102,10 +102,11 @@ public class AvroUtilTest {
 
   private static final String RESULT_TOPIC_NAME = "actual-name";
 
-  private static final Formats FORMATS = Formats.of(
-      KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA.name())),
-      ValueFormat.of(FormatInfo.of(Format.AVRO.name(), ImmutableMap
-          .of(FormatInfo.FULL_SCHEMA_NAME, SCHEMA_NAME))),
+  private static final io.confluent.ksql.execution.plan.Formats FORMATS = io.confluent.ksql.execution.plan.Formats
+      .of(
+      KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())),
+      ValueFormat.of(FormatInfo.of(FormatFactory.AVRO.name(), ImmutableMap
+          .of(AvroFormat.FULL_SCHEMA_NAME, SCHEMA_NAME))),
       SerdeOption.none()
   );
 
@@ -197,9 +198,9 @@ public class AvroUtilTest {
     // Given:
     when(ddlCommand.getSchema()).thenReturn(SINGLE_FIELD_SCHEMA);
     when(ddlCommand.getFormats())
-        .thenReturn(Formats.of(
-            KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA.name())),
-            ValueFormat.of(FormatInfo.of(Format.AVRO.name())),
+        .thenReturn(io.confluent.ksql.execution.plan.Formats.of(
+            KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())),
+            ValueFormat.of(FormatInfo.of(FormatFactory.AVRO.name())),
             ImmutableSet.of(SerdeOption.UNWRAP_SINGLE_VALUES)
         ));
     final PhysicalSchema schema = PhysicalSchema

--- a/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGen.java
+++ b/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGen.java
@@ -19,7 +19,10 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.RateLimiter;
 import io.confluent.avro.random.generator.Generator;
 import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
+import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -270,7 +273,7 @@ public final class DataGen {
         help = false;
         bootstrapServer = "localhost:9092";
         schemaFile = null;
-        keyFormat = Format.KAFKA;
+        keyFormat = FormatFactory.KAFKA;
         valueFormat = null;
         valueDelimiter = ',';
         topicName = null;
@@ -316,11 +319,11 @@ public final class DataGen {
         }
 
         public Format getKeyFormat() {
-          return Format.KAFKA;
+          return FormatFactory.KAFKA;
         }
 
         public Format getValueFormat() {
-          return Format.JSON;
+          return FormatFactory.JSON;
         }
       }
 
@@ -460,8 +463,8 @@ public final class DataGen {
 
       private static Format parseFormat(final String formatString) {
         try {
-          return Format.valueOf(formatString.toUpperCase());
-        } catch (final IllegalArgumentException exception) {
+          return FormatFactory.of(FormatInfo.of(formatString));
+        } catch (final KsqlException exception) {
           throw new ArgumentParseException(String.format(
               "Invalid format in '%s'; was expecting one of AVRO, JSON, KAFKA or DELIMITED "
               + "(case-insensitive)",

--- a/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGenProducer.java
+++ b/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGenProducer.java
@@ -127,7 +127,7 @@ public class DataGenProducer {
 
   private Serializer<Struct> getKeySerializer() {
     final PersistenceSchema schema = PersistenceSchema
-        .from(RowGenerator.KEY_SCHEMA, keySerializerFactory.format().supportsUnwrapping());
+        .from(RowGenerator.KEY_SCHEMA, keySerializerFactory.format().supportsWrapping());
 
     return keySerializerFactory.create(schema);
   }

--- a/ksql-examples/src/main/java/io/confluent/ksql/datagen/SchemaRegistryClientFactory.java
+++ b/ksql-examples/src/main/java/io/confluent/ksql/datagen/SchemaRegistryClientFactory.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.datagen;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Optional;
@@ -32,7 +33,7 @@ final class SchemaRegistryClientFactory {
       final Format valueFormat,
       final KsqlConfig ksqlConfig
   ) {
-    if (keyFormat != Format.AVRO && valueFormat != Format.AVRO) {
+    if (keyFormat != FormatFactory.AVRO && valueFormat != FormatFactory.AVRO) {
       return Optional.empty();
     }
 

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/builder/KsqlQueryBuilderTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/builder/KsqlQueryBuilderTest.java
@@ -37,12 +37,13 @@ import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeySerdeFactory;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.ValueSerdeFactory;
 import io.confluent.ksql.serde.WindowInfo;
+import io.confluent.ksql.serde.avro.AvroFormat;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
 import java.time.Duration;
@@ -72,7 +73,7 @@ public class KsqlQueryBuilderTest {
   private static final QueryId QUERY_ID = new QueryId("fred");
 
   private static final FormatInfo FORMAT_INFO = FormatInfo
-      .of(Format.AVRO.name(), ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, "io.confluent.ksql"));
+      .of(FormatFactory.AVRO.name(), ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "io.confluent.ksql"));
 
   private static final WindowInfo WINDOW_INFO = WindowInfo
       .of(WindowType.TUMBLING, Optional.of(Duration.ofMillis(1000)));

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/KeyFormatNode.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/KeyFormatNode.java
@@ -20,6 +20,8 @@ import static org.hamcrest.Matchers.allOf;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.confluent.ksql.model.WindowType;
 import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
+import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.test.model.matchers.FormatMatchers.KeyFormatMatchers;
 import java.time.Duration;
@@ -36,11 +38,13 @@ public final class KeyFormatNode {
   private final Optional<Duration> windowSize;
 
   public KeyFormatNode(
-      @JsonProperty("format") final Format format,
+      @JsonProperty("format") final String format,
       @JsonProperty("windowType") final WindowType windowType,
       @JsonProperty("windowSize") final Long windowSize
   ) {
-    this.format = Optional.ofNullable(format);
+    this.format = Optional.ofNullable(format)
+        .map(FormatInfo::of)
+        .map(FormatFactory::of);
     this.windowType = Optional.ofNullable(windowType);
     this.windowSize = Optional.ofNullable(windowSize)
         .map(Duration::ofMillis);

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestCaseBuilderUtil.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestCaseBuilderUtil.java
@@ -30,7 +30,7 @@ import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.SqlBaseParser;
 import io.confluent.ksql.parser.tree.CreateSource;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.test.model.RecordNode;
 import io.confluent.ksql.test.model.TopicNode;
@@ -147,7 +147,7 @@ public final class TestCaseBuilderUtil {
 
       final ValueFormat valueFormat = ksqlTopic.getValueFormat();
       final Optional<org.apache.avro.Schema> avroSchema;
-      if (valueFormat.getFormat() == Format.AVRO) {
+      if (valueFormat.getFormat() == FormatFactory.AVRO) {
         // add avro schema
         final SchemaBuilder schemaBuilder = SchemaBuilder.struct();
         statement.getElements().forEach(e -> schemaBuilder.field(

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutorUtil.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutorUtil.java
@@ -42,7 +42,7 @@ import io.confluent.ksql.parser.tree.InsertValues;
 import io.confluent.ksql.planner.plan.ConfiguredKsqlPlan;
 import io.confluent.ksql.schema.ksql.inference.DefaultSchemaInjector;
 import io.confluent.ksql.schema.ksql.inference.SchemaRegistryTopicSchemaSupplier;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
@@ -173,7 +173,7 @@ public final class TestExecutorUtil {
   private static Optional<Schema> getAvroSchema(
       final DataSource dataSource,
       final SchemaRegistryClient schemaRegistryClient) {
-    if (dataSource.getKsqlTopic().getValueFormat().getFormat() == Format.AVRO) {
+    if (dataSource.getKsqlTopic().getValueFormat().getFormat() == FormatFactory.AVRO) {
       try {
         final SchemaMetadata schemaMetadata = schemaRegistryClient.getLatestSchemaMetadata(
             dataSource.getKafkaTopicName() + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX);

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/utils/SerdeUtil.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/utils/SerdeUtil.java
@@ -22,6 +22,10 @@ import io.confluent.ksql.model.WindowType;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.KeyFormat;
+import io.confluent.ksql.serde.avro.AvroFormat;
+import io.confluent.ksql.serde.delimited.DelimitedFormat;
+import io.confluent.ksql.serde.json.JsonFormat;
+import io.confluent.ksql.serde.kafka.KafkaFormat;
 import io.confluent.ksql.test.serde.SerdeSupplier;
 import io.confluent.ksql.test.serde.avro.ValueSpecAvroSerdeSupplier;
 import io.confluent.ksql.test.serde.json.ValueSpecJsonSerdeSupplier;
@@ -47,14 +51,14 @@ public final class SerdeUtil {
       final Format format,
       final LogicalSchema schema
   ) {
-    switch (format) {
-      case AVRO:
+    switch (format.name()) {
+      case AvroFormat.NAME:
         return new ValueSpecAvroSerdeSupplier();
-      case JSON:
+      case JsonFormat.NAME:
         return new ValueSpecJsonSerdeSupplier();
-      case DELIMITED:
+      case DelimitedFormat.NAME:
         return new StringSerdeSupplier();
-      case KAFKA:
+      case KafkaFormat.NAME:
         return new KafkaSerdeSupplier(schema);
       default:
         throw new InvalidFieldException("format", "unsupported value: " + format);

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorTest.java
@@ -36,7 +36,7 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.ValueFormat;
@@ -356,9 +356,9 @@ public class TestExecutorTest {
   private void givenDataSourceTopic(final LogicalSchema schema) {
     final KsqlTopic topic = mock(KsqlTopic.class);
     when(topic.getKeyFormat())
-        .thenReturn(KeyFormat.of(FormatInfo.of(Format.KAFKA.name()), Optional.empty()));
+        .thenReturn(KeyFormat.of(FormatInfo.of(FormatFactory.KAFKA.name()), Optional.empty()));
     when(topic.getValueFormat())
-        .thenReturn(ValueFormat.of(FormatInfo.of(Format.JSON.name())));
+        .thenReturn(ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name())));
 
     final DataSource dataSource = mock(DataSource.class);
     when(dataSource.getKsqlTopic()).thenReturn(topic);

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/delimited.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/delimited.json
@@ -178,7 +178,7 @@
         }
       ],
       "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlException",
+        "type": "io.confluent.ksql.util.KsqlStatementException",
         "message": "JSON does not support the following configs: [delimiter]"
       },
       "inputs": [],

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/formats.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/formats.json
@@ -1,0 +1,22 @@
+{
+  "tests": [
+    {
+      "name": "invalid format name",
+      "statements": [
+        "CREATE STREAM TEST WITH (kafka_topic='test_topic', value_format='FOO');"
+      ],
+      "topics": [
+        {
+          "name": "test_topic",
+          "format": "JSON"
+        }
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Unknown format: FOO"
+      },
+      "inputs": [],
+      "outputs": []
+    }
+  ]
+}

--- a/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/MetaStoreModelTest.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/MetaStoreModelTest.java
@@ -31,7 +31,7 @@ import io.confluent.ksql.schema.ksql.Column.Namespace;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.ValueFormat;
@@ -56,8 +56,8 @@ public class MetaStoreModelTest {
       .<Class<?>, Object>builder()
       .put(KsqlTopic.class, new KsqlTopic(
           "bob",
-          KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA.name())),
-          ValueFormat.of(FormatInfo.of(Format.JSON.name()))
+          KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())),
+          ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name()))
       ))
       .put(ColumnName.class, ColumnName.of("f0"))
       .put(SourceName.class, SourceName.of("f0"))
@@ -69,8 +69,8 @@ public class MetaStoreModelTest {
       .put(LogicalSchema.class, LogicalSchema.builder()
           .valueColumn(ColumnName.of("f0"), SqlTypes.BIGINT)
           .build())
-      .put(KeyFormat.class, KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA.name())))
-      .put(ValueFormat.class, ValueFormat.of(FormatInfo.of(Format.JSON.name())))
+      .put(KeyFormat.class, KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())))
+      .put(ValueFormat.class, ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name())))
       .build();
 
   private final Class<?> modelClass;

--- a/ksql-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
@@ -27,7 +27,7 @@ import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
@@ -40,7 +40,7 @@ public final class MetaStoreFixture {
   }
 
   public static MutableMetaStore getNewMetaStore(final FunctionRegistry functionRegistry) {
-    return getNewMetaStore(functionRegistry, ValueFormat.of(FormatInfo.of(Format.JSON.name())));
+    return getNewMetaStore(functionRegistry, ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name())));
   }
 
   public static MutableMetaStore getNewMetaStore(
@@ -49,7 +49,7 @@ public final class MetaStoreFixture {
   ) {
     final MutableMetaStore metaStore = new MetaStoreImpl(functionRegistry);
 
-    final KeyFormat keyFormat = KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA.name()));
+    final KeyFormat keyFormat = KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name()));
 
     final LogicalSchema test1Schema = LogicalSchema.builder()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.BIGINT)

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceAsProperties.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceAsProperties.java
@@ -25,7 +25,10 @@ import io.confluent.ksql.parser.ColumnReferenceParser;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
 import io.confluent.ksql.properties.with.CreateAsConfigs;
 import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
+import io.confluent.ksql.serde.avro.AvroFormat;
+import io.confluent.ksql.serde.delimited.DelimitedFormat;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Map;
 import java.util.Objects;
@@ -64,7 +67,7 @@ public final class CreateSourceAsProperties {
   }
 
   public Optional<Format> getValueFormat() {
-    return getFormatInfo().map(Format::of);
+    return getFormatInfo().map(FormatFactory::of);
   }
 
   public Optional<String> getKafkaTopic() {
@@ -102,12 +105,12 @@ public final class CreateSourceAsProperties {
 
     final String schemaName = props.getString(CommonCreateConfigs.VALUE_AVRO_SCHEMA_FULL_NAME);
     if (schemaName != null) {
-      builder.put(FormatInfo.FULL_SCHEMA_NAME, schemaName);
+      builder.put(AvroFormat.FULL_SCHEMA_NAME, schemaName);
     }
 
     final String delimiter = props.getString(CommonCreateConfigs.VALUE_DELIMITER_PROPERTY);
     if (delimiter != null) {
-      builder.put(FormatInfo.DELIMITER, delimiter);
+      builder.put(DelimitedFormat.DELIMITER, delimiter);
     }
 
     return builder.build();

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceProperties.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceProperties.java
@@ -27,7 +27,10 @@ import io.confluent.ksql.parser.DurationParser;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
 import io.confluent.ksql.properties.with.CreateConfigs;
 import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
+import io.confluent.ksql.serde.avro.AvroFormat;
+import io.confluent.ksql.serde.delimited.DelimitedFormat;
 import io.confluent.ksql.testing.EffectivelyImmutable;
 import io.confluent.ksql.util.KsqlException;
 import java.time.Duration;
@@ -73,7 +76,7 @@ public final class CreateSourceProperties {
   }
 
   public Format getValueFormat() {
-    return Format.of(getFormatInfo());
+    return FormatFactory.of(getFormatInfo());
   }
 
   public String getKafkaTopic() {
@@ -141,12 +144,12 @@ public final class CreateSourceProperties {
 
     final String schemaName = props.getString(CommonCreateConfigs.VALUE_AVRO_SCHEMA_FULL_NAME);
     if (schemaName != null) {
-      builder.put(FormatInfo.FULL_SCHEMA_NAME, schemaName);
+      builder.put(AvroFormat.FULL_SCHEMA_NAME, schemaName);
     }
 
     final String delimiter = props.getString(CommonCreateConfigs.VALUE_DELIMITER_PROPERTY);
     if (delimiter != null) {
-      builder.put(FormatInfo.DELIMITER, delimiter);
+      builder.put(DelimitedFormat.DELIMITER, delimiter);
     }
 
     return builder.build();

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -87,7 +87,7 @@ import io.confluent.ksql.schema.ksql.types.SqlArray;
 import io.confluent.ksql.schema.ksql.types.SqlStruct;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
@@ -154,8 +154,8 @@ public class KsqlParserTest {
 
     final KsqlTopic ksqlTopicOrders = new KsqlTopic(
         "orders_topic",
-        KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA.name())),
-        ValueFormat.of(FormatInfo.of(Format.JSON.name()))
+        KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())),
+        ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name()))
     );
 
     final KsqlStream<?> ksqlStreamOrders = new KsqlStream<>(
@@ -173,8 +173,8 @@ public class KsqlParserTest {
 
     final KsqlTopic ksqlTopicItems = new KsqlTopic(
         "item_topic",
-        KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA.name())),
-        ValueFormat.of(FormatInfo.of(Format.JSON.name()))
+        KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())),
+        ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name()))
     );
 
     final KsqlTable<String> ksqlTableOrders = new KsqlTable<>(
@@ -542,7 +542,7 @@ public class KsqlParserTest {
     assertThat(Iterables.get(result.getElements(), 0).getName(), equalTo(ColumnName.of("ORDERTIME")));
     assertThat(Iterables.get(result.getElements(), 6).getType().getSqlType().baseType(), equalTo(SqlBaseType.STRUCT));
     assertThat(result.getProperties().getKafkaTopic(), equalTo("orders_topic"));
-    assertThat(result.getProperties().getValueFormat(), equalTo(Format.AVRO));
+    assertThat(result.getProperties().getValueFormat(), equalTo(FormatFactory.AVRO));
   }
 
   @Test
@@ -557,7 +557,7 @@ public class KsqlParserTest {
     assertThat(Iterables.size(result.getElements()), equalTo(4));
     assertThat(Iterables.get(result.getElements(), 0).getName(), equalTo(ColumnName.of("USERTIME")));
     assertThat(result.getProperties().getKafkaTopic(), equalTo("foo"));
-    assertThat(result.getProperties().getValueFormat(), equalTo(Format.JSON));
+    assertThat(result.getProperties().getValueFormat(), equalTo(FormatFactory.JSON));
     assertThat(result.getProperties().getKeyField(), equalTo(Optional.of(ColumnName.of("USERID"))));
   }
 

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
@@ -61,7 +61,7 @@ import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlStruct;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
@@ -164,8 +164,8 @@ public class SqlFormatterTest {
 
     final KsqlTopic ksqlTopicOrders = new KsqlTopic(
         "orders_topic",
-        KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA.name())),
-        ValueFormat.of(FormatInfo.of(Format.JSON.name()))
+        KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())),
+        ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name()))
     );
 
     final KsqlStream ksqlStreamOrders = new KsqlStream<>(
@@ -183,8 +183,8 @@ public class SqlFormatterTest {
 
     final KsqlTopic ksqlTopicItems = new KsqlTopic(
         "item_topic",
-        KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA.name())),
-        ValueFormat.of(FormatInfo.of(Format.JSON.name()))
+        KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())),
+        ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name()))
     );
     final KsqlTable<String> ksqlTableOrders = new KsqlTable<>(
         "sqlexpression",

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourceAsPropertiesTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourceAsPropertiesTest.java
@@ -27,7 +27,7 @@ import io.confluent.ksql.execution.expression.tree.Literal;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
-import io.confluent.ksql.serde.FormatInfo;
+import io.confluent.ksql.serde.avro.AvroFormat;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Optional;
 import org.junit.Rule;
@@ -114,7 +114,7 @@ public class CreateSourceAsPropertiesTest {
         ImmutableMap.of(CommonCreateConfigs.VALUE_AVRO_SCHEMA_FULL_NAME, new StringLiteral("schema")));
 
     // Then:
-    assertThat(properties.getFormatProperties().get(FormatInfo.FULL_SCHEMA_NAME), is("schema"));
+    assertThat(properties.getFormatProperties().get(AvroFormat.FULL_SCHEMA_NAME), is("schema"));
   }
 
   @Test

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourcePropertiesTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourcePropertiesTest.java
@@ -31,8 +31,9 @@ import io.confluent.ksql.model.WindowType;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
 import io.confluent.ksql.properties.with.CreateConfigs;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
+import io.confluent.ksql.serde.avro.AvroFormat;
 import io.confluent.ksql.util.KsqlException;
 import java.time.Duration;
 import java.util.HashMap;
@@ -67,7 +68,7 @@ public class CreateSourcePropertiesTest {
 
     // Then:
     assertThat(properties.getKafkaTopic(), is("foo"));
-    assertThat(properties.getValueFormat(), is(Format.AVRO));
+    assertThat(properties.getValueFormat(), is(FormatFactory.AVRO));
   }
 
   @Test
@@ -295,7 +296,7 @@ public class CreateSourcePropertiesTest {
             .build());
 
     // Then:
-    assertThat(properties.getFormatInfo().getProperties().get(FormatInfo.FULL_SCHEMA_NAME), is("schema"));
+    assertThat(properties.getFormatInfo().getProperties().get(AvroFormat.FULL_SCHEMA_NAME), is("schema"));
   }
 
   @Test

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ClusterTerminator.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ClusterTerminator.java
@@ -21,7 +21,7 @@ import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.schema.registry.SchemaRegistryUtil;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.ExecutorUtil;
 import io.confluent.ksql.util.KsqlConstants;
@@ -145,7 +145,7 @@ public class ClusterTerminator {
 
   private static Set<String> subjectNames(final List<DataSource> sources) {
     return sources.stream()
-        .filter(s -> s.getKsqlTopic().getValueFormat().getFormat() == Format.AVRO)
+        .filter(s -> s.getKsqlTopic().getValueFormat().getFormat() == FormatFactory.AVRO)
         .map(DataSource::getKsqlTopic)
         .map(KsqlTopic::getKafkaTopicName)
         .map(topicName -> topicName + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX)

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
@@ -32,7 +32,7 @@ import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.SqlBaseType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
@@ -100,7 +100,7 @@ public class QueryDescriptionFactoryTest {
     when(topology.describe()).thenReturn(topologyDescription);
     when(queryStreams.state()).thenReturn(State.RUNNING);
 
-    when(sinkTopic.getKeyFormat()).thenReturn(KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA.name())));
+    when(sinkTopic.getKeyFormat()).thenReturn(KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())));
 
     transientQuery = new TransientQueryMetadata(
         SQL_TEXT,

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionFactoryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionFactoryTest.java
@@ -31,7 +31,7 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
@@ -76,8 +76,8 @@ public class SourceDescriptionFactoryTest {
 
     final KsqlTopic topic = new KsqlTopic(
         kafkaTopicName,
-        KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA.name())),
-        ValueFormat.of(FormatInfo.of(Format.JSON.name()))
+        KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())),
+        ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name()))
     );
 
     return new KsqlStream<>(

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/ClusterTerminationTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/ClusterTerminationTest.java
@@ -15,7 +15,7 @@
 
 package io.confluent.ksql.rest.integration;
 
-import static io.confluent.ksql.serde.Format.JSON;
+import static io.confluent.ksql.serde.FormatFactory.JSON;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/HeartbeatAgentFunctionalTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/HeartbeatAgentFunctionalTest.java
@@ -25,7 +25,7 @@ import io.confluent.ksql.rest.entity.ClusterStatusResponse;
 import io.confluent.ksql.rest.entity.KsqlHostEntity;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.test.util.secure.ClientTrustStore;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.PageViewDataProvider;
@@ -82,7 +82,7 @@ public class HeartbeatAgentFunctionalTest {
   @BeforeClass
   public static void setUpClass() {
     TEST_HARNESS.ensureTopics(2, PAGE_VIEW_TOPIC);
-    TEST_HARNESS.produceRows(PAGE_VIEW_TOPIC, PAGE_VIEWS_PROVIDER, Format.JSON);
+    TEST_HARNESS.produceRows(PAGE_VIEW_TOPIC, PAGE_VIEWS_PROVIDER, FormatFactory.JSON);
     RestIntegrationTestUtil.createStream(REST_APP_0, PAGE_VIEWS_PROVIDER);
     RestIntegrationTestUtil.makeKsqlRequest(
         REST_APP_0,

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/KsqlResourceFunctionalTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/KsqlResourceFunctionalTest.java
@@ -36,7 +36,7 @@ import io.confluent.ksql.rest.server.TestKsqlRestApp;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.avro.AvroSchemas;
 import io.confluent.ksql.util.KsqlConfig;
@@ -188,7 +188,7 @@ public class KsqlResourceFunctionalTest {
             0,
             0L,
             123L)),
-        Format.AVRO,
+        FormatFactory.AVRO,
         schema
     );
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/LagReportingAgentFunctionalTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/LagReportingAgentFunctionalTest.java
@@ -16,7 +16,7 @@ import io.confluent.ksql.rest.entity.QueryStateStoreId;
 import io.confluent.ksql.rest.entity.StateStoreLags;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.util.PageViewDataProvider;
 import java.io.IOException;
 import java.util.Comparator;
@@ -111,7 +111,7 @@ public class LagReportingAgentFunctionalTest {
   public static void setUpClass() {
     TEST_HARNESS.deleteInternalTopics("KSQL");
     TEST_HARNESS.ensureTopics(2, PAGE_VIEW_TOPIC);
-    TEST_HARNESS.produceRows(PAGE_VIEW_TOPIC, PAGE_VIEWS_PROVIDER, Format.JSON);
+    TEST_HARNESS.produceRows(PAGE_VIEW_TOPIC, PAGE_VIEWS_PROVIDER, FormatFactory.JSON);
     RestIntegrationTestUtil.createStream(REST_APP_0, PAGE_VIEWS_PROVIDER);
     RestIntegrationTestUtil.makeKsqlRequest(
         REST_APP_0,

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryFunctionalTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryFunctionalTest.java
@@ -35,6 +35,7 @@ import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.test.util.KsqlIdentifierTestUtil;
 import io.confluent.ksql.test.util.TestBasicJaasConfig;
@@ -86,7 +87,7 @@ public class PullQueryFunctionalTest {
   private static final String USER_WITH_ACCESS_PWD = "changeme";
 
   private static final UserDataProvider USER_PROVIDER = new UserDataProvider();
-  private static final Format VALUE_FORMAT = Format.JSON;
+  private static final Format VALUE_FORMAT = FormatFactory.JSON;
   private static final int HEADER = 1;
 
   private static final TestBasicJaasConfig JASS_CONFIG = TestBasicJaasConfig
@@ -157,7 +158,7 @@ public class PullQueryFunctionalTest {
             + " WITH ("
             + "   kafka_topic='" + USER_TOPIC + "', "
             + "   key='" + USER_PROVIDER.key() + "', "
-            + "   value_format='" + VALUE_FORMAT + "'"
+            + "   value_format='" + VALUE_FORMAT.name() + "'"
             + ");"
     );
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -44,13 +44,12 @@ import io.confluent.ksql.integration.IntegrationTestHarness;
 import io.confluent.ksql.json.JsonMapper;
 import io.confluent.ksql.rest.entity.Versions;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster;
 import io.confluent.ksql.test.util.secure.ClientTrustStore;
 import io.confluent.ksql.test.util.secure.Credentials;
 import io.confluent.ksql.test.util.secure.SecureKafkaHelper;
-import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.PageViewDataProvider;
 import java.util.Arrays;
 import java.util.List;
@@ -173,7 +172,7 @@ public class RestApiTest {
   public static void setUpClass() {
     TEST_HARNESS.ensureTopics(PAGE_VIEW_TOPIC);
 
-    TEST_HARNESS.produceRows(PAGE_VIEW_TOPIC, PAGE_VIEWS_PROVIDER, Format.JSON);
+    TEST_HARNESS.produceRows(PAGE_VIEW_TOPIC, PAGE_VIEWS_PROVIDER, FormatFactory.JSON);
 
     RestIntegrationTestUtil.createStream(REST_APP, PAGE_VIEWS_PROVIDER);
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorFunctionalTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorFunctionalTest.java
@@ -15,8 +15,8 @@
 
 package io.confluent.ksql.rest.server;
 
-import static io.confluent.ksql.serde.Format.AVRO;
-import static io.confluent.ksql.serde.Format.JSON;
+import static io.confluent.ksql.serde.FormatFactory.AVRO;
+import static io.confluent.ksql.serde.FormatFactory.JSON;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.common.utils.IntegrationTest;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
@@ -40,7 +40,7 @@ import io.confluent.ksql.parser.DefaultKsqlParser;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SqlTypeParser;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
@@ -121,8 +121,8 @@ public class TemporaryEngine extends ExternalResource {
 
     final KsqlTopic topic = new KsqlTopic(
         name,
-        KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA.name())),
-        ValueFormat.of(FormatInfo.of(Format.JSON.name()))
+        KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())),
+        ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name()))
     );
 
     final DataSource source;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutorTest.java
@@ -43,7 +43,7 @@ import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SqlBaseType;
 import io.confluent.ksql.schema.ksql.types.SqlPrimitiveType;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.ValueFormat;
@@ -127,8 +127,8 @@ public class DescribeConnectorExecutorTest {
     when(source.getKsqlTopic()).thenReturn(
         new KsqlTopic(
             TOPIC,
-            KeyFormat.nonWindowed(FormatInfo.of(Format.AVRO.name())),
-            ValueFormat.of(FormatInfo.of(Format.AVRO.name()))
+            KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.AVRO.name())),
+            ValueFormat.of(FormatInfo.of(FormatFactory.AVRO.name()))
         )
     );
     when(source.getSchema()).thenReturn(

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ExplainExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ExplainExecutorTest.java
@@ -32,7 +32,7 @@ import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.entity.QueryDescriptionEntity;
 import io.confluent.ksql.rest.entity.QueryDescriptionFactory;
 import io.confluent.ksql.rest.server.TemporaryEngine;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.statement.ConfiguredStatement;
@@ -162,7 +162,7 @@ public class ExplainExecutorTest {
     when(metadata.getStatementString()).thenReturn("sql");
 
     final KsqlTopic sinkTopic = mock(KsqlTopic.class);
-    when(sinkTopic.getKeyFormat()).thenReturn(KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA.name())));
+    when(sinkTopic.getKeyFormat()).thenReturn(KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())));
     when(metadata.getResultTopic()).thenReturn(sinkTopic);
 
     return metadata;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
@@ -34,7 +34,7 @@ import io.confluent.ksql.rest.entity.QueryDescriptionFactory;
 import io.confluent.ksql.rest.entity.QueryDescriptionList;
 import io.confluent.ksql.rest.entity.RunningQuery;
 import io.confluent.ksql.rest.server.TemporaryEngine;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.statement.ConfiguredStatement;
@@ -124,7 +124,7 @@ public class ListQueriesExecutorTest {
     when(metadata.getExecutionPlan()).thenReturn("plan");
 
     final KsqlTopic sinkTopic = mock(KsqlTopic.class);
-    when(sinkTopic.getKeyFormat()).thenReturn(KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA.name())));
+    when(sinkTopic.getKeyFormat()).thenReturn(KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())));
     when(sinkTopic.getKafkaTopicName()).thenReturn(id);
     when(metadata.getResultTopic()).thenReturn(sinkTopic);
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -127,7 +127,7 @@ import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.security.KsqlAuthorizationValidator;
 import io.confluent.ksql.security.KsqlSecurityContext;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
@@ -2144,8 +2144,8 @@ public class KsqlResourceTest {
   ) {
     final KsqlTopic ksqlTopic = new KsqlTopic(
         topicName,
-        KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA.name())),
-        ValueFormat.of(FormatInfo.of(Format.JSON.name()))
+        KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())),
+        ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name()))
     );
 
     givenKafkaTopicExists(topicName);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/ClusterTerminatorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/ClusterTerminatorTest.java
@@ -41,6 +41,7 @@ import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.services.KafkaTopicClient;
@@ -145,7 +146,7 @@ public class ClusterTerminatorTest {
   public void shouldClosePersistentQueriesBeforeDeletingTopics() {
     // Given:
     givenTopicsExistInKafka("topic1");
-    givenSinkTopicsExistInMetastore(Format.DELIMITED,"topic1");
+    givenSinkTopicsExistInMetastore(FormatFactory.DELIMITED,"topic1");
 
     // When:
     clusterTerminator.terminateCluster(Collections.singletonList("topic1"));
@@ -160,7 +161,7 @@ public class ClusterTerminatorTest {
   public void shouldDeleteTopicListWithExplicitTopicName() {
     // Given:
     givenTopicsExistInKafka("K_Foo");
-    givenSinkTopicsExistInMetastore(Format.DELIMITED,"K_Foo");
+    givenSinkTopicsExistInMetastore(FormatFactory.DELIMITED,"K_Foo");
 
     // When:
     clusterTerminator.terminateCluster(ImmutableList.of("K_Foo"));
@@ -173,7 +174,7 @@ public class ClusterTerminatorTest {
   public void shouldCleanUpSchemasForExplicitTopicList() throws Exception {
     // Given:
     givenTopicsExistInKafka("K_Foo");
-    givenSinkTopicsExistInMetastore(Format.AVRO, "K_Foo");
+    givenSinkTopicsExistInMetastore(FormatFactory.AVRO, "K_Foo");
     givenSchemasForTopicsExistInSchemaRegistry("K_Foo");
 
     // When:
@@ -187,7 +188,7 @@ public class ClusterTerminatorTest {
   public void shouldOnlyDeleteExistingTopics() {
     // Given:
     givenTopicsExistInKafka("K_Bar");
-    givenSinkTopicsExistInMetastore(Format.JSON, "K_Foo", "K_Bar");
+    givenSinkTopicsExistInMetastore(FormatFactory.JSON, "K_Foo", "K_Bar");
 
     // When:
     clusterTerminator.terminateCluster(ImmutableList.of("K_Foo", "K_Bar"));
@@ -200,7 +201,7 @@ public class ClusterTerminatorTest {
   public void shouldCleanUpSchemaEvenIfTopicDoesNotExist() throws Exception {
     // Given:
     givenTopicsExistInKafka("K_Bar");
-    givenSinkTopicsExistInMetastore(Format.AVRO, "K_Foo", "K_Bar");
+    givenSinkTopicsExistInMetastore(FormatFactory.AVRO, "K_Foo", "K_Bar");
     givenSchemasForTopicsExistInSchemaRegistry("K_Foo", "K_Bar");
 
     // When:
@@ -214,7 +215,7 @@ public class ClusterTerminatorTest {
   public void shouldNotCleanUpSchemaIfSchemaDoesNotExist() throws Exception {
     // Given:
     givenTopicsExistInKafka("K_Foo", "K_Bar");
-    givenSinkTopicsExistInMetastore(Format.AVRO, "K_Foo", "K_Bar");
+    givenSinkTopicsExistInMetastore(FormatFactory.AVRO, "K_Foo", "K_Bar");
     givenSchemasForTopicsExistInSchemaRegistry("K_Bar");
 
     // When:
@@ -256,7 +257,7 @@ public class ClusterTerminatorTest {
   public void shouldNotDeleteNonMatchingCaseSensitiveTopics() {
     // Given:
     givenTopicsExistInKafka("K_FOO");
-    givenSinkTopicsExistInMetastore(Format.AVRO, "K_FOO");
+    givenSinkTopicsExistInMetastore(FormatFactory.AVRO, "K_FOO");
 
     // When:
     clusterTerminator.terminateCluster(ImmutableList.of("K_Foo"));
@@ -270,7 +271,7 @@ public class ClusterTerminatorTest {
   public void shouldDeleteTopicListWithPattern() {
     // Given:
     givenTopicsExistInKafka("K_Fo", "K_Foo", "K_Fooo", "NotMatched");
-    givenSinkTopicsExistInMetastore(Format.JSON, "K_Fo", "K_Foo", "K_Fooo", "NotMatched");
+    givenSinkTopicsExistInMetastore(FormatFactory.JSON, "K_Fo", "K_Foo", "K_Fooo", "NotMatched");
     final ArgumentCaptor<Collection<String>> argumentCaptor = ArgumentCaptor
         .forClass(Collection.class);
 
@@ -288,7 +289,7 @@ public class ClusterTerminatorTest {
   public void shouldCleanUpSchemasForTopicListWithPattern() throws Exception {
     // Given:
     givenTopicsExistInKafka("K_Fo", "K_Foo", "K_Fooo", "NotMatched");
-    givenSinkTopicsExistInMetastore(Format.AVRO, "K_Fo", "K_Foo", "K_Fooo", "NotMatched");
+    givenSinkTopicsExistInMetastore(FormatFactory.AVRO, "K_Fo", "K_Foo", "K_Fooo", "NotMatched");
     givenSchemasForTopicsExistInSchemaRegistry("K_Fo", "K_Foo", "K_Fooo", "NotMatched");
 
     // When:
@@ -302,7 +303,7 @@ public class ClusterTerminatorTest {
   @Test
   public void shouldRemoveNonExistentTopicsOnEachDeleteAttempt() {
     //Given:
-    givenSinkTopicsExistInMetastore(Format.JSON, "Foo", "Bar");
+    givenSinkTopicsExistInMetastore(FormatFactory.JSON, "Foo", "Bar");
 
     when(kafkaTopicClient.listTopicNames())
         .thenReturn(ImmutableSet.of("Other", "Foo", "Bar"))
@@ -326,7 +327,7 @@ public class ClusterTerminatorTest {
   public void shouldThrowIfCouldNotDeleteTopicListWithPattern() {
     // Given:
     givenTopicsExistInKafka("K_Foo");
-    givenSinkTopicsExistInMetastore(Format.DELIMITED, "K_Foo");
+    givenSinkTopicsExistInMetastore(FormatFactory.DELIMITED, "K_Foo");
     doThrow(KsqlException.class)
         .doThrow(KsqlException.class)
         .doThrow(KsqlException.class)
@@ -380,7 +381,7 @@ public class ClusterTerminatorTest {
   public void shouldNotThrowOnTopicDeletionDisabledException() throws Exception {
     // Given:
     givenTopicsExistInKafka("K_Foo");
-    givenSinkTopicsExistInMetastore(Format.AVRO,"K_Foo");
+    givenSinkTopicsExistInMetastore(FormatFactory.AVRO,"K_Foo");
     givenSchemasForTopicsExistInSchemaRegistry("K_Foo");
     doThrow(TopicDeletionDisabledException.class).when(kafkaTopicClient).deleteTopics(any());
 
@@ -395,7 +396,7 @@ public class ClusterTerminatorTest {
   public void shouldNotThrowIfCannotCleanUpSchema() throws Exception {
     // Given:
     givenTopicsExistInKafka("K_Foo", "K_Bar");
-    givenSinkTopicsExistInMetastore(Format.AVRO,"K_Foo", "K_Bar");
+    givenSinkTopicsExistInMetastore(FormatFactory.AVRO,"K_Foo", "K_Bar");
     givenSchemasForTopicsExistInSchemaRegistry("K_Foo", "K_Bar");
     when(schemaRegistryClient.deleteSubject(startsWith("K_Foo")))
         .thenThrow(new RestClientException("bad", 404, 40401));
@@ -411,7 +412,7 @@ public class ClusterTerminatorTest {
   public void shouldNotCleanUpSchemaForNonAvroTopic() throws Exception {
     // Given:
     givenTopicsExistInKafka("K_Foo");
-    givenSinkTopicsExistInMetastore(Format.JSON,"K_Foo");
+    givenSinkTopicsExistInMetastore(FormatFactory.JSON,"K_Foo");
     givenSchemasForTopicsExistInSchemaRegistry("K_Foo");
 
     // When:
@@ -431,7 +432,7 @@ public class ClusterTerminatorTest {
 
   @SuppressWarnings("SameParameterValue")
   private void givenNonSinkTopicsExistInMetastore(final String kafkaTopicName) {
-    givenSourceRegisteredWithTopic(Format.AVRO, kafkaTopicName, false);
+    givenSourceRegisteredWithTopic(FormatFactory.AVRO, kafkaTopicName, false);
   }
 
   private void givenSourceRegisteredWithTopic(

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/ProcessingLogServerUtilsTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/ProcessingLogServerUtilsTest.java
@@ -42,7 +42,7 @@ import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.Column;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.TestServiceContext;
@@ -152,7 +152,7 @@ public class ProcessingLogServerUtilsTest {
     assertThat(dataSource, instanceOf(KsqlStream.class));
     final KsqlStream<?> stream = (KsqlStream) dataSource;
     final Schema expected = ProcessingLogServerUtils.getMessageSchema();
-    assertThat(stream.getKsqlTopic().getValueFormat().getFormat(), is(Format.JSON));
+    assertThat(stream.getKsqlTopic().getValueFormat().getFormat(), is(FormatFactory.JSON));
     assertThat(stream.getKsqlTopic().getKafkaTopicName(), equalTo(topicName));
     assertThat(
         stream.getSchema().value().stream().map(Column::name).map(ColumnName::name).collect(toList()),

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/FormatFactory.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/FormatFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.serde;
+
+import io.confluent.ksql.serde.avro.AvroFormat;
+import io.confluent.ksql.serde.delimited.DelimitedFormat;
+import io.confluent.ksql.serde.json.JsonFormat;
+import io.confluent.ksql.serde.kafka.KafkaFormat;
+import io.confluent.ksql.util.KsqlException;
+
+/**
+ * A class containing the builtin supported formats in ksqlDB.
+ */
+public final class FormatFactory {
+
+  public static final Format AVRO       = new AvroFormat();
+  public static final Format JSON       = new JsonFormat();
+  public static final Format KAFKA      = new KafkaFormat();
+  public static final Format DELIMITED  = new DelimitedFormat();
+
+  private FormatFactory() { }
+
+  /**
+   * @param formatInfo the format specification
+   * @return the corresponding {@code Format} if available
+   *
+   * @throws KsqlException if the {@link FormatInfo#getFormat()} is not a builtin
+   *                       format in ksqlDB
+   */
+  public static Format of(final FormatInfo formatInfo) {
+    final Format format = fromName(formatInfo.getFormat().toUpperCase());
+    format.validateProperties(formatInfo.getProperties());
+    return format;
+  }
+
+  private static Format fromName(final String name) {
+    switch (name) {
+      case AvroFormat.NAME:       return AVRO;
+      case JsonFormat.NAME:       return JSON;
+      case KafkaFormat.NAME:      return KAFKA;
+      case DelimitedFormat.NAME:  return DELIMITED;
+      default:
+        throw new KsqlException("Unknown format: " + name);
+    }
+  }
+}

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/KeyFormat.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/KeyFormat.java
@@ -58,7 +58,7 @@ public final class KeyFormat {
 
   @JsonIgnore
   public Format getFormat() {
-    return Format.of(format);
+    return FormatFactory.of(format);
   }
 
   public FormatInfo getFormatInfo() {

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/KsqlSerdeFactories.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/KsqlSerdeFactories.java
@@ -59,6 +59,6 @@ final class KsqlSerdeFactories implements SerdeFactories {
 
   @VisibleForTesting
   static KsqlSerdeFactory create(final FormatInfo format) {
-    return Format.of(format).getSerdeFactory(format);
+    return FormatFactory.of(format).getSerdeFactory(format);
   }
 }

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/ValueFormat.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/ValueFormat.java
@@ -42,7 +42,7 @@ public final class ValueFormat {
 
   @JsonIgnore
   public Format getFormat() {
-    return Format.of(format);
+    return FormatFactory.of(format);
   }
 
   @JsonValue

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/AvroFormat.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/AvroFormat.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.serde.avro;
+
+import com.google.common.collect.ImmutableSet;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatInfo;
+import io.confluent.ksql.serde.KsqlSerdeFactory;
+import io.confluent.ksql.util.KsqlConstants;
+import java.util.Set;
+
+public final class AvroFormat implements Format {
+
+  public static final String FULL_SCHEMA_NAME = "fullSchemaName";
+  public static final String NAME = AvroSchema.TYPE;
+
+  @Override
+  public String name() {
+    return NAME;
+  }
+
+  @Override
+  public boolean supportsSchemaInference() {
+    return true;
+  }
+
+  @Override
+  public Set<String> getSupportedProperties() {
+    return ImmutableSet.of(FULL_SCHEMA_NAME);
+  }
+
+  @Override
+  public Set<String> getInheritableProperties() {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public KsqlSerdeFactory getSerdeFactory(final FormatInfo info) {
+    final String schemaFullName = info
+        .getProperties()
+        .getOrDefault(FULL_SCHEMA_NAME, KsqlConstants.DEFAULT_AVRO_SCHEMA_FULL_NAME);
+
+    return new KsqlAvroSerdeFactory(schemaFullName);
+  }
+}

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/delimited/DelimitedFormat.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/delimited/DelimitedFormat.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.serde.delimited;
+
+import com.google.common.collect.ImmutableSet;
+import io.confluent.ksql.serde.Delimiter;
+import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatInfo;
+import io.confluent.ksql.serde.KsqlSerdeFactory;
+import java.util.Optional;
+import java.util.Set;
+
+public final class DelimitedFormat implements Format {
+
+  public static final String DELIMITER = "delimiter";
+  public static final String NAME = "DELIMITED";
+
+  @Override
+  public String name() {
+    return NAME;
+  }
+
+  @Override
+  public boolean supportsWrapping() {
+    return false;
+  }
+
+  @Override
+  public Set<String> getSupportedProperties() {
+    return ImmutableSet.of(DELIMITER);
+  }
+
+  @Override
+  public KsqlSerdeFactory getSerdeFactory(final FormatInfo info) {
+    return new KsqlDelimitedSerdeFactory(
+        Optional
+            .ofNullable(info.getProperties().get(DELIMITER))
+            .map(Delimiter::parse)
+    );
+  }
+}

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerdeFactory.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerdeFactory.java
@@ -20,7 +20,7 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.schema.connect.SchemaWalker;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.serde.Delimiter;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.KsqlSerdeFactory;
 import io.confluent.ksql.testing.EffectivelyImmutable;
 import io.confluent.ksql.util.DecimalUtil;
@@ -88,7 +88,7 @@ public class KsqlDelimitedSerdeFactory implements KsqlSerdeFactory {
     }
 
     public Void visitSchema(final Schema schema) {
-      throw new KsqlException("The '" + Format.DELIMITED
+      throw new KsqlException("The '" + FormatFactory.DELIMITED.name()
           + "' format does not support type '" + schema.type().toString() + "'");
     }
   }

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/json/JsonFormat.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/json/JsonFormat.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.serde.json;
+
+import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatInfo;
+import io.confluent.ksql.serde.KsqlSerdeFactory;
+
+public class JsonFormat implements Format {
+
+  public static final String NAME = "JSON";
+
+  @Override
+  public String name() {
+    return NAME;
+  }
+
+  @Override
+  public KsqlSerdeFactory getSerdeFactory(final FormatInfo info) {
+    return new KsqlJsonSerdeFactory();
+  }
+}

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/kafka/KafkaFormat.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/kafka/KafkaFormat.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.serde.kafka;
+
+import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatInfo;
+import io.confluent.ksql.serde.KsqlSerdeFactory;
+
+public class KafkaFormat implements Format {
+
+  public static final String NAME = "KAFKA";
+
+  @Override
+  public String name() {
+    return NAME;
+  }
+
+  @Override
+  public boolean supportsWrapping() {
+    return false;
+  }
+
+  @Override
+  public KsqlSerdeFactory getSerdeFactory(final FormatInfo info) {
+    return new KafkaSerdeFactory();
+  }
+}

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/kafka/KafkaSerdeFactory.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/kafka/KafkaSerdeFactory.java
@@ -22,7 +22,7 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.schema.connect.SqlSchemaFormatter;
 import io.confluent.ksql.schema.connect.SqlSchemaFormatter.Option;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.KsqlSerdeFactory;
 import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlConfig;
@@ -86,7 +86,7 @@ public class KafkaSerdeFactory implements KsqlSerdeFactory {
     final List<Field> fields = schema.fields();
     if (fields.size() != 1) {
       final String got = new SqlSchemaFormatter(w -> false, Option.AS_COLUMN_LIST).format(schema);
-      throw new KsqlException("The '" + Format.KAFKA
+      throw new KsqlException("The '" + FormatFactory.KAFKA.name()
           + "' format only supports a single field. Got: " + got);
     }
 
@@ -97,7 +97,7 @@ public class KafkaSerdeFactory implements KsqlSerdeFactory {
           ? "DECIMAL"
           : type.toString();
 
-      throw new KsqlException("The '" + Format.KAFKA
+      throw new KsqlException("The '" + FormatFactory.KAFKA.name()
           + "' format does not support type '" + typeString + "'");
     }
 

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/FormatFactoryTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/FormatFactoryTest.java
@@ -19,28 +19,22 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.serde.avro.AvroFormat;
 import io.confluent.ksql.util.KsqlException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-public class FormatTest {
+public class FormatFactoryTest {
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void shouldCreateFromString() {
-    assertThat(Format.of(FormatInfo.of("JsoN")), is(Format.JSON));
-    assertThat(Format.of(FormatInfo.of("AvRo")), is(Format.AVRO));
-    assertThat(Format.of(FormatInfo.of("Delimited")), is(Format.DELIMITED));
-  }
-
-  @Test
-  public void shouldHaveCorrectToString() {
-    assertThat(Format.JSON.toString(), is("JSON"));
-    assertThat(Format.AVRO.toString(), is("AVRO"));
-    assertThat(Format.DELIMITED.toString(), is("DELIMITED"));
+    assertThat(FormatFactory.of(FormatInfo.of("JsoN")), is(FormatFactory.JSON));
+    assertThat(FormatFactory.of(FormatInfo.of("AvRo")), is(FormatFactory.AVRO));
+    assertThat(FormatFactory.of(FormatInfo.of("Delimited")), is(FormatFactory.DELIMITED));
   }
 
   @Test
@@ -50,33 +44,33 @@ public class FormatTest {
     expectedException.expectMessage("Unknown format: BOB");
 
     // When:
-    Format.of(FormatInfo.of("bob"));
+    FormatFactory.of(FormatInfo.of("bob"));
   }
 
   @Test
   public void shouldThrowOnNonAvroWithAvroSchemaName() {
     // Given:
-    final FormatInfo format = FormatInfo.of("JSON", ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, "foo"));
+    final FormatInfo format = FormatInfo.of("JSON", ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "foo"));
 
     // Then:
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage("JSON does not support the following configs: [fullSchemaName]");
 
     // When:
-    Format.of(format);
+    FormatFactory.of(format);
   }
 
   @Test
   public void shouldThrowOnEmptyAvroSchemaName() {
     // Given:
-    final FormatInfo format = FormatInfo.of("AVRO", ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, " "));
+    final FormatInfo format = FormatInfo.of("AVRO", ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, " "));
 
     // Then:
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage("fullSchemaName cannot be empty. Format configuration: {fullSchemaName= }");
 
     // When:
-    Format.of(format);
+    FormatFactory.of(format);
   }
 
   @Test
@@ -89,7 +83,7 @@ public class FormatTest {
     expectedException.expectMessage("JSON does not support the following configs: [delimiter]");
 
     // When:
-    Format.of(format);
+    FormatFactory.of(format);
 
   }
 

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/GenericKeySerDeTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/GenericKeySerDeTest.java
@@ -61,7 +61,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class GenericKeySerDeTest {
 
-  private static final FormatInfo FORMAT = FormatInfo.of(Format.JSON.name());
+  private static final FormatInfo FORMAT = FormatInfo.of(FormatFactory.JSON.name());
   private static final KsqlConfig CONFIG = new KsqlConfig(ImmutableMap.of());
   private static final String LOGGER_NAME_PREFIX = "bob";
 

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/GenericRowSerDeTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/GenericRowSerDeTest.java
@@ -58,7 +58,7 @@ public class GenericRowSerDeTest {
   private static final String LOGGER_PREFIX = "bob";
 
   private static final FormatInfo FORMAT =
-      FormatInfo.of(Format.JSON.name());
+      FormatInfo.of(FormatFactory.JSON.name());
 
   private static final PersistenceSchema MUTLI_FIELD_SCHEMA =
       PersistenceSchema.from(

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/KeyFormatTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/KeyFormatTest.java
@@ -17,9 +17,9 @@ package io.confluent.ksql.serde;
 
 import static io.confluent.ksql.model.WindowType.HOPPING;
 import static io.confluent.ksql.model.WindowType.SESSION;
-import static io.confluent.ksql.serde.Format.AVRO;
-import static io.confluent.ksql.serde.Format.DELIMITED;
-import static io.confluent.ksql.serde.Format.JSON;
+import static io.confluent.ksql.serde.FormatFactory.AVRO;
+import static io.confluent.ksql.serde.FormatFactory.DELIMITED;
+import static io.confluent.ksql.serde.FormatFactory.JSON;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.mock;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
 import com.google.common.testing.NullPointerTester;
+import io.confluent.ksql.serde.avro.AvroFormat;
 import java.time.Duration;
 import java.util.Optional;
 import org.junit.Test;
@@ -75,7 +76,7 @@ public class KeyFormatTest {
   @Test
   public void shouldImplementToString() {
     // Given:
-    final FormatInfo formatInfo = FormatInfo.of(AVRO.name(), ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, "something"));
+    final FormatInfo formatInfo = FormatInfo.of(AVRO.name(), ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "something"));
     final WindowInfo windowInfo = WindowInfo.of(HOPPING, Optional.of(Duration.ofMillis(10101)));
 
     final KeyFormat keyFormat = KeyFormat.windowed(formatInfo, windowInfo);
@@ -98,13 +99,13 @@ public class KeyFormatTest {
     final Format result = keyFormat.getFormat();
 
     // Then:
-    assertThat(result, is(Format.of(format)));
+    assertThat(result, is(FormatFactory.of(format)));
   }
 
   @Test
   public void shouldGetFormatInfo() {
     // Given:
-    final FormatInfo format = FormatInfo.of(AVRO.name(), ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, "something"));
+    final FormatInfo format = FormatInfo.of(AVRO.name(), ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "something"));
     final KeyFormat keyFormat = KeyFormat.nonWindowed(format);
 
     // When:
@@ -143,12 +144,12 @@ public class KeyFormatTest {
   public void shouldHandleWindowedWithAvroSchemaName() {
     // Given:
     final KeyFormat keyFormat = KeyFormat.windowed(
-        FormatInfo.of(AVRO.name(), ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, "something")),
+        FormatInfo.of(AVRO.name(), ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "something")),
         WindowInfo.of(HOPPING, Optional.of(Duration.ofMinutes(4)))
     );
 
     // Then:
-    assertThat(keyFormat.getFormatInfo(), is(FormatInfo.of(AVRO.name(), ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, "something"))));
+    assertThat(keyFormat.getFormatInfo(), is(FormatInfo.of(AVRO.name(), ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "something"))));
   }
 
   @Test

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/KsqlSerdeFactoriesTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/KsqlSerdeFactoriesTest.java
@@ -15,10 +15,10 @@
 
 package io.confluent.ksql.serde;
 
-import static io.confluent.ksql.serde.Format.AVRO;
-import static io.confluent.ksql.serde.Format.DELIMITED;
-import static io.confluent.ksql.serde.Format.JSON;
-import static io.confluent.ksql.serde.Format.KAFKA;
+import static io.confluent.ksql.serde.FormatFactory.AVRO;
+import static io.confluent.ksql.serde.FormatFactory.DELIMITED;
+import static io.confluent.ksql.serde.FormatFactory.JSON;
+import static io.confluent.ksql.serde.FormatFactory.KAFKA;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/ValueFormatTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/ValueFormatTest.java
@@ -15,8 +15,8 @@
 
 package io.confluent.ksql.serde;
 
-import static io.confluent.ksql.serde.Format.AVRO;
-import static io.confluent.ksql.serde.Format.JSON;
+import static io.confluent.ksql.serde.FormatFactory.AVRO;
+import static io.confluent.ksql.serde.FormatFactory.JSON;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.is;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
 import com.google.common.testing.NullPointerTester;
+import io.confluent.ksql.serde.avro.AvroFormat;
 import org.junit.Test;
 
 public class ValueFormatTest {
@@ -31,7 +32,7 @@ public class ValueFormatTest {
   private static final FormatInfo FORMAT_INFO =
       FormatInfo.of(
           AVRO.name(),
-          ImmutableMap.of(FormatInfo.FULL_SCHEMA_NAME, "something")
+          ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "something")
       );
 
   @Test
@@ -74,7 +75,7 @@ public class ValueFormatTest {
     final Format result = valueFormat.getFormat();
 
     // Then:
-    assertThat(result, is(Format.of(FORMAT_INFO)));
+    assertThat(result, is(FormatFactory.of(FORMAT_INFO)));
   }
 
   @Test

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamAggregateBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamAggregateBuilderTest.java
@@ -40,7 +40,6 @@ import io.confluent.ksql.execution.materialization.MaterializationInfo;
 import io.confluent.ksql.execution.materialization.MaterializationInfo.MapperInfo;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.ExecutionStepPropertiesV1;
-import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.plan.KGroupedStreamHolder;
 import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.KeySerdeFactory;
@@ -59,7 +58,7 @@ import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SerdeOption;
 import java.time.Duration;
@@ -136,8 +135,8 @@ public class StreamAggregateBuilderTest {
       new QueryContext.Stacker().push("agg").push("regate").getQueryContext();
   private static final QueryContext MATERIALIZE_CTX = QueryContext.Stacker.of(CTX)
       .push("Materialize").getQueryContext();
-  private static final FormatInfo KEY_FORMAT = FormatInfo.of(Format.KAFKA.name());
-  private static final FormatInfo VALUE_FORMAT = FormatInfo.of(Format.JSON.name());
+  private static final FormatInfo KEY_FORMAT = FormatInfo.of(FormatFactory.KAFKA.name());
+  private static final FormatInfo VALUE_FORMAT = FormatInfo.of(FormatFactory.JSON.name());
   private static final Duration WINDOW = Duration.ofMillis(30000);
   private static final Duration HOP = Duration.ofMillis(10000);
 
@@ -243,7 +242,7 @@ public class StreamAggregateBuilderTest {
     aggregate = new StreamAggregate(
         new ExecutionStepPropertiesV1(CTX),
         sourceStep,
-        Formats.of(KEY_FORMAT, VALUE_FORMAT, SerdeOption.none()),
+        io.confluent.ksql.execution.plan.Formats.of(KEY_FORMAT, VALUE_FORMAT, SerdeOption.none()),
         NON_AGG_COLUMNS,
         FUNCTIONS
     );
@@ -265,7 +264,7 @@ public class StreamAggregateBuilderTest {
     windowedAggregate = new StreamWindowedAggregate(
         new ExecutionStepPropertiesV1(CTX),
         sourceStep,
-        Formats.of(KEY_FORMAT, VALUE_FORMAT, SerdeOption.none()),
+        io.confluent.ksql.execution.plan.Formats.of(KEY_FORMAT, VALUE_FORMAT, SerdeOption.none()),
         NON_AGG_COLUMNS,
         FUNCTIONS,
         new TumblingWindowExpression(WINDOW.getSeconds(), TimeUnit.SECONDS)
@@ -277,7 +276,7 @@ public class StreamAggregateBuilderTest {
     windowedAggregate = new StreamWindowedAggregate(
         new ExecutionStepPropertiesV1(CTX),
         sourceStep,
-        Formats.of(KEY_FORMAT, VALUE_FORMAT, SerdeOption.none()),
+        io.confluent.ksql.execution.plan.Formats.of(KEY_FORMAT, VALUE_FORMAT, SerdeOption.none()),
         NON_AGG_COLUMNS,
         FUNCTIONS,
         new HoppingWindowExpression(
@@ -301,7 +300,7 @@ public class StreamAggregateBuilderTest {
     windowedAggregate = new StreamWindowedAggregate(
         new ExecutionStepPropertiesV1(CTX),
         sourceStep,
-        Formats.of(KEY_FORMAT, VALUE_FORMAT, SerdeOption.none()),
+        io.confluent.ksql.execution.plan.Formats.of(KEY_FORMAT, VALUE_FORMAT, SerdeOption.none()),
         NON_AGG_COLUMNS,
         FUNCTIONS,
         new SessionWindowExpression(WINDOW.getSeconds(), TimeUnit.SECONDS)

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderTest.java
@@ -17,7 +17,6 @@ import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.ExecutionStepPropertiesV1;
-import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.plan.KGroupedStreamHolder;
 import io.confluent.ksql.execution.plan.KStreamHolder;
 import io.confluent.ksql.execution.plan.KeySerdeFactory;
@@ -32,7 +31,7 @@ import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.util.KsqlConfig;
@@ -90,9 +89,10 @@ public class StreamGroupByBuilderTest {
   private static final ExecutionStepPropertiesV1 PROPERTIES = new ExecutionStepPropertiesV1(
       STEP_CTX
   );
-  private static final Formats FORMATS = Formats.of(
-      FormatInfo.of(Format.KAFKA.name()),
-      FormatInfo.of(Format.JSON.name()),
+  private static final io.confluent.ksql.execution.plan.Formats FORMATS = io.confluent.ksql.execution.plan.Formats
+      .of(
+      FormatInfo.of(FormatFactory.KAFKA.name()),
+      FormatInfo.of(FormatFactory.JSON.name()),
       SerdeOption.none()
   );
 

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderTest.java
@@ -40,7 +40,7 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.util.KsqlConfig;
@@ -155,12 +155,12 @@ public class StreamSelectKeyBuilderTest {
 
     // Then:
     result.getKeySerdeFactory().buildKeySerde(
-        FormatInfo.of(Format.JSON.name()),
+        FormatInfo.of(FormatFactory.JSON.name()),
         PhysicalSchema.from(SOURCE_SCHEMA, SerdeOption.none()),
         queryContext
     );
     verify(queryBuilder).buildKeySerde(
-        FormatInfo.of(Format.JSON.name()),
+        FormatInfo.of(FormatFactory.JSON.name()),
         PhysicalSchema.from(SOURCE_SCHEMA, SerdeOption.none()),
         queryContext);
   }

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSinkBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSinkBuilderTest.java
@@ -27,7 +27,6 @@ import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.ExecutionStepPropertiesV1;
-import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.plan.KStreamHolder;
 import io.confluent.ksql.execution.plan.KeySerdeFactory;
 import io.confluent.ksql.execution.plan.PlanBuilder;
@@ -36,7 +35,7 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SerdeOption;
 import org.apache.kafka.common.serialization.Serde;
@@ -63,8 +62,8 @@ public class StreamSinkBuilderTest {
 
   private static final PhysicalSchema PHYSICAL_SCHEMA =
       PhysicalSchema.from(SCHEMA.withoutMetaAndKeyColsInValue(), SerdeOption.none());
-  private static final FormatInfo KEY_FORMAT = FormatInfo.of(Format.KAFKA.name());
-  private static final FormatInfo VALUE_FORMAT = FormatInfo.of(Format.JSON.name());
+  private static final FormatInfo KEY_FORMAT = FormatInfo.of(FormatFactory.KAFKA.name());
+  private static final FormatInfo VALUE_FORMAT = FormatInfo.of(FormatFactory.JSON.name());
 
   @Mock
   private KsqlQueryBuilder queryBuilder;
@@ -95,7 +94,7 @@ public class StreamSinkBuilderTest {
     sink = new StreamSink<>(
         new ExecutionStepPropertiesV1(queryContext),
         source,
-        Formats.of(KEY_FORMAT, VALUE_FORMAT, SerdeOption.none()),
+        io.confluent.ksql.execution.plan.Formats.of(KEY_FORMAT, VALUE_FORMAT, SerdeOption.none()),
         TOPIC
     );
     planBuilder = new KSPlanBuilder(

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilderTest.java
@@ -17,7 +17,6 @@ import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.ExecutionStepPropertiesV1;
-import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.plan.JoinType;
 import io.confluent.ksql.execution.plan.KStreamHolder;
 import io.confluent.ksql.execution.plan.KeySerdeFactory;
@@ -27,7 +26,7 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SerdeOption;
 import java.time.Duration;
@@ -61,15 +60,17 @@ public class StreamStreamJoinBuilderTest {
   private static final PhysicalSchema RIGHT_PHYSICAL =
       PhysicalSchema.from(RIGHT_SCHEMA, SerdeOption.none());
 
-  private static final Formats LEFT_FMT = Formats.of(
-      FormatInfo.of(Format.KAFKA.name()),
-      FormatInfo.of(Format.JSON.name()),
+  private static final io.confluent.ksql.execution.plan.Formats LEFT_FMT = io.confluent.ksql.execution.plan.Formats
+      .of(
+      FormatInfo.of(FormatFactory.KAFKA.name()),
+      FormatInfo.of(FormatFactory.JSON.name()),
       SerdeOption.none()
   );
 
-  private static final Formats RIGHT_FMT = Formats.of(
-      FormatInfo.of(Format.KAFKA.name()),
-      FormatInfo.of(Format.AVRO.name()),
+  private static final io.confluent.ksql.execution.plan.Formats RIGHT_FMT = io.confluent.ksql.execution.plan.Formats
+      .of(
+      FormatInfo.of(FormatFactory.KAFKA.name()),
+      FormatInfo.of(FormatFactory.AVRO.name()),
       SerdeOption.none()
   );
 
@@ -111,9 +112,9 @@ public class StreamStreamJoinBuilderTest {
   @SuppressWarnings("unchecked")
   public void init() {
     when(keySerdeFactory.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
-    when(queryBuilder.buildValueSerde(eq(FormatInfo.of(Format.JSON.name())), any(), any()))
+    when(queryBuilder.buildValueSerde(eq(FormatInfo.of(FormatFactory.JSON.name())), any(), any()))
         .thenReturn(leftSerde);
-    when(queryBuilder.buildValueSerde(eq(FormatInfo.of(Format.AVRO.name())), any(), any()))
+    when(queryBuilder.buildValueSerde(eq(FormatInfo.of(FormatFactory.AVRO.name())), any(), any()))
         .thenReturn(rightSerde);
     when(streamJoinedFactory.create(any(Serde.class), any(Serde.class), any(Serde.class), anyString(), anyString())).thenReturn(joined);
     when(left.build(any())).thenReturn(
@@ -289,7 +290,7 @@ public class StreamStreamJoinBuilderTest {
 
     // Then:
     final QueryContext leftCtx = QueryContext.Stacker.of(CTX).push("Left").getQueryContext();
-    verify(queryBuilder).buildValueSerde(FormatInfo.of(Format.JSON.name()), LEFT_PHYSICAL, leftCtx);
+    verify(queryBuilder).buildValueSerde(FormatInfo.of(FormatFactory.JSON.name()), LEFT_PHYSICAL, leftCtx);
   }
 
   @Test
@@ -302,6 +303,6 @@ public class StreamStreamJoinBuilderTest {
 
     // Then:
     final QueryContext leftCtx = QueryContext.Stacker.of(CTX).push("Right").getQueryContext();
-    verify(queryBuilder).buildValueSerde(FormatInfo.of(Format.AVRO.name()), RIGHT_PHYSICAL, leftCtx);
+    verify(queryBuilder).buildValueSerde(FormatInfo.of(FormatFactory.AVRO.name()), RIGHT_PHYSICAL, leftCtx);
   }
 }

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilderTest.java
@@ -15,7 +15,6 @@ import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.ExecutionStepPropertiesV1;
-import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.plan.JoinType;
 import io.confluent.ksql.execution.plan.KStreamHolder;
 import io.confluent.ksql.execution.plan.KTableHolder;
@@ -26,7 +25,7 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SerdeOption;
 import org.apache.kafka.common.serialization.Serde;
@@ -58,9 +57,10 @@ public class StreamTableJoinBuilderTest {
   private static final PhysicalSchema LEFT_PHYSICAL =
       PhysicalSchema.from(LEFT_SCHEMA, SerdeOption.none());
 
-  private static final Formats LEFT_FMT = Formats.of(
-      FormatInfo.of(Format.KAFKA.name()),
-      FormatInfo.of(Format.JSON.name()),
+  private static final io.confluent.ksql.execution.plan.Formats LEFT_FMT = io.confluent.ksql.execution.plan.Formats
+      .of(
+      FormatInfo.of(FormatFactory.KAFKA.name()),
+      FormatInfo.of(FormatFactory.JSON.name()),
       SerdeOption.none()
   );
 
@@ -100,7 +100,7 @@ public class StreamTableJoinBuilderTest {
   @SuppressWarnings("unchecked")
   public void init() {
     when(keySerdeFactory.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
-    when(queryBuilder.buildValueSerde(eq(FormatInfo.of(Format.JSON.name())), any(), any()))
+    when(queryBuilder.buildValueSerde(eq(FormatInfo.of(FormatFactory.JSON.name())), any(), any()))
         .thenReturn(leftSerde);
     when(joinedFactory.create(any(Serde.class), any(), any(), any())).thenReturn(joined);
     when(left.build(any())).thenReturn(
@@ -253,6 +253,6 @@ public class StreamTableJoinBuilderTest {
 
     // Then:
     final QueryContext leftCtx = QueryContext.Stacker.of(CTX).push("Left").getQueryContext();
-    verify(queryBuilder).buildValueSerde(FormatInfo.of(Format.JSON.name()), LEFT_PHYSICAL, leftCtx);
+    verify(queryBuilder).buildValueSerde(FormatInfo.of(FormatFactory.JSON.name()), LEFT_PHYSICAL, leftCtx);
   }
 }

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableAggregateBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableAggregateBuilderTest.java
@@ -39,7 +39,6 @@ import io.confluent.ksql.execution.materialization.MaterializationInfo;
 import io.confluent.ksql.execution.materialization.MaterializationInfo.MapperInfo;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.ExecutionStepPropertiesV1;
-import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.plan.KGroupedTableHolder;
 import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.PlanBuilder;
@@ -52,7 +51,7 @@ import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SerdeOption;
 import java.util.List;
@@ -108,8 +107,8 @@ public class TableAggregateBuilderTest {
       new QueryContext.Stacker().push("agg").push("regate").getQueryContext();
   private static final QueryContext MATERIALIZE_CTX = QueryContext.Stacker.of(CTX)
       .push("Materialize").getQueryContext();
-  private static final FormatInfo KEY_FORMAT = FormatInfo.of(Format.KAFKA.name());
-  private static final FormatInfo VALUE_FORMAT = FormatInfo.of(Format.JSON.name());
+  private static final FormatInfo KEY_FORMAT = FormatInfo.of(FormatFactory.KAFKA.name());
+  private static final FormatInfo VALUE_FORMAT = FormatInfo.of(FormatFactory.JSON.name());
 
   @Mock
   private KGroupedTable<Struct, GenericRow> groupedTable;
@@ -172,7 +171,7 @@ public class TableAggregateBuilderTest {
     aggregate = new TableAggregate(
         new ExecutionStepPropertiesV1(CTX),
         sourceStep,
-        Formats.of(KEY_FORMAT, VALUE_FORMAT, SerdeOption.none()),
+        io.confluent.ksql.execution.plan.Formats.of(KEY_FORMAT, VALUE_FORMAT, SerdeOption.none()),
         NON_AGG_COLUMNS,
         FUNCTIONS
     );

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableGroupByBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableGroupByBuilderTest.java
@@ -17,7 +17,6 @@ import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.ExecutionStepPropertiesV1;
-import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.plan.KGroupedTableHolder;
 import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.KeySerdeFactory;
@@ -31,7 +30,7 @@ import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.util.KsqlConfig;
@@ -84,9 +83,10 @@ public class TableGroupByBuilderTest {
   private static final ExecutionStepPropertiesV1 PROPERTIES = new ExecutionStepPropertiesV1(
       STEP_CONTEXT
   );
-  private static final Formats FORMATS = Formats.of(
-      FormatInfo.of(Format.KAFKA.name()),
-      FormatInfo.of(Format.JSON.name()),
+  private static final io.confluent.ksql.execution.plan.Formats FORMATS = io.confluent.ksql.execution.plan.Formats
+      .of(
+      FormatInfo.of(FormatFactory.KAFKA.name()),
+      FormatInfo.of(FormatFactory.JSON.name()),
       SerdeOption.none()
   );
 

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableSinkBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableSinkBuilderTest.java
@@ -28,7 +28,6 @@ import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.ExecutionStepPropertiesV1;
-import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.KeySerdeFactory;
 import io.confluent.ksql.execution.plan.PlanBuilder;
@@ -37,7 +36,7 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SerdeOption;
 import org.apache.kafka.common.serialization.Serde;
@@ -67,8 +66,8 @@ public class TableSinkBuilderTest {
 
   private static final PhysicalSchema PHYSICAL_SCHEMA =
       PhysicalSchema.from(SCHEMA.withoutMetaAndKeyColsInValue(), SerdeOption.none());
-  private static final FormatInfo KEY_FORMAT = FormatInfo.of(Format.KAFKA.name());
-  private static final FormatInfo VALUE_FORMAT = FormatInfo.of(Format.JSON.name());
+  private static final FormatInfo KEY_FORMAT = FormatInfo.of(FormatFactory.KAFKA.name());
+  private static final FormatInfo VALUE_FORMAT = FormatInfo.of(FormatFactory.JSON.name());
 
   @Mock
   private KsqlQueryBuilder queryBuilder;
@@ -104,7 +103,7 @@ public class TableSinkBuilderTest {
     sink = new TableSink<>(
         new ExecutionStepPropertiesV1(queryContext),
         source,
-        Formats.of(KEY_FORMAT, VALUE_FORMAT, SerdeOption.none()),
+        io.confluent.ksql.execution.plan.Formats.of(KEY_FORMAT, VALUE_FORMAT, SerdeOption.none()),
         TOPIC
     );
     planBuilder = new KSPlanBuilder(


### PR DESCRIPTION
### Description 

This change looks large but it's really quite simple - most of it is just auto-renaming of things:

- Extract an interface `Format` and rename the existing enum `Formats`
- Move each enum into its own class (e.g. `Format.AVRO` is now `AvroFormat`)
- Move some functionality into the classes instead of using switch statements throughout the code

This sets us up toward allowing pluggable schema support and makes it easier to add new formats (e.g. protobuf, coming soon).

### Review Guide

- All you really need to look at are `Format`, `Formats`, `AvroFormat`, `JsonFormat`, `KafkaFormat` and `DelimitedFormat`. The rest is basically IDE jitter.

### Testing done 

- Added some new tests
- `mvn clean install`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

