### PR TITLE
chore: include support metrics in the project

### DIFF
--- a/ksql-engine/pom.xml
+++ b/ksql-engine/pom.xml
@@ -44,11 +44,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.confluent.support</groupId>
-            <artifactId>support-metrics-common</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>io.confluent.ksql</groupId>
             <artifactId>ksql-serde</artifactId>
         </dependency>

--- a/ksql-version-metrics-client/pom.xml
+++ b/ksql-version-metrics-client/pom.xml
@@ -30,11 +30,6 @@
     <dependencies>
 
         <dependency>
-            <groupId>io.confluent.support</groupId>
-            <artifactId>support-metrics-common</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>io.confluent.ksql</groupId>
             <artifactId>ksql-common</artifactId>
         </dependency>

--- a/ksql-version-metrics-client/pom.xml
+++ b/ksql-version-metrics-client/pom.xml
@@ -67,6 +67,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpmime</artifactId>
+            <version>4.5.2</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-client-java</artifactId>
             <version>3.10.4</version>

--- a/ksql-version-metrics-client/src/main/java/io/confluent/ksql/version/metrics/KsqlVersionChecker.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/ksql/version/metrics/KsqlVersionChecker.java
@@ -20,7 +20,6 @@ import io.confluent.ksql.version.metrics.collector.KsqlModuleType;
 import io.confluent.support.metrics.BaseMetricsReporter;
 import io.confluent.support.metrics.BaseSupportConfig;
 import io.confluent.support.metrics.common.Collector;
