### PR TITLE
docs: fix tutorial stack file versions in master (DOCS-3330)

### DIFF
--- a/docs-md/operate-and-deploy/installation/installing.md
+++ b/docs-md/operate-and-deploy/installation/installing.md
@@ -153,7 +153,7 @@ these services:
 - {{ site.sr }} -- enables Avro
 - ksqlDB Server -- one instance
 
-Download the [docker-compose.yml file](https://github.com/confluentinc/ksql/blob/master/docs/tutorials/docker-compose.yml)
+Download the [docker-compose.yml file](https://github.com/confluentinc/ksql/blob/master/docs-md/tutorials/docker-compose.yml)
 for the [ksqlDB Tutorial](../../tutorials/basics-docker.md) to get started with
 a local installation of ksqlDB.
 
@@ -235,7 +235,7 @@ After the ksqlDB CLI starts, your terminal should resemble the following.
 
 Copyright 2017-2019 Confluent Inc.
 
-CLI v{{ site.release }}, Server v{{ site.release }} located at http://localhost:8088
+CLI v{{ site.release }}, Server v{{ site.release }} located at http://ksql-server:8088
 
 Having trouble? Type 'help' (case-insensitive) for a rundown of how things work!
 

--- a/docs-md/tutorials/docker-compose.yml
+++ b/docs-md/tutorials/docker-compose.yml
@@ -2,13 +2,13 @@
 version: '2'
 services:
   zookeeper:
-    image: "confluentinc/cp-zookeeper:5.4.0"
+    image: "confluentinc/cp-zookeeper:latest"
     environment:
       ZOOKEEPER_CLIENT_PORT: 32181
       ZOOKEEPER_TICK_TIME: 2000
 
   kafka:
-    image: "confluentinc/cp-enterprise-kafka:5.4.0"
+    image: "confluentinc/cp-enterprise-kafka:latest"
     ports:
       - '39092:39092'
     depends_on:
@@ -30,7 +30,7 @@ services:
       CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
   schema-registry:
-    image: "confluentinc/cp-schema-registry:5.4.0"
+    image: "confluentinc/cp-schema-registry:latest"
     depends_on:
       - zookeeper
       - kafka
@@ -39,7 +39,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: zookeeper:32181
 
   ksql-server:
-    image: "confluentinc/cp-ksql-server:5.4.0"
+    image: "confluentinc/ksqldb-server:latest"
     depends_on:
       - kafka
       - schema-registry


### PR DESCRIPTION
I munged the CP version while working on the ksqlDB version, d'oh.