### PR TITLE
chore: support window bound columns in selection of windowed group by

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
@@ -15,6 +15,10 @@
 
 package io.confluent.ksql.schema.ksql;
 
+import static io.confluent.ksql.util.SchemaUtil.WINDOWBOUND_TYPE;
+import static io.confluent.ksql.util.SchemaUtil.WINDOWEND_NAME;
+import static io.confluent.ksql.util.SchemaUtil.WINDOWSTART_NAME;
+
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.name.ColumnName;
@@ -239,8 +243,8 @@ public final class LogicalSchema {
 
     int valueIndex = 0;
     for (final Column c : value) {
-      if (c.name().equals(SchemaUtil.WINDOWSTART_NAME)
-          || c.name().equals(SchemaUtil.WINDOWEND_NAME)
+      if (c.name().equals(WINDOWSTART_NAME)
+          || c.name().equals(WINDOWEND_NAME)
       ) {
         continue;
       }
@@ -265,9 +269,9 @@ public final class LogicalSchema {
 
       if (windowedKey) {
         builder.add(
-            Column.of(SchemaUtil.WINDOWSTART_NAME, SqlTypes.BIGINT, Namespace.VALUE, valueIndex++));
+            Column.of(WINDOWSTART_NAME, WINDOWBOUND_TYPE, Namespace.VALUE, valueIndex++));
         builder.add(
-            Column.of(SchemaUtil.WINDOWEND_NAME, SqlTypes.BIGINT, Namespace.VALUE, valueIndex));
+            Column.of(WINDOWEND_NAME, WINDOWBOUND_TYPE, Namespace.VALUE, valueIndex));
       }
     }
 

--- a/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
@@ -35,6 +35,7 @@ import io.confluent.ksql.schema.ksql.types.SqlArray;
 import io.confluent.ksql.schema.ksql.types.SqlMap;
 import io.confluent.ksql.schema.ksql.types.SqlStruct;
 import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
@@ -48,13 +49,18 @@ public final class SchemaUtil {
   public static final ColumnName ROWTIME_NAME = ColumnName.of("ROWTIME");
   public static final ColumnName WINDOWSTART_NAME = ColumnName.of("WINDOWSTART");
   public static final ColumnName WINDOWEND_NAME = ColumnName.of("WINDOWEND");
+  public static final SqlType WINDOWBOUND_TYPE = SqlTypes.BIGINT;
 
-  private static final Set<ColumnName> SYSTEM_COLUMN_NAMES = ImmutableSet.of(
-      ROWKEY_NAME,
-      ROWTIME_NAME,
+  private static final Set<ColumnName> WINDOW_BOUNDS_COLUMN_NAMES = ImmutableSet.of(
       WINDOWSTART_NAME,
       WINDOWEND_NAME
   );
+
+  private static final Set<ColumnName> SYSTEM_COLUMN_NAMES = ImmutableSet.<ColumnName>builder()
+      .add(ROWKEY_NAME)
+      .add(ROWTIME_NAME)
+      .addAll(WINDOW_BOUNDS_COLUMN_NAMES)
+      .build();
 
   private static final Set<Schema.Type> ARITHMETIC_TYPES = ImmutableSet.of(
       Type.INT8,
@@ -68,6 +74,18 @@ public final class SchemaUtil {
   private static final char FIELD_NAME_DELIMITER = '.';
 
   private SchemaUtil() {
+  }
+
+  public static boolean isWindowBound(final ColumnName columnName) {
+    return windowBoundsColumnNames().contains(columnName);
+  }
+
+  public static Set<ColumnName> windowBoundsColumnNames() {
+    return WINDOW_BOUNDS_COLUMN_NAMES;
+  }
+
+  public static boolean isSystemColumn(final ColumnName columnName) {
+    return systemColumnNames().contains(columnName);
   }
 
   public static Set<ColumnName> systemColumnNames() {

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/AggregateAnalyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/AggregateAnalyzer.java
@@ -25,6 +25,7 @@ import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.SchemaUtil;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
@@ -36,21 +37,26 @@ class AggregateAnalyzer {
   private final MutableAggregateAnalysis aggregateAnalysis;
   private final QualifiedColumnReferenceExp defaultArgument;
   private final FunctionRegistry functionRegistry;
+  private final boolean hasWindowExpression;
 
   AggregateAnalyzer(
       final MutableAggregateAnalysis aggregateAnalysis,
       final QualifiedColumnReferenceExp defaultArgument,
+      final boolean hasWindowExpression,
       final FunctionRegistry functionRegistry
   ) {
     this.aggregateAnalysis = Objects.requireNonNull(aggregateAnalysis, "aggregateAnalysis");
     this.defaultArgument = Objects.requireNonNull(defaultArgument, "defaultArgument");
     this.functionRegistry = Objects.requireNonNull(functionRegistry, "functionRegistry");
+    this.hasWindowExpression = hasWindowExpression;
   }
 
   void processSelect(final Expression expression) {
     final Set<ColumnReferenceExp> nonAggParams = new HashSet<>();
     final AggregateVisitor visitor = new AggregateVisitor((aggFuncName, node) -> {
-      if (!aggFuncName.isPresent()) {
+      if (aggFuncName.isPresent()) {
+        throwOnWindowBoundColumnIfWindowedAggregate(node);
+      } else {
         nonAggParams.add(node);
       }
     });
@@ -70,6 +76,15 @@ class AggregateAnalyzer {
         throw new KsqlException("GROUP BY does not support aggregate functions: "
             + aggFuncName.get().name() + " is an aggregate function.");
       }
+      throwOnWindowBoundColumnIfWindowedAggregate(node);
+    });
+
+    visitor.process(expression, null);
+  }
+
+  void processWhere(final Expression expression) {
+    final AggregateVisitor visitor = new AggregateVisitor((aggFuncName, node) -> {
+      throwOnWindowBoundColumnIfWindowedAggregate(node);
     });
 
     visitor.process(expression, null);
@@ -77,11 +92,29 @@ class AggregateAnalyzer {
 
   void processHaving(final Expression expression) {
     final AggregateVisitor visitor = new AggregateVisitor((aggFuncName, node) -> {
+      throwOnWindowBoundColumnIfWindowedAggregate(node);
       if (!aggFuncName.isPresent()) {
         aggregateAnalysis.addNonAggregateHavingField(node);
       }
     });
     visitor.process(expression, null);
+  }
+
+  private void throwOnWindowBoundColumnIfWindowedAggregate(final ColumnReferenceExp node) {
+    // Window bounds are supported for operations on windowed sources
+    if (!hasWindowExpression) {
+      return;
+    }
+
+    // For non-windowed sources, with a windowed GROUP BY, they are only supported in selects:
+    if (SchemaUtil.isWindowBound(node.getReference())) {
+      throw new KsqlException(
+          "Window bounds column " + node + " can only be used in the SELECT clause of "
+              + "windowed aggregations."
+              + System.lineSeparator()
+              + "See https://github.com/confluentinc/ksql/issues/4397"
+      );
+    }
   }
 
   private final class AggregateVisitor extends TraversalExpressionVisitor<Void> {
@@ -135,7 +168,10 @@ class AggregateAnalyzer {
         final Void context
     ) {
       dereferenceCollector.accept(aggFunctionName, node);
-      aggregateAnalysis.addRequiredColumn(node);
+
+      if (!SchemaUtil.isWindowBound(node.getReference())) {
+        aggregateAnalysis.addRequiredColumn(node);
+      }
       return null;
     }
 
@@ -145,7 +181,10 @@ class AggregateAnalyzer {
         final Void context
     ) {
       dereferenceCollector.accept(aggFunctionName, node);
-      aggregateAnalysis.addRequiredColumn(node);
+
+      if (!SchemaUtil.isWindowBound(node.getReference())) {
+        aggregateAnalysis.addRequiredColumn(node);
+      }
       return null;
     }
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/ImmutableAnalysis.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/ImmutableAnalysis.java
@@ -60,5 +60,5 @@ public interface ImmutableAnalysis {
 
   CreateSourceAsProperties getProperties();
 
-  SourceSchemas getFromSourceSchemas();
+  SourceSchemas getFromSourceSchemas(boolean postAggregate);
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/RewrittenAnalysis.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/RewrittenAnalysis.java
@@ -140,8 +140,8 @@ public class RewrittenAnalysis implements ImmutableAnalysis {
   }
 
   @Override
-  public SourceSchemas getFromSourceSchemas() {
-    return original.getFromSourceSchemas();
+  public SourceSchemas getFromSourceSchemas(final boolean postAggregate) {
+    return original.getFromSourceSchemas(postAggregate);
   }
 
   private <T extends Expression> Optional<T> rewriteOptional(final Optional<T> expression) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
@@ -172,7 +172,7 @@ public final class CreateSourceFactory {
     tableElements.forEach(e -> {
       final boolean isRowKey = e.getName().equals(SchemaUtil.ROWKEY_NAME);
 
-      if (!isRowKey && SchemaUtil.systemColumnNames().contains(e.getName())) {
+      if (!isRowKey && SchemaUtil.isSystemColumn(e.getName())) {
         throw new KsqlException("'" + e.getName().name() + "' is a reserved column name.");
       }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -83,7 +83,7 @@ public class LogicalPlanner {
     this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig");
     Objects.requireNonNull(analysis, "analysis");
     final ColumnReferenceRewriter refRewriter =
-        new ColumnReferenceRewriter(analysis.getFromSourceSchemas());
+        new ColumnReferenceRewriter(analysis.getFromSourceSchemas(false));
     this.analysis = new RewrittenAnalysis(analysis, refRewriter::process);
     this.aggregateAnalysis = new RewrittenAggregateAnalysis(
         Objects.requireNonNull(aggregateAnalysis, "aggregateAnalysis"),
@@ -174,7 +174,7 @@ public class LogicalPlanner {
         : null;
 
     final Optional<ColumnName> keyFieldName = getSelectAliasMatching((expression, alias) ->
-            expression.equals(groupBy) && !SchemaUtil.systemColumnNames().contains(alias),
+            expression.equals(groupBy) && !SchemaUtil.isSystemColumn(alias),
         sourcePlanNode.getSelectExpressions());
 
     return new AggregateNode(
@@ -418,7 +418,8 @@ public class LogicalPlanner {
     }
 
     final LogicalSchema sourceSchema = buildProjectionSchema(
-        sourcePlanNode.getSchema(),
+        sourcePlanNode.getSchema()
+            .withMetaAndKeyColsInValue(analysis.getWindowExpression().isPresent()),
         sourcePlanNode.getSelectExpressions()
     );
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -188,7 +188,7 @@ public class SchemaKStream<K> {
 
     final Optional<ColumnName> filtered = found
         // System columns can not be key fields:
-        .filter(f -> !SchemaUtil.systemColumnNames().contains(f.name()))
+        .filter(f -> !SchemaUtil.isSystemColumn(f.name()))
         .map(Column::ref);
 
     return KeyField.of(filtered);

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AggregateAnalyzerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AggregateAnalyzerTest.java
@@ -72,7 +72,7 @@ public class AggregateAnalyzerTest {
   @Before
   public void init() {
     analysis = new MutableAggregateAnalysis();
-    analyzer = new AggregateAnalyzer(analysis, DEFAULT_ARGUMENT, functionRegistry);
+    analyzer = new AggregateAnalyzer(analysis, DEFAULT_ARGUMENT, false, functionRegistry);
   }
 
   @Test
@@ -292,5 +292,29 @@ public class AggregateAnalyzerTest {
     assertThat(analysis.getAggregateFunctions(), hasSize(1));
     assertThat(analysis.getAggregateFunctions().get(0).getName(), is(emptyFunc.getName()));
     assertThat(analysis.getAggregateFunctions().get(0).getArguments(), contains(DEFAULT_ARGUMENT));
+  }
+
+  @Test
+  public void shouldNotCaptureWindowStartAsRequiredColumn() {
+    // When:
+    analyzer.processSelect(new QualifiedColumnReferenceExp(
+        ORDERS,
+        SchemaUtil.WINDOWSTART_NAME
+    ));
+
+    // Then:
+    assertThat(analysis.getRequiredColumns(), is(empty()));
+  }
+
+  @Test
+  public void shouldNotCaptureWindowEndAsRequiredColumn() {
+    // When:
+    analyzer.processSelect(new QualifiedColumnReferenceExp(
+        ORDERS,
+        SchemaUtil.WINDOWEND_NAME
+    ));
+
+    // Then:
+    assertThat(analysis.getRequiredColumns(), is(empty()));
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalysisTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalysisTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.analyzer;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
+import io.confluent.ksql.metastore.model.KsqlStream;
+import io.confluent.ksql.model.WindowType;
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.parser.tree.ResultMaterialization;
+import io.confluent.ksql.parser.tree.WindowExpression;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.serde.FormatInfo;
+import io.confluent.ksql.serde.KeyFormat;
+import io.confluent.ksql.serde.WindowInfo;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AnalysisTest {
+
+  private static final SourceName ALIAS = SourceName.of("ds1");
+  private static final FormatInfo A_FORMAT = FormatInfo.of("JSON");
+  private static final WindowInfo A_WINDOW = WindowInfo.of(WindowType.SESSION, Optional.empty());
+
+  private static final LogicalSchema SOURCE_SCHEMA = LogicalSchema.builder()
+      .valueColumn(ColumnName.of("bob"), SqlTypes.BIGINT)
+      .build();
+
+  @Mock
+  private ResultMaterialization resultMaterialization;
+  @Mock
+  private KsqlStream<?> dataSource;
+  @Mock
+  private Function<Map<SourceName, LogicalSchema>, SourceSchemas> sourceSchemasFactory;
+  @Mock
+  private WindowExpression windowExpression;
+
+  private Analysis analysis;
+
+  @Before
+  public void setUp() {
+    analysis = new Analysis(resultMaterialization, sourceSchemasFactory);
+
+    when(dataSource.getSchema()).thenReturn(SOURCE_SCHEMA);
+  }
+
+  @Test
+  public void shouldGetNoneWindowedSourceSchemasPreAggregate() {
+    // Given:
+    analysis.addDataSource(ALIAS, dataSource);
+
+    givenNoneWindowedSource(dataSource);
+
+    // When:
+    analysis.getFromSourceSchemas(false);
+
+    // Then:
+    verify(sourceSchemasFactory).apply(ImmutableMap.of(
+        ALIAS,
+        SOURCE_SCHEMA.withMetaAndKeyColsInValue(false)
+    ));
+  }
+
+  @Test
+  public void shouldGetWindowedSourceSchemasPreAggregate() {
+    // Given:
+    analysis.addDataSource(ALIAS, dataSource);
+
+    givenWindowedSource(dataSource);
+
+    // When:
+    analysis.getFromSourceSchemas(false);
+
+    // Then:
+    verify(sourceSchemasFactory).apply(ImmutableMap.of(
+        ALIAS,
+        SOURCE_SCHEMA.withMetaAndKeyColsInValue(true)
+    ));
+  }
+
+  @Test
+  public void shouldGetWindowedGroupBySourceSchemasPreAggregate() {
+    // Given:
+    analysis.addDataSource(ALIAS, dataSource);
+
+    givenNoneWindowedSource(dataSource);
+    analysis.setWindowExpression(windowExpression);
+
+    // When:
+    analysis.getFromSourceSchemas(false);
+
+    // Then:
+    verify(sourceSchemasFactory).apply(ImmutableMap.of(
+        ALIAS,
+        SOURCE_SCHEMA.withMetaAndKeyColsInValue(false)
+    ));
+  }
+
+  @Test
+  public void shouldGetNonWindowedSourceSchemasPostAggregate() {
+    // Given:
+    analysis.addDataSource(ALIAS, dataSource);
+
+    givenNoneWindowedSource(dataSource);
+
+    // When:
+    analysis.getFromSourceSchemas(true);
+
+    // Then:
+    verify(sourceSchemasFactory).apply(ImmutableMap.of(
+        ALIAS,
+        SOURCE_SCHEMA.withMetaAndKeyColsInValue(false)
+    ));
+  }
+
+  @Test
+  public void shouldGetWindowedSourceSchemasPostAggregate() {
+    // Given:
+    analysis.addDataSource(ALIAS, dataSource);
+
+    givenWindowedSource(dataSource);
+
+    // When:
+    analysis.getFromSourceSchemas(true);
+
+    // Then:
+    verify(sourceSchemasFactory).apply(ImmutableMap.of(
+        ALIAS,
+        SOURCE_SCHEMA.withMetaAndKeyColsInValue(true)
+    ));
+  }
+
+  @Test
+  public void shouldGetWindowedGroupBySourceSchemasPostAggregate() {
+    // Given:
+    analysis.addDataSource(ALIAS, dataSource);
+
+    givenNoneWindowedSource(dataSource);
+    analysis.setWindowExpression(windowExpression);
+
+    // When:
+    analysis.getFromSourceSchemas(true);
+
+    // Then:
+    verify(sourceSchemasFactory).apply(ImmutableMap.of(
+        ALIAS,
+        SOURCE_SCHEMA.withMetaAndKeyColsInValue(true)
+    ));
+  }
+
+
+  private static void givenNoneWindowedSource(final KsqlStream<?> dataSource) {
+    final KsqlTopic topic = mock(KsqlTopic.class);
+    when(topic.getKeyFormat()).thenReturn(KeyFormat.nonWindowed(A_FORMAT));
+    when(dataSource.getKsqlTopic()).thenReturn(topic);
+  }
+
+  private static void givenWindowedSource(final KsqlStream<?> dataSource) {
+    final KsqlTopic topic = mock(KsqlTopic.class);
+    when(topic.getKeyFormat()).thenReturn(KeyFormat.windowed(A_FORMAT, A_WINDOW));
+    when(dataSource.getKsqlTopic()).thenReturn(topic);
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
@@ -244,7 +244,8 @@ public class DataSourceNodeTest {
         PLAN_NODE_ID,
         table,
         table.getName(),
-        Collections.emptyList());
+        Collections.emptyList()
+    );
 
     // When:
     final SchemaKStream<?> result = buildStream(node);

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
@@ -184,8 +184,8 @@ public class ExpressionTypeManager {
     ) {
       final Optional<Column> possibleColumn = schema.findValueColumn(node.getReference());
 
-      final Column schemaColumn = possibleColumn.orElseThrow(() ->
-          new KsqlException(String.format("Invalid Expression %s.", node.toString())));
+      final Column schemaColumn = possibleColumn
+          .orElseThrow(() -> new KsqlException("Unknown column " + node + "."));
 
       expressionTypeContext.setSqlType(schemaColumn.type());
       return null;

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/having_-_table_having
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/having_-_table_having
@@ -58,11 +58,14 @@ Topologies:
       --> Aggregate-Aggregate-ToOutputSchema
       <-- Aggregate-Prepare
     Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
-      --> Aggregate-HavingFilter-ApplyPredicate
+      --> Aggregate-Aggregate-WindowSelect2
       <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect2 (stores: [])
+      --> Aggregate-HavingFilter-ApplyPredicate
+      <-- Aggregate-Aggregate-ToOutputSchema
     Processor: Aggregate-HavingFilter-ApplyPredicate (stores: [])
       --> Aggregate-HavingFilter-Filter
-      <-- Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Aggregate-WindowSelect2
     Processor: Aggregate-HavingFilter-Filter (stores: [])
       --> Aggregate-HavingFilter-PostProcess
       <-- Aggregate-HavingFilter-ApplyPredicate
@@ -70,11 +73,11 @@ Topologies:
       --> Aggregate-Project
       <-- Aggregate-HavingFilter-Filter
     Processor: Aggregate-Project (stores: [])
-      --> KTABLE-TOSTREAM-0000000009
+      --> KTABLE-TOSTREAM-0000000010
       <-- Aggregate-HavingFilter-PostProcess
-    Processor: KTABLE-TOSTREAM-0000000009 (stores: [])
-      --> KSTREAM-SINK-0000000010
+    Processor: KTABLE-TOSTREAM-0000000010 (stores: [])
+      --> KSTREAM-SINK-0000000011
       <-- Aggregate-Project
-    Sink: KSTREAM-SINK-0000000010 (topic: T1)
-      <-- KTABLE-TOSTREAM-0000000009
+    Sink: KSTREAM-SINK-0000000011 (topic: T1)
+      <-- KTABLE-TOSTREAM-0000000010
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/hopping-windows_-_count
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/hopping-windows_-_count
@@ -58,14 +58,17 @@ Topologies:
       --> Aggregate-Aggregate-ToOutputSchema
       <-- Aggregate-Prepare
     Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
-      --> Aggregate-Project
+      --> Aggregate-Aggregate-WindowSelect2
       <-- KSTREAM-AGGREGATE-0000000003
-    Processor: Aggregate-Project (stores: [])
-      --> KTABLE-TOSTREAM-0000000006
+    Processor: Aggregate-Aggregate-WindowSelect2 (stores: [])
+      --> Aggregate-Project
       <-- Aggregate-Aggregate-ToOutputSchema
-    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
-      --> KSTREAM-SINK-0000000007
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect2
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
       <-- Aggregate-Project
-    Sink: KSTREAM-SINK-0000000007 (topic: S2)
-      <-- KTABLE-TOSTREAM-0000000006
+    Sink: KSTREAM-SINK-0000000008 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000007
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/hopping-windows_-_max_hopping
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/hopping-windows_-_max_hopping
@@ -58,14 +58,17 @@ Topologies:
       --> Aggregate-Aggregate-ToOutputSchema
       <-- Aggregate-Prepare
     Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
-      --> Aggregate-Project
+      --> Aggregate-Aggregate-WindowSelect2
       <-- KSTREAM-AGGREGATE-0000000003
-    Processor: Aggregate-Project (stores: [])
-      --> KTABLE-TOSTREAM-0000000006
+    Processor: Aggregate-Aggregate-WindowSelect2 (stores: [])
+      --> Aggregate-Project
       <-- Aggregate-Aggregate-ToOutputSchema
-    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
-      --> KSTREAM-SINK-0000000007
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect2
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
       <-- Aggregate-Project
-    Sink: KSTREAM-SINK-0000000007 (topic: S2)
-      <-- KTABLE-TOSTREAM-0000000006
+    Sink: KSTREAM-SINK-0000000008 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000007
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/hopping-windows_-_min_hopping
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/hopping-windows_-_min_hopping
@@ -58,14 +58,17 @@ Topologies:
       --> Aggregate-Aggregate-ToOutputSchema
       <-- Aggregate-Prepare
     Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
-      --> Aggregate-Project
+      --> Aggregate-Aggregate-WindowSelect2
       <-- KSTREAM-AGGREGATE-0000000003
-    Processor: Aggregate-Project (stores: [])
-      --> KTABLE-TOSTREAM-0000000006
+    Processor: Aggregate-Aggregate-WindowSelect2 (stores: [])
+      --> Aggregate-Project
       <-- Aggregate-Aggregate-ToOutputSchema
-    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
-      --> KSTREAM-SINK-0000000007
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect2
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
       <-- Aggregate-Project
-    Sink: KSTREAM-SINK-0000000007 (topic: S2)
-      <-- KTABLE-TOSTREAM-0000000006
+    Sink: KSTREAM-SINK-0000000008 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000007
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/hopping-windows_-_topk_hopping
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/hopping-windows_-_topk_hopping
@@ -58,14 +58,17 @@ Topologies:
       --> Aggregate-Aggregate-ToOutputSchema
       <-- Aggregate-Prepare
     Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
-      --> Aggregate-Project
+      --> Aggregate-Aggregate-WindowSelect2
       <-- KSTREAM-AGGREGATE-0000000003
-    Processor: Aggregate-Project (stores: [])
-      --> KTABLE-TOSTREAM-0000000006
+    Processor: Aggregate-Aggregate-WindowSelect2 (stores: [])
+      --> Aggregate-Project
       <-- Aggregate-Aggregate-ToOutputSchema
-    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
-      --> KSTREAM-SINK-0000000007
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect2
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
       <-- Aggregate-Project
-    Sink: KSTREAM-SINK-0000000007 (topic: S2)
-      <-- KTABLE-TOSTREAM-0000000006
+    Sink: KSTREAM-SINK-0000000008 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000007
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/hopping-windows_-_topkdistinct_hopping
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/hopping-windows_-_topkdistinct_hopping
@@ -58,14 +58,17 @@ Topologies:
       --> Aggregate-Aggregate-ToOutputSchema
       <-- Aggregate-Prepare
     Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
-      --> Aggregate-Project
+      --> Aggregate-Aggregate-WindowSelect2
       <-- KSTREAM-AGGREGATE-0000000003
-    Processor: Aggregate-Project (stores: [])
-      --> KTABLE-TOSTREAM-0000000006
+    Processor: Aggregate-Aggregate-WindowSelect2 (stores: [])
+      --> Aggregate-Project
       <-- Aggregate-Aggregate-ToOutputSchema
-    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
-      --> KSTREAM-SINK-0000000007
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect2
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
       <-- Aggregate-Project
-    Sink: KSTREAM-SINK-0000000007 (topic: S2)
-      <-- KTABLE-TOSTREAM-0000000006
+    Sink: KSTREAM-SINK-0000000008 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000007
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/session-windows_-_max_session
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/session-windows_-_max_session
@@ -58,14 +58,17 @@ Topologies:
       --> Aggregate-Aggregate-ToOutputSchema
       <-- Aggregate-Prepare
     Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
-      --> Aggregate-Project
+      --> Aggregate-Aggregate-WindowSelect2
       <-- KSTREAM-AGGREGATE-0000000003
-    Processor: Aggregate-Project (stores: [])
-      --> KTABLE-TOSTREAM-0000000006
+    Processor: Aggregate-Aggregate-WindowSelect2 (stores: [])
+      --> Aggregate-Project
       <-- Aggregate-Aggregate-ToOutputSchema
-    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
-      --> KSTREAM-SINK-0000000007
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect2
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
       <-- Aggregate-Project
-    Sink: KSTREAM-SINK-0000000007 (topic: S2)
-      <-- KTABLE-TOSTREAM-0000000006
+    Sink: KSTREAM-SINK-0000000008 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000007
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/tumbling-windows_-_max_tumbling
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/tumbling-windows_-_max_tumbling
@@ -58,14 +58,17 @@ Topologies:
       --> Aggregate-Aggregate-ToOutputSchema
       <-- Aggregate-Prepare
     Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
-      --> Aggregate-Project
+      --> Aggregate-Aggregate-WindowSelect2
       <-- KSTREAM-AGGREGATE-0000000003
-    Processor: Aggregate-Project (stores: [])
-      --> KTABLE-TOSTREAM-0000000006
+    Processor: Aggregate-Aggregate-WindowSelect2 (stores: [])
+      --> Aggregate-Project
       <-- Aggregate-Aggregate-ToOutputSchema
-    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
-      --> KSTREAM-SINK-0000000007
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect2
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
       <-- Aggregate-Project
-    Sink: KSTREAM-SINK-0000000007 (topic: S2)
-      <-- KTABLE-TOSTREAM-0000000006
+    Sink: KSTREAM-SINK-0000000008 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000007
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/tumbling-windows_-_min_tumbling
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/tumbling-windows_-_min_tumbling
@@ -58,14 +58,17 @@ Topologies:
       --> Aggregate-Aggregate-ToOutputSchema
       <-- Aggregate-Prepare
     Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
-      --> Aggregate-Project
+      --> Aggregate-Aggregate-WindowSelect2
       <-- KSTREAM-AGGREGATE-0000000003
-    Processor: Aggregate-Project (stores: [])
-      --> KTABLE-TOSTREAM-0000000006
+    Processor: Aggregate-Aggregate-WindowSelect2 (stores: [])
+      --> Aggregate-Project
       <-- Aggregate-Aggregate-ToOutputSchema
-    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
-      --> KSTREAM-SINK-0000000007
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect2
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
       <-- Aggregate-Project
-    Sink: KSTREAM-SINK-0000000007 (topic: S2)
-      <-- KTABLE-TOSTREAM-0000000006
+    Sink: KSTREAM-SINK-0000000008 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000007
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/tumbling-windows_-_topk_tumbling
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/tumbling-windows_-_topk_tumbling
@@ -58,14 +58,17 @@ Topologies:
       --> Aggregate-Aggregate-ToOutputSchema
       <-- Aggregate-Prepare
     Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
-      --> Aggregate-Project
+      --> Aggregate-Aggregate-WindowSelect2
       <-- KSTREAM-AGGREGATE-0000000003
-    Processor: Aggregate-Project (stores: [])
-      --> KTABLE-TOSTREAM-0000000006
+    Processor: Aggregate-Aggregate-WindowSelect2 (stores: [])
+      --> Aggregate-Project
       <-- Aggregate-Aggregate-ToOutputSchema
-    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
-      --> KSTREAM-SINK-0000000007
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect2
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
       <-- Aggregate-Project
-    Sink: KSTREAM-SINK-0000000007 (topic: S2)
-      <-- KTABLE-TOSTREAM-0000000006
+    Sink: KSTREAM-SINK-0000000008 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000007
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/tumbling-windows_-_topkdistinct_tumbling
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/tumbling-windows_-_topkdistinct_tumbling
@@ -58,14 +58,17 @@ Topologies:
       --> Aggregate-Aggregate-ToOutputSchema
       <-- Aggregate-Prepare
     Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
-      --> Aggregate-Project
+      --> Aggregate-Aggregate-WindowSelect2
       <-- KSTREAM-AGGREGATE-0000000003
-    Processor: Aggregate-Project (stores: [])
-      --> KTABLE-TOSTREAM-0000000006
+    Processor: Aggregate-Aggregate-WindowSelect2 (stores: [])
+      --> Aggregate-Project
       <-- Aggregate-Aggregate-ToOutputSchema
-    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
-      --> KSTREAM-SINK-0000000007
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect2
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
       <-- Aggregate-Project
-    Sink: KSTREAM-SINK-0000000007 (topic: S2)
-      <-- KTABLE-TOSTREAM-0000000006
+    Sink: KSTREAM-SINK-0000000008 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000007
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/window-bounds_-_in_expressions
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/window-bounds_-_in_expressions
@@ -58,17 +58,20 @@ Topologies:
       --> Aggregate-Aggregate-ToOutputSchema
       <-- Aggregate-Prepare
     Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
-      --> Aggregate-Aggregate-WindowSelect
+      --> Aggregate-Aggregate-WindowSelect2
       <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect2 (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- Aggregate-Aggregate-ToOutputSchema
     Processor: Aggregate-Aggregate-WindowSelect (stores: [])
       --> Aggregate-Project
-      <-- Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Aggregate-WindowSelect2
     Processor: Aggregate-Project (stores: [])
-      --> KTABLE-TOSTREAM-0000000007
+      --> KTABLE-TOSTREAM-0000000008
       <-- Aggregate-Aggregate-WindowSelect
-    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000008
+    Processor: KTABLE-TOSTREAM-0000000008 (stores: [])
+      --> KSTREAM-SINK-0000000009
       <-- Aggregate-Project
-    Sink: KSTREAM-SINK-0000000008 (topic: S2)
-      <-- KTABLE-TOSTREAM-0000000007
+    Sink: KSTREAM-SINK-0000000009 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/window-bounds_-_table_hopping
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/window-bounds_-_table_hopping
@@ -58,17 +58,20 @@ Topologies:
       --> Aggregate-Aggregate-ToOutputSchema
       <-- Aggregate-Prepare
     Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
-      --> Aggregate-Aggregate-WindowSelect
+      --> Aggregate-Aggregate-WindowSelect2
       <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect2 (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- Aggregate-Aggregate-ToOutputSchema
     Processor: Aggregate-Aggregate-WindowSelect (stores: [])
       --> Aggregate-Project
-      <-- Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Aggregate-WindowSelect2
     Processor: Aggregate-Project (stores: [])
-      --> KTABLE-TOSTREAM-0000000007
+      --> KTABLE-TOSTREAM-0000000008
       <-- Aggregate-Aggregate-WindowSelect
-    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000008
+    Processor: KTABLE-TOSTREAM-0000000008 (stores: [])
+      --> KSTREAM-SINK-0000000009
       <-- Aggregate-Project
-    Sink: KSTREAM-SINK-0000000008 (topic: S2)
-      <-- KTABLE-TOSTREAM-0000000007
+    Sink: KSTREAM-SINK-0000000009 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/window-bounds_-_table_session
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/window-bounds_-_table_session
@@ -58,17 +58,20 @@ Topologies:
       --> Aggregate-Aggregate-ToOutputSchema
       <-- Aggregate-Prepare
     Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
-      --> Aggregate-Aggregate-WindowSelect
+      --> Aggregate-Aggregate-WindowSelect2
       <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect2 (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- Aggregate-Aggregate-ToOutputSchema
     Processor: Aggregate-Aggregate-WindowSelect (stores: [])
       --> Aggregate-Project
-      <-- Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Aggregate-WindowSelect2
     Processor: Aggregate-Project (stores: [])
-      --> KTABLE-TOSTREAM-0000000007
+      --> KTABLE-TOSTREAM-0000000008
       <-- Aggregate-Aggregate-WindowSelect
-    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000008
+    Processor: KTABLE-TOSTREAM-0000000008 (stores: [])
+      --> KSTREAM-SINK-0000000009
       <-- Aggregate-Project
-    Sink: KSTREAM-SINK-0000000008 (topic: S2)
-      <-- KTABLE-TOSTREAM-0000000007
+    Sink: KSTREAM-SINK-0000000009 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/window-bounds_-_table_tumbling
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/window-bounds_-_table_tumbling
@@ -58,17 +58,20 @@ Topologies:
       --> Aggregate-Aggregate-ToOutputSchema
       <-- Aggregate-Prepare
     Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
-      --> Aggregate-Aggregate-WindowSelect
+      --> Aggregate-Aggregate-WindowSelect2
       <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect2 (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- Aggregate-Aggregate-ToOutputSchema
     Processor: Aggregate-Aggregate-WindowSelect (stores: [])
       --> Aggregate-Project
-      <-- Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Aggregate-WindowSelect2
     Processor: Aggregate-Project (stores: [])
-      --> KTABLE-TOSTREAM-0000000007
+      --> KTABLE-TOSTREAM-0000000008
       <-- Aggregate-Aggregate-WindowSelect
-    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000008
+    Processor: KTABLE-TOSTREAM-0000000008 (stores: [])
+      --> KSTREAM-SINK-0000000009
       <-- Aggregate-Project
-    Sink: KSTREAM-SINK-0000000008 (topic: S2)
-      <-- KTABLE-TOSTREAM-0000000007
+    Sink: KSTREAM-SINK-0000000009 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000008
 

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/window-bounds.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/window-bounds.json
@@ -110,6 +110,112 @@
         {"topic": "S2", "key": 0,"value": "0,0,15000", "timestamp": 4999, "window": {"start": 0, "end": 30000, "type": "time"}},
         {"topic": "S2", "key": 0,"value": "0,0,15000", "timestamp": 5000, "window": {"start": 0, "end": 30000, "type": "time"}}
       ]
+    },
+    {
+      "name": "windowed group by - non-aggregate window bounds in SELECT",
+      "statements": [
+        "CREATE STREAM INPUT (ROWKEY INT KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT as SELECT count(1) as count, windowstart as WSTART, windowend AS WEND FROM INPUT WINDOW TUMBLING (SIZE 1 SECOND) group by ROWKEY;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {}, "timestamp": 10345},
+        {"topic": "test_topic", "key": 0, "value": {}, "timestamp": 10445},
+        {"topic": "test_topic", "key": 0, "value": {}, "timestamp": 13251}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"COUNT":1, "WSTART": 10000, "WEND": 11000}, "timestamp": 10345, "window": {"start": 10000, "end": 11000, "type": "time"}},
+        {"topic": "OUTPUT", "key": 0, "value": {"COUNT":2, "WSTART": 10000, "WEND": 11000}, "timestamp": 10445, "window": {"start": 10000, "end": 11000, "type": "time"}},
+        {"topic": "OUTPUT", "key": 0, "value": {"COUNT":1, "WSTART": 13000, "WEND": 14000}, "timestamp": 13251, "window": {"start": 13000, "end": 14000, "type": "time"}}
+      ],
+      "post": {
+        "sources": [
+          {
+            "name": "OUTPUT",
+            "type": "table",
+            "keyFormat": {"format": "KAFKA", "windowType": "TUMBLING", "windowSize": 1000},
+            "schema": "`ROWKEY` INTEGER KEY, `COUNT` BIGINT, `WSTART` BIGINT, `WEND` BIGINT"
+          }
+        ]
+      }
+    },
+    {
+      "name": "windowed group by - aggregate window bounds in UDAF in SELECT",
+      "statements": [
+        "CREATE STREAM TEST (ROWKEY INT KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE S2 as SELECT count(1), min(windowstart), min(windowend) FROM test WINDOW TUMBLING (SIZE 1 SECOND) group by ROWKEY;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Window bounds column TEST.WINDOWSTART can only be used in the SELECT clause of windowed aggregations"
+      }
+    },
+    {
+      "name": "windowed group by - aggregate window bounds in SELECT",
+      "statements": [
+        "CREATE STREAM TEST (ROWKEY INT KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE S2 as SELECT count(1) * windowend FROM test WINDOW TUMBLING (SIZE 1 SECOND) group by ROWKEY;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Field used in aggregate SELECT expression(s) outside of aggregate functions not part of GROUP BY: [TEST.WINDOWEND]"
+      }
+    },
+    {
+      "name": "windowed group by - aggregate window bounds in WHERE",
+      "statements": [
+        "CREATE STREAM TEST (ROWKEY INT KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE S2 as SELECT count(1) as count FROM test WINDOW TUMBLING (SIZE 1 SECOND) WHERE min(windowEnd) < 15000 group by ROWKEY;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Window bounds column TEST.WINDOWEND can only be used in the SELECT clause of windowed aggregations"
+      }
+    },
+    {
+      "name": "windowed group by -  window bounds in GROUP BY",
+      "comment": "Window bounds in group by are ignored, as the GROUP BY is implicitly by window bounds",
+      "statements": [
+        "CREATE STREAM TEST (ROWKEY INT KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE S2 as SELECT count(1) as count FROM test WINDOW TUMBLING (SIZE 1 SECOND) group by ROWKEY, WINDOWSTART, WINDOWEND;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Window bounds column TEST.WINDOWSTART can only be used in the SELECT clause of windowed aggregations"
+      }
+    },
+    {
+      "name": "windowed group by -  only window bounds in GROUP BY",
+      "comment": "In the future this can be supported, but isn't as yet",
+      "statements": [
+        "CREATE STREAM TEST (ROWKEY INT KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE S2 as SELECT count(1) as count FROM test WINDOW TUMBLING (SIZE 1 SECOND) group by WINDOWSTART, WINDOWEND;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Window bounds column TEST.WINDOWSTART can only be used in the SELECT clause of windowed aggregations"
+      }
+    },
+    {
+      "name": "windowed group by - window bounds in expression in GROUP BY",
+      "statements": [
+        "CREATE STREAM TEST (ROWKEY INT KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE S2 as SELECT count(1) as count FROM test WINDOW TUMBLING (SIZE 1 SECOND) group by ROWKEY, WINDOWSTART / 1000, ABS(WINDOWEND);"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Window bounds column TEST.WINDOWSTART can only be used in the SELECT clause of windowed aggregations"
+      }
+    },
+    {
+      "name": "windowed group by - window bounds in HAVING",
+      "statements": [
+        "CREATE STREAM TEST (ROWKEY INT KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE S2 as SELECT count(1) as count FROM test WINDOW TUMBLING (SIZE 1 SECOND) group by ROWKEY HAVING windowStart > 11000 AND min(windowEnd) < 15000;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Window bounds column TEST.WINDOWSTART can only be used in the SELECT clause of windowed aggregations"
+      }
     }
   ]
 }

--- a/ksql-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
+++ b/ksql-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
@@ -996,6 +996,26 @@
           {"row":{"columns":["2020-01-28 14:54:43 +0000", "2020-01-28 14:54:44 +0000", "en", 1]}}
         ]}
       ]
+    },
+    {
+      "name": "access window bounds in selection",
+      "statements": [
+        "CREATE STREAM INPUT (ROWKEY DOUBLE KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ROWKEY;",
+        "SELECT ROWKEY, TIMESTAMPTOSTRING(WINDOWSTART, 'yyyy-MM-dd HH:mm:ss Z', 'UTC') AS WSTART, TIMESTAMPTOSTRING(WINDOWEND, 'yyyy-MM-dd HH:mm:ss Z', 'UTC') AS WEND, ROWTIME, COUNT FROM AGGREGATE WHERE ROWKEY=10.1 AND WINDOWSTART=1580223282000;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 1580223282123, "key": 11.1, "value": {"val": 1}},
+        {"topic": "test_topic", "timestamp": 1580223282456, "key": 10.1, "value": {"val": 2}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ROWKEY` DOUBLE KEY, `WSTART` STRING, `WEND` STRING, `ROWTIME` BIGINT, `COUNT` BIGINT"}},
+          {"row":{"columns":[10.1, "2020-01-28 14:54:42 +0000", "2020-01-28 14:54:43 +0000", 1580223282456, 1]}}
+        ]}
+      ]
     }
   ]
 }

--- a/ksql-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
+++ b/ksql-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
@@ -299,6 +299,50 @@
           {"finalMessage":"Limit Reached"}
         ]}
       ]
+    },
+    {
+      "name": "windowed group by - window bounds in SELECT",
+      "statements": [
+        "CREATE STREAM TEST (ROWKEY INT KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "SELECT windowstart as wstart, windowend as wend, count(1) as count FROM test WINDOW TUMBLING (SIZE 1 SECOND) group by ROWKEY EMIT CHANGES LIMIT 2;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {}, "timestamp": 10345},
+        {"topic": "test_topic", "key": 0, "value": {}, "timestamp": 13251}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`WSTART` BIGINT, `WEND` BIGINT, `COUNT` BIGINT"}},
+          {"row":{"columns":[10000, 11000, 1]}},
+          {"row":{"columns":[13000, 14000, 1]}},
+          {"finalMessage":"Limit Reached"}
+        ]}
+      ]
+    },
+    {
+      "name": "windowed group by - window bounds in WHERE",
+      "statements": [
+        "CREATE STREAM TEST (ROWKEY INT KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "SELECT count(1) FROM test WINDOW TUMBLING (SIZE 1 SECOND) WHERE windowstart > 1000 AND windowend < 1000000000 group by ROWKEY EMIT CHANGES LIMIT 1;"
+      ],
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlErrorMessage",
+        "message": "Window bounds column TEST.WINDOWSTART can only be used in the SELECT clause of windowed aggregations",
+        "status": 400
+      }
+    },
+    {
+      "name": "windowed group by - window bounds in HAVING",
+      "statements": [
+        "CREATE STREAM TEST (ROWKEY INT KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "SELECT count(1) FROM test WINDOW TUMBLING (SIZE 1 SECOND) group by ROWKEY having min(windowstart) > 1000 EMIT CHANGES LIMIT 1;"
+      ],
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlErrorMessage",
+        "message": "Window bounds column TEST.WINDOWSTART can only be used in the SELECT clause of windowed aggregations",
+        "status": 400
+      }
     }
   ]
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PullQueryExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PullQueryExecutor.java
@@ -568,7 +568,7 @@ public final class PullQueryExecutor {
       final Stacker contextStacker
   ) {
     final boolean noSystemColumns = analysis.getSelectColumnRefs().stream()
-        .noneMatch(ref -> SchemaUtil.systemColumnNames().contains(ref));
+        .noneMatch(ref -> SchemaUtil.isSystemColumn(ref));
 
     final LogicalSchema intermediateSchema;
     final Function<TableRow, GenericRow> preSelectTransform;

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StepSchemaResolver.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StepSchemaResolver.java
@@ -142,7 +142,8 @@ public final class StepSchemaResolver {
     return buildAggregateSchema(
         schema,
         step.getNonAggregateColumns(),
-        step.getAggregationFunctions()
+        step.getAggregationFunctions(),
+        false
     );
   }
 
@@ -153,7 +154,8 @@ public final class StepSchemaResolver {
     return buildAggregateSchema(
         schema,
         step.getNonAggregateColumns(),
-        step.getAggregationFunctions()
+        step.getAggregationFunctions(),
+        true
     );
   }
 
@@ -240,7 +242,8 @@ public final class StepSchemaResolver {
     return buildAggregateSchema(
         schema,
         step.getNonAggregateColumns(),
-        step.getAggregationFunctions()
+        step.getAggregationFunctions(),
+        false
     );
   }
 
@@ -278,13 +281,15 @@ public final class StepSchemaResolver {
   private LogicalSchema buildAggregateSchema(
       final LogicalSchema schema,
       final List<ColumnName> nonAggregateColumns,
-      final List<FunctionCall> aggregationFunctions
+      final List<FunctionCall> aggregationFunctions,
+      final boolean windowedAggregation
   ) {
     return new AggregateParamsFactory().create(
         schema,
         nonAggregateColumns,
         functionRegistry,
-        aggregationFunctions
+        aggregationFunctions,
+        windowedAggregation
     ).getSchema();
   }
 

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamAggregateBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamAggregateBuilder.java
@@ -27,6 +27,7 @@ import io.confluent.ksql.execution.plan.KeySerdeFactory;
 import io.confluent.ksql.execution.plan.StreamAggregate;
 import io.confluent.ksql.execution.plan.StreamWindowedAggregate;
 import io.confluent.ksql.execution.streams.transform.KsTransformer;
+import io.confluent.ksql.execution.transform.KsqlProcessingContext;
 import io.confluent.ksql.execution.transform.KsqlTransformer;
 import io.confluent.ksql.execution.transform.window.WindowSelectMapper;
 import io.confluent.ksql.execution.windows.HoppingWindowExpression;
@@ -49,6 +50,7 @@ import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Named;
 import org.apache.kafka.streams.kstream.SessionWindows;
 import org.apache.kafka.streams.kstream.TimeWindows;
+import org.apache.kafka.streams.kstream.Window;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.state.KeyValueStore;
 
@@ -82,7 +84,8 @@ public final class StreamAggregateBuilder {
         sourceSchema,
         nonFuncColumns,
         queryBuilder.getFunctionRegistry(),
-        aggregate.getAggregationFunctions()
+        aggregate.getAggregationFunctions(),
+        false
     );
     final LogicalSchema aggregateSchema = aggregateParams.getAggregateSchema();
     final LogicalSchema resultSchema = aggregateParams.getSchema();
@@ -155,7 +158,8 @@ public final class StreamAggregateBuilder {
         sourceSchema,
         nonFuncColumns,
         queryBuilder.getFunctionRegistry(),
-        aggregate.getAggregationFunctions()
+        aggregate.getAggregationFunctions(),
+        true
     );
     final LogicalSchema aggregateSchema = aggregateParams.getAggregateSchema();
     final LogicalSchema resultSchema = aggregateParams.getSchema();
@@ -187,6 +191,19 @@ public final class StreamAggregateBuilder {
             resultSchema
         );
 
+    reduced = reduced.transformValues(
+        () -> new KsTransformer<>(new WindowBoundsPopulator()),
+        Named.as(StreamsUtil.buildOpName(
+            AggregateBuilderUtils.windowSelectContext(aggregate)
+        ) + "2")
+    );
+
+    materializationBuilder.map(
+        pl -> (KsqlTransformer) new WindowBoundsPopulator(),
+        resultSchema,
+        AggregateBuilderUtils.windowSelectContext(aggregate)
+    );
+
     final WindowSelectMapper windowSelectMapper = aggregateParams.getWindowSelectMapper();
     if (windowSelectMapper.hasSelects()) {
       reduced = reduced.transformValues(
@@ -196,7 +213,7 @@ public final class StreamAggregateBuilder {
 
       materializationBuilder.map(
           pl -> (KsqlTransformer) windowSelectMapper.getTransformer(),
-          aggregateSchema,
+          resultSchema,
           AggregateBuilderUtils.windowSelectContext(aggregate)
       );
     }
@@ -303,6 +320,26 @@ public final class StreamAggregateBuilder {
               materializedFactory.create(
                   keySerde, valueSerde, StreamsUtil.buildOpName(queryContext))
           );
+    }
+  }
+
+  private static final class WindowBoundsPopulator
+      implements KsqlTransformer<Windowed<Struct>, GenericRow> {
+
+    @Override
+    public GenericRow transform(
+        final Windowed<Struct> readOnlyKey,
+        final GenericRow value,
+        final KsqlProcessingContext ctx
+    ) {
+      if (value == null) {
+        return null;
+      }
+      final Window window = readOnlyKey.window();
+      value.ensureAdditionalCapacity(2);
+      value.append(window.start());
+      value.append(window.end());
+      return value;
     }
   }
 }

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StepSchemaResolverTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StepSchemaResolverTest.java
@@ -160,6 +160,8 @@ public class StepSchemaResolverTest {
         LogicalSchema.builder()
             .valueColumn(ColumnName.of("ORANGE"), SqlTypes.INTEGER)
             .valueColumn(ColumnName.aggregateColumn(0), SqlTypes.BIGINT)
+            .valueColumn(SchemaUtil.WINDOWSTART_NAME, SchemaUtil.WINDOWBOUND_TYPE)
+            .valueColumn(SchemaUtil.WINDOWEND_NAME, SchemaUtil.WINDOWBOUND_TYPE)
             .build())
     );
   }

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamAggregateBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamAggregateBuilderTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.clearInvocations;
@@ -77,7 +78,6 @@ import org.apache.kafka.streams.kstream.SessionWindowedKStream;
 import org.apache.kafka.streams.kstream.SessionWindows;
 import org.apache.kafka.streams.kstream.TimeWindowedKStream;
 import org.apache.kafka.streams.kstream.TimeWindows;
-import org.apache.kafka.streams.kstream.ValueTransformerWithKeySupplier;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.Windows;
 import org.apache.kafka.streams.state.KeyValueStore;
@@ -86,8 +86,6 @@ import org.apache.kafka.streams.state.WindowStore;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -156,7 +154,9 @@ public class StreamAggregateBuilderTest {
   @Mock
   private KTable<Windowed<Struct>, GenericRow> windowedWithResults;
   @Mock
-  private KTable<Windowed<Struct>, GenericRow> windowedWithWindowBoundaries;
+  private KTable<Windowed<Struct>, GenericRow> windowedWithWindowBounds;
+  @Mock
+  private KTable<Windowed<Struct>, GenericRow> windowedWithWindowUdafs;
   @Mock
   private KsqlQueryBuilder queryBuilder;
   @Mock
@@ -174,8 +174,6 @@ public class StreamAggregateBuilderTest {
   @Mock
   private WindowSelectMapper windowSelectMapper;
   @Mock
-  private KsqlTransformer<Windowed<Object>, GenericRow> windowSelectTransformer;
-  @Mock
   private Merger<Struct, GenericRow> merger;
   @Mock
   private MaterializedFactory materializedFactory;
@@ -191,9 +189,6 @@ public class StreamAggregateBuilderTest {
   private Materialized<Struct, GenericRow, SessionStore<Bytes, byte[]>> sessionWindowMaterialized;
   @Mock
   private ExecutionStep<KGroupedStreamHolder> sourceStep;
-  @Captor
-  private ArgumentCaptor<ValueTransformerWithKeySupplier<Windowed<Struct>, GenericRow, GenericRow>>
-      windowedTransformerCaptor;
   @Mock
   private KsqlProcessingContext ctx;
 
@@ -208,7 +203,7 @@ public class StreamAggregateBuilderTest {
     when(queryBuilder.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
     when(queryBuilder.buildValueSerde(any(), any(), any())).thenReturn(valueSerde);
     when(queryBuilder.getFunctionRegistry()).thenReturn(functionRegistry);
-    when(aggregateParamsFactory.create(any(), any(), any(), any()))
+    when(aggregateParamsFactory.create(any(), any(), any(), any(), anyBoolean()))
         .thenReturn(aggregateParams);
     when(aggregateParams.getAggregator()).thenReturn((KudafAggregator) aggregator);
     when(aggregateParams.getAggregateSchema()).thenReturn(AGGREGATE_SCHEMA);
@@ -258,6 +253,8 @@ public class StreamAggregateBuilderTest {
         .thenReturn(windowed);
     when(windowed.transformValues(any(), any(Named.class)))
         .thenReturn((KTable) windowedWithResults);
+    when(windowedWithResults.transformValues(any(), any(Named.class)))
+        .thenReturn((KTable) windowedWithWindowBounds);
   }
 
   private void givenTumblingWindowedAggregate() {
@@ -298,6 +295,9 @@ public class StreamAggregateBuilderTest {
         .thenReturn(windowed);
     when(windowed.transformValues(any(), any(Named.class)))
         .thenReturn((KTable) windowedWithResults);
+    when(windowedWithResults.transformValues(any(), any(Named.class)))
+        .thenReturn((KTable) windowedWithWindowBounds);
+
     windowedAggregate = new StreamWindowedAggregate(
         new ExecutionStepPropertiesV1(CTX),
         sourceStep,
@@ -345,7 +345,7 @@ public class StreamAggregateBuilderTest {
     final KTableHolder<Struct> result = aggregate.build(planBuilder);
 
     // Then:
-    assertCorrectMaterializationBuilder(result);
+    assertCorrectMaterializationBuilder(result, false);
   }
 
   @Test
@@ -413,7 +413,8 @@ public class StreamAggregateBuilderTest {
         INPUT_SCHEMA,
         NON_AGG_COLUMNS,
         functionRegistry,
-        FUNCTIONS
+        FUNCTIONS,
+        false
     );
   }
 
@@ -426,16 +427,18 @@ public class StreamAggregateBuilderTest {
     final KTableHolder<Windowed<Struct>> result = windowedAggregate.build(planBuilder);
 
     // Then:
-    assertThat(result.getTable(), is(windowedWithResults));
+    assertThat(result.getTable(), is(windowedWithWindowBounds));
     final InOrder inOrder = Mockito.inOrder(
         groupedStream,
         timeWindowedStream,
         windowed,
-        windowedWithResults
+        windowedWithResults,
+        windowedWithWindowBounds
     );
     inOrder.verify(groupedStream).windowedBy(TimeWindows.of(WINDOW));
     inOrder.verify(timeWindowedStream).aggregate(initializer, aggregator, timeWindowMaterialized);
     inOrder.verify(windowed).transformValues(any(), any(Named.class));
+    inOrder.verify(windowedWithResults).transformValues(any(), any(Named.class));
     inOrder.verifyNoMoreInteractions();
   }
 
@@ -448,16 +451,18 @@ public class StreamAggregateBuilderTest {
     final KTableHolder<Windowed<Struct>> result = windowedAggregate.build(planBuilder);
 
     // Then:
-    assertThat(result.getTable(), is(windowedWithResults));
+    assertThat(result.getTable(), is(windowedWithWindowBounds));
     final InOrder inOrder = Mockito.inOrder(
         groupedStream,
         timeWindowedStream,
         windowed,
-        windowedWithResults
+        windowedWithResults,
+        windowedWithWindowBounds
     );
     inOrder.verify(groupedStream).windowedBy(TimeWindows.of(WINDOW).advanceBy(HOP));
     inOrder.verify(timeWindowedStream).aggregate(initializer, aggregator, timeWindowMaterialized);
     inOrder.verify(windowed).transformValues(any(), any(Named.class));
+    inOrder.verify(windowedWithResults).transformValues(any(), any(Named.class));
     inOrder.verifyNoMoreInteractions();
   }
 
@@ -470,12 +475,13 @@ public class StreamAggregateBuilderTest {
     final KTableHolder<Windowed<Struct>> result = windowedAggregate.build(planBuilder);
 
     // Then:
-    assertThat(result.getTable(), is(windowedWithResults));
+    assertThat(result.getTable(), is(windowedWithWindowBounds));
     final InOrder inOrder = Mockito.inOrder(
         groupedStream,
         sessionWindowedStream,
         windowed,
-        windowedWithResults
+        windowedWithResults,
+        windowedWithWindowBounds
     );
     inOrder.verify(groupedStream).windowedBy(SessionWindows.with(WINDOW));
     inOrder.verify(sessionWindowedStream).aggregate(
@@ -485,6 +491,7 @@ public class StreamAggregateBuilderTest {
         sessionWindowMaterialized
     );
     inOrder.verify(windowed).transformValues(any(), any(Named.class));
+    inOrder.verify(windowedWithResults).transformValues(any(), any(Named.class));
     inOrder.verifyNoMoreInteractions();
   }
 
@@ -497,7 +504,7 @@ public class StreamAggregateBuilderTest {
     final KTableHolder<?> result = windowedAggregate.build(planBuilder);
 
     // Then:
-    assertCorrectMaterializationBuilder(result);
+    assertCorrectMaterializationBuilder(result, true);
   }
 
   @Test
@@ -618,7 +625,7 @@ public class StreamAggregateBuilderTest {
           aggregated,
           aggregateParamsFactory
       );
-      when(aggregateParamsFactory.create(any(), any(), any(), any()))
+      when(aggregateParamsFactory.create(any(), any(), any(), any(), anyBoolean()))
           .thenReturn(aggregateParams);
       given.run();
 
@@ -627,7 +634,7 @@ public class StreamAggregateBuilderTest {
 
       // Then:
       verify(aggregateParamsFactory)
-          .create(INPUT_SCHEMA, NON_AGG_COLUMNS, functionRegistry, FUNCTIONS);
+          .create(INPUT_SCHEMA, NON_AGG_COLUMNS, functionRegistry, FUNCTIONS, true);
     }
   }
 
@@ -636,11 +643,11 @@ public class StreamAggregateBuilderTest {
   public void shouldAddWindowBoundariesIfSpecified() {
     for (final Runnable given : given()) {
       // Given:
-      clearInvocations(
-          groupedStream, timeWindowedStream, sessionWindowedStream, windowed, windowedWithResults);
+      clearInvocations(groupedStream, timeWindowedStream, sessionWindowedStream, windowed,
+          windowedWithResults, windowedWithWindowBounds);
       when(windowSelectMapper.hasSelects()).thenReturn(true);
-      when(windowedWithResults.transformValues(any(), any(Named.class))).thenReturn(
-          (KTable) windowedWithWindowBoundaries);
+      when(windowedWithWindowBounds.transformValues(any(), any(Named.class))).thenReturn(
+          (KTable) windowedWithWindowUdafs);
       given.run();
 
       // When:
@@ -648,20 +655,22 @@ public class StreamAggregateBuilderTest {
           windowedAggregate.build(planBuilder);
 
       // Then:
-      assertThat(result.getTable(), is(windowedWithWindowBoundaries));
-      verify(windowedWithResults)
-          .transformValues(windowedTransformerCaptor.capture(), any(Named.class));
+      assertThat(result.getTable(), is(windowedWithWindowUdafs));
+      verify(windowedWithWindowBounds).transformValues(any(), any(Named.class));
     }
   }
 
-  private void assertCorrectMaterializationBuilder(final KTableHolder<?> result) {
+  private void assertCorrectMaterializationBuilder(
+      final KTableHolder<?> result,
+      final boolean windowed
+  ) {
     assertThat(result.getMaterializationBuilder().isPresent(), is(true));
 
     final MaterializationInfo info = result.getMaterializationBuilder().get().build();
     assertThat(info.stateStoreName(), equalTo("agg-regate-Materialize"));
     assertThat(info.getSchema(), equalTo(OUTPUT_SCHEMA));
     assertThat(info.getStateStoreSchema(), equalTo(AGGREGATE_SCHEMA));
-    assertThat(info.getTransforms(), hasSize(1));
+    assertThat(info.getTransforms(), hasSize(1 + (windowed ? 1 : 0)));
 
     final MapperInfo aggMapInfo = (MapperInfo) info.getTransforms().get(0);
     final KsqlTransformer<Object, GenericRow> mapper = aggMapInfo.getMapper(name -> null);


### PR DESCRIPTION
### Description 

Fixes bits of https://github.com/confluentinc/ksql/issues/4397

KSQL currently lets you take a non-windowed stream and perform a windowed group by:

```sql
CREATE TABLE T as SELECT stuff FROM S WINDOW TUMBLING (SIZE 1 SECOND) group by something;
```

Which is essentially grouping by not just `something`, but also implicitly by the window bounds.

This might be more correctly written with a Tumbling table function:

```sql
CREATE TABLE T as SELECT stuff FROM Tumbling(S, SIZE 1 SECOND) group by something, windowstart, windowend;
```

Where the Tumbling table function returns one row for each row in `S`, with the addition of the `windowstart` and `windowend` columns.   (Note: Hopping and session table functions are also possible, though in the case of the latter the table function would also emit retractions).

In a correct SQL model `windowstart` and `windowend` would therefore be available as fields within the selection, e.g.

```
CREATE TABLE T as SELECT windowstart, windowend, something, count() FROM Tumbling(S, SIZE 1 SECOND) group by something, windowstart, windowend;
```

This change makes such awesomeness possible.

### How to review.

The changes, TBH, feel a little hacky.  They're too spread around the code base. However, without some restructuring there's little choice but to hack the window bounds in. The planned structured keys work will improve things, and we probably need to rethink windowing at some point.   That said, reviewing notes are:

1. `QueryAnalyser` has been enhanced to also pass WHERE expressions to the aggregate analyser, so that it can throw on any window bounds columns.
1. `AggregateAnalyzer` has been enhanced to throw if the window bound columns are used anywhere but in the select of windowed group by statements. (We'll need a Streams change to support anything else).
1. `Analysis.getFromSourceSchemas` now takes a boolean flag to indicate if the returned schemas should, for windowed group bys, include the window bounds columns.  Basically, the window bound columns are only available post the aggregation.  A lot of the code passes `true` to get the schema with the window bounds in it, and relying on the fact that the `AggregateAnalyzer` has already rejected anything invalid.
1. `AggregateNode` and `LogicalPlanner` have some magic to handle the special window bounds columns, where appropriate.
1. `AggregateParamsFactory` now takes a flag to indicate a windowed group by, and adds appropriate window bounds columns to the result schema.
1. `StreamAggregateBuilder` adds a new `transformValues` step to populate the window bounds values from the windowed key.  

Note: there are some expected topology changes, but these will mostly be reverted by a follow on PR and are also backwards compatible.  The topologies also include a dubiously named `Aggregate-Aggregate-WindowSelect2` node. This will also go in the follow up PR.

### Testing done 

Suitable tests added for pull, push and persistent queries.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