-import io.confluent.support.metrics.submitters.Submitter;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
@@ -48,19 +47,6 @@ public class KsqlVersionChecker extends BaseMetricsReporter {
     Objects.requireNonNull(serverRuntime, "serverRuntime is required");
     serverRuntime.addShutdownHook(new Thread(() -> shuttingDown.set(true)));
     this.metricsCollector = new BasicCollector(moduleType, activenessStatusSupplier);
-  }
-
-  // This is used when collecting metrics in a kafka topic. Since KSQL isn't aware of ZK, we are
-  // returning null here to disable KafkaSubmitter and also turning off topic metrics collection in
-  // KsqlVersionCheckerConfig.
-  @Override
-  protected Submitter createKafkaSubmitter(final String supportTopic) {
-    return null;
-  }
-
-  @Override
-  protected boolean kafkaSubmitterReady(final String supportTopic) {
-    return false;
   }
 
   @Override

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/BaseMetricsReporter.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/BaseMetricsReporter.java
@@ -1,0 +1,239 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.support.metrics;
+
+import org.apache.avro.generic.GenericContainer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Objects;
+
+import io.confluent.support.metrics.common.Collector;
+import io.confluent.support.metrics.serde.AvroSerializer;
+import io.confluent.support.metrics.submitters.ConfluentSubmitter;
+import io.confluent.support.metrics.submitters.ResponseHandler;
+import io.confluent.support.metrics.submitters.Submitter;
+import io.confluent.support.metrics.utils.Jitter;
+
+/**
+ * Periodically reports metrics collected from a Kafka broker.
+ *
+ * <p>Metrics are being reported to a Kafka topic within the same cluster and/or to Confluent via
+ * the Internet.
+ *
+ * <p>This class is not thread-safe.
+ */
+public abstract class BaseMetricsReporter extends Thread implements Closeable {
+
+    private static final Logger log = LoggerFactory.getLogger(BaseMetricsReporter.class);
+
+    /**
+     * Default "retention.ms" setting (i.e. time-based retention) of the support metrics topic. Used
+     * when creating the topic in case it doesn't exist yet.
+     */
+    protected static final long RETENTION_MS = 365 * 24 * 60 * 60 * 1000L;
+
+    /**
+     * Default replication factor of the support metrics topic. Used when creating the topic in case
+     * it doesn't exist yet.
+     */
+    public static final int SUPPORT_TOPIC_REPLICATION = 3;
+
+    /**
+     * Default number of partitions of the support metrics topic. Used when creating the topic in case
+     * it doesn't exist yet.
+     */
+    protected static final int SUPPORT_TOPIC_PARTITIONS = 1;
+
+    /**
+     * Length of the wait period we give the server to start up completely (in a different thread)
+     * before we begin metrics collection.
+     */
+    private static final long SETTLING_TIME_MS = 10 * 1000L;
+    private final boolean enableSettlingTime;
+
+    private String customerId;
+    private long reportIntervalMs;
+    private String supportTopic;
+    private Submitter kafkaSubmitter;
+    private Submitter confluentSubmitter;
+    private Collector metricsCollector;
+    private final AvroSerializer encoder = new AvroSerializer();
+    protected final BaseSupportConfig supportConfig;
+    private final ResponseHandler responseHandler;
+    private volatile boolean isClosing = false;
+
+    public BaseMetricsReporter(String threadName,
+            boolean isDaemon,
+            BaseSupportConfig serverConfiguration) {
+        this(threadName, isDaemon, serverConfiguration, null, true);
+    }
+
+    /**
+     * @param supportConfig The properties this server was created from, plus extra Proactive Support
+     *     (PS) one Note that Kafka does not understand PS properties, hence server->KafkaConfig()
+     *     does not contain any of them, necessitating passing this extra argument to the API.
+     * @param responseHandler Http Response Handler
+     * @param enableSettlingTime Enable settling time before starting metrics
+     */
+    public BaseMetricsReporter(String threadName,
+            boolean isDaemon,
+            BaseSupportConfig supportConfig,
+            ResponseHandler responseHandler,
+            boolean enableSettlingTime) {
+        super(threadName);
+        setDaemon(isDaemon);
+        Objects.requireNonNull(supportConfig, "supportConfig can't be null");
+        this.supportConfig = supportConfig;
+        this.responseHandler = responseHandler;
+        this.enableSettlingTime = enableSettlingTime;
+    }
+
+    public void init() {
+        customerId = supportConfig.getCustomerId();
+        metricsCollector = metricsCollector();
+        metricsCollector.setRuntimeState(Collector.RuntimeState.Running);
+
+        reportIntervalMs = supportConfig.getReportIntervalMs();
+        supportTopic = supportConfig.getKafkaTopic();
+
+        if (!supportTopic.isEmpty()) {
+            kafkaSubmitter = createKafkaSubmitter(supportTopic);
+        } else {
+            kafkaSubmitter = null;
+        }
+
+        String endpointHTTP = supportConfig.getEndpointHTTP();
+        String endpointHTTPS = supportConfig.getEndpointHTTPS();
+        String proxyURI = supportConfig.getProxy();
+
+        if (!endpointHTTP.isEmpty() || !endpointHTTPS.isEmpty()) {
+            confluentSubmitter = new ConfluentSubmitter(customerId, endpointHTTP, endpointHTTPS,
+                    proxyURI, responseHandler);
+        } else {
+            confluentSubmitter = null;
+        }
+
+        if (!reportingEnabled()) {
+            log.info("Metrics collection disabled by component configuration");
+        }
+    }
+
+    protected abstract Submitter createKafkaSubmitter(String supportTopic);
+
+    protected abstract boolean kafkaSubmitterReady(String supportTopic);
+
+    protected abstract Collector metricsCollector();
+
+    protected boolean reportingEnabled() {
+        return sendToKafkaEnabled() || sendToConfluentEnabled();
+    }
+
+    protected boolean sendToKafkaEnabled() {
+        return kafkaSubmitter != null;
+    }
+
+    protected boolean sendToConfluentEnabled() {
+        return confluentSubmitter != null;
+    }
+
+    @Override
+    public void run() {
+        try {
+            if (reportingEnabled()) {
+                waitForServer();
+                while (!isClosing) {
+                    log.info("Attempting to collect and submit metrics");
+                    submitMetrics();
+                    Thread.sleep(Jitter.addOnePercentJitter(reportIntervalMs));
+                }
+            }
+        } catch (InterruptedException e) {
+            log.error("Caught InterruptedException during metrics collection", e);
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            log.error("Caught exception during metrics collection", e);
+        } finally {
+            if (isClosing) {
+                log.info("Gracefully terminating metrics collection");
+                metricsCollector.setRuntimeState(Collector.RuntimeState.ShuttingDown);
+                submitMetrics();
+            }
+            log.info("Metrics collection stopped");
+        }
+    }
+
+    @Override
+    public void close() {
+        log.info("Closing BaseMetricsReporter");
+        isClosing = true;
+        interrupt();
+    }
+
+    // Waits for the monitored service to fully start up.
+    private void waitForServer() throws InterruptedException {
+        log.info("Waiting until monitored service is ready for metrics collection");
+        while (!isClosing && !isReadyForMetricsCollection() && !isShuttingDown()) {
+            if (enableSettlingTime) {
+                long waitTimeMs = Jitter.addOnePercentJitter(SETTLING_TIME_MS);
+                log.info("Waiting {} ms for the monitored service to finish starting up", waitTimeMs);
+                Thread.sleep(waitTimeMs);
+            }
+        }
+        if (isShuttingDown()) {
+            close();
+        } else {
+            log.info("Monitored service is now ready");
+        }
+    }
+
+    protected abstract boolean isReadyForMetricsCollection();
+
+    protected abstract boolean isShuttingDown();
+
+    // package-private for tests
+    void submitMetrics() {
+        byte[] encodedMetricsRecord = null;
+        GenericContainer metricsRecord = metricsCollector.collectMetrics();
+        try {
+            encodedMetricsRecord = encoder.serialize(metricsRecord);
+        } catch (IOException e) {
+            log.error("Could not serialize metrics record: {}", e.toString());
+        }
+
+        try {
+            if (sendToKafkaEnabled() && encodedMetricsRecord != null) {
+                // attempt to create the topic. If failures occur, try again in the next round, however
+                // the current batch of metrics will be lost.
+                if (kafkaSubmitterReady(supportTopic)) {
+                    kafkaSubmitter.submit(encodedMetricsRecord);
+                }
+            }
+        } catch (RuntimeException e) {
+            log.error("Could not submit metrics to Kafka topic {}: {}", supportTopic, e.getMessage());
+        }
+
+        try {
+            if (sendToConfluentEnabled() && encodedMetricsRecord != null) {
+                confluentSubmitter.submit(encodedMetricsRecord);
+            }
+        } catch (RuntimeException e) {
+            log.error("Could not submit metrics to Confluent: {}", e.getMessage());
+        }
+    }
+
+}

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/BaseMetricsReporter.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/BaseMetricsReporter.java
@@ -1,15 +1,16 @@
-/**
- * Copyright 2015 Confluent Inc.
+/*
+ * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 
 package io.confluent.support.metrics;

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/BaseMetricsReporter.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/BaseMetricsReporter.java
@@ -15,20 +15,18 @@
 
 package io.confluent.support.metrics;
 
-import org.apache.avro.generic.GenericContainer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.Closeable;
-import java.io.IOException;
-import java.util.Objects;
-
 import io.confluent.support.metrics.common.Collector;
 import io.confluent.support.metrics.serde.AvroSerializer;
 import io.confluent.support.metrics.submitters.ConfluentSubmitter;
 import io.confluent.support.metrics.submitters.ResponseHandler;
 import io.confluent.support.metrics.submitters.Submitter;
 import io.confluent.support.metrics.utils.Jitter;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Objects;
+import org.apache.avro.generic.GenericContainer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Periodically reports metrics collected from a Kafka broker.
@@ -40,201 +38,203 @@ import io.confluent.support.metrics.utils.Jitter;
  */
 public abstract class BaseMetricsReporter extends Thread implements Closeable {
 
-    private static final Logger log = LoggerFactory.getLogger(BaseMetricsReporter.class);
+  private static final Logger log = LoggerFactory.getLogger(BaseMetricsReporter.class);
 
-    /**
-     * Default "retention.ms" setting (i.e. time-based retention) of the support metrics topic. Used
-     * when creating the topic in case it doesn't exist yet.
-     */
-    protected static final long RETENTION_MS = 365 * 24 * 60 * 60 * 1000L;
+  /**
+   * Default "retention.ms" setting (i.e. time-based retention) of the support metrics topic. Used
+   * when creating the topic in case it doesn't exist yet.
+   */
+  protected static final long RETENTION_MS = 365 * 24 * 60 * 60 * 1000L;
 
-    /**
-     * Default replication factor of the support metrics topic. Used when creating the topic in case
-     * it doesn't exist yet.
-     */
-    public static final int SUPPORT_TOPIC_REPLICATION = 3;
+  /**
+   * Default replication factor of the support metrics topic. Used when creating the topic in case
+   * it doesn't exist yet.
+   */
+  public static final int SUPPORT_TOPIC_REPLICATION = 3;
 
-    /**
-     * Default number of partitions of the support metrics topic. Used when creating the topic in case
-     * it doesn't exist yet.
-     */
-    protected static final int SUPPORT_TOPIC_PARTITIONS = 1;
+  /**
+   * Default number of partitions of the support metrics topic. Used when creating the topic in case
+   * it doesn't exist yet.
+   */
+  protected static final int SUPPORT_TOPIC_PARTITIONS = 1;
 
-    /**
-     * Length of the wait period we give the server to start up completely (in a different thread)
-     * before we begin metrics collection.
-     */
-    private static final long SETTLING_TIME_MS = 10 * 1000L;
-    private final boolean enableSettlingTime;
+  /**
+   * Length of the wait period we give the server to start up completely (in a different thread)
+   * before we begin metrics collection.
+   */
+  private static final long SETTLING_TIME_MS = 10 * 1000L;
+  private final boolean enableSettlingTime;
 
-    private String customerId;
-    private long reportIntervalMs;
-    private String supportTopic;
-    private Submitter kafkaSubmitter;
-    private Submitter confluentSubmitter;
-    private Collector metricsCollector;
-    private final AvroSerializer encoder = new AvroSerializer();
-    protected final BaseSupportConfig supportConfig;
-    private final ResponseHandler responseHandler;
-    private volatile boolean isClosing = false;
+  private String customerId;
+  private long reportIntervalMs;
+  private String supportTopic;
+  private Submitter kafkaSubmitter;
+  private Submitter confluentSubmitter;
+  private Collector metricsCollector;
+  private final AvroSerializer encoder = new AvroSerializer();
+  protected final BaseSupportConfig supportConfig;
+  private final ResponseHandler responseHandler;
+  private volatile boolean isClosing = false;
 
-    public BaseMetricsReporter(String threadName,
-            boolean isDaemon,
-            BaseSupportConfig serverConfiguration) {
-        this(threadName, isDaemon, serverConfiguration, null, true);
+  public BaseMetricsReporter(final String threadName,
+      final boolean isDaemon,
+      final BaseSupportConfig serverConfiguration) {
+    this(threadName, isDaemon, serverConfiguration, null, true);
+  }
+
+  /**
+   * @param supportConfig The properties this server was created from, plus extra Proactive Support
+   *     (PS) one Note that Kafka does not understand PS properties, hence server->KafkaConfig()
+   *     does not contain any of them, necessitating passing this extra argument to the API.
+   * @param responseHandler Http Response Handler
+   * @param enableSettlingTime Enable settling time before starting metrics
+   */
+  public BaseMetricsReporter(final String threadName,
+      final boolean isDaemon,
+      final BaseSupportConfig supportConfig,
+      final ResponseHandler responseHandler,
+      final boolean enableSettlingTime) {
+    super(threadName);
+    setDaemon(isDaemon);
+    Objects.requireNonNull(supportConfig, "supportConfig can't be null");
+    this.supportConfig = supportConfig;
+    this.responseHandler = responseHandler;
+    this.enableSettlingTime = enableSettlingTime;
+  }
+
+  public void init() {
+    customerId = supportConfig.getCustomerId();
+    metricsCollector = metricsCollector();
+    metricsCollector.setRuntimeState(Collector.RuntimeState.Running);
+
+    reportIntervalMs = supportConfig.getReportIntervalMs();
+    supportTopic = supportConfig.getKafkaTopic();
+
+    if (!supportTopic.isEmpty()) {
+      kafkaSubmitter = createKafkaSubmitter(supportTopic);
+    } else {
+      kafkaSubmitter = null;
     }
 
-    /**
-     * @param supportConfig The properties this server was created from, plus extra Proactive Support
-     *     (PS) one Note that Kafka does not understand PS properties, hence server->KafkaConfig()
-     *     does not contain any of them, necessitating passing this extra argument to the API.
-     * @param responseHandler Http Response Handler
-     * @param enableSettlingTime Enable settling time before starting metrics
-     */
-    public BaseMetricsReporter(String threadName,
-            boolean isDaemon,
-            BaseSupportConfig supportConfig,
-            ResponseHandler responseHandler,
-            boolean enableSettlingTime) {
-        super(threadName);
-        setDaemon(isDaemon);
-        Objects.requireNonNull(supportConfig, "supportConfig can't be null");
-        this.supportConfig = supportConfig;
-        this.responseHandler = responseHandler;
-        this.enableSettlingTime = enableSettlingTime;
+    final String endpointHttp = supportConfig.getEndpointHttp();
+    final String endpointHttps = supportConfig.getEndpointHttps();
+    final String proxyURI = supportConfig.getProxy();
+
+    if (!endpointHttp.isEmpty() || !endpointHttps.isEmpty()) {
+      confluentSubmitter = new ConfluentSubmitter(customerId, endpointHttp, endpointHttps,
+          proxyURI, responseHandler);
+    } else {
+      confluentSubmitter = null;
     }
 
-    public void init() {
-        customerId = supportConfig.getCustomerId();
-        metricsCollector = metricsCollector();
-        metricsCollector.setRuntimeState(Collector.RuntimeState.Running);
+    if (!reportingEnabled()) {
+      log.info("Metrics collection disabled by component configuration");
+    }
+  }
 
-        reportIntervalMs = supportConfig.getReportIntervalMs();
-        supportTopic = supportConfig.getKafkaTopic();
+  protected abstract Submitter createKafkaSubmitter(String supportTopic);
 
-        if (!supportTopic.isEmpty()) {
-            kafkaSubmitter = createKafkaSubmitter(supportTopic);
-        } else {
-            kafkaSubmitter = null;
+  protected abstract boolean kafkaSubmitterReady(String supportTopic);
+
+  protected abstract Collector metricsCollector();
+
+  protected boolean reportingEnabled() {
+    return sendToKafkaEnabled() || sendToConfluentEnabled();
+  }
+
+  protected boolean sendToKafkaEnabled() {
+    return kafkaSubmitter != null;
+  }
+
+  protected boolean sendToConfluentEnabled() {
+    return confluentSubmitter != null;
+  }
+
+  @Override
+  public void run() {
+    try {
+      if (reportingEnabled()) {
+        waitForServer();
+        while (!isClosing) {
+          log.info("Attempting to collect and submit metrics");
+          submitMetrics();
+          Thread.sleep(Jitter.addOnePercentJitter(reportIntervalMs));
         }
+      }
+    } catch (InterruptedException e) {
+      log.error("Caught InterruptedException during metrics collection", e);
+      Thread.currentThread().interrupt();
+    } catch (Exception e) {
+      log.error("Caught exception during metrics collection", e);
+    } finally {
+      if (isClosing) {
+        log.info("Gracefully terminating metrics collection");
+        metricsCollector.setRuntimeState(Collector.RuntimeState.ShuttingDown);
+        submitMetrics();
+      }
+      log.info("Metrics collection stopped");
+    }
+  }
 
-        String endpointHTTP = supportConfig.getEndpointHTTP();
-        String endpointHTTPS = supportConfig.getEndpointHTTPS();
-        String proxyURI = supportConfig.getProxy();
+  @Override
+  public void close() {
+    log.info("Closing BaseMetricsReporter");
+    isClosing = true;
+    interrupt();
+  }
 
-        if (!endpointHTTP.isEmpty() || !endpointHTTPS.isEmpty()) {
-            confluentSubmitter = new ConfluentSubmitter(customerId, endpointHTTP, endpointHTTPS,
-                    proxyURI, responseHandler);
-        } else {
-            confluentSubmitter = null;
-        }
+  // Waits for the monitored service to fully start up.
+  private void waitForServer() throws InterruptedException {
+    log.info("Waiting until monitored service is ready for metrics collection");
+    while (!isClosing && !isReadyForMetricsCollection() && !isShuttingDown()) {
+      if (enableSettlingTime) {
+        final long waitTimeMs = Jitter.addOnePercentJitter(SETTLING_TIME_MS);
+        log.info("Waiting {} ms for the monitored service to finish starting up",
+            waitTimeMs);
+        Thread.sleep(waitTimeMs);
+      }
+    }
+    if (isShuttingDown()) {
+      close();
+    } else {
+      log.info("Monitored service is now ready");
+    }
+  }
 
-        if (!reportingEnabled()) {
-            log.info("Metrics collection disabled by component configuration");
-        }
+  protected abstract boolean isReadyForMetricsCollection();
+
+  protected abstract boolean isShuttingDown();
+
+  // package-private for tests
+  void submitMetrics() {
+    byte[] encodedMetricsRecord = null;
+    final GenericContainer metricsRecord = metricsCollector.collectMetrics();
+    try {
+      encodedMetricsRecord = encoder.serialize(metricsRecord);
+    } catch (IOException e) {
+      log.error("Could not serialize metrics record: {}", e.toString());
     }
 
-    protected abstract Submitter createKafkaSubmitter(String supportTopic);
-
-    protected abstract boolean kafkaSubmitterReady(String supportTopic);
-
-    protected abstract Collector metricsCollector();
-
-    protected boolean reportingEnabled() {
-        return sendToKafkaEnabled() || sendToConfluentEnabled();
-    }
-
-    protected boolean sendToKafkaEnabled() {
-        return kafkaSubmitter != null;
-    }
-
-    protected boolean sendToConfluentEnabled() {
-        return confluentSubmitter != null;
-    }
-
-    @Override
-    public void run() {
-        try {
-            if (reportingEnabled()) {
-                waitForServer();
-                while (!isClosing) {
-                    log.info("Attempting to collect and submit metrics");
-                    submitMetrics();
-                    Thread.sleep(Jitter.addOnePercentJitter(reportIntervalMs));
-                }
-            }
-        } catch (InterruptedException e) {
-            log.error("Caught InterruptedException during metrics collection", e);
-            Thread.currentThread().interrupt();
-        } catch (Exception e) {
-            log.error("Caught exception during metrics collection", e);
-        } finally {
-            if (isClosing) {
-                log.info("Gracefully terminating metrics collection");
-                metricsCollector.setRuntimeState(Collector.RuntimeState.ShuttingDown);
-                submitMetrics();
-            }
-            log.info("Metrics collection stopped");
+    try {
+      if (sendToKafkaEnabled() && encodedMetricsRecord != null) {
+        // attempt to create the topic. If failures occur, try again in the next round, however
+        // the current batch of metrics will be lost.
+        if (kafkaSubmitterReady(supportTopic)) {
+          kafkaSubmitter.submit(encodedMetricsRecord);
         }
+      }
+    } catch (RuntimeException e) {
+      log.error("Could not submit metrics to Kafka topic {}: {}", supportTopic,
+          e.getMessage());
     }
 
-    @Override
-    public void close() {
-        log.info("Closing BaseMetricsReporter");
-        isClosing = true;
-        interrupt();
+    try {
+      if (sendToConfluentEnabled() && encodedMetricsRecord != null) {
+        confluentSubmitter.submit(encodedMetricsRecord);
+      }
+    } catch (RuntimeException e) {
+      log.error("Could not submit metrics to Confluent: {}", e.getMessage());
     }
-
-    // Waits for the monitored service to fully start up.
-    private void waitForServer() throws InterruptedException {
-        log.info("Waiting until monitored service is ready for metrics collection");
-        while (!isClosing && !isReadyForMetricsCollection() && !isShuttingDown()) {
-            if (enableSettlingTime) {
-                long waitTimeMs = Jitter.addOnePercentJitter(SETTLING_TIME_MS);
-                log.info("Waiting {} ms for the monitored service to finish starting up", waitTimeMs);
-                Thread.sleep(waitTimeMs);
-            }
-        }
-        if (isShuttingDown()) {
-            close();
-        } else {
-            log.info("Monitored service is now ready");
-        }
-    }
-
-    protected abstract boolean isReadyForMetricsCollection();
-
-    protected abstract boolean isShuttingDown();
-
-    // package-private for tests
-    void submitMetrics() {
-        byte[] encodedMetricsRecord = null;
-        GenericContainer metricsRecord = metricsCollector.collectMetrics();
-        try {
-            encodedMetricsRecord = encoder.serialize(metricsRecord);
-        } catch (IOException e) {
-            log.error("Could not serialize metrics record: {}", e.toString());
-        }
-
-        try {
-            if (sendToKafkaEnabled() && encodedMetricsRecord != null) {
-                // attempt to create the topic. If failures occur, try again in the next round, however
-                // the current batch of metrics will be lost.
-                if (kafkaSubmitterReady(supportTopic)) {
-                    kafkaSubmitter.submit(encodedMetricsRecord);
-                }
-            }
-        } catch (RuntimeException e) {
-            log.error("Could not submit metrics to Kafka topic {}: {}", supportTopic, e.getMessage());
-        }
-
-        try {
-            if (sendToConfluentEnabled() && encodedMetricsRecord != null) {
-                confluentSubmitter.submit(encodedMetricsRecord);
-            }
-        } catch (RuntimeException e) {
-            log.error("Could not submit metrics to Confluent: {}", e.getMessage());
-        }
-    }
+  }
 
 }

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/BaseSupportConfig.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/BaseSupportConfig.java
@@ -72,7 +72,7 @@ public abstract class BaseSupportConfig {
       "confluent.support.metrics.topic";
   private static final String CONFLUENT_SUPPORT_METRICS_TOPIC_DOC =
       "Internal topic used for metric collection. If missing, metrics will not be collected in a "
-      + "Kafka topic ";
+          + "Kafka topic ";
   public static final String CONFLUENT_SUPPORT_METRICS_TOPIC_DEFAULT =
       "__confluent.support.metrics";
 
@@ -104,8 +104,8 @@ public abstract class BaseSupportConfig {
 
 
   /**
-   * Confluent endpoints. These are internal properties that cannot be set from a config file
-   * but that are added to the original config file at startup time
+   * Confluent endpoints. These are internal properties that cannot be set from a config file but
+   * that are added to the original config file at startup time
    */
   public static final String CONFLUENT_SUPPORT_METRICS_ENDPOINT_INSECURE_CONFIG =
       "confluent.support.metrics.endpoint.insecure";
@@ -133,7 +133,7 @@ public abstract class BaseSupportConfig {
    * Returns the default Proactive Support properties
    */
   protected Properties getDefaultProps() {
-    Properties props = new Properties();
+    final Properties props = new Properties();
     props.setProperty(
         CONFLUENT_SUPPORT_METRICS_ENABLE_CONFIG,
         CONFLUENT_SUPPORT_METRICS_ENABLE_DEFAULT
@@ -159,26 +159,25 @@ public abstract class BaseSupportConfig {
     return props;
   }
 
-
-  // TODO(apovzner) remove this after all derived classes use constructor with endpointPath
-  public BaseSupportConfig(Properties originals) {
+  public BaseSupportConfig(final Properties originals) {
     mergeAndValidateWithDefaultProperties(originals, null);
   }
 
-  public BaseSupportConfig(Properties originals, String endpointPath) {
+  public BaseSupportConfig(final Properties originals, final String endpointPath) {
     mergeAndValidateWithDefaultProperties(originals, endpointPath);
   }
 
   /**
-   * Takes default properties from getDefaultProps() and a set of override properties and
-   * returns a merged properties object, where the defaults are overridden.
-   * Sanitizes and validates the returned properties
+   * Takes default properties from getDefaultProps() and a set of override properties and returns a
+   * merged properties object, where the defaults are overridden. Sanitizes and validates the
+   * returned properties
    *
    * @param overrides Parameters that override the default properties
    */
-  private void mergeAndValidateWithDefaultProperties(Properties overrides, String endpointPath) {
-    Properties defaults = getDefaultProps();
-    Properties props;
+  private void mergeAndValidateWithDefaultProperties(final Properties overrides,
+      final String endpointPath) {
+    final Properties defaults = getDefaultProps();
+    final Properties props;
 
     if (overrides == null) {
       props = defaults;
@@ -194,77 +193,78 @@ public abstract class BaseSupportConfig {
     props.remove(CONFLUENT_SUPPORT_METRICS_ENDPOINT_INSECURE_CONFIG);
     props.remove(CONFLUENT_SUPPORT_METRICS_ENDPOINT_SECURE_CONFIG);
 
-    String customerId = getCustomerId();
+    final String customerId = getCustomerId();
 
     // new way to set endpoint
     if (endpointPath != null) {
       // derived class provided URI
       if (isHttpEnabled()) {
-        setEndpointHTTP(getEndpoint(false, customerId, endpointPath));
+        setEndpointHttp(getEndpoint(false, customerId, endpointPath));
       }
       if (isHttpsEnabled()) {
-        setEndpointHTTPS(getEndpoint(true, customerId, endpointPath));
+        setEndpointHttps(getEndpoint(true, customerId, endpointPath));
       }
     } else {
-      // TODO(apovzner) once all existing clients provide endpointPath, remove this code
       // set the correct customer id/endpoint pair
       setEndpointsOldWay(customerId);
     }
   }
 
-  private void setEndpointsOldWay(String customerId) {
+  private void setEndpointsOldWay(final String customerId) {
     if (isAnonymousUser(customerId)) {
       if (isHttpEnabled()) {
-        setEndpointHTTP(getAnonymousEndpoint(false));
+        setEndpointHttp(getAnonymousEndpoint(false));
       }
       if (isHttpsEnabled()) {
-        setEndpointHTTPS(getAnonymousEndpoint(true));
-      }
-    } else if (isTestUser(customerId)) {
-      if (isHttpEnabled()) {
-        setEndpointHTTP(getTestEndpoint(false));
-      }
-      if (isHttpsEnabled()) {
-        setEndpointHTTPS(getTestEndpoint(true));
+        setEndpointHttps(getAnonymousEndpoint(true));
       }
     } else {
-      if (isHttpEnabled()) {
-        setEndpointHTTP(getCustomerEndpoint(false));
-      }
-      if (isHttpsEnabled()) {
-        setEndpointHTTPS(getCustomerEndpoint(true));
+      if (isTestUser(customerId)) {
+        if (isHttpEnabled()) {
+          setEndpointHttp(getTestEndpoint(false));
+        }
+        if (isHttpsEnabled()) {
+          setEndpointHttps(getTestEndpoint(true));
+        }
+      } else {
+        if (isHttpEnabled()) {
+          setEndpointHttp(getCustomerEndpoint(false));
+        }
+        if (isHttpsEnabled()) {
+          setEndpointHttps(getCustomerEndpoint(true));
+        }
       }
     }
   }
 
-  // TODO(apovzner) remove this after all derived classes use constructor with endpointPath
-  protected String getAnonymousEndpoint(boolean secure) {
+  protected String getAnonymousEndpoint(final boolean secure) {
     return null;
   }
 
-  // TODO(apovzner) remove this after all derived classes use constructor with endpointPath
-  protected String getTestEndpoint(boolean secure) {
+  protected String getTestEndpoint(final boolean secure) {
     return null;
   }
 
-  // TODO(apovzner) remove this after all derived classes use constructor with endpointPath
-  protected String getCustomerEndpoint(boolean secure) {
+  protected String getCustomerEndpoint(final boolean secure) {
     return null;
   }
 
-  public static String getEndpoint(boolean secure, String customerId, String endpointPath) {
-    String base = secure ? CONFLUENT_PHONE_HOME_ENDPOINT_BASE_SECURE
-                         : CONFLUENT_PHONE_HOME_ENDPOINT_BASE_INSECURE;
+  public static String getEndpoint(final boolean secure, final String customerId,
+      final String endpointPath) {
+    final String base = secure ? CONFLUENT_PHONE_HOME_ENDPOINT_BASE_SECURE
+        : CONFLUENT_PHONE_HOME_ENDPOINT_BASE_INSECURE;
     return base + "/" + endpointPath + "/" + getEndpointSuffix(customerId);
   }
 
-  private static String getEndpointSuffix(String customerId) {
+  private static String getEndpointSuffix(final String customerId) {
     if (isAnonymousUser(customerId)) {
       return CONFLUENT_PHONE_HOME_ENDPOINT_SUFFIX_USER_ANON;
-    } else if (isTestUser(customerId)) {
-      return CONFLUENT_PHONE_HOME_ENDPOINT_SUFFIX_USER_TEST;
     } else {
-      return CONFLUENT_PHONE_HOME_ENDPOINT_SUFFIX_USER_CUSTOMER;
+      if (isTestUser(customerId)) {
+        return CONFLUENT_PHONE_HOME_ENDPOINT_SUFFIX_USER_TEST;
+      } else {
+        return CONFLUENT_PHONE_HOME_ENDPOINT_SUFFIX_USER_CUSTOMER;
+      }
     }
   }
 
@@ -285,7 +285,7 @@ public abstract class BaseSupportConfig {
    * @param customerId The value of "confluent.support.customer.id".
    * @return True if the value matches the setting we use to denote anonymous users.
    */
-  public static boolean isAnonymousUser(String customerId) {
+  public static boolean isAnonymousUser(final String customerId) {
     return customerId != null && customerId.toLowerCase(Locale.ROOT).equals(
         CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT);
   }
@@ -294,26 +294,27 @@ public abstract class BaseSupportConfig {
    * @param customerId The value of "confluent.support.customer.id".
    * @return True if the value matches the setting we use to denote internal testing.
    */
-  public static boolean isTestUser(String customerId) {
-    return customerId != null && customerId.toLowerCase(Locale.ROOT).equals(CONFLUENT_SUPPORT_TEST_ID_DEFAULT);
+  public static boolean isTestUser(final String customerId) {
+    return customerId != null && customerId.toLowerCase(Locale.ROOT)
+        .equals(CONFLUENT_SUPPORT_TEST_ID_DEFAULT);
   }
 
   /**
    * @param customerId The value of "confluent.support.customer.id".
    * @return True if the value matches the pattern of Confluent's internal customer ids.
    */
-  public static boolean isConfluentCustomer(String customerId) {
+  public static boolean isConfluentCustomer(final String customerId) {
     return customerId != null
-           && (CUSTOMER_PATTERN.matcher(customerId.toLowerCase(Locale.ROOT)).matches()
-               || NEW_CUSTOMER_CASE_INSENSISTIVE_PATTERN.matcher(customerId).matches()
-               || NEW_CUSTOMER_CASE_SENSISTIVE_PATTERN.matcher(customerId).matches());
+        && (CUSTOMER_PATTERN.matcher(customerId.toLowerCase(Locale.ROOT)).matches()
+        || NEW_CUSTOMER_CASE_INSENSISTIVE_PATTERN.matcher(customerId).matches()
+        || NEW_CUSTOMER_CASE_SENSISTIVE_PATTERN.matcher(customerId).matches());
   }
 
   /**
    * @param customerId The value of "confluent.support.customer.id".
    * @return True if the value is syntactically correct.
    */
-  public static boolean isSyntacticallyCorrectCustomerId(String customerId) {
+  public static boolean isSyntacticallyCorrectCustomerId(final String customerId) {
     return isAnonymousUser(customerId) || isConfluentCustomer(customerId);
   }
 
@@ -321,10 +322,11 @@ public abstract class BaseSupportConfig {
    * The 15-character alpha-numeric customer IDs are case-sensitive, others are case-insensitive.
    * The old-style customer ID "c\\d{1,30}" maybe look the same as a 15-character alpha-numeric ID,
    * if its length is also 15 characters. In that case, this method will return true.
+   *
    * @param customerId The value of "confluent.support.customer.id".
    * @return true if customer Id is case sensitive
    */
-  public static boolean isCaseSensitiveCustomerId(String customerId) {
+  public static boolean isCaseSensitiveCustomerId(final String customerId) {
     return NEW_CUSTOMER_CASE_SENSISTIVE_PATTERN.matcher(customerId).matches();
   }
 
@@ -332,8 +334,8 @@ public abstract class BaseSupportConfig {
     return getCustomerId(properties);
   }
 
-  public static String getCustomerId(Properties props) {
-    String fallbackId = CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT;
+  public static String getCustomerId(final Properties props) {
+    final String fallbackId = CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT;
     String id = props.getProperty(CONFLUENT_SUPPORT_CUSTOMER_ID_CONFIG);
     if (id == null || id.isEmpty()) {
       log.info("No customer ID configured -- falling back to id '{}'", fallbackId);
@@ -359,7 +361,7 @@ public abstract class BaseSupportConfig {
       intervalString = CONFLUENT_SUPPORT_METRICS_REPORT_INTERVAL_HOURS_DEFAULT;
     }
     try {
-      long intervalHours = Long.parseLong(intervalString);
+      final long intervalHours = Long.parseLong(intervalString);
       if (intervalHours < 1) {
         throw new ConfigException(
             CONFLUENT_SUPPORT_METRICS_REPORT_INTERVAL_HOURS_CONFIG,
@@ -382,53 +384,52 @@ public abstract class BaseSupportConfig {
   }
 
   public boolean getMetricsEnabled() {
-    String enableString = properties
+    final String enableString = properties
         .getProperty(CONFLUENT_SUPPORT_METRICS_ENABLE_CONFIG, "false");
     return Boolean.parseBoolean(enableString);
   }
 
   public boolean isHttpEnabled() {
-    String enableHTTP =
+    final String enableHttp =
         properties.getProperty(
             CONFLUENT_SUPPORT_METRICS_ENDPOINT_INSECURE_ENABLE_CONFIG,
             CONFLUENT_SUPPORT_METRICS_ENDPOINT_INSECURE_ENABLE_DEFAULT
         );
-    return Boolean.parseBoolean(enableHTTP);
+    return Boolean.parseBoolean(enableHttp);
   }
 
-  public String getEndpointHTTP() {
+  public String getEndpointHttp() {
     return properties
         .getProperty(CONFLUENT_SUPPORT_METRICS_ENDPOINT_INSECURE_CONFIG, "");
   }
 
-  public void setEndpointHTTP(String endpointHTTP) {
-
+  public void setEndpointHttp(final String endpointHttp) {
     properties.setProperty(
         CONFLUENT_SUPPORT_METRICS_ENDPOINT_INSECURE_CONFIG,
-        endpointHTTP
+        endpointHttp
     );
   }
 
   public boolean isHttpsEnabled() {
-    String enableHTTPS =
+    final String enableHttps =
         properties.getProperty(
             CONFLUENT_SUPPORT_METRICS_ENDPOINT_SECURE_ENABLE_CONFIG,
             CONFLUENT_SUPPORT_METRICS_ENDPOINT_SECURE_ENABLE_DEFAULT
         );
-    return Boolean.parseBoolean(enableHTTPS);
+    return Boolean.parseBoolean(enableHttps);
   }
 
-  public String getEndpointHTTPS() {
+  public String getEndpointHttps() {
     return properties.getProperty(
         CONFLUENT_SUPPORT_METRICS_ENDPOINT_SECURE_CONFIG,
         ""
     );
   }
 
-  public void setEndpointHTTPS(String endpointHTTPS) {
+  public void setEndpointHttps(final String endpointHttps) {
     properties.setProperty(
         CONFLUENT_SUPPORT_METRICS_ENDPOINT_SECURE_CONFIG,
-        endpointHTTPS
+        endpointHttps
     );
   }
 

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/BaseSupportConfig.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/BaseSupportConfig.java
@@ -66,17 +66,6 @@ public abstract class BaseSupportConfig {
   public static final String CONFLUENT_SUPPORT_METRICS_REPORT_INTERVAL_HOURS_DEFAULT = "24";
 
   /**
-   * <code>confluent.support.metrics.topic</code>
-   */
-  public static final String CONFLUENT_SUPPORT_METRICS_TOPIC_CONFIG =
-      "confluent.support.metrics.topic";
-  private static final String CONFLUENT_SUPPORT_METRICS_TOPIC_DOC =
-      "Internal topic used for metric collection. If missing, metrics will not be collected in a "
-          + "Kafka topic ";
-  public static final String CONFLUENT_SUPPORT_METRICS_TOPIC_DEFAULT =
-      "__confluent.support.metrics";
-
-  /**
    * <code>confluent.support.metrics.endpoint.insecure.enable</code>
    */
   public static final String CONFLUENT_SUPPORT_METRICS_ENDPOINT_INSECURE_ENABLE_CONFIG =
@@ -142,10 +131,6 @@ public abstract class BaseSupportConfig {
     props.setProperty(
         CONFLUENT_SUPPORT_METRICS_REPORT_INTERVAL_HOURS_CONFIG,
         CONFLUENT_SUPPORT_METRICS_REPORT_INTERVAL_HOURS_DEFAULT
-    );
-    props.setProperty(
-        CONFLUENT_SUPPORT_METRICS_TOPIC_CONFIG,
-        CONFLUENT_SUPPORT_METRICS_TOPIC_DEFAULT
     );
     props.setProperty(
         CONFLUENT_SUPPORT_METRICS_ENDPOINT_INSECURE_ENABLE_CONFIG,
@@ -377,10 +362,6 @@ public abstract class BaseSupportConfig {
           "Interval is not an integer number"
       );
     }
-  }
-
-  public String getKafkaTopic() {
-    return properties.getProperty(CONFLUENT_SUPPORT_METRICS_TOPIC_CONFIG, "");
   }
 
   public boolean getMetricsEnabled() {

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/BaseSupportConfig.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/BaseSupportConfig.java
@@ -1,0 +1,438 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.support.metrics;
+
+import java.util.Locale;
+import java.util.Properties;
+import java.util.regex.Pattern;
+import org.apache.kafka.common.config.ConfigException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Configuration for the Confluent Support options.
+ */
+public abstract class BaseSupportConfig {
+
+  private static final Logger log = LoggerFactory
+      .getLogger(io.confluent.support.metrics.BaseSupportConfig.class);
+
+  static final String CONFLUENT_PHONE_HOME_ENDPOINT_BASE_SECURE =
+      "https://version-check.confluent.io";
+  static final String CONFLUENT_PHONE_HOME_ENDPOINT_BASE_INSECURE =
+      "http://version-check.confluent.io";
+  public static final String CONFLUENT_PHONE_HOME_ENDPOINT_SUFFIX_USER_ANON = "anon";
+  public static final String CONFLUENT_PHONE_HOME_ENDPOINT_SUFFIX_USER_TEST = "test";
+  public static final String CONFLUENT_PHONE_HOME_ENDPOINT_SUFFIX_USER_CUSTOMER = "submit";
+
+  /**
+   * <code>confluent.support.metrics.enable</code>
+   */
+  public static final String CONFLUENT_SUPPORT_METRICS_ENABLE_CONFIG =
+      "confluent.support.metrics.enable";
+  private static final String CONFLUENT_SUPPORT_METRICS_ENABLE_DOC =
+      "False to disable metric collection, true otherwise.";
+  public static final String CONFLUENT_SUPPORT_METRICS_ENABLE_DEFAULT = "true";
+
+  /**
+   * <code>confluent.support.customer.id</code>
+   */
+  public static final String CONFLUENT_SUPPORT_CUSTOMER_ID_CONFIG = "confluent.support.customer.id";
+  private static final String CONFLUENT_SUPPORT_CUSTOMER_ID_DOC =
+      "Customer ID assigned by Confluent";
+  public static final String CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT = "anonymous";
+  public static final String CONFLUENT_SUPPORT_TEST_ID_DEFAULT = "c0";
+
+  /**
+   * <code>confluent.support.metrics.report.interval.hours</code>
+   */
+  public static final String CONFLUENT_SUPPORT_METRICS_REPORT_INTERVAL_HOURS_CONFIG =
+      "confluent.support.metrics.report.interval.hours";
+  private static final String CONFLUENT_SUPPORT_METRICS_REPORT_INTERVAL_HOURS_DOC =
+      "Frequency of reporting in hours, e.g., 24 would indicate every day ";
+  public static final String CONFLUENT_SUPPORT_METRICS_REPORT_INTERVAL_HOURS_DEFAULT = "24";
+
+  /**
+   * <code>confluent.support.metrics.topic</code>
+   */
+  public static final String CONFLUENT_SUPPORT_METRICS_TOPIC_CONFIG =
+      "confluent.support.metrics.topic";
+  private static final String CONFLUENT_SUPPORT_METRICS_TOPIC_DOC =
+      "Internal topic used for metric collection. If missing, metrics will not be collected in a "
+      + "Kafka topic ";
+  public static final String CONFLUENT_SUPPORT_METRICS_TOPIC_DEFAULT =
+      "__confluent.support.metrics";
+
+  /**
+   * <code>confluent.support.metrics.endpoint.insecure.enable</code>
+   */
+  public static final String CONFLUENT_SUPPORT_METRICS_ENDPOINT_INSECURE_ENABLE_CONFIG =
+      "confluent.support.metrics.endpoint.insecure.enable";
+  public static final String CONFLUENT_SUPPORT_METRICS_ENDPOINT_INSECURE_ENABLE_DOC =
+      "False to disable reporting over HTTP, true otherwise";
+  public static final String CONFLUENT_SUPPORT_METRICS_ENDPOINT_INSECURE_ENABLE_DEFAULT = "true";
+
+  /**
+   * <code>confluent.support.metrics.endpoint.secure.enable</code>
+   */
+  public static final String CONFLUENT_SUPPORT_METRICS_ENDPOINT_SECURE_ENABLE_CONFIG =
+      "confluent.support.metrics.endpoint.secure.enable";
+  public static final String CONFLUENT_SUPPORT_METRICS_ENDPOINT_SECURE_ENABLE_DOC =
+      "False to disable reporting over HTTPS, true otherwise";
+  public static final String CONFLUENT_SUPPORT_METRICS_ENDPOINT_SECURE_ENABLE_DEFAULT = "true";
+
+  /**
+   * <code>confluent.support.proxy</code>
+   */
+  public static final String CONFLUENT_SUPPORT_PROXY_CONFIG = "confluent.support.proxy";
+  public static final String CONFLUENT_SUPPORT_PROXY_DOC =
+      "HTTP forward proxy used to support metrics to Confluent";
+  public static final String CONFLUENT_SUPPORT_PROXY_DEFAULT = "";
+
+
+  /**
+   * Confluent endpoints. These are internal properties that cannot be set from a config file
+   * but that are added to the original config file at startup time
+   */
+  public static final String CONFLUENT_SUPPORT_METRICS_ENDPOINT_INSECURE_CONFIG =
+      "confluent.support.metrics.endpoint.insecure";
+
+  public static final String CONFLUENT_SUPPORT_METRICS_ENDPOINT_SECURE_CONFIG =
+      "confluent.support.metrics.endpoint.secure";
+
+
+  private static final Pattern CUSTOMER_PATTERN = Pattern.compile("c\\d{1,30}");
+  private static final Pattern NEW_CUSTOMER_CASE_SENSISTIVE_PATTERN = Pattern.compile(
+      "[a-zA-Z0-9]{15}"
+  );
+  private static final Pattern NEW_CUSTOMER_CASE_INSENSISTIVE_PATTERN = Pattern.compile(
+      "[a-zA-Z0-9]{18}"
+  );
+
+  public Properties getProperties() {
+    return properties;
+  }
+
+  private Properties properties;
+
+
+  /**
+   * Returns the default Proactive Support properties
+   */
+  protected Properties getDefaultProps() {
+    Properties props = new Properties();
+    props.setProperty(
+        CONFLUENT_SUPPORT_METRICS_ENABLE_CONFIG,
+        CONFLUENT_SUPPORT_METRICS_ENABLE_DEFAULT
+    );
+    props.setProperty(CONFLUENT_SUPPORT_CUSTOMER_ID_CONFIG, CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT);
+    props.setProperty(
+        CONFLUENT_SUPPORT_METRICS_REPORT_INTERVAL_HOURS_CONFIG,
+        CONFLUENT_SUPPORT_METRICS_REPORT_INTERVAL_HOURS_DEFAULT
+    );
+    props.setProperty(
+        CONFLUENT_SUPPORT_METRICS_TOPIC_CONFIG,
+        CONFLUENT_SUPPORT_METRICS_TOPIC_DEFAULT
+    );
+    props.setProperty(
+        CONFLUENT_SUPPORT_METRICS_ENDPOINT_INSECURE_ENABLE_CONFIG,
+        CONFLUENT_SUPPORT_METRICS_ENDPOINT_INSECURE_ENABLE_DEFAULT
+    );
+    props.setProperty(
+        CONFLUENT_SUPPORT_METRICS_ENDPOINT_SECURE_ENABLE_CONFIG,
+        CONFLUENT_SUPPORT_METRICS_ENDPOINT_SECURE_ENABLE_DEFAULT
+    );
+    props.setProperty(CONFLUENT_SUPPORT_PROXY_CONFIG, CONFLUENT_SUPPORT_PROXY_DEFAULT);
+    return props;
+  }
+
+
+  // TODO(apovzner) remove this after all derived classes use constructor with endpointPath
+  public BaseSupportConfig(Properties originals) {
+    mergeAndValidateWithDefaultProperties(originals, null);
+  }
+
+  public BaseSupportConfig(Properties originals, String endpointPath) {
+    mergeAndValidateWithDefaultProperties(originals, endpointPath);
+  }
+
+  /**
+   * Takes default properties from getDefaultProps() and a set of override properties and
+   * returns a merged properties object, where the defaults are overridden.
+   * Sanitizes and validates the returned properties
+   *
+   * @param overrides Parameters that override the default properties
+   */
+  private void mergeAndValidateWithDefaultProperties(Properties overrides, String endpointPath) {
+    Properties defaults = getDefaultProps();
+    Properties props;
+
+    if (overrides == null) {
+      props = defaults;
+    } else {
+      props = new Properties();
+      props.putAll(defaults);
+      props.putAll(overrides);
+    }
+    this.properties = props;
+
+    // make sure users are not setting internal properties in the config file
+    // sanitize props just in case
+    props.remove(CONFLUENT_SUPPORT_METRICS_ENDPOINT_INSECURE_CONFIG);
+    props.remove(CONFLUENT_SUPPORT_METRICS_ENDPOINT_SECURE_CONFIG);
+
+    String customerId = getCustomerId();
+
+    // new way to set endpoint
+    if (endpointPath != null) {
+      // derived class provided URI
+      if (isHttpEnabled()) {
+        setEndpointHTTP(getEndpoint(false, customerId, endpointPath));
+      }
+      if (isHttpsEnabled()) {
+        setEndpointHTTPS(getEndpoint(true, customerId, endpointPath));
+      }
+    } else {
+      // TODO(apovzner) once all existing clients provide endpointPath, remove this code
+      // set the correct customer id/endpoint pair
+      setEndpointsOldWay(customerId);
+    }
+  }
+
+  private void setEndpointsOldWay(String customerId) {
+    if (isAnonymousUser(customerId)) {
+      if (isHttpEnabled()) {
+        setEndpointHTTP(getAnonymousEndpoint(false));
+      }
+      if (isHttpsEnabled()) {
+        setEndpointHTTPS(getAnonymousEndpoint(true));
+      }
+    } else if (isTestUser(customerId)) {
+      if (isHttpEnabled()) {
+        setEndpointHTTP(getTestEndpoint(false));
+      }
+      if (isHttpsEnabled()) {
+        setEndpointHTTPS(getTestEndpoint(true));
+      }
+    } else {
+      if (isHttpEnabled()) {
+        setEndpointHTTP(getCustomerEndpoint(false));
+      }
+      if (isHttpsEnabled()) {
+        setEndpointHTTPS(getCustomerEndpoint(true));
+      }
+    }
+  }
+
+  // TODO(apovzner) remove this after all derived classes use constructor with endpointPath
+  protected String getAnonymousEndpoint(boolean secure) {
+    return null;
+  }
+
+  // TODO(apovzner) remove this after all derived classes use constructor with endpointPath
+  protected String getTestEndpoint(boolean secure) {
+    return null;
+  }
+
+  // TODO(apovzner) remove this after all derived classes use constructor with endpointPath
+  protected String getCustomerEndpoint(boolean secure) {
+    return null;
+  }
+
+  public static String getEndpoint(boolean secure, String customerId, String endpointPath) {
+    String base = secure ? CONFLUENT_PHONE_HOME_ENDPOINT_BASE_SECURE
+                         : CONFLUENT_PHONE_HOME_ENDPOINT_BASE_INSECURE;
+    return base + "/" + endpointPath + "/" + getEndpointSuffix(customerId);
+  }
+
+  private static String getEndpointSuffix(String customerId) {
+    if (isAnonymousUser(customerId)) {
+      return CONFLUENT_PHONE_HOME_ENDPOINT_SUFFIX_USER_ANON;
+    } else if (isTestUser(customerId)) {
+      return CONFLUENT_PHONE_HOME_ENDPOINT_SUFFIX_USER_TEST;
+    } else {
+      return CONFLUENT_PHONE_HOME_ENDPOINT_SUFFIX_USER_CUSTOMER;
+    }
+  }
+
+  /**
+   * A check on whether Proactive Support (PS) is enabled or not. PS is disabled when
+   * CONFLUENT_SUPPORT_METRICS_ENABLE_CONFIG is false or is not defined
+   *
+   * @return false if PS is not enabled, true if PS is enabled
+   */
+  public boolean isProactiveSupportEnabled() {
+    if (properties == null) {
+      return false;
+    }
+    return getMetricsEnabled();
+  }
+
+  /**
+   * @param customerId The value of "confluent.support.customer.id".
+   * @return True if the value matches the setting we use to denote anonymous users.
+   */
+  public static boolean isAnonymousUser(String customerId) {
+    return customerId != null && customerId.toLowerCase(Locale.ROOT).equals(
+        CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT);
+  }
+
+  /**
+   * @param customerId The value of "confluent.support.customer.id".
+   * @return True if the value matches the setting we use to denote internal testing.
+   */
+  public static boolean isTestUser(String customerId) {
+    return customerId != null && customerId.toLowerCase(Locale.ROOT).equals(CONFLUENT_SUPPORT_TEST_ID_DEFAULT);
+  }
+
+  /**
+   * @param customerId The value of "confluent.support.customer.id".
+   * @return True if the value matches the pattern of Confluent's internal customer ids.
+   */
+  public static boolean isConfluentCustomer(String customerId) {
+    return customerId != null
+           && (CUSTOMER_PATTERN.matcher(customerId.toLowerCase(Locale.ROOT)).matches()
+               || NEW_CUSTOMER_CASE_INSENSISTIVE_PATTERN.matcher(customerId).matches()
+               || NEW_CUSTOMER_CASE_SENSISTIVE_PATTERN.matcher(customerId).matches());
+  }
+
+  /**
+   * @param customerId The value of "confluent.support.customer.id".
+   * @return True if the value is syntactically correct.
+   */
+  public static boolean isSyntacticallyCorrectCustomerId(String customerId) {
+    return isAnonymousUser(customerId) || isConfluentCustomer(customerId);
+  }
+
+  /**
+   * The 15-character alpha-numeric customer IDs are case-sensitive, others are case-insensitive.
+   * The old-style customer ID "c\\d{1,30}" maybe look the same as a 15-character alpha-numeric ID,
+   * if its length is also 15 characters. In that case, this method will return true.
+   * @param customerId The value of "confluent.support.customer.id".
+   * @return true if customer Id is case sensitive
+   */
+  public static boolean isCaseSensitiveCustomerId(String customerId) {
+    return NEW_CUSTOMER_CASE_SENSISTIVE_PATTERN.matcher(customerId).matches();
+  }
+
+  public String getCustomerId() {
+    return getCustomerId(properties);
+  }
+
+  public static String getCustomerId(Properties props) {
+    String fallbackId = CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT;
+    String id = props.getProperty(CONFLUENT_SUPPORT_CUSTOMER_ID_CONFIG);
+    if (id == null || id.isEmpty()) {
+      log.info("No customer ID configured -- falling back to id '{}'", fallbackId);
+      id = fallbackId;
+    }
+    if (!isSyntacticallyCorrectCustomerId(id)) {
+      log.error(
+          "'{}' is not a valid Confluent customer ID -- falling back to id '{}'",
+          id,
+          fallbackId
+      );
+      id = fallbackId;
+    }
+    return id;
+  }
+
+  public long getReportIntervalMs() {
+    String intervalString =
+        properties.getProperty(
+            CONFLUENT_SUPPORT_METRICS_REPORT_INTERVAL_HOURS_CONFIG
+        );
+    if (intervalString == null || intervalString.isEmpty()) {
+      intervalString = CONFLUENT_SUPPORT_METRICS_REPORT_INTERVAL_HOURS_DEFAULT;
+    }
+    try {
+      long intervalHours = Long.parseLong(intervalString);
+      if (intervalHours < 1) {
+        throw new ConfigException(
+            CONFLUENT_SUPPORT_METRICS_REPORT_INTERVAL_HOURS_CONFIG,
+            intervalString,
+            "Interval must be >= 1"
+        );
+      }
+      return intervalHours * 60 * 60 * 1000;
+    } catch (NumberFormatException e) {
+      throw new ConfigException(
+          CONFLUENT_SUPPORT_METRICS_REPORT_INTERVAL_HOURS_CONFIG,
+          intervalString,
+          "Interval is not an integer number"
+      );
+    }
+  }
+
+  public String getKafkaTopic() {
+    return properties.getProperty(CONFLUENT_SUPPORT_METRICS_TOPIC_CONFIG, "");
+  }
+
+  public boolean getMetricsEnabled() {
+    String enableString = properties
+        .getProperty(CONFLUENT_SUPPORT_METRICS_ENABLE_CONFIG, "false");
+    return Boolean.parseBoolean(enableString);
+  }
+
+  public boolean isHttpEnabled() {
+    String enableHTTP =
+        properties.getProperty(
+            CONFLUENT_SUPPORT_METRICS_ENDPOINT_INSECURE_ENABLE_CONFIG,
+            CONFLUENT_SUPPORT_METRICS_ENDPOINT_INSECURE_ENABLE_DEFAULT
+        );
+    return Boolean.parseBoolean(enableHTTP);
+  }
+
+  public String getEndpointHTTP() {
+    return properties
+        .getProperty(CONFLUENT_SUPPORT_METRICS_ENDPOINT_INSECURE_CONFIG, "");
+  }
+
+  public void setEndpointHTTP(String endpointHTTP) {
+
+    properties.setProperty(
+        CONFLUENT_SUPPORT_METRICS_ENDPOINT_INSECURE_CONFIG,
+        endpointHTTP
+    );
+  }
+
+  public boolean isHttpsEnabled() {
+    String enableHTTPS =
+        properties.getProperty(
+            CONFLUENT_SUPPORT_METRICS_ENDPOINT_SECURE_ENABLE_CONFIG,
+            CONFLUENT_SUPPORT_METRICS_ENDPOINT_SECURE_ENABLE_DEFAULT
+        );
+    return Boolean.parseBoolean(enableHTTPS);
+  }
+
+  public String getEndpointHTTPS() {
+    return properties.getProperty(
+        CONFLUENT_SUPPORT_METRICS_ENDPOINT_SECURE_CONFIG,
+        ""
+    );
+  }
+
+  public void setEndpointHTTPS(String endpointHTTPS) {
+    properties.setProperty(
+        CONFLUENT_SUPPORT_METRICS_ENDPOINT_SECURE_CONFIG,
+        endpointHTTPS
+    );
+  }
+
+  public String getProxy() {
+    return properties.getProperty(
+        CONFLUENT_SUPPORT_PROXY_CONFIG,
+        CONFLUENT_SUPPORT_PROXY_DEFAULT
+    );
+  }
+}

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/BaseSupportConfig.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/BaseSupportConfig.java
@@ -1,13 +1,16 @@
-/**
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+/*
+ * Copyright 2020 Confluent Inc.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 
 package io.confluent.support.metrics;

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/PhoneHomeConfig.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/PhoneHomeConfig.java
@@ -1,15 +1,16 @@
-/**
- * Copyright 2018 Confluent Inc.
+/*
+ * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 
 package io.confluent.support.metrics;

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/PhoneHomeConfig.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/PhoneHomeConfig.java
@@ -30,7 +30,6 @@ public class PhoneHomeConfig extends BaseSupportConfig {
   private static final Logger log = LoggerFactory
       .getLogger(io.confluent.support.metrics.PhoneHomeConfig.class);
 
-  private static final boolean CONFLUENT_SUPPORT_METRICS_TOPIC_ENABLED_DEFAULT = false;
   private static final boolean CONFLUENT_SUPPORT_CUSTOMER_ID_ENABLED_DEFAULT = false;
 
   /**
@@ -38,36 +37,25 @@ public class PhoneHomeConfig extends BaseSupportConfig {
    * endpoint.
    */
   public PhoneHomeConfig(final Properties originals, final String componentId) {
-    this(originals, componentId,
-        CONFLUENT_SUPPORT_METRICS_TOPIC_ENABLED_DEFAULT,
-        CONFLUENT_SUPPORT_CUSTOMER_ID_ENABLED_DEFAULT);
+    this(originals, componentId, CONFLUENT_SUPPORT_CUSTOMER_ID_ENABLED_DEFAULT);
   }
 
   private PhoneHomeConfig(final Properties originals, final String componentId,
-      final boolean supportMetricsTopicEnabled, final boolean supportCustomerIdEnabled) {
-    super(setupProperties(originals, supportMetricsTopicEnabled, supportCustomerIdEnabled),
-        getEndpointPath(componentId));
+      final boolean supportCustomerIdEnabled) {
+    super(setupProperties(originals, supportCustomerIdEnabled), getEndpointPath(componentId));
   }
 
   @SuppressWarnings("checkstyle:FinalParameters")
   private static Properties setupProperties(Properties originals,
-      final boolean supportMetricsTopicEnabled,
       final boolean supportCustomerIdEnabled) {
-    if (!supportCustomerIdEnabled || !supportMetricsTopicEnabled) {
-      //disable publish to topic
+    if (!supportCustomerIdEnabled) {
       if (originals == null) {
         originals = new Properties();
       }
-      if (!supportMetricsTopicEnabled) {
-        log.warn("Writing to metrics Kafka topic will be disabled");
-        originals.setProperty(BaseSupportConfig.CONFLUENT_SUPPORT_METRICS_TOPIC_CONFIG, "");
-      }
-      if (!supportCustomerIdEnabled) {
-        if (!isTestUser(getCustomerId(originals))) {
-          log.warn("Enforcing customer ID '{}'", CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT);
-          originals.setProperty(CONFLUENT_SUPPORT_CUSTOMER_ID_CONFIG,
-              CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT);
-        }
+      if (!isTestUser(getCustomerId(originals))) {
+        log.warn("Enforcing customer ID '{}'", CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT);
+        originals.setProperty(CONFLUENT_SUPPORT_CUSTOMER_ID_CONFIG,
+            CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT);
       }
     }
     return originals;

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/PhoneHomeConfig.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/PhoneHomeConfig.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.support.metrics;
+
+import io.confluent.support.metrics.BaseSupportConfig;
+import java.util.Properties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Use this config for component-specific phone-home clients. It disables writing metrics to
+ * Kafka topic and ensures that non-test customer Ids are "anonymous", even if the client sets
+ * support topic and customer id in the config.
+ * TODO(apovzner) this class will probably be extended for standard phone-home libraries (the
+ * difference is a different URI format).
+ */
+public class PhoneHomeConfig extends BaseSupportConfig {
+
+  private static final Logger log = LoggerFactory
+      .getLogger(io.confluent.support.metrics.PhoneHomeConfig.class);
+
+  private static final boolean CONFLUENT_SUPPORT_METRICS_TOPIC_ENABLED_DEFAULT = false;
+  private static final boolean CONFLUENT_SUPPORT_CUSTOMER_ID_ENABLED_DEFAULT = false;
+
+  /**
+   * Will make sure that writing to support metrics topic is disabled and there is no customer
+   * endpoint.
+   */
+  public PhoneHomeConfig(Properties originals, String componentId) {
+    this(originals, componentId,
+         CONFLUENT_SUPPORT_METRICS_TOPIC_ENABLED_DEFAULT,
+         CONFLUENT_SUPPORT_CUSTOMER_ID_ENABLED_DEFAULT);
+  }
+
+  private PhoneHomeConfig(Properties originals, String componentId,
+                          boolean supportMetricsTopicEnabled, boolean supportCustomerIdEnabled) {
+    super(setupProperties(originals, supportMetricsTopicEnabled, supportCustomerIdEnabled),
+          getEndpointPath(componentId));
+  }
+
+  private static Properties setupProperties(Properties originals,
+                                            boolean supportMetricsTopicEnabled,
+                                            boolean supportCustomerIdEnabled) {
+    if (!supportCustomerIdEnabled || !supportMetricsTopicEnabled) {
+      //disable publish to topic
+      if (originals == null) {
+        originals = new Properties();
+      }
+      if (!supportMetricsTopicEnabled) {
+        log.warn("Writing to metrics Kafka topic will be disabled");
+        originals.setProperty(BaseSupportConfig.CONFLUENT_SUPPORT_METRICS_TOPIC_CONFIG, "");
+      }
+      if (!supportCustomerIdEnabled) {
+        if (!isTestUser(getCustomerId(originals))) {
+          log.warn("Enforcing customer ID '{}'", CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT);
+          originals.setProperty(CONFLUENT_SUPPORT_CUSTOMER_ID_CONFIG,
+                                CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT);
+        }
+      }
+    }
+    return originals;
+  }
+
+
+  /**
+   * The resulting secure endpoint will be:
+   * BaseSupportConfig.CONFLUENT_PHONE_HOME_ENDPOINT_BASE_SECURE/getEndpointPath()/{anon|test}
+   * The resulting insecure endpoint will be:
+   * BaseSupportConfig.CONFLUENT_PHONE_HOME_ENDPOINT_BASE_INSECURE/getEndpointPath()/{anon|test}
+   */
+  private static String getEndpointPath(String componentId) {
+    return componentId;
+  }
+
+}

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/PhoneHomeConfig.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/PhoneHomeConfig.java
@@ -15,17 +15,15 @@
 
 package io.confluent.support.metrics;
 
-import io.confluent.support.metrics.BaseSupportConfig;
 import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Use this config for component-specific phone-home clients. It disables writing metrics to
- * Kafka topic and ensures that non-test customer Ids are "anonymous", even if the client sets
- * support topic and customer id in the config.
- * TODO(apovzner) this class will probably be extended for standard phone-home libraries (the
- * difference is a different URI format).
+ * Use this config for component-specific phone-home clients. It disables writing metrics to Kafka
+ * topic and ensures that non-test customer Ids are "anonymous", even if the client sets support
+ * topic and customer id in the config. standard phone-home libraries (the difference is a different
+ * URI format).
  */
 public class PhoneHomeConfig extends BaseSupportConfig {
 
@@ -39,21 +37,22 @@ public class PhoneHomeConfig extends BaseSupportConfig {
    * Will make sure that writing to support metrics topic is disabled and there is no customer
    * endpoint.
    */
-  public PhoneHomeConfig(Properties originals, String componentId) {
+  public PhoneHomeConfig(final Properties originals, final String componentId) {
     this(originals, componentId,
-         CONFLUENT_SUPPORT_METRICS_TOPIC_ENABLED_DEFAULT,
-         CONFLUENT_SUPPORT_CUSTOMER_ID_ENABLED_DEFAULT);
+        CONFLUENT_SUPPORT_METRICS_TOPIC_ENABLED_DEFAULT,
+        CONFLUENT_SUPPORT_CUSTOMER_ID_ENABLED_DEFAULT);
   }
 
-  private PhoneHomeConfig(Properties originals, String componentId,
-                          boolean supportMetricsTopicEnabled, boolean supportCustomerIdEnabled) {
+  private PhoneHomeConfig(final Properties originals, final String componentId,
+      final boolean supportMetricsTopicEnabled, final boolean supportCustomerIdEnabled) {
     super(setupProperties(originals, supportMetricsTopicEnabled, supportCustomerIdEnabled),
-          getEndpointPath(componentId));
+        getEndpointPath(componentId));
   }
 
+  @SuppressWarnings("checkstyle:FinalParameters")
   private static Properties setupProperties(Properties originals,
-                                            boolean supportMetricsTopicEnabled,
-                                            boolean supportCustomerIdEnabled) {
+      final boolean supportMetricsTopicEnabled,
+      final boolean supportCustomerIdEnabled) {
     if (!supportCustomerIdEnabled || !supportMetricsTopicEnabled) {
       //disable publish to topic
       if (originals == null) {
@@ -67,7 +66,7 @@ public class PhoneHomeConfig extends BaseSupportConfig {
         if (!isTestUser(getCustomerId(originals))) {
           log.warn("Enforcing customer ID '{}'", CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT);
           originals.setProperty(CONFLUENT_SUPPORT_CUSTOMER_ID_CONFIG,
-                                CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT);
+              CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT);
         }
       }
     }
@@ -81,7 +80,7 @@ public class PhoneHomeConfig extends BaseSupportConfig {
    * The resulting insecure endpoint will be:
    * BaseSupportConfig.CONFLUENT_PHONE_HOME_ENDPOINT_BASE_INSECURE/getEndpointPath()/{anon|test}
    */
-  private static String getEndpointPath(String componentId) {
+  private static String getEndpointPath(final String componentId) {
     return componentId;
   }
 

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/Collector.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/Collector.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.support.metrics.common;
+
+import org.apache.avro.generic.GenericContainer;
+
+public abstract class Collector {
+
+  public enum RuntimeState {
+
+    Stopped(0), ShuttingDown(1), Running(2);
+
+    private final int stateId;
+
+    RuntimeState(int stateId) {
+      this.stateId = stateId;
+    }
+
+    public int stateId() {
+      return stateId;
+    }
+
+  }
+
+  private RuntimeState runtimeState;
+
+  public Collector() {
+    this.runtimeState = RuntimeState.Stopped;
+  }
+
+  /**
+   * Collects metrics from a Kafka broker.
+   *
+   * @return An Avro record that contains the collected metrics.
+   */
+  public abstract GenericContainer collectMetrics();
+
+  /**
+   * Gets the runtime state of this collector.
+   */
+  public RuntimeState getRuntimeState() {
+    return runtimeState;
+  }
+
+  /**
+   * Sets the runtime state of this collector.
+   */
+  public void setRuntimeState(RuntimeState runtimeState) {
+    this.runtimeState = runtimeState;
+  }
+
+}

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/Collector.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/Collector.java
@@ -25,7 +25,7 @@ public abstract class Collector {
 
     private final int stateId;
 
-    RuntimeState(int stateId) {
+    RuntimeState(final int stateId) {
       this.stateId = stateId;
     }
 
@@ -58,7 +58,7 @@ public abstract class Collector {
   /**
    * Sets the runtime state of this collector.
    */
-  public void setRuntimeState(RuntimeState runtimeState) {
+  public void setRuntimeState(final RuntimeState runtimeState) {
     this.runtimeState = runtimeState;
   }
 

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/Collector.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/Collector.java
@@ -1,15 +1,16 @@
-/**
- * Copyright 2015 Confluent Inc.
+/*
+ * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 
 package io.confluent.support.metrics.common;

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/CollectorType.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/CollectorType.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.support.metrics.common;
+
+public enum CollectorType {
+  BASIC(0, "basic"), FULL(1, "full");
+  public final int id;
+  public final String name;
+
+  CollectorType(int id, String name) {
+    this.id = id;
+    this.name = name;
+  }
+
+  public static io.confluent.support.metrics.common.CollectorType forId(int id) {
+    switch (id) {
+      case 0:
+        return BASIC;
+      case 1:
+        return FULL;
+      default:
+        throw new IllegalArgumentException("Unknown collector type id: " + id);
+    }
+  }
+
+  public static io.confluent.support.metrics.common.CollectorType forName(String name) {
+    if (BASIC.name.equals(name)) {
+      return BASIC;
+    } else if (FULL.name.equals(name)) {
+      return FULL;
+    } else {
+      throw new IllegalArgumentException("Unknown collector name: " + name);
+    }
+  }
+}

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/CollectorType.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/CollectorType.java
@@ -20,12 +20,12 @@ public enum CollectorType {
   public final int id;
   public final String name;
 
-  CollectorType(int id, String name) {
+  CollectorType(final int id, final String name) {
     this.id = id;
     this.name = name;
   }
 
-  public static io.confluent.support.metrics.common.CollectorType forId(int id) {
+  public static io.confluent.support.metrics.common.CollectorType forId(final int id) {
     switch (id) {
       case 0:
         return BASIC;
@@ -36,7 +36,7 @@ public enum CollectorType {
     }
   }
 
-  public static io.confluent.support.metrics.common.CollectorType forName(String name) {
+  public static io.confluent.support.metrics.common.CollectorType forName(final String name) {
     if (BASIC.name.equals(name)) {
       return BASIC;
     } else if (FULL.name.equals(name)) {

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/CollectorType.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/CollectorType.java
@@ -1,15 +1,16 @@
-/**
- * Copyright 2015 Confluent Inc.
+/*
+ * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 
 package io.confluent.support.metrics.common;

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/Filter.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/Filter.java
@@ -31,24 +31,24 @@ public class Filter {
     this(new HashSet<>());
   }
 
-  public Filter(Set<String> keysToRemove) {
+  public Filter(final Set<String> keysToRemove) {
     this.keysToRemove = new HashSet<>(keysToRemove);
   }
 
   /**
    * Returns a copy of the input with any to-be-filtered keys removed.
    */
-  public Properties apply(Properties properties) {
+  public Properties apply(final Properties properties) {
     if (properties == null) {
       throw new IllegalArgumentException("properties must not be null");
     } else {
       if (properties.isEmpty()) {
         return new Properties();
       } else {
-        Properties filtered = new Properties();
+        final Properties filtered = new Properties();
         for (Map.Entry<Object, Object> entry : properties.entrySet()) {
-          Object key = entry.getKey();
-          Object value = entry.getValue();
+          final Object key = entry.getKey();
+          final Object value = entry.getValue();
           if (!keysToRemove.contains(key)) {
             filtered.put(key, value);
           }

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/Filter.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/Filter.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.support.metrics.common;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+public class Filter {
+
+  private final Set<String> keysToRemove;
+
+  /**
+   * The default filter does not filter anything.
+   */
+  public Filter() {
+    this(new HashSet<>());
+  }
+
+  public Filter(Set<String> keysToRemove) {
+    this.keysToRemove = new HashSet<>(keysToRemove);
+  }
+
+  /**
+   * Returns a copy of the input with any to-be-filtered keys removed.
+   */
+  public Properties apply(Properties properties) {
+    if (properties == null) {
+      throw new IllegalArgumentException("properties must not be null");
+    } else {
+      if (properties.isEmpty()) {
+        return new Properties();
+      } else {
+        Properties filtered = new Properties();
+        for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+          Object key = entry.getKey();
+          Object value = entry.getValue();
+          if (!keysToRemove.contains(key)) {
+            filtered.put(key, value);
+          }
+        }
+        return filtered;
+      }
+    }
+  }
+
+  public Set<String> getKeys() {
+    return new HashSet<>(keysToRemove);
+  }
+
+}

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/Filter.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/Filter.java
@@ -1,15 +1,16 @@
-/**
- * Copyright 2015 Confluent Inc.
+/*
+ * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 
 package io.confluent.support.metrics.common;

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/Uuid.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/Uuid.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.support.metrics.common;
+
+import java.util.UUID;
+
+public class Uuid {
+
+  /**
+   * For the purposes of metrics collection we want to use type-4 UUIDs.
+   */
+  private final UUID uuid = UUID.randomUUID();
+
+  public String getUUID() {
+    return toString();
+  }
+
+  @Override
+  public String toString() {
+    return uuid.toString();
+  }
+
+}

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/Uuid.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/Uuid.java
@@ -24,7 +24,7 @@ public class Uuid {
    */
   private final UUID uuid = UUID.randomUUID();
 
-  public String getUUID() {
+  public String getUuid() {
     return toString();
   }
 

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/Uuid.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/Uuid.java
@@ -1,15 +1,16 @@
-/**
- * Copyright 2015 Confluent Inc.
+/*
+ * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 
 package io.confluent.support.metrics.common;

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/time/Clock.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/time/Clock.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.support.metrics.common.time;
+
+public interface Clock {
+
+  long currentTimeMs();
+
+}

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/time/Clock.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/time/Clock.java
@@ -1,15 +1,16 @@
-/**
- * Copyright 2015 Confluent Inc.
+/*
+ * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 
 package io.confluent.support.metrics.common.time;

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/time/TimeUtils.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/time/TimeUtils.java
@@ -1,15 +1,16 @@
-/**
- * Copyright 2015 Confluent Inc.
+/*
+ * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 
 package io.confluent.support.metrics.common.time;

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/time/TimeUtils.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/time/TimeUtils.java
@@ -15,8 +15,6 @@
 
 package io.confluent.support.metrics.common.time;
 
-import io.confluent.support.metrics.common.time.Clock;
-
 public class TimeUtils {
 
   private static class SystemClock implements Clock {
@@ -34,7 +32,7 @@ public class TimeUtils {
     this(new SystemClock());
   }
 
-  public TimeUtils(Clock clock) {
+  public TimeUtils(final Clock clock) {
     this.clock = clock;
   }
 

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/time/TimeUtils.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/common/time/TimeUtils.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.support.metrics.common.time;
+
+import io.confluent.support.metrics.common.time.Clock;
+
+public class TimeUtils {
+
+  private static class SystemClock implements Clock {
+
+    @Override
+    public long currentTimeMs() {
+      return System.currentTimeMillis();
+    }
+
+  }
+
+  private final Clock clock;
+
+  public TimeUtils() {
+    this(new SystemClock());
+  }
+
+  public TimeUtils(Clock clock) {
+    this.clock = clock;
+  }
+
+  /**
+   * Returns the current time in seconds since the epoch (aka Unix time).
+   */
+  public long nowInUnixTime() {
+    return clock.currentTimeMs() / 1000;
+  }
+
+}

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/response/ErrorResponse.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/response/ErrorResponse.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.support.metrics.response;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+public class ErrorResponse {
+
+  private final String message;
+
+  @JsonCreator
+  public ErrorResponse(@JsonProperty("message") String message) {
+    this.message = message;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof io.confluent.support.metrics.response.ErrorResponse)) {
+      return false;
+    }
+    io.confluent.support.metrics.response.ErrorResponse that = (io.confluent.support.metrics.response.ErrorResponse) o;
+    return Objects.equals(getMessage(), that.getMessage());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getMessage(), getMessage());
+  }
+
+}

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/response/ErrorResponse.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/response/ErrorResponse.java
@@ -24,7 +24,7 @@ public class ErrorResponse {
   private final String message;
 
   @JsonCreator
-  public ErrorResponse(@JsonProperty("message") String message) {
+  public ErrorResponse(@JsonProperty("message") final String message) {
     this.message = message;
   }
 
@@ -33,14 +33,15 @@ public class ErrorResponse {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(final Object o) {
     if (this == o) {
       return true;
     }
     if (!(o instanceof io.confluent.support.metrics.response.ErrorResponse)) {
       return false;
     }
-    io.confluent.support.metrics.response.ErrorResponse that = (io.confluent.support.metrics.response.ErrorResponse) o;
+    final io.confluent.support.metrics.response.ErrorResponse that =
+        (io.confluent.support.metrics.response.ErrorResponse) o;
     return Objects.equals(getMessage(), that.getMessage());
   }
 

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/response/ErrorResponse.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/response/ErrorResponse.java
@@ -1,15 +1,16 @@
-/**
- * Copyright 2018 Confluent Inc.
+/*
+ * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 
 package io.confluent.support.metrics.response;

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/response/PhoneHomeResponse.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/response/PhoneHomeResponse.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.support.metrics.response;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+public class PhoneHomeResponse {
+
+  private final String confluentPlatformVersion;
+  private final String informationForUser;
+
+  @JsonCreator
+  public PhoneHomeResponse(
+      @JsonProperty("confluentPlatformVersion") String confluentPlatformVersion,
+      @JsonProperty("informationForUser") String informationForUser
+  ) {
+    this.confluentPlatformVersion = confluentPlatformVersion;
+    this.informationForUser = informationForUser;
+  }
+
+  /**
+   * The latest available version of the Confluent Platform or null.
+   */
+  public String getConfluentPlatformVersion() {
+    return confluentPlatformVersion;
+  }
+
+  /**
+   * Short text with information to the user or null.
+   */
+  public String getInformationForUser() {
+    return informationForUser;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof io.confluent.support.metrics.response.PhoneHomeResponse)) {
+      return false;
+    }
+    io.confluent.support.metrics.response.PhoneHomeResponse that = (io.confluent.support.metrics.response.PhoneHomeResponse) o;
+    return Objects.equals(getConfluentPlatformVersion(), that.getConfluentPlatformVersion())
+           && Objects.equals(getInformationForUser(), that.getInformationForUser());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getConfluentPlatformVersion(), getInformationForUser());
+  }
+}

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/response/PhoneHomeResponse.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/response/PhoneHomeResponse.java
@@ -26,8 +26,8 @@ public class PhoneHomeResponse {
 
   @JsonCreator
   public PhoneHomeResponse(
-      @JsonProperty("confluentPlatformVersion") String confluentPlatformVersion,
-      @JsonProperty("informationForUser") String informationForUser
+      @JsonProperty("confluentPlatformVersion") final String confluentPlatformVersion,
+      @JsonProperty("informationForUser") final String informationForUser
   ) {
     this.confluentPlatformVersion = confluentPlatformVersion;
     this.informationForUser = informationForUser;
@@ -48,14 +48,15 @@ public class PhoneHomeResponse {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(final Object o) {
     if (this == o) {
       return true;
     }
     if (!(o instanceof io.confluent.support.metrics.response.PhoneHomeResponse)) {
       return false;
     }
-    io.confluent.support.metrics.response.PhoneHomeResponse that = (io.confluent.support.metrics.response.PhoneHomeResponse) o;
+    final io.confluent.support.metrics.response.PhoneHomeResponse that =
+        (io.confluent.support.metrics.response.PhoneHomeResponse) o;
     return Objects.equals(getConfluentPlatformVersion(), that.getConfluentPlatformVersion())
            && Objects.equals(getInformationForUser(), that.getInformationForUser());
   }

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/response/PhoneHomeResponse.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/response/PhoneHomeResponse.java
@@ -1,15 +1,16 @@
-/**
- * Copyright 2018 Confluent Inc.
+/*
+ * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 
 package io.confluent.support.metrics.response;

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/serde/AvroSerializer.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/serde/AvroSerializer.java
@@ -1,17 +1,16 @@
-/**
- * Copyright 2015 Confluent Inc.
+/*
+ * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 
 package io.confluent.support.metrics.serde;

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/serde/AvroSerializer.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/serde/AvroSerializer.java
@@ -15,39 +15,39 @@
 
 package io.confluent.support.metrics.serde;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericContainer;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.io.DatumWriter;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-
 public class AvroSerializer {
 
-    /**
-     * Serializes the record as an in-memory representation of a standard Avro file.
-     *
-     * <p>That is, the returned bytes include a standard Avro header that contains a magic byte, the
-     * record's Avro schema (and so on), followed by the byte representation of the record.
-     *
-     * <p>Implementation detail:  This method uses Avro's {@code DataFileWriter}.
-     *
-     * @return Avro-encoded record (bytes) that includes the Avro schema
-     */
-    public byte[] serialize(GenericContainer record) throws IOException {
-        if (record != null) {
-            DatumWriter<GenericContainer> datumWriter = new GenericDatumWriter<>(record.getSchema());
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-            DataFileWriter<GenericContainer> writer = new DataFileWriter<>(datumWriter);
-            writer.create(record.getSchema(), out);
-            writer.append(record);
-            writer.close();
-            out.close();
-            return out.toByteArray();
-        } else {
-            return null;
-        }
+  /**
+   * Serializes the record as an in-memory representation of a standard Avro file.
+   *
+   * <p>That is, the returned bytes include a standard Avro header that contains a magic byte, the
+   * record's Avro schema (and so on), followed by the byte representation of the record.
+   *
+   * <p>Implementation detail:  This method uses Avro's {@code DataFileWriter}.
+   *
+   * @return Avro-encoded record (bytes) that includes the Avro schema
+   */
+  public byte[] serialize(final GenericContainer record) throws IOException {
+    if (record != null) {
+      final DatumWriter<GenericContainer> datumWriter = new GenericDatumWriter<>(
+          record.getSchema());
+      final ByteArrayOutputStream out = new ByteArrayOutputStream();
+      final DataFileWriter<GenericContainer> writer = new DataFileWriter<>(datumWriter);
+      writer.create(record.getSchema(), out);
+      writer.append(record);
+      writer.close();
+      out.close();
+      return out.toByteArray();
+    } else {
+      return null;
     }
+  }
 
 }

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/serde/AvroSerializer.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/serde/AvroSerializer.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.support.metrics.serde;
+
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericContainer;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.io.DatumWriter;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public class AvroSerializer {
+
+    /**
+     * Serializes the record as an in-memory representation of a standard Avro file.
+     *
+     * <p>That is, the returned bytes include a standard Avro header that contains a magic byte, the
+     * record's Avro schema (and so on), followed by the byte representation of the record.
+     *
+     * <p>Implementation detail:  This method uses Avro's {@code DataFileWriter}.
+     *
+     * @return Avro-encoded record (bytes) that includes the Avro schema
+     */
+    public byte[] serialize(GenericContainer record) throws IOException {
+        if (record != null) {
+            DatumWriter<GenericContainer> datumWriter = new GenericDatumWriter<>(record.getSchema());
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            DataFileWriter<GenericContainer> writer = new DataFileWriter<>(datumWriter);
+            writer.create(record.getSchema(), out);
+            writer.append(record);
+            writer.close();
+            out.close();
+            return out.toByteArray();
+        } else {
+            return null;
+        }
+    }
+
+}

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/submitters/ConfluentSubmitter.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/submitters/ConfluentSubmitter.java
@@ -1,15 +1,16 @@
-/**
- * Copyright 2015 Confluent Inc.
+/*
+ * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 
 package io.confluent.support.metrics.submitters;

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/submitters/ConfluentSubmitter.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/submitters/ConfluentSubmitter.java
@@ -1,0 +1,205 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.support.metrics.submitters;
+
+import io.confluent.support.metrics.BaseSupportConfig;
+import io.confluent.support.metrics.submitters.ResponseHandler;
+import io.confluent.support.metrics.submitters.Submitter;
+import io.confluent.support.metrics.utils.StringUtils;
+import io.confluent.support.metrics.utils.WebClient;
+import java.net.URI;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpPost;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConfluentSubmitter implements Submitter {
+
+  private static final Logger log = LoggerFactory
+      .getLogger(io.confluent.support.metrics.submitters.ConfluentSubmitter.class);
+
+  private final String customerId;
+  private final String endpointHTTP;
+  private final String endpointHTTPS;
+  private HttpHost proxy;
+  private ResponseHandler responseHandler;
+
+  public String getProxy() {
+    return proxy == null ? null : proxy.toString();
+  }
+
+  public void setProxy(String name, int port, String scheme) {
+    this.proxy = new HttpHost(name, port, scheme);
+  }
+
+  /**
+   * Class that decides how to send data to Confluent.
+   *
+   * @param endpointHTTP HTTP endpoint for the Confluent support service. Can be null.
+   * @param endpointHTTPS HTTPS endpoint for the Confluent support service. Can be null.
+   */
+  public ConfluentSubmitter(String customerId, String endpointHTTP, String endpointHTTPS) {
+    this(customerId, endpointHTTP, endpointHTTPS, null, null);
+  }
+
+  /**
+   * Constructor for phone-home clients which use ConfluentSubmitter directly instead of
+   * BaseMetricsReporter and, as a result, don't need PhoneHomeConfig.
+   * Sets customerId = "anonymous"
+   */
+  public ConfluentSubmitter(String componentId, ResponseHandler responseHandler) {
+    this(BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT, componentId, responseHandler);
+  }
+
+  /**
+   * Also constructor for phone-home clients which use ConfluentSubmitter directly, but lets set
+   * customer ID.
+   * Common use-case is customerId = "anonymous" (BaseSupportConfig
+   * .CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT) for production code, and "c0"
+   * (BaseSupportConfig.CONFLUENT_SUPPORT_TEST_ID_DEFAULT) for internal testing. E.g. if we don't
+   * want to include any internal testing data to aggregations and analysis we do on S3 data that
+   * the server stores.
+   * If customerID is "anonymous", then the endpoint path ends in "/anon", and if customerId is
+   * "c0", then the endpoint path ends in "/test". CustomerId is also included in the body of
+   * the phone-home ping.
+   */
+  public ConfluentSubmitter(
+      String customerId, String componentId, ResponseHandler responseHandler
+  ) {
+    this(customerId,
+         BaseSupportConfig.getEndpoint(false, customerId, componentId),
+         BaseSupportConfig.getEndpoint(true, customerId, componentId),
+         BaseSupportConfig.CONFLUENT_SUPPORT_PROXY_DEFAULT,
+         responseHandler);
+  }
+
+  public ConfluentSubmitter(
+      String customerId,
+      String endpointHTTP,
+      String endpointHTTPS,
+      String proxyURIString,
+      ResponseHandler responseHandler
+  ) {
+
+    if (StringUtils.isNullOrEmpty(endpointHTTP) && StringUtils.isNullOrEmpty(endpointHTTPS)) {
+      throw new IllegalArgumentException("must specify endpoints");
+    }
+    if (!StringUtils.isNullOrEmpty(endpointHTTP)) {
+      if (!endpointHTTP.startsWith("http://")) {
+        throw new IllegalArgumentException("invalid HTTP endpoint " + endpointHTTP);
+      }
+    }
+    if (!StringUtils.isNullOrEmpty(endpointHTTPS)) {
+      if (!endpointHTTPS.startsWith("https://")) {
+        throw new IllegalArgumentException("invalid HTTPS endpoint " + endpointHTTPS);
+      }
+    }
+    if (!BaseSupportConfig.isSyntacticallyCorrectCustomerId(customerId)) {
+      throw new IllegalArgumentException("invalid customer ID "  + customerId);
+    }
+    this.endpointHTTP = endpointHTTP;
+    this.endpointHTTPS = endpointHTTPS;
+    this.customerId = customerId;
+    this.responseHandler = responseHandler;
+
+    if (!StringUtils.isNullOrEmpty(proxyURIString)) {
+      URI proxyURI = URI.create(proxyURIString);
+      this.setProxy(proxyURI.getHost(), proxyURI.getPort(), proxyURI.getScheme());
+    }
+  }
+
+  /**
+   * Submits metrics to Confluent via the Internet.  Ignores null or empty inputs.
+   */
+  @Override
+  public void submit(byte[] bytes) {
+    if (bytes != null && bytes.length > 0) {
+      if (isSecureEndpointEnabled()) {
+        if (!submittedSuccessfully(sendSecurely(bytes))) {
+          if (isInsecureEndpointEnabled()) {
+            log.error(
+                "Failed to submit metrics via secure endpoint, falling back to insecure endpoint"
+            );
+            submitToInsecureEndpoint(bytes);
+          } else {
+            log.error(
+                "Failed to submit metrics via secure endpoint={} -- giving up",
+                endpointHTTPS
+            );
+          }
+        } else {
+          log.info("Successfully submitted metrics to Confluent via secure endpoint");
+        }
+      } else {
+        if (isInsecureEndpointEnabled()) {
+          submitToInsecureEndpoint(bytes);
+        } else {
+          log.error("Metrics will not be submitted because all endpoints are disabled");
+        }
+      }
+    } else {
+      log.error("Could not submit metrics to Confluent (metrics data missing)");
+    }
+  }
+
+  private void submitToInsecureEndpoint(byte[] encodedMetricsRecord) {
+    int statusCode = sendInsecurely(encodedMetricsRecord);
+    if (submittedSuccessfully(statusCode)) {
+      log.info("Successfully submitted metrics to Confluent via insecure endpoint");
+    } else {
+      log.error(
+          "Failed to submit metrics to Confluent via insecure endpoint={} -- giving up",
+          endpointHTTP
+      );
+    }
+  }
+
+  private boolean isSecureEndpointEnabled() {
+    return !endpointHTTPS.isEmpty();
+  }
+
+  private boolean isInsecureEndpointEnabled() {
+    return !endpointHTTP.isEmpty();
+  }
+
+  /**
+   * Getters for testing
+   */
+  String getEndpointHTTP() {
+    return endpointHTTP;
+  }
+
+  String getEndpointHTTPS() {
+    return endpointHTTPS;
+  }
+
+  private boolean submittedSuccessfully(int statusCode) {
+    return statusCode == HttpStatus.SC_OK;
+  }
+
+  private int sendSecurely(byte[] encodedMetricsRecord) {
+    return send(encodedMetricsRecord, endpointHTTPS);
+  }
+
+  private int sendInsecurely(byte[] encodedMetricsRecord) {
+    return send(encodedMetricsRecord, endpointHTTP);
+  }
+
+  private int send(byte[] encodedMetricsRecord, String endpoint) {
+    return WebClient
+        .send(customerId, encodedMetricsRecord, new HttpPost(endpoint), proxy, responseHandler);
+  }
+}

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/submitters/ResponseHandler.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/submitters/ResponseHandler.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.support.metrics.submitters;
+
+import org.apache.http.HttpResponse;
+
+public interface ResponseHandler {
+
+  void handle(HttpResponse response);
+
+}

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/submitters/ResponseHandler.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/submitters/ResponseHandler.java
@@ -1,17 +1,16 @@
 /*
- * Copyright 2017 Confluent Inc.
+ * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 
 package io.confluent.support.metrics.submitters;

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/submitters/Submitter.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/submitters/Submitter.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.support.metrics.submitters;
+
+public interface Submitter {
+
+  void submit(byte[] bytes);
+
+}

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/submitters/Submitter.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/submitters/Submitter.java
@@ -1,15 +1,16 @@
-/**
- * Copyright 2015 Confluent Inc.
+/*
+ * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 
 package io.confluent.support.metrics.submitters;

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/utils/Jitter.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/utils/Jitter.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.support.metrics.utils;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public class Jitter {
+  /**
+   * Adds 1% to a value. If value is 0, returns 0. If value is negative, adds 1% of abs(value) to it
+   *
+   * @param value Number to add 1% to. Could be negative.
+   * @return Value +1% of abs(value)
+   */
+  public static long addOnePercentJitter(long value) {
+    if (value == 0 || value < 100) {
+      return value;
+    }
+    return value + ThreadLocalRandom.current().nextInt((int) Math.abs(value) / 100);
+  }
+}

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/utils/Jitter.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/utils/Jitter.java
@@ -1,15 +1,16 @@
-/**
- * Copyright 2015 Confluent Inc.
+/*
+ * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 
 package io.confluent.support.metrics.utils;

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/utils/Jitter.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/utils/Jitter.java
@@ -17,14 +17,19 @@ package io.confluent.support.metrics.utils;
 
 import java.util.concurrent.ThreadLocalRandom;
 
-public class Jitter {
+public final class Jitter {
+
+  private Jitter() {
+    throw new IllegalStateException("Utility class should not be instantiated");
+  }
+
   /**
    * Adds 1% to a value. If value is 0, returns 0. If value is negative, adds 1% of abs(value) to it
    *
    * @param value Number to add 1% to. Could be negative.
    * @return Value +1% of abs(value)
    */
-  public static long addOnePercentJitter(long value) {
+  public static long addOnePercentJitter(final long value) {
     if (value == 0 || value < 100) {
       return value;
     }

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/utils/StringUtils.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/utils/StringUtils.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.support.metrics.utils;
+
+public class StringUtils {
+  public static boolean isNullOrBlank(CharSequence cs) {
+    if (cs == null) {
+      return true;
+    }
+    for (int c : cs.chars().toArray()) {
+      if (!Character.isWhitespace(c)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  public static boolean isNullOrEmpty(CharSequence cs) {
+    return (cs == null) || (cs.length() == 0);
+  }
+}

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/utils/StringUtils.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/utils/StringUtils.java
@@ -1,15 +1,16 @@
-/**
- * Copyright 2019 Confluent Inc.
+/*
+ * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 
 package io.confluent.support.metrics.utils;

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/utils/StringUtils.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/utils/StringUtils.java
@@ -15,8 +15,13 @@
 
 package io.confluent.support.metrics.utils;
 
-public class StringUtils {
-  public static boolean isNullOrBlank(CharSequence cs) {
+public final class StringUtils {
+
+  private StringUtils() {
+    throw new IllegalStateException("Utility class should not be instantiated");
+  }
+
+  public static boolean isNullOrBlank(final CharSequence cs) {
     if (cs == null) {
       return true;
     }
@@ -28,7 +33,7 @@ public class StringUtils {
     return true;
   }
 
-  public static boolean isNullOrEmpty(CharSequence cs) {
+  public static boolean isNullOrEmpty(final CharSequence cs) {
     return (cs == null) || (cs.length() == 0);
   }
 }

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/utils/WebClient.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/utils/WebClient.java
@@ -1,15 +1,16 @@
-/**
- * Copyright 2015 Confluent Inc.
+/*
+ * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 
 package io.confluent.support.metrics.utils;

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/utils/WebClient.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/utils/WebClient.java
@@ -31,12 +31,16 @@ import org.apache.http.impl.conn.DefaultProxyRoutePlanner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class WebClient {
+public final class WebClient {
 
   private static final Logger log = LoggerFactory
       .getLogger(io.confluent.support.metrics.utils.WebClient.class);
   private static final int REQUEST_TIMEOUT_MS = 2000;
   public static final int DEFAULT_STATUS_CODE = HttpStatus.SC_BAD_GATEWAY;
+
+  private WebClient() {
+    throw new IllegalStateException("Utility class should not be instantiated");
+  }
 
   /**
    * Sends a POST request to a web server
@@ -50,15 +54,16 @@ public class WebClient {
    * @return an HTTP Status code
    * @see #send(String, byte[], HttpPost, ResponseHandler)
    */
+  @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:FinalParameters"})
   protected static int send(
-      String customerId, byte[] bytes, HttpPost httpPost, HttpHost proxy,
-      CloseableHttpClient httpClient, ResponseHandler responseHandler
+      final String customerId, final byte[] bytes, final HttpPost httpPost, final HttpHost proxy,
+      CloseableHttpClient httpClient, final ResponseHandler responseHandler
   ) {
     int statusCode = DEFAULT_STATUS_CODE;
     if (bytes != null && bytes.length > 0 && httpPost != null && customerId != null) {
 
       // add the body to the request
-      MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+      final MultipartEntityBuilder builder = MultipartEntityBuilder.create();
       builder.setMode(HttpMultipartMode.BROWSER_COMPATIBLE);
       builder.addTextBody("cid", customerId);
       builder.addBinaryBody("file", bytes, ContentType.DEFAULT_BINARY, "filename");
@@ -79,7 +84,7 @@ public class WebClient {
           log.debug("setting proxy to {}", proxy);
           config = RequestConfig.copy(config).setProxy(proxy).build();
           httpPost.setConfig(config);
-          DefaultProxyRoutePlanner routePlanner = new DefaultProxyRoutePlanner(proxy);
+          final DefaultProxyRoutePlanner routePlanner = new DefaultProxyRoutePlanner(proxy);
           if (httpClient == null) {
             httpClient = HttpClientBuilder
                 .create()
@@ -135,11 +140,11 @@ public class WebClient {
    * @return an HTTP Status code
    */
   public static int send(
-      String customerId,
-      byte[] bytes,
-      HttpPost httpPost,
-      HttpHost proxy,
-      ResponseHandler responseHandler
+      final String customerId,
+      final byte[] bytes,
+      final HttpPost httpPost,
+      final HttpHost proxy,
+      final ResponseHandler responseHandler
   ) {
     return send(customerId, bytes, httpPost, proxy, null, responseHandler);
   }
@@ -153,10 +158,10 @@ public class WebClient {
    * @return an HTTP Status code
    */
   public static int send(
-      String customerId,
-      byte[] bytes,
-      HttpPost httpPost,
-      ResponseHandler responseHandler
+      final String customerId,
+      final byte[] bytes,
+      final HttpPost httpPost,
+      final ResponseHandler responseHandler
   ) {
     return send(customerId, bytes, httpPost, null, responseHandler);
   }

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/utils/WebClient.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/utils/WebClient.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.support.metrics.utils;
+
+import io.confluent.support.metrics.submitters.ResponseHandler;
+import java.io.IOException;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.mime.HttpMultipartMode;
+import org.apache.http.entity.mime.MultipartEntityBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.conn.DefaultProxyRoutePlanner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WebClient {
+
+  private static final Logger log = LoggerFactory
+      .getLogger(io.confluent.support.metrics.utils.WebClient.class);
+  private static final int REQUEST_TIMEOUT_MS = 2000;
+  public static final int DEFAULT_STATUS_CODE = HttpStatus.SC_BAD_GATEWAY;
+
+  /**
+   * Sends a POST request to a web server
+   * This method requires a pre-configured http client instance
+   *
+   * @param customerId customer Id on behalf of which the request is sent
+   * @param bytes request payload
+   * @param httpPost A POST request structure
+   * @param proxy a http (passive) proxy
+   * @param httpClient http client instance configured by caller
+   * @return an HTTP Status code
+   * @see #send(String, byte[], HttpPost, ResponseHandler)
+   */
+  protected static int send(
+      String customerId, byte[] bytes, HttpPost httpPost, HttpHost proxy,
+      CloseableHttpClient httpClient, ResponseHandler responseHandler
+  ) {
+    int statusCode = DEFAULT_STATUS_CODE;
+    if (bytes != null && bytes.length > 0 && httpPost != null && customerId != null) {
+
+      // add the body to the request
+      MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+      builder.setMode(HttpMultipartMode.BROWSER_COMPATIBLE);
+      builder.addTextBody("cid", customerId);
+      builder.addBinaryBody("file", bytes, ContentType.DEFAULT_BINARY, "filename");
+      httpPost.setEntity(builder.build());
+      httpPost.addHeader("api-version", "phone-home-v1");
+
+      // set the HTTP config
+      RequestConfig config = RequestConfig.custom()
+          .setConnectTimeout(REQUEST_TIMEOUT_MS)
+          .setConnectionRequestTimeout(REQUEST_TIMEOUT_MS)
+          .setSocketTimeout(REQUEST_TIMEOUT_MS)
+          .build();
+
+      CloseableHttpResponse response = null;
+
+      try {
+        if (proxy != null) {
+          log.debug("setting proxy to {}", proxy);
+          config = RequestConfig.copy(config).setProxy(proxy).build();
+          httpPost.setConfig(config);
+          DefaultProxyRoutePlanner routePlanner = new DefaultProxyRoutePlanner(proxy);
+          if (httpClient == null) {
+            httpClient = HttpClientBuilder
+                .create()
+                .setRoutePlanner(routePlanner)
+                .setDefaultRequestConfig(config)
+                .build();
+          }
+        } else {
+          if (httpClient == null) {
+            httpClient = HttpClientBuilder.create().setDefaultRequestConfig(config).build();
+          }
+        }
+
+        response = httpClient.execute(httpPost);
+        if (responseHandler != null) {
+          responseHandler.handle(response);
+        }
+
+        // send request
+        log.debug("POST request returned {}", response.getStatusLine().toString());
+        statusCode = response.getStatusLine().getStatusCode();
+      } catch (IOException e) {
+        log.error("Could not submit metrics to Confluent: {}", e.getMessage());
+      } finally {
+        if (httpClient != null) {
+          try {
+            httpClient.close();
+          } catch (IOException e) {
+            log.warn("could not close http client", e);
+          }
+        }
+        if (response != null) {
+          try {
+            response.close();
+          } catch (IOException e) {
+            log.warn("could not close http response", e);
+          }
+        }
+      }
+    } else {
+      statusCode = HttpStatus.SC_BAD_REQUEST;
+    }
+    return statusCode;
+  }
+
+  /**
+   * Sends a POST request to a web server via a HTTP proxy
+   *
+   * @param customerId customer Id on behalf of which the request is sent
+   * @param bytes request payload
+   * @param httpPost A POST request structure
+   * @param proxy a http (passive) proxy
+   * @return an HTTP Status code
+   */
+  public static int send(
+      String customerId,
+      byte[] bytes,
+      HttpPost httpPost,
+      HttpHost proxy,
+      ResponseHandler responseHandler
+  ) {
+    return send(customerId, bytes, httpPost, proxy, null, responseHandler);
+  }
+
+  /**
+   * Sends a POST request to a web server
+   *
+   * @param customerId customer Id on behalf of which the request is sent
+   * @param bytes request payload
+   * @param httpPost A POST request structure
+   * @return an HTTP Status code
+   */
+  public static int send(
+      String customerId,
+      byte[] bytes,
+      HttpPost httpPost,
+      ResponseHandler responseHandler
+  ) {
+    return send(customerId, bytes, httpPost, null, responseHandler);
+  }
+
+}

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/validate/KSqlValidModuleType.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/validate/KSqlValidModuleType.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.support.metrics.validate;
+
+/**
+ * Maintains current and previous valid types of KsqlModuleType
+ */
+public enum KSqlValidModuleType {
+  LOCAL_CLI,
+  REMOTE_CLI,
+  CLI,
+  EMBEDDED,
+  SERVER;
+}

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/validate/KSqlValidModuleType.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/validate/KSqlValidModuleType.java
@@ -1,15 +1,16 @@
-/**
- * Copyright 2015 Confluent Inc.
+/*
+ * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 
 package io.confluent.support.metrics.validate;

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/validate/MetricsValidation.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/validate/MetricsValidation.java
@@ -1,15 +1,16 @@
-/**
- * Copyright 2015 Confluent Inc.
+/*
+ * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 
 package io.confluent.support.metrics.validate;

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/validate/MetricsValidation.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/validate/MetricsValidation.java
@@ -15,14 +15,16 @@
 
 package io.confluent.support.metrics.validate;
 
-import io.confluent.support.metrics.validate.KSqlValidModuleType;
-
 /**
  * Utility methods to verify metrics fields for various components
  */
-public class MetricsValidation {
+public final class MetricsValidation {
 
-  public static boolean isValidKsqlModuleType(String moduleType) {
+  private MetricsValidation() {
+    throw new IllegalStateException("Utility class should not be instantiated");
+  }
+
+  public static boolean isValidKsqlModuleType(final String moduleType) {
     for (KSqlValidModuleType type: KSqlValidModuleType.values()) {
       if (moduleType.equals(type.name())) {
         return true;

--- a/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/validate/MetricsValidation.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/support/metrics/validate/MetricsValidation.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.support.metrics.validate;
+
+import io.confluent.support.metrics.validate.KSqlValidModuleType;
+
+/**
+ * Utility methods to verify metrics fields for various components
+ */
+public class MetricsValidation {
+
+  public static boolean isValidKsqlModuleType(String moduleType) {
+    for (KSqlValidModuleType type: KSqlValidModuleType.values()) {
+      if (moduleType.equals(type.name())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+}

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/BaseSupportConfigTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/BaseSupportConfigTest.java
@@ -38,20 +38,20 @@ public class BaseSupportConfigTest {
   @Test
   public void testValidNewCustomer() {
     String[] validNewCustomerIds = Stream.concat(
-        Arrays.stream(CustomerIdExamples.VALID_CASE_SENSISTIVE_NEW_CUSTOMER_IDS),
-        Arrays.stream(CustomerIdExamples.VALID_CASE_INSENSISTIVE_NEW_CUSTOMER_IDS)).
+        CustomerIdExamples.VALID_CASE_SENSISTIVE_NEW_CUSTOMER_IDS.stream(),
+        CustomerIdExamples.VALID_CASE_INSENSISTIVE_NEW_CUSTOMER_IDS.stream()).
         toArray(String[]::new);
     for (String validId : validNewCustomerIds) {
       assertTrue(validId + " is an invalid new customer identifier",
-                 BaseSupportConfig.isConfluentCustomer(validId));
+          BaseSupportConfig.isConfluentCustomer(validId));
     }
   }
 
   @Test
   public void testInvalidCustomer() {
     String[] invalidIds = Stream.concat(
-        Arrays.stream(CustomerIdExamples.INVALID_CUSTOMER_IDS),
-        Arrays.stream(CustomerIdExamples.VALID_ANONYMOUS_IDS)).
+        CustomerIdExamples.INVALID_CUSTOMER_IDS.stream(),
+        CustomerIdExamples.VALID_ANONYMOUS_IDS.stream()).
         toArray(String[]::new);
     for (String invalidCustomerId : invalidIds) {
       assertFalse(invalidCustomerId + " is a valid customer identifier",
@@ -70,8 +70,8 @@ public class BaseSupportConfigTest {
   @Test
   public void testInvalidAnonymousUser() {
     String[] invalidIds = Stream.concat(
-        Arrays.stream(CustomerIdExamples.INVALID_ANONYMOUS_IDS),
-        Arrays.stream(CustomerIdExamples.VALID_CUSTOMER_IDS)).
+        CustomerIdExamples.INVALID_ANONYMOUS_IDS.stream(),
+        CustomerIdExamples.VALID_CUSTOMER_IDS.stream()).
         toArray(String[]::new);
     for (String invalidId : invalidIds) {
       assertFalse(invalidId + " is a valid anonymous user identifier",
@@ -82,28 +82,28 @@ public class BaseSupportConfigTest {
   @Test
   public void testCustomerIdValidSettings() {
     String[] validValues = Stream.concat(
-        Arrays.stream(CustomerIdExamples.VALID_ANONYMOUS_IDS),
-        Arrays.stream(CustomerIdExamples.VALID_CUSTOMER_IDS)).
+        CustomerIdExamples.VALID_ANONYMOUS_IDS.stream(),
+        CustomerIdExamples.VALID_CUSTOMER_IDS.stream()).
         toArray(String[]::new);
     for (String validValue : validValues) {
       assertTrue(validValue + " is an invalid value for " +
-          BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_CONFIG,
+              BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_CONFIG,
           BaseSupportConfig.isSyntacticallyCorrectCustomerId(validValue));
       // old customer Ids are all case-insensitive
       assertFalse(validValue + " is case-sensitive customer ID.",
-                 BaseSupportConfig.isCaseSensitiveCustomerId(validValue));
+          BaseSupportConfig.isCaseSensitiveCustomerId(validValue));
     }
   }
 
   @Test
   public void testCustomerIdInvalidSettings() {
     String[] invalidValues = Stream.concat(
-        Arrays.stream(CustomerIdExamples.INVALID_ANONYMOUS_IDS),
-        Arrays.stream(CustomerIdExamples.INVALID_CUSTOMER_IDS)).
+        CustomerIdExamples.INVALID_ANONYMOUS_IDS.stream(),
+        CustomerIdExamples.INVALID_CUSTOMER_IDS.stream()).
         toArray(String[]::new);
     for (String invalidValue : invalidValues) {
       assertFalse(invalidValue + " is a valid value for " +
-          BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_CONFIG,
+              BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_CONFIG,
           BaseSupportConfig.isSyntacticallyCorrectCustomerId(invalidValue));
     }
   }
@@ -112,7 +112,7 @@ public class BaseSupportConfigTest {
   public void testCaseInsensitiveNewCustomerIds() {
     for (String validValue : CustomerIdExamples.VALID_CASE_INSENSISTIVE_NEW_CUSTOMER_IDS) {
       assertFalse(validValue + " is case-sensitive customer ID.",
-                 BaseSupportConfig.isCaseSensitiveCustomerId(validValue));
+          BaseSupportConfig.isCaseSensitiveCustomerId(validValue));
     }
   }
 
@@ -120,7 +120,7 @@ public class BaseSupportConfigTest {
   public void testCaseSensitiveNewCustomerIds() {
     for (String validValue : CustomerIdExamples.VALID_CASE_SENSISTIVE_NEW_CUSTOMER_IDS) {
       assertTrue(validValue + " is case-insensitive customer ID.",
-                 BaseSupportConfig.isCaseSensitiveCustomerId(validValue));
+          BaseSupportConfig.isCaseSensitiveCustomerId(validValue));
     }
   }
 
@@ -193,7 +193,7 @@ public class BaseSupportConfigTest {
     BaseSupportConfig supportConfig = new TestSupportConfig(overrideProps);
 
     // Then
-    assertEquals(reportIntervalHours * 60 * 60 * 1000, supportConfig.getReportIntervalMs());
+    assertEquals((long) reportIntervalHours * 60 * 60 * 1000, supportConfig.getReportIntervalMs());
   }
 
   @Test
@@ -288,7 +288,7 @@ public class BaseSupportConfigTest {
     assertTrue(supportConfig.isProactiveSupportEnabled());
   }
 
-  public class TestSupportConfig extends BaseSupportConfig {
+  public static class TestSupportConfig extends BaseSupportConfig {
 
     public TestSupportConfig(Properties originals) {
       super(originals);

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/BaseSupportConfigTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/BaseSupportConfigTest.java
@@ -20,11 +20,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import io.confluent.support.metrics.utils.CustomerIdExamples;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Properties;
 import java.util.stream.Stream;
-import kafka.server.KafkaConfig;
 import org.junit.Test;
 
 public class BaseSupportConfigTest {
@@ -142,8 +140,8 @@ public class BaseSupportConfigTest {
     assertTrue(supportConfig.isHttpsEnabled());
     assertTrue(supportConfig.isProactiveSupportEnabled());
     assertEquals("", supportConfig.getProxy());
-    assertEquals("http://support-metrics.confluent.io/anon", supportConfig.getEndpointHTTP());
-    assertEquals("https://support-metrics.confluent.io/anon", supportConfig.getEndpointHTTPS());
+    assertEquals("http://support-metrics.confluent.io/anon", supportConfig.getEndpointHttp());
+    assertEquals("https://support-metrics.confluent.io/anon", supportConfig.getEndpointHttps());
   }
 
   @Test
@@ -162,8 +160,8 @@ public class BaseSupportConfigTest {
     BaseSupportConfig supportConfig = new TestSupportConfig(overrideProps);
 
     // Then
-    assertEquals("http://support-metrics.confluent.io/anon", supportConfig.getEndpointHTTP());
-    assertEquals("https://support-metrics.confluent.io/anon", supportConfig.getEndpointHTTPS());
+    assertEquals("http://support-metrics.confluent.io/anon", supportConfig.getEndpointHttp());
+    assertEquals("https://support-metrics.confluent.io/anon", supportConfig.getEndpointHttps());
   }
 
   @Test
@@ -178,8 +176,8 @@ public class BaseSupportConfigTest {
     BaseSupportConfig supportConfig = new TestSupportConfig(overrideProps);
 
     // Then
-    assertTrue(supportConfig.getEndpointHTTP().isEmpty());
-    assertTrue(supportConfig.getEndpointHTTPS().isEmpty());
+    assertTrue(supportConfig.getEndpointHttp().isEmpty());
+    assertTrue(supportConfig.getEndpointHttps().isEmpty());
   }
 
   @Test

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/BaseSupportConfigTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/BaseSupportConfigTest.java
@@ -1,0 +1,358 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.confluent.support.metrics;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import io.confluent.support.metrics.utils.CustomerIdExamples;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Properties;
+import java.util.stream.Stream;
+import kafka.server.KafkaConfig;
+import org.junit.Test;
+
+public class BaseSupportConfigTest {
+
+  @Test
+  public void testValidCustomer() {
+    for (String validId : CustomerIdExamples.VALID_CUSTOMER_IDS) {
+      assertTrue(validId + " is an invalid customer identifier",
+          BaseSupportConfig.isConfluentCustomer(validId));
+    }
+  }
+
+  @Test
+  public void testValidNewCustomer() {
+    String[] validNewCustomerIds = Stream.concat(
+        Arrays.stream(CustomerIdExamples.VALID_CASE_SENSISTIVE_NEW_CUSTOMER_IDS),
+        Arrays.stream(CustomerIdExamples.VALID_CASE_INSENSISTIVE_NEW_CUSTOMER_IDS)).
+        toArray(String[]::new);
+    for (String validId : validNewCustomerIds) {
+      assertTrue(validId + " is an invalid new customer identifier",
+                 BaseSupportConfig.isConfluentCustomer(validId));
+    }
+  }
+
+  @Test
+  public void testInvalidCustomer() {
+    String[] invalidIds = Stream.concat(
+        Arrays.stream(CustomerIdExamples.INVALID_CUSTOMER_IDS),
+        Arrays.stream(CustomerIdExamples.VALID_ANONYMOUS_IDS)).
+        toArray(String[]::new);
+    for (String invalidCustomerId : invalidIds) {
+      assertFalse(invalidCustomerId + " is a valid customer identifier",
+          BaseSupportConfig.isConfluentCustomer(invalidCustomerId));
+    }
+  }
+
+  @Test
+  public void testValidAnonymousUser() {
+    for (String validId : CustomerIdExamples.VALID_ANONYMOUS_IDS) {
+      assertTrue(validId + " is an invalid anonymous user identifier",
+          BaseSupportConfig.isAnonymousUser(validId));
+    }
+  }
+
+  @Test
+  public void testInvalidAnonymousUser() {
+    String[] invalidIds = Stream.concat(
+        Arrays.stream(CustomerIdExamples.INVALID_ANONYMOUS_IDS),
+        Arrays.stream(CustomerIdExamples.VALID_CUSTOMER_IDS)).
+        toArray(String[]::new);
+    for (String invalidId : invalidIds) {
+      assertFalse(invalidId + " is a valid anonymous user identifier",
+          BaseSupportConfig.isAnonymousUser(invalidId));
+    }
+  }
+
+  @Test
+  public void testCustomerIdValidSettings() {
+    String[] validValues = Stream.concat(
+        Arrays.stream(CustomerIdExamples.VALID_ANONYMOUS_IDS),
+        Arrays.stream(CustomerIdExamples.VALID_CUSTOMER_IDS)).
+        toArray(String[]::new);
+    for (String validValue : validValues) {
+      assertTrue(validValue + " is an invalid value for " +
+          BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_CONFIG,
+          BaseSupportConfig.isSyntacticallyCorrectCustomerId(validValue));
+      // old customer Ids are all case-insensitive
+      assertFalse(validValue + " is case-sensitive customer ID.",
+                 BaseSupportConfig.isCaseSensitiveCustomerId(validValue));
+    }
+  }
+
+  @Test
+  public void testCustomerIdInvalidSettings() {
+    String[] invalidValues = Stream.concat(
+        Arrays.stream(CustomerIdExamples.INVALID_ANONYMOUS_IDS),
+        Arrays.stream(CustomerIdExamples.INVALID_CUSTOMER_IDS)).
+        toArray(String[]::new);
+    for (String invalidValue : invalidValues) {
+      assertFalse(invalidValue + " is a valid value for " +
+          BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_CONFIG,
+          BaseSupportConfig.isSyntacticallyCorrectCustomerId(invalidValue));
+    }
+  }
+
+  @Test
+  public void testCaseInsensitiveNewCustomerIds() {
+    for (String validValue : CustomerIdExamples.VALID_CASE_INSENSISTIVE_NEW_CUSTOMER_IDS) {
+      assertFalse(validValue + " is case-sensitive customer ID.",
+                 BaseSupportConfig.isCaseSensitiveCustomerId(validValue));
+    }
+  }
+
+  @Test
+  public void testCaseSensitiveNewCustomerIds() {
+    for (String validValue : CustomerIdExamples.VALID_CASE_SENSISTIVE_NEW_CUSTOMER_IDS) {
+      assertTrue(validValue + " is case-insensitive customer ID.",
+                 BaseSupportConfig.isCaseSensitiveCustomerId(validValue));
+    }
+  }
+
+  @Test
+  public void proactiveSupportConfigIsValidKafkaConfig() throws IOException {
+    // Given
+    Properties brokerConfiguration = defaultBrokerConfiguration();
+
+    // When
+    KafkaConfig cfg = KafkaConfig.fromProps(brokerConfiguration);
+
+    // Then
+    assertEquals(0, cfg.brokerId());
+    assertTrue(cfg.zkConnect().startsWith("localhost:"));
+  }
+
+  private Properties defaultBrokerConfiguration() throws IOException {
+    Properties brokerConfiguration = new Properties();
+    brokerConfiguration.load(BaseSupportConfigTest.class.getResourceAsStream("/default-server"
+                                                                             + ".properties"));
+    return brokerConfiguration;
+  }
+
+  @Test
+  public void canParseProactiveSupportConfiguration() throws IOException {
+    // Given
+    Properties brokerConfiguration = defaultBrokerConfiguration();
+
+    BaseSupportConfig supportConfig = new TestSupportConfig(brokerConfiguration);
+    // When/Then
+    assertTrue(supportConfig.getMetricsEnabled());
+    assertEquals("c0", supportConfig.getCustomerId());
+    assertTrue(supportConfig.isProactiveSupportEnabled());
+  }
+
+
+  @Test
+  public void testGetDefaultProps() {
+    // Given
+    Properties overrideProps = new Properties();
+    // When
+    BaseSupportConfig supportConfig = new TestSupportConfig(overrideProps);
+
+    // Then
+    assertTrue(supportConfig.getMetricsEnabled());
+    assertEquals("anonymous", supportConfig.getCustomerId());
+    assertEquals(24 * 60 * 60 * 1000, supportConfig.getReportIntervalMs());
+    assertEquals("__confluent.support.metrics", supportConfig.getKafkaTopic());
+    assertTrue(supportConfig.isHttpEnabled());
+    assertTrue(supportConfig.isHttpsEnabled());
+    assertTrue(supportConfig.isProactiveSupportEnabled());
+    assertEquals("", supportConfig.getProxy());
+    assertEquals("http://support-metrics.confluent.io/anon", supportConfig.getEndpointHTTP());
+    assertEquals("https://support-metrics.confluent.io/anon", supportConfig.getEndpointHTTPS());
+  }
+
+  @Test
+  public void testMergeAndValidatePropsFilterDisallowedKeys() {
+    // Given
+    Properties overrideProps = new Properties();
+    overrideProps.setProperty(
+        BaseSupportConfig.CONFLUENT_SUPPORT_METRICS_ENDPOINT_INSECURE_CONFIG,
+        "anyValue"
+    );
+    overrideProps.setProperty(
+        BaseSupportConfig.CONFLUENT_SUPPORT_METRICS_ENDPOINT_SECURE_CONFIG,
+        "anyValue"
+    );
+    // When
+    BaseSupportConfig supportConfig = new TestSupportConfig(overrideProps);
+
+    // Then
+    assertEquals("http://support-metrics.confluent.io/anon", supportConfig.getEndpointHTTP());
+    assertEquals("https://support-metrics.confluent.io/anon", supportConfig.getEndpointHTTPS());
+  }
+
+  @Test
+  public void testMergeAndValidatePropsDisableEndpoints() {
+    // Given
+    Properties overrideProps = new Properties();
+    overrideProps.setProperty(
+        BaseSupportConfig.CONFLUENT_SUPPORT_METRICS_ENDPOINT_INSECURE_ENABLE_CONFIG, "false");
+    overrideProps.setProperty(
+        BaseSupportConfig.CONFLUENT_SUPPORT_METRICS_ENDPOINT_SECURE_ENABLE_CONFIG, "false");
+    // When
+    BaseSupportConfig supportConfig = new TestSupportConfig(overrideProps);
+
+    // Then
+    assertTrue(supportConfig.getEndpointHTTP().isEmpty());
+    assertTrue(supportConfig.getEndpointHTTPS().isEmpty());
+  }
+
+  @Test
+  public void testOverrideReportInterval() {
+    // Given
+    Properties overrideProps = new Properties();
+    int reportIntervalHours = 1;
+    overrideProps.setProperty(
+        BaseSupportConfig.CONFLUENT_SUPPORT_METRICS_REPORT_INTERVAL_HOURS_CONFIG,
+        String.valueOf(reportIntervalHours)
+    );
+    // When
+    BaseSupportConfig supportConfig = new TestSupportConfig(overrideProps);
+
+    // Then
+    assertEquals(reportIntervalHours * 60 * 60 * 1000, supportConfig.getReportIntervalMs());
+  }
+
+  @Test
+  public void testOverrideTopic() {
+    // Given
+    Properties overrideProps = new Properties();
+    overrideProps.setProperty(
+        BaseSupportConfig.CONFLUENT_SUPPORT_METRICS_TOPIC_CONFIG,
+        "__another_example_topic"
+    );
+    // When
+    BaseSupportConfig supportConfig = new TestSupportConfig(overrideProps);
+
+    // Then
+    assertEquals("__another_example_topic", supportConfig.getKafkaTopic());
+  }
+
+  @Test
+  public void isProactiveSupportEnabledFull() {
+    // Given
+    Properties serverProperties = new Properties();
+    serverProperties.setProperty(BaseSupportConfig.CONFLUENT_SUPPORT_METRICS_ENABLE_CONFIG, "true");
+
+    BaseSupportConfig supportConfig = new TestSupportConfig(serverProperties);
+    // When/Then
+    assertTrue(supportConfig.isProactiveSupportEnabled());
+  }
+
+  @Test
+  public void isProactiveSupportDisabledFull() {
+    // Given
+    Properties serverProperties = new Properties();
+
+    serverProperties
+        .setProperty(BaseSupportConfig.CONFLUENT_SUPPORT_METRICS_ENABLE_CONFIG, "false");
+    serverProperties
+        .setProperty(BaseSupportConfig.CONFLUENT_SUPPORT_METRICS_TOPIC_CONFIG, "anyTopic");
+    serverProperties.setProperty(
+        BaseSupportConfig.CONFLUENT_SUPPORT_METRICS_ENDPOINT_INSECURE_ENABLE_CONFIG,
+        "true"
+    );
+    serverProperties.setProperty(
+        BaseSupportConfig.CONFLUENT_SUPPORT_METRICS_ENDPOINT_SECURE_ENABLE_CONFIG,
+        "true"
+    );
+    BaseSupportConfig supportConfig = new TestSupportConfig(serverProperties);
+    // When/Then
+    assertFalse(supportConfig.isProactiveSupportEnabled());
+  }
+
+  @Test
+  public void isProactiveSupportEnabledTopicOnly() {
+    // Given
+    Properties serverProperties = new Properties();
+    serverProperties
+        .setProperty(BaseSupportConfig.CONFLUENT_SUPPORT_METRICS_TOPIC_CONFIG, "anyTopic");
+    BaseSupportConfig supportConfig = new TestSupportConfig(serverProperties);
+    // When/Then
+    assertTrue(supportConfig.isProactiveSupportEnabled());
+  }
+
+  @Test
+  public void isProactiveSupportEnabledHTTPOnly() {
+    // Given
+    Properties serverProperties = new Properties();
+    serverProperties.setProperty(
+        BaseSupportConfig.CONFLUENT_SUPPORT_METRICS_ENDPOINT_INSECURE_ENABLE_CONFIG,
+        "true"
+    );
+    BaseSupportConfig supportConfig = new TestSupportConfig(serverProperties);
+    // When/Then
+    assertTrue(supportConfig.isProactiveSupportEnabled());
+  }
+
+  @Test
+  public void isProactiveSupportEnabledHTTPSOnly() {
+    // Given
+    Properties serverProperties = new Properties();
+    serverProperties.setProperty(
+        BaseSupportConfig.CONFLUENT_SUPPORT_METRICS_ENDPOINT_SECURE_ENABLE_CONFIG, "true");
+    BaseSupportConfig supportConfig = new TestSupportConfig(serverProperties);
+    // When/Then
+    assertTrue(supportConfig.isProactiveSupportEnabled());
+  }
+
+  @Test
+  public void proactiveSupportIsDisabledByDefaultWhenBrokerConfigurationIsEmpty() {
+    // Given
+    Properties serverProperties = new Properties();
+    BaseSupportConfig supportConfig = new TestSupportConfig(serverProperties);
+    // When/Then
+    assertTrue(supportConfig.isProactiveSupportEnabled());
+  }
+
+  public class TestSupportConfig extends BaseSupportConfig {
+
+    public TestSupportConfig(Properties originals) {
+      super(originals);
+    }
+
+    @Override
+    protected String getAnonymousEndpoint(boolean secure) {
+      if (!secure) {
+        return "http://support-metrics.confluent.io/anon";
+      } else {
+        return "https://support-metrics.confluent.io/anon";
+      }
+    }
+
+    @Override
+    protected String getTestEndpoint(boolean secure) {
+      if (!secure) {
+        return "http://support-metrics.confluent.io/test";
+      } else {
+        return "https://support-metrics.confluent.io/test";
+      }
+    }
+
+    @Override
+    protected String getCustomerEndpoint(boolean secure) {
+      if (!secure) {
+        return "http://support-metrics.confluent.io/submit";
+      } else {
+        return "https://support-metrics.confluent.io/submit";
+      }
+    }
+  }
+
+}

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/BaseSupportConfigTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/BaseSupportConfigTest.java
@@ -1,16 +1,18 @@
-/**
- * Copyright 2015 Confluent Inc.
+/*
+ * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
+
 package io.confluent.support.metrics;
 
 import static org.junit.Assert.assertEquals;

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/BaseSupportConfigTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/BaseSupportConfigTest.java
@@ -127,39 +127,6 @@ public class BaseSupportConfigTest {
   }
 
   @Test
-  public void proactiveSupportConfigIsValidKafkaConfig() throws IOException {
-    // Given
-    Properties brokerConfiguration = defaultBrokerConfiguration();
-
-    // When
-    KafkaConfig cfg = KafkaConfig.fromProps(brokerConfiguration);
-
-    // Then
-    assertEquals(0, cfg.brokerId());
-    assertTrue(cfg.zkConnect().startsWith("localhost:"));
-  }
-
-  private Properties defaultBrokerConfiguration() throws IOException {
-    Properties brokerConfiguration = new Properties();
-    brokerConfiguration.load(BaseSupportConfigTest.class.getResourceAsStream("/default-server"
-                                                                             + ".properties"));
-    return brokerConfiguration;
-  }
-
-  @Test
-  public void canParseProactiveSupportConfiguration() throws IOException {
-    // Given
-    Properties brokerConfiguration = defaultBrokerConfiguration();
-
-    BaseSupportConfig supportConfig = new TestSupportConfig(brokerConfiguration);
-    // When/Then
-    assertTrue(supportConfig.getMetricsEnabled());
-    assertEquals("c0", supportConfig.getCustomerId());
-    assertTrue(supportConfig.isProactiveSupportEnabled());
-  }
-
-
-  @Test
   public void testGetDefaultProps() {
     // Given
     Properties overrideProps = new Properties();

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/BaseSupportConfigTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/BaseSupportConfigTest.java
@@ -135,7 +135,6 @@ public class BaseSupportConfigTest {
     assertTrue(supportConfig.getMetricsEnabled());
     assertEquals("anonymous", supportConfig.getCustomerId());
     assertEquals(24 * 60 * 60 * 1000, supportConfig.getReportIntervalMs());
-    assertEquals("__confluent.support.metrics", supportConfig.getKafkaTopic());
     assertTrue(supportConfig.isHttpEnabled());
     assertTrue(supportConfig.isHttpsEnabled());
     assertTrue(supportConfig.isProactiveSupportEnabled());
@@ -197,21 +196,6 @@ public class BaseSupportConfigTest {
   }
 
   @Test
-  public void testOverrideTopic() {
-    // Given
-    Properties overrideProps = new Properties();
-    overrideProps.setProperty(
-        BaseSupportConfig.CONFLUENT_SUPPORT_METRICS_TOPIC_CONFIG,
-        "__another_example_topic"
-    );
-    // When
-    BaseSupportConfig supportConfig = new TestSupportConfig(overrideProps);
-
-    // Then
-    assertEquals("__another_example_topic", supportConfig.getKafkaTopic());
-  }
-
-  @Test
   public void isProactiveSupportEnabledFull() {
     // Given
     Properties serverProperties = new Properties();
@@ -229,8 +213,6 @@ public class BaseSupportConfigTest {
 
     serverProperties
         .setProperty(BaseSupportConfig.CONFLUENT_SUPPORT_METRICS_ENABLE_CONFIG, "false");
-    serverProperties
-        .setProperty(BaseSupportConfig.CONFLUENT_SUPPORT_METRICS_TOPIC_CONFIG, "anyTopic");
     serverProperties.setProperty(
         BaseSupportConfig.CONFLUENT_SUPPORT_METRICS_ENDPOINT_INSECURE_ENABLE_CONFIG,
         "true"
@@ -248,8 +230,6 @@ public class BaseSupportConfigTest {
   public void isProactiveSupportEnabledTopicOnly() {
     // Given
     Properties serverProperties = new Properties();
-    serverProperties
-        .setProperty(BaseSupportConfig.CONFLUENT_SUPPORT_METRICS_TOPIC_CONFIG, "anyTopic");
     BaseSupportConfig supportConfig = new TestSupportConfig(serverProperties);
     // When/Then
     assertTrue(supportConfig.isProactiveSupportEnabled());

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/PhoneHomeConfigTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/PhoneHomeConfigTest.java
@@ -1,15 +1,16 @@
-/**
- * Copyright 2018 Confluent Inc.
+/*
+ * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 
 package io.confluent.support.metrics;

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/PhoneHomeConfigTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/PhoneHomeConfigTest.java
@@ -17,8 +17,6 @@ package io.confluent.support.metrics;
 
 import static org.junit.Assert.assertEquals;
 
-import io.confluent.support.metrics.BaseSupportConfig;
-import io.confluent.support.metrics.PhoneHomeConfig;
 import java.util.Properties;
 import org.junit.Test;
 
@@ -37,9 +35,9 @@ public class PhoneHomeConfigTest {
     assertEquals("", config.getKafkaTopic());
     assertEquals(BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT, config.getCustomerId());
     assertEquals(EXPECTED_SECURE_ENDPOINT + "/TestComponent/anon",
-                 config.getEndpointHTTPS());
+                 config.getEndpointHttps());
     assertEquals(EXPECTED_INSECURE_ENDPOINT + "/TestComponent/anon",
-                 config.getEndpointHTTP());
+                 config.getEndpointHttp());
   }
 
   @Test
@@ -52,9 +50,9 @@ public class PhoneHomeConfigTest {
     assertEquals("", config.getKafkaTopic());
     assertEquals(BaseSupportConfig.CONFLUENT_SUPPORT_TEST_ID_DEFAULT, config.getCustomerId());
     assertEquals(EXPECTED_SECURE_ENDPOINT + "/TestComponent/test",
-                 config.getEndpointHTTPS());
+                 config.getEndpointHttps());
     assertEquals(EXPECTED_INSECURE_ENDPOINT + "/TestComponent/test",
-                 config.getEndpointHTTP());
+                 config.getEndpointHttp());
   }
 
   @Test
@@ -66,9 +64,9 @@ public class PhoneHomeConfigTest {
     BaseSupportConfig config = new PhoneHomeConfig(overrideProps, "TestComponent");
     assertEquals(BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT, config.getCustomerId());
     assertEquals(EXPECTED_SECURE_ENDPOINT + "/TestComponent/anon",
-                 config.getEndpointHTTPS());
+                 config.getEndpointHttps());
     assertEquals("",
-                 config.getEndpointHTTP());
+                 config.getEndpointHttp());
   }
 
 }

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/PhoneHomeConfigTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/PhoneHomeConfigTest.java
@@ -29,7 +29,7 @@ public class PhoneHomeConfigTest {
   public void testProductionEndpoints() {
     Properties overrideProps = new Properties();
     overrideProps.setProperty(BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_CONFIG, "c11");
-    overrideProps.getProperty(BaseSupportConfig.CONFLUENT_SUPPORT_METRICS_TOPIC_CONFIG, "topic");
+    overrideProps.setProperty(BaseSupportConfig.CONFLUENT_SUPPORT_METRICS_TOPIC_CONFIG, "topic");
 
     BaseSupportConfig config = new PhoneHomeConfig(overrideProps, "TestComponent");
     assertEquals("", config.getKafkaTopic());

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/PhoneHomeConfigTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/PhoneHomeConfigTest.java
@@ -29,10 +29,8 @@ public class PhoneHomeConfigTest {
   public void testProductionEndpoints() {
     Properties overrideProps = new Properties();
     overrideProps.setProperty(BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_CONFIG, "c11");
-    overrideProps.setProperty(BaseSupportConfig.CONFLUENT_SUPPORT_METRICS_TOPIC_CONFIG, "topic");
 
     BaseSupportConfig config = new PhoneHomeConfig(overrideProps, "TestComponent");
-    assertEquals("", config.getKafkaTopic());
     assertEquals(BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT, config.getCustomerId());
     assertEquals(EXPECTED_SECURE_ENDPOINT + "/TestComponent/anon",
                  config.getEndpointHttps());
@@ -47,7 +45,7 @@ public class PhoneHomeConfigTest {
                               BaseSupportConfig.CONFLUENT_SUPPORT_TEST_ID_DEFAULT);
 
     BaseSupportConfig config = new PhoneHomeConfig(overrideProps, "TestComponent");
-    assertEquals("", config.getKafkaTopic());
+
     assertEquals(BaseSupportConfig.CONFLUENT_SUPPORT_TEST_ID_DEFAULT, config.getCustomerId());
     assertEquals(EXPECTED_SECURE_ENDPOINT + "/TestComponent/test",
                  config.getEndpointHttps());

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/PhoneHomeConfigTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/PhoneHomeConfigTest.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.support.metrics;
+
+import static org.junit.Assert.assertEquals;
+
+import io.confluent.support.metrics.BaseSupportConfig;
+import io.confluent.support.metrics.PhoneHomeConfig;
+import java.util.Properties;
+import org.junit.Test;
+
+public class PhoneHomeConfigTest {
+
+  private static final String EXPECTED_SECURE_ENDPOINT = "https://version-check.confluent.io";
+  private static final String EXPECTED_INSECURE_ENDPOINT = "http://version-check.confluent.io";
+
+  @Test
+  public void testProductionEndpoints() {
+    Properties overrideProps = new Properties();
+    overrideProps.setProperty(BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_CONFIG, "c11");
+    overrideProps.getProperty(BaseSupportConfig.CONFLUENT_SUPPORT_METRICS_TOPIC_CONFIG, "topic");
+
+    BaseSupportConfig config = new PhoneHomeConfig(overrideProps, "TestComponent");
+    assertEquals("", config.getKafkaTopic());
+    assertEquals(BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT, config.getCustomerId());
+    assertEquals(EXPECTED_SECURE_ENDPOINT + "/TestComponent/anon",
+                 config.getEndpointHTTPS());
+    assertEquals(EXPECTED_INSECURE_ENDPOINT + "/TestComponent/anon",
+                 config.getEndpointHTTP());
+  }
+
+  @Test
+  public void testTestEndpoints() {
+    Properties overrideProps = new Properties();
+    overrideProps.setProperty(BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_CONFIG,
+                              BaseSupportConfig.CONFLUENT_SUPPORT_TEST_ID_DEFAULT);
+
+    BaseSupportConfig config = new PhoneHomeConfig(overrideProps, "TestComponent");
+    assertEquals("", config.getKafkaTopic());
+    assertEquals(BaseSupportConfig.CONFLUENT_SUPPORT_TEST_ID_DEFAULT, config.getCustomerId());
+    assertEquals(EXPECTED_SECURE_ENDPOINT + "/TestComponent/test",
+                 config.getEndpointHTTPS());
+    assertEquals(EXPECTED_INSECURE_ENDPOINT + "/TestComponent/test",
+                 config.getEndpointHTTP());
+  }
+
+  @Test
+  public void testInsecureEndpointDisabled() {
+    Properties overrideProps = new Properties();
+    overrideProps.setProperty(
+        BaseSupportConfig.CONFLUENT_SUPPORT_METRICS_ENDPOINT_INSECURE_ENABLE_CONFIG, "false");
+
+    BaseSupportConfig config = new PhoneHomeConfig(overrideProps, "TestComponent");
+    assertEquals(BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT, config.getCustomerId());
+    assertEquals(EXPECTED_SECURE_ENDPOINT + "/TestComponent/anon",
+                 config.getEndpointHTTPS());
+    assertEquals("",
+                 config.getEndpointHTTP());
+  }
+
+}

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/common/FilterTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/common/FilterTest.java
@@ -1,16 +1,18 @@
-/**
- * Copyright 2015 Confluent Inc.
+/*
+ * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
+
 package io.confluent.support.metrics.common;
 
 import static org.junit.Assert.assertEquals;

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/common/FilterTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/common/FilterTest.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.confluent.support.metrics.common;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import io.confluent.support.metrics.common.Filter;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+import org.junit.Test;
+
+public class FilterTest {
+
+  @Test
+  public void doesNotAcceptNullInput() {
+    // Given
+    Properties nullProperties = null;
+    Filter f = new Filter();
+
+    // When/Then
+    try {
+      f.apply(nullProperties);
+      fail("IllegalArgumentException expected because input is null");
+    } catch (IllegalArgumentException e) {
+      // ignore
+    }
+  }
+
+  @Test
+  public void emptyInputResultsInEmptyOutput() {
+    // Given
+    Properties emptyProperties = new Properties();
+    Filter f = new Filter();
+
+    // When
+    Properties filtered = f.apply(emptyProperties);
+
+    // Then
+    assertEquals(0, filtered.size());
+  }
+
+  @Test
+  public void filtersNothingByDefault() {
+    // Given
+    Properties anyProperties = System.getProperties();
+    Filter f = new Filter();
+
+    // When
+    Properties filtered = f.apply(anyProperties);
+
+    // Then
+    assertEquals(anyProperties, filtered);
+    assertEquals(anyProperties.size(), filtered.size());
+  }
+
+  @Test
+  public void filtersMatchingKey() {
+    // Given
+    Properties properties = new Properties();
+    properties.put("one", 1);
+    properties.put("two", 2);
+    Set<String> removeOneKey = new HashSet<>();
+    removeOneKey.add("one");
+    Filter f = new Filter(removeOneKey);
+
+    // When
+    Properties filtered = f.apply(properties);
+
+    // Then
+    assertEquals(properties.size() - 1, filtered.size());
+    assertFalse(filtered.containsKey("one"));
+    assertTrue(filtered.containsKey("two"));
+    assertEquals(properties.get("two"), filtered.get("two"));
+  }
+
+  @Test
+  public void filtersMatchingKeys() {
+    // Given
+    Properties properties = new Properties();
+    properties.put("one", 1);
+    properties.put("two", 2);
+    properties.put("three", 3);
+    properties.put("four", 4);
+    properties.put("five", 5);
+    Set<String> removeAllKeys = new HashSet<>();
+    for (Object key : properties.keySet()) {
+      removeAllKeys.add(key.toString());
+    }
+    Filter f = new Filter(removeAllKeys);
+
+    // When
+    Properties filtered = f.apply(properties);
+
+    // Then
+    assertEquals(0, filtered.size());
+  }
+
+  @Test
+  public void doesNotFilterMismatchingKeys() {
+    // Given
+    Properties properties = new Properties();
+    properties.put("one", 1);
+    properties.put("two", 2);
+    Set<String> keysToRemove = new HashSet<>();
+    keysToRemove.add("three");
+    Filter f = new Filter(keysToRemove);
+
+    // When
+    Properties filtered = f.apply(properties);
+
+    // Then
+    assertEquals(properties.size(), filtered.size());
+    assertTrue(filtered.containsKey("one"));
+    assertTrue(filtered.containsKey("two"));
+  }
+
+}

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/common/UuidTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/common/UuidTest.java
@@ -1,16 +1,18 @@
-/**
- * Copyright 2015 Confluent Inc.
+/*
+ * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
+
 package io.confluent.support.metrics.common;
 
 import static org.junit.Assert.assertEquals;

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/common/UuidTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/common/UuidTest.java
@@ -18,7 +18,6 @@ package io.confluent.support.metrics.common;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import io.confluent.support.metrics.common.Uuid;
 import org.junit.Test;
 
 public class UuidTest {
@@ -28,7 +27,7 @@ public class UuidTest {
     Uuid uuid = new Uuid();
 
     // When
-    String generatedUUID = uuid.getUUID();
+    String generatedUUID = uuid.getUuid();
 
     // Then
     assertTrue(generatedUUID.matches("[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"));
@@ -40,7 +39,7 @@ public class UuidTest {
     Uuid uuid = new Uuid();
 
     // When/Then
-    assertEquals(uuid.getUUID(), uuid.toString());
+    assertEquals(uuid.getUuid(), uuid.toString());
   }
 
   @Test
@@ -49,8 +48,8 @@ public class UuidTest {
     Uuid uuid = new Uuid();
 
     // When
-    String firstUuid = uuid.getUUID();
-    String secondUuid = uuid.getUUID();
+    String firstUuid = uuid.getUuid();
+    String secondUuid = uuid.getUuid();
 
     // Then
     assertEquals(secondUuid, firstUuid);

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/common/UuidTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/common/UuidTest.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.confluent.support.metrics.common;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import io.confluent.support.metrics.common.Uuid;
+import org.junit.Test;
+
+public class UuidTest {
+  @Test
+  public void generatesValidType4UUID() {
+    // Given
+    Uuid uuid = new Uuid();
+
+    // When
+    String generatedUUID = uuid.getUUID();
+
+    // Then
+    assertTrue(generatedUUID.matches("[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"));
+  }
+
+  @Test
+  public void stringRepresentationIsIdenticalToGeneratedUUID() {
+    // Given
+    Uuid uuid = new Uuid();
+
+    // When/Then
+    assertEquals(uuid.getUUID(), uuid.toString());
+  }
+
+  @Test
+  public void uuidDoesNotChangeBetweenRuns() {
+    // Given
+    Uuid uuid = new Uuid();
+
+    // When
+    String firstUuid = uuid.getUUID();
+    String secondUuid = uuid.getUUID();
+
+    // Then
+    assertEquals(secondUuid, firstUuid);
+  }
+}

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/common/time/TimeUtilsTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/common/time/TimeUtilsTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 public class TimeUtilsTest {
 
-  private class FixedClock implements Clock {
+  private static class FixedClock implements Clock {
 
     private final long fixedTimeMs;
 

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/common/time/TimeUtilsTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/common/time/TimeUtilsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.support.metrics.common.time;
 
 import static org.junit.Assert.assertEquals;

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/common/time/TimeUtilsTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/common/time/TimeUtilsTest.java
@@ -1,0 +1,35 @@
+package io.confluent.support.metrics.common.time;
+
+import static org.junit.Assert.assertEquals;
+
+import io.confluent.support.metrics.common.time.Clock;
+import io.confluent.support.metrics.common.time.TimeUtils;
+import org.junit.Test;
+
+public class TimeUtilsTest {
+
+  private class FixedClock implements Clock {
+
+    private final long fixedTimeMs;
+
+    public FixedClock(long fixedTimeMs) {
+      this.fixedTimeMs = fixedTimeMs;
+    }
+
+    @Override
+    public long currentTimeMs() {
+      return fixedTimeMs;
+    }
+
+  }
+
+  @Test
+  public void returnsCurrentUnixTime() {
+    // Given
+    long expCurrentUnixTime = 12345678L;
+    TimeUtils tu = new TimeUtils(new FixedClock(expCurrentUnixTime * 1000));
+
+    // When/Then
+    assertEquals(expCurrentUnixTime, tu.nowInUnixTime());
+  }
+}

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/submitters/ConfluentSubmitterTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/submitters/ConfluentSubmitterTest.java
@@ -20,8 +20,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import io.confluent.support.metrics.BaseSupportConfig;
-import io.confluent.support.metrics.submitters.ConfluentSubmitter;
-import io.confluent.support.metrics.submitters.ResponseHandler;
 import io.confluent.support.metrics.utils.CustomerIdExamples;
 import io.confluent.support.metrics.utils.StringUtils;
 import org.apache.http.HttpResponse;
@@ -110,12 +108,12 @@ public class ConfluentSubmitterTest {
         false,
         BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT,
         "test-component"),
-        submitter.getEndpointHTTP());
+        submitter.getEndpointHttp());
     assertEquals(BaseSupportConfig.getEndpoint(
         true,
         BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT,
         "test-component"),
-        submitter.getEndpointHTTPS());
+        submitter.getEndpointHttps());
   }
 
   @Test
@@ -132,9 +130,9 @@ public class ConfluentSubmitterTest {
         new ConfluentSubmitter(customerId, "test-component", responseHandler);
     assertTrue(StringUtils.isNullOrEmpty(submitter.getProxy()));
     assertEquals(BaseSupportConfig.getEndpoint(false, customerId, "test-component"),
-        submitter.getEndpointHTTP());
+        submitter.getEndpointHttp());
     assertEquals(BaseSupportConfig.getEndpoint(true, customerId, "test-component"),
-        submitter.getEndpointHTTPS());
+        submitter.getEndpointHttps());
   }
 
   @Test

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/submitters/ConfluentSubmitterTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/submitters/ConfluentSubmitterTest.java
@@ -1,0 +1,234 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.support.metrics.submitters;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import io.confluent.support.metrics.BaseSupportConfig;
+import io.confluent.support.metrics.submitters.ConfluentSubmitter;
+import io.confluent.support.metrics.submitters.ResponseHandler;
+import io.confluent.support.metrics.utils.CustomerIdExamples;
+import io.confluent.support.metrics.utils.StringUtils;
+import org.apache.http.HttpResponse;
+import org.junit.Test;
+
+public class ConfluentSubmitterTest {
+
+  private String customerId = BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT;
+
+
+  @Test
+  public void testInvalidArgumentsForConstructorNullEndpoints() {
+    // Given
+    String httpEndpoint = null;
+    String httpsEndpoint = null;
+
+    // When/Then
+    try {
+      new ConfluentSubmitter(customerId, httpEndpoint, httpsEndpoint);
+      fail("IllegalArgumentException expected because endpoints are null");
+    } catch (IllegalArgumentException e) {
+      assertTrue(e.getMessage().contains("must specify endpoints"));
+    }
+  }
+
+  @Test
+  public void testInvalidArgumentsForConstructorEmptyEndpoints() {
+    // Given
+    String httpEndpoint = "";
+    String httpsEndpoint = "";
+
+    // When/Then
+    try {
+      new ConfluentSubmitter(customerId, httpEndpoint, httpsEndpoint);
+      fail("IllegalArgumentException expected because endpoints are empty");
+    } catch (IllegalArgumentException e) {
+      assertTrue(e.getMessage().contains("must specify endpoints"));
+    }
+  }
+
+  @Test
+  public void testInvalidArgumentsForConstructorNullEmptyEndpoints() {
+    // Given
+    String httpEndpoint = null;
+    String httpsEndpoint = "";
+
+    // When/Then
+    try {
+      new ConfluentSubmitter(customerId, httpEndpoint, httpsEndpoint);
+      fail("IllegalArgumentException expected because endpoints are null/empty");
+    } catch (IllegalArgumentException e) {
+      assertTrue(e.getMessage().contains("must specify endpoints"));
+    }
+  }
+
+  @Test
+  public void testInvalidArgumentsForConstructorEmptyNullEndpoints() {
+    // Given
+    String httpEndpoint = "";
+    String httpsEndpoint = null;
+
+    // When/Then
+    try {
+      new ConfluentSubmitter(customerId, httpEndpoint, httpsEndpoint);
+      fail("IllegalArgumentException expected because endpoints are empty/null");
+    } catch (IllegalArgumentException e) {
+      assertTrue(e.getMessage().contains("must specify endpoints"));
+    }
+  }
+
+  @Test
+  public void testValidArgumentsForConstructor() {
+    // Given
+    String httpEndpoint = "http://example.com";
+    String httpsEndpoint = "https://example.com";
+
+    // When/Then
+    new ConfluentSubmitter(customerId, httpEndpoint, httpsEndpoint);
+  }
+
+  @Test
+  public void testValidArgumentsForPhoneHomeConstructorWithoutCustomerId() {
+    ConfluentSubmitter submitter = new ConfluentSubmitter("test-component", null);
+    assertTrue(StringUtils.isNullOrEmpty(submitter.getProxy()));
+    assertEquals(BaseSupportConfig.getEndpoint(
+        false,
+        BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT,
+        "test-component"),
+        submitter.getEndpointHTTP());
+    assertEquals(BaseSupportConfig.getEndpoint(
+        true,
+        BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT,
+        "test-component"),
+        submitter.getEndpointHTTPS());
+  }
+
+  @Test
+  public void testValidArgumentsForPhoneHomeConstructorWithCustomerId() {
+    final String customerId = BaseSupportConfig.CONFLUENT_SUPPORT_TEST_ID_DEFAULT;
+    final ResponseHandler responseHandler = new ResponseHandler() {
+      @Override
+      public void handle(HttpResponse response) {
+        //
+      }
+    };
+
+    ConfluentSubmitter submitter =
+        new ConfluentSubmitter(customerId, "test-component", responseHandler);
+    assertTrue(StringUtils.isNullOrEmpty(submitter.getProxy()));
+    assertEquals(BaseSupportConfig.getEndpoint(false, customerId, "test-component"),
+        submitter.getEndpointHTTP());
+    assertEquals(BaseSupportConfig.getEndpoint(true, customerId, "test-component"),
+        submitter.getEndpointHTTPS());
+  }
+
+  @Test
+  public void testInvalidArgumentsForConstructorInvalidHttpEndpoint() {
+    // Given
+    String httpEndpoint = "invalid URL";
+    String httpsEndpoint = "https://example.com";
+
+    // When/Then
+    try {
+      new ConfluentSubmitter(customerId, httpEndpoint, httpsEndpoint);
+      fail("IllegalArgumentException expected because endpoints are invalid");
+    } catch (IllegalArgumentException e) {
+      assertTrue(e.getMessage().startsWith("invalid HTTP endpoint"));
+    }
+  }
+
+  @Test
+  public void testInvalidArgumentsForConstructorInvalidHttpsEndpoint() {
+    // Given
+    String httpEndpoint = "http://example.com";
+    String httpsEndpoint = "invalid URL";
+
+    // When/Then
+    try {
+      new ConfluentSubmitter(customerId, httpEndpoint, httpsEndpoint);
+      fail("IllegalArgumentException expected because endpoints are invalid");
+    } catch (IllegalArgumentException e) {
+      assertTrue(e.getMessage().startsWith("invalid HTTPS endpoint"));
+    }
+  }
+
+  @Test
+  public void testInvalidArgumentsForConstructorMismatchedEndpoints() {
+    // Given
+    String httpEndpoint = "http://example.com";
+    String httpsEndpoint = "https://example.com";
+
+    // When/Then
+    try {
+      new ConfluentSubmitter(customerId, httpsEndpoint, httpEndpoint);
+      fail("IllegalArgumentException expected because endpoints were provided in the wrong order");
+    } catch (IllegalArgumentException e) {
+      assertTrue(e.getMessage().startsWith("invalid HTTP endpoint"));
+    }
+  }
+
+  @Test
+  public void testInvalidArgumentsForConstructorCustomerIdInvalid() {
+    // Given
+    String httpEndpoint = "http://example.com";
+    String httpsEndpoint = "https://example.com";
+
+    // When/Then
+    for (String invalidCustomerId : CustomerIdExamples.INVALID_CUSTOMER_IDS) {
+      try {
+        new ConfluentSubmitter(invalidCustomerId, httpEndpoint, httpsEndpoint);
+        fail("IllegalArgumentException expected because customer ID is invalid");
+      } catch (IllegalArgumentException e) {
+        assertTrue(e.getMessage().startsWith("invalid customer ID"));
+      }
+    }
+  }
+
+  @Test
+  public void testInvalidArgumentsForConstructorAnonymousIdInvalid() {
+    // Given
+    String httpEndpoint = "http://example.com";
+    String httpsEndpoint = "https://example.com";
+
+    // When/Then
+    for (String invalidCustomerId : CustomerIdExamples.INVALID_ANONYMOUS_IDS) {
+      try {
+        new ConfluentSubmitter(invalidCustomerId, httpEndpoint, httpsEndpoint);
+        fail("IllegalArgumentException expected because customer ID is invalid");
+      } catch (IllegalArgumentException e) {
+        assertTrue(e.getMessage().startsWith("invalid customer ID"));
+      }
+    }
+  }
+
+  @Test
+  public void testInvalidArgumentsForConstructorWithProxy() {
+    // Given
+    String httpEndpoint = "http://example.com";
+    String httpsEndpoint = "https://example.com";
+    String proxyURI = null;
+
+    // When/Then
+    ConfluentSubmitter submitter = new ConfluentSubmitter(customerId, httpEndpoint,
+        httpsEndpoint, proxyURI, null);
+    assertTrue(submitter.getProxy() == null);
+
+    proxyURI = "https://proxy.example.com";
+    submitter = new ConfluentSubmitter(customerId, httpEndpoint, httpsEndpoint, proxyURI, null);
+    assertEquals(proxyURI, submitter.getProxy());
+  }
+}

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/submitters/ConfluentSubmitterTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/submitters/ConfluentSubmitterTest.java
@@ -1,15 +1,16 @@
-/**
- * Copyright 2015 Confluent Inc.
+/*
+ * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 
 package io.confluent.support.metrics.submitters;

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/utils/CustomerIdExamples.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/utils/CustomerIdExamples.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.confluent.support.metrics.utils;
+
+public class CustomerIdExamples {
+
+  public static final String[] VALID_CUSTOMER_IDS = {
+      "C0", "c1", "C1", "c12", "C22", "c123", "C333", "c1234", "C4444",
+      "C00000", "C12345", "C99999", "C123456789", "C123456789012345678901234567890",
+      "c00000", "c12345", "c99999", "c123456789", "c123456789012345678901234567890",
+  };
+
+  public static final String[] VALID_CASE_SENSISTIVE_NEW_CUSTOMER_IDS = {
+      "5003001200D8cyJ",
+      "abbcaabcaaDwcyJ",
+      "abbcaabcaadwcyj",
+      "abbcaAbcAadwcyj",
+      "AGGQAAFLSSDWPYJ",
+      "AGGQAAfLSSDWpYJ",
+      "123456789012345",
+      "c23456789012345",
+      "C23456789012345"
+  };
+
+  public static final String[] VALID_CASE_INSENSISTIVE_NEW_CUSTOMER_IDS = {
+      "123456789012345123",
+      "123456789012345avc",
+      "5003001200D8cyJaaa",
+      "5003001200D8cyJ123",
+      "abbcaabcaadwcyjsss",
+      "AGGQAAFLSSDWPYJTTT"
+  };
+
+  // These invalid customer ids should not include valid anonymous user IDs.
+  public static final String[] INVALID_CUSTOMER_IDS = {
+      "0c000", "0000C", null, "", "c", "C", "Hello", "World", "1", "12", "123", "1234", "12345",
+      "5003001200D8cy",
+      "abbcaabcaaDwcyJa",
+      "abbcaabcaadwc*j",
+      "AGGQAAFLSSD^PYJ",
+      "123456789$12345",
+      "12345678901234512",
+      "123456789012345avca",
+      "5003001200D8cyJaaa88",
+      "5003001200D8cyJ1@3",
+      "abbcaabcaadwcyj!ss",
+      "AGGQAAFLSSDWPYJ_TT",
+  };
+
+  public static final String[] VALID_ANONYMOUS_IDS = {"anonymous", "ANONYMOUS", "anonyMOUS"};
+
+  // These invalid anonymous user IDs should not include valid customer IDs.
+  public static final String[] INVALID_ANONYMOUS_IDS = {null, "", "anon", "anonymou", "ANONYMOU"};
+
+}

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/utils/CustomerIdExamples.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/utils/CustomerIdExamples.java
@@ -1,16 +1,18 @@
-/**
- * Copyright 2015 Confluent Inc.
+/*
+ * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
+
 package io.confluent.support.metrics.utils;
 
 public class CustomerIdExamples {

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/utils/CustomerIdExamples.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/utils/CustomerIdExamples.java
@@ -15,54 +15,63 @@
 
 package io.confluent.support.metrics.utils;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 public class CustomerIdExamples {
 
-  public static final String[] VALID_CUSTOMER_IDS = {
+  public static final List<String> VALID_CUSTOMER_IDS = Collections.unmodifiableList(Arrays.asList(
       "C0", "c1", "C1", "c12", "C22", "c123", "C333", "c1234", "C4444",
       "C00000", "C12345", "C99999", "C123456789", "C123456789012345678901234567890",
-      "c00000", "c12345", "c99999", "c123456789", "c123456789012345678901234567890",
-  };
+      "c00000", "c12345", "c99999", "c123456789", "c123456789012345678901234567890"
+  ));
 
-  public static final String[] VALID_CASE_SENSISTIVE_NEW_CUSTOMER_IDS = {
-      "5003001200D8cyJ",
-      "abbcaabcaaDwcyJ",
-      "abbcaabcaadwcyj",
-      "abbcaAbcAadwcyj",
-      "AGGQAAFLSSDWPYJ",
-      "AGGQAAfLSSDWpYJ",
-      "123456789012345",
-      "c23456789012345",
-      "C23456789012345"
-  };
+  public static final List<String> VALID_CASE_SENSISTIVE_NEW_CUSTOMER_IDS =
+      Collections.unmodifiableList(Arrays.asList(
+          "5003001200D8cyJ",
+          "abbcaabcaaDwcyJ",
+          "abbcaabcaadwcyj",
+          "abbcaAbcAadwcyj",
+          "AGGQAAFLSSDWPYJ",
+          "AGGQAAfLSSDWpYJ",
+          "123456789012345",
+          "c23456789012345",
+          "C23456789012345"
+      ));
 
-  public static final String[] VALID_CASE_INSENSISTIVE_NEW_CUSTOMER_IDS = {
-      "123456789012345123",
-      "123456789012345avc",
-      "5003001200D8cyJaaa",
-      "5003001200D8cyJ123",
-      "abbcaabcaadwcyjsss",
-      "AGGQAAFLSSDWPYJTTT"
-  };
+  public static final List<String> VALID_CASE_INSENSISTIVE_NEW_CUSTOMER_IDS =
+      Collections.unmodifiableList(Arrays.asList(
+          "123456789012345123",
+          "123456789012345avc",
+          "5003001200D8cyJaaa",
+          "5003001200D8cyJ123",
+          "abbcaabcaadwcyjsss",
+          "AGGQAAFLSSDWPYJTTT"
+      ));
 
   // These invalid customer ids should not include valid anonymous user IDs.
-  public static final String[] INVALID_CUSTOMER_IDS = {
-      "0c000", "0000C", null, "", "c", "C", "Hello", "World", "1", "12", "123", "1234", "12345",
-      "5003001200D8cy",
-      "abbcaabcaaDwcyJa",
-      "abbcaabcaadwc*j",
-      "AGGQAAFLSSD^PYJ",
-      "123456789$12345",
-      "12345678901234512",
-      "123456789012345avca",
-      "5003001200D8cyJaaa88",
-      "5003001200D8cyJ1@3",
-      "abbcaabcaadwcyj!ss",
-      "AGGQAAFLSSDWPYJ_TT",
-  };
+  public static final List<String> INVALID_CUSTOMER_IDS =
+      Collections.unmodifiableList(Arrays.asList(
+          "0c000", "0000C", null, "", "c", "C", "Hello", "World", "1", "12", "123", "1234", "12345",
+          "5003001200D8cy",
+          "abbcaabcaaDwcyJa",
+          "abbcaabcaadwc*j",
+          "AGGQAAFLSSD^PYJ",
+          "123456789$12345",
+          "12345678901234512",
+          "123456789012345avca",
+          "5003001200D8cyJaaa88",
+          "5003001200D8cyJ1@3",
+          "abbcaabcaadwcyj!ss",
+          "AGGQAAFLSSDWPYJ_TT"
+      ));
 
-  public static final String[] VALID_ANONYMOUS_IDS = {"anonymous", "ANONYMOUS", "anonyMOUS"};
+  public static final List<String> VALID_ANONYMOUS_IDS =
+      Collections.unmodifiableList(Arrays.asList("anonymous", "ANONYMOUS", "anonyMOUS"));
 
   // These invalid anonymous user IDs should not include valid customer IDs.
-  public static final String[] INVALID_ANONYMOUS_IDS = {null, "", "anon", "anonymou", "ANONYMOU"};
+  public static final List<String> INVALID_ANONYMOUS_IDS =
+      Collections.unmodifiableList(Arrays.asList(null, "", "anon", "anonymou", "ANONYMOU"));
 
 }

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/utils/JitterTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/utils/JitterTest.java
@@ -1,16 +1,18 @@
-/**
- * Copyright 2015 Confluent Inc.
+/*
+ * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
+
 package io.confluent.support.metrics.utils;
 
 import static org.junit.Assert.assertTrue;

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/utils/JitterTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/utils/JitterTest.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.confluent.support.metrics.utils;
+
+import static org.junit.Assert.assertTrue;
+
+import io.confluent.support.metrics.utils.Jitter;
+import java.io.IOException;
+import org.junit.Test;
+
+public class JitterTest {
+  @Test
+  public void testAddOnePercentJitter() throws IOException {
+    // Given
+    long[] baseArray = {-2232, -1, 0, 99, 100, 101, 1000, 10000, 38742};
+
+    // When/Then
+    for (long base : baseArray) {
+      long val = Jitter.addOnePercentJitter(base);
+      assertTrue(base <= val);
+      assertTrue(val <= base + Math.abs(base) / 100);
+    }
+  }
+}

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/utils/StringUtilsTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/utils/StringUtilsTest.java
@@ -1,15 +1,16 @@
-/**
- * Copyright 2019 Confluent Inc.
+/*
+ * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 
 package io.confluent.support.metrics.utils;

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/utils/StringUtilsTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/utils/StringUtilsTest.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.support.metrics.utils;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import io.confluent.support.metrics.utils.StringUtils;
+import java.io.IOException;
+import org.junit.Test;
+
+public class StringUtilsTest {
+  @Test
+  public void testIsBlank() throws IOException {
+    assertTrue(StringUtils.isNullOrBlank(null));
+    assertTrue(StringUtils.isNullOrBlank(""));
+    assertTrue(StringUtils.isNullOrBlank("  "));
+    assertFalse(StringUtils.isNullOrBlank(" a "));
+    assertFalse(StringUtils.isNullOrBlank("abc"));
+  }
+
+  @Test
+  public void testIsNullOrEmpty() throws IOException {
+    assertTrue(StringUtils.isNullOrEmpty(null));
+    assertTrue(StringUtils.isNullOrEmpty(""));
+    assertFalse(StringUtils.isNullOrEmpty(" "));
+    assertFalse(StringUtils.isNullOrEmpty("abc"));
+    assertFalse(StringUtils.isNullOrEmpty(" a"));
+  }
+}

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/utils/WebClientTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/utils/WebClientTest.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.confluent.support.metrics.utils;
+
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+import java.util.concurrent.ThreadLocalRandom;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpPost;
+import org.junit.Test;
+
+public class WebClientTest {
+  private String customerId = CustomerIdExamples.VALID_CUSTOMER_IDS[0];
+  private static final String SECURE_LIVE_TEST_ENDPOINT = "https://support-metrics.confluent.io/test";
+
+  @Test
+  public void testSubmitIgnoresNullInput() {
+    // Given
+    HttpPost p = mock(HttpPost.class);
+    byte[] nullData = null;
+
+    // When
+    WebClient.send(customerId, nullData, p, null);
+
+    // Then
+    verifyZeroInteractions(p);
+  }
+
+  @Test
+  public void testSubmitIgnoresEmptyInput() {
+    // Given
+    HttpPost p = mock(HttpPost.class);
+    byte[] emptyData = new byte[0];
+
+    // When
+    WebClient.send(customerId, emptyData, p, null);
+
+    // Then
+    verifyZeroInteractions(p);
+  }
+
+  @Test
+  public void testSubmitInvalidCustomer() {
+    // Given
+    HttpPost p = new HttpPost(SECURE_LIVE_TEST_ENDPOINT);
+    byte[] anyData = "anyData".getBytes();
+    int randomIndex = ThreadLocalRandom.current().nextInt(CustomerIdExamples.INVALID_CUSTOMER_IDS.length);
+    String invalidCustomerId = CustomerIdExamples.INVALID_CUSTOMER_IDS[randomIndex];
+
+    // When/Then
+    assertNotEquals("customerId=" + invalidCustomerId,
+                    HttpStatus.SC_OK, WebClient.send(invalidCustomerId, anyData, p, null));
+  }
+
+  @Test
+  public void testSubmitInvalidAnonymousUser() {
+    // Given
+    HttpPost p = new HttpPost(SECURE_LIVE_TEST_ENDPOINT);
+    byte[] anyData = "anyData".getBytes();
+    int randomIndex = ThreadLocalRandom.current().nextInt(CustomerIdExamples.INVALID_ANONYMOUS_IDS.length);
+    String invalidCustomerId = CustomerIdExamples.INVALID_ANONYMOUS_IDS[randomIndex];
+
+    // When/Then
+    assertNotEquals("customerId=" + invalidCustomerId,
+                    HttpStatus.SC_OK, WebClient.send(invalidCustomerId, anyData, p, null));
+  }
+
+  @Test
+  public void testSubmitValidCustomer() {
+    // Given
+    HttpPost p = new HttpPost(SECURE_LIVE_TEST_ENDPOINT);
+    byte[] anyData = "anyData".getBytes();
+    int randomIndex = ThreadLocalRandom.current().nextInt(CustomerIdExamples.VALID_CUSTOMER_IDS.length);
+    String validCustomerId = CustomerIdExamples.VALID_CUSTOMER_IDS[randomIndex];
+
+    // When/Then
+    int status = WebClient.send(validCustomerId, anyData, p, null);
+    // if we are not connected to the internet this test should still pass
+    assertTrue("customerId=" + validCustomerId,
+               status == HttpStatus.SC_OK || status == HttpStatus.SC_BAD_GATEWAY);
+  }
+
+  @Test
+  public void testSubmitValidAnonymousUser() {
+    // Given
+    HttpPost p = new HttpPost(SECURE_LIVE_TEST_ENDPOINT);
+    byte[] anyData = "anyData".getBytes();
+    int randomIndex = ThreadLocalRandom.current().nextInt(CustomerIdExamples.VALID_ANONYMOUS_IDS.length);
+    String validCustomerId = CustomerIdExamples.VALID_ANONYMOUS_IDS[randomIndex];
+
+    // When/Then
+    int status = WebClient.send(validCustomerId, anyData, p, null);
+    // if we are not connected to the internet this test should still pass
+    assertTrue("customerId=" + validCustomerId,
+               status == HttpStatus.SC_OK || status == HttpStatus.SC_BAD_GATEWAY);
+  }
+
+}

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/utils/WebClientTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/utils/WebClientTest.java
@@ -20,13 +20,15 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpPost;
 import org.junit.Test;
 
 public class WebClientTest {
-  private String customerId = CustomerIdExamples.VALID_CUSTOMER_IDS[0];
+  private String customerId = CustomerIdExamples.VALID_CUSTOMER_IDS.get(0);
   private static final String SECURE_LIVE_TEST_ENDPOINT = "https://support-metrics.confluent.io/test";
 
   @Test
@@ -59,9 +61,9 @@ public class WebClientTest {
   public void testSubmitInvalidCustomer() {
     // Given
     HttpPost p = new HttpPost(SECURE_LIVE_TEST_ENDPOINT);
-    byte[] anyData = "anyData".getBytes();
-    int randomIndex = ThreadLocalRandom.current().nextInt(CustomerIdExamples.INVALID_CUSTOMER_IDS.length);
-    String invalidCustomerId = CustomerIdExamples.INVALID_CUSTOMER_IDS[randomIndex];
+    byte[] anyData = "anyData".getBytes(StandardCharsets.UTF_8);
+    int randomIndex = ThreadLocalRandom.current().nextInt(CustomerIdExamples.INVALID_CUSTOMER_IDS.size());
+    String invalidCustomerId = CustomerIdExamples.INVALID_CUSTOMER_IDS.get(randomIndex);
 
     // When/Then
     assertNotEquals("customerId=" + invalidCustomerId,
@@ -72,9 +74,9 @@ public class WebClientTest {
   public void testSubmitInvalidAnonymousUser() {
     // Given
     HttpPost p = new HttpPost(SECURE_LIVE_TEST_ENDPOINT);
-    byte[] anyData = "anyData".getBytes();
-    int randomIndex = ThreadLocalRandom.current().nextInt(CustomerIdExamples.INVALID_ANONYMOUS_IDS.length);
-    String invalidCustomerId = CustomerIdExamples.INVALID_ANONYMOUS_IDS[randomIndex];
+    byte[] anyData = "anyData".getBytes(StandardCharsets.UTF_8);
+    int randomIndex = ThreadLocalRandom.current().nextInt(CustomerIdExamples.INVALID_ANONYMOUS_IDS.size());
+    String invalidCustomerId = CustomerIdExamples.INVALID_ANONYMOUS_IDS.get(randomIndex);
 
     // When/Then
     assertNotEquals("customerId=" + invalidCustomerId,
@@ -85,9 +87,9 @@ public class WebClientTest {
   public void testSubmitValidCustomer() {
     // Given
     HttpPost p = new HttpPost(SECURE_LIVE_TEST_ENDPOINT);
-    byte[] anyData = "anyData".getBytes();
-    int randomIndex = ThreadLocalRandom.current().nextInt(CustomerIdExamples.VALID_CUSTOMER_IDS.length);
-    String validCustomerId = CustomerIdExamples.VALID_CUSTOMER_IDS[randomIndex];
+    byte[] anyData = "anyData".getBytes(StandardCharsets.UTF_8);
+    int randomIndex = ThreadLocalRandom.current().nextInt(CustomerIdExamples.VALID_CUSTOMER_IDS.size());
+    String validCustomerId = CustomerIdExamples.VALID_CUSTOMER_IDS.get(randomIndex);
 
     // When/Then
     int status = WebClient.send(validCustomerId, anyData, p, null);
@@ -100,9 +102,9 @@ public class WebClientTest {
   public void testSubmitValidAnonymousUser() {
     // Given
     HttpPost p = new HttpPost(SECURE_LIVE_TEST_ENDPOINT);
-    byte[] anyData = "anyData".getBytes();
-    int randomIndex = ThreadLocalRandom.current().nextInt(CustomerIdExamples.VALID_ANONYMOUS_IDS.length);
-    String validCustomerId = CustomerIdExamples.VALID_ANONYMOUS_IDS[randomIndex];
+    byte[] anyData = "anyData".getBytes(StandardCharsets.UTF_8);
+    int randomIndex = ThreadLocalRandom.current().nextInt(CustomerIdExamples.VALID_ANONYMOUS_IDS.size());
+    String validCustomerId = CustomerIdExamples.VALID_ANONYMOUS_IDS.get(randomIndex);
 
     // When/Then
     int status = WebClient.send(validCustomerId, anyData, p, null);

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/utils/WebClientTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/utils/WebClientTest.java
@@ -1,16 +1,18 @@
-/**
- * Copyright 2015 Confluent Inc.
+/*
+ * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
+
 package io.confluent.support.metrics.utils;
 
 import static org.junit.Assert.assertNotEquals;

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/validate/MetricsValidationTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/validate/MetricsValidationTest.java
@@ -1,16 +1,18 @@
-/**
- * Copyright 2015 Confluent Inc.
+/*
+ * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
+
 package io.confluent.support.metrics.validate;
 
 import static org.junit.Assert.assertFalse;

--- a/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/validate/MetricsValidationTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/support/metrics/validate/MetricsValidationTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.confluent.support.metrics.validate;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import io.confluent.support.metrics.validate.MetricsValidation;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+
+public class MetricsValidationTest {
+  @Test
+  public void testValidKsqlDeploymentMode() {
+    List<String> validDeploymentModes = Arrays.asList(
+        "LOCAL_CLI", "REMOTE_CLI", "SERVER", "EMBEDDED", "CLI"
+    );
+    for (String mode: validDeploymentModes) {
+      assertTrue("Expected KSQL deployment mode '" + mode + "' to be valid",
+                 MetricsValidation.isValidKsqlModuleType(mode));
+    }
+  }
+
+  @Test
+  public void testInvalidKsqlDeploymentMode() {
+    List<String> invalidDeploymentModes = Arrays.asList(
+        "local_CLI", "REMOTECLI", "servER", "random", "ANOTHER_CLI"
+    );
+    for (String mode: invalidDeploymentModes) {
+      assertFalse("Expected KSQL deployment mode '" + mode + "' to be invalid",
+                 MetricsValidation.isValidKsqlModuleType(mode));
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -275,12 +275,6 @@
             </dependency>
 
             <dependency>
-                <groupId>io.confluent.support</groupId>
-                <artifactId>support-metrics-common</artifactId>
-                <version>${kafka.version}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-log4j-appender</artifactId>
                 <version>${kafka.version}</version>


### PR DESCRIPTION
### Description
ksqlDB is the only user of these classes, so include it in the project instead of consuming it as a library.

Source files were copied from Confluent Kafka's support-metrics-common module. They were updated to match ksqlDB checkstyle and to remove functionality that submits metrics to a Kafka topic (this was never used by ksqlDB).

### Testing done 
Tested by building a docker image and running it locally using the docker-compose file in the ksqldb.io quickstart as a template. Based on inspecting network traffic sent at server startup, there was an HTTP POST to the version-checker endpoint with the expected Avro payload. 

```
POST /ksql/anon HTTP/1.1
api-version: phone-home-v1
Content-Length: 1155
Content-Type: multipart/form-data; boundary=Hf24SYtnRPyDwcgTVg30h6rdXnQ0-Xfw0jC
Host: version-check.confluent.io
Connection: Keep-Alive
User-Agent: Apache-HttpClient/4.5.3 (Java/1.8.0_212)
Accept-Encoding: gzip,deflate

--Hf24SYtnRPyDwcgTVg30h6rdXnQ0-Xfw0jC
Content-Disposition: form-data; name="cid"

anonymous
--Hf24SYtnRPyDwcgTVg30h6rdXnQ0-Xfw0jC
Content-Disposition: form-data; name="file"; filename="filename"
Content-Type: application/octet-stream

Objavro.schema¤{"type":"record","name":"KsqlVersionMetrics","namespace":"io.confluent.ksql.version.metrics","doc":"Represents basic metrics captured on a single ksql component","fields":[{"name":"timestamp","type":"long","doc":"Time when this data record was created on the ksql component (Unix time)."},{"name":"confluentPlatformVersion","type":["null",{"type":"string","avro.java.string":"String"}],"doc":"The version of the Confluent Platform this ksql component is running."},{"name":"ksqlComponentType","type":{"type":"string","avro.java.string":"String"},"doc":"Identifies the ksql component"},{"name":"isActive","type":"boolean","doc":"Indicates if the server was active in the last 24 hours. A server is considered active if it received a rest request or it has at least one running query."}]}ðpÛúÜ6&¡·ùÂ:ô¼å5.5.0-SNAPSHOTSERVERðpÛúÜ6&¡·ùÂ
--Hf24SYtnRPyDwcgTVg30h6rdXnQ0-Xfw0jC--

```

(The ksqldb-server container was configured to send data to the insecure version-checker endpoint, so that the payload could be more easily verified)

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

