### PR TITLE
fix: exception on shutdown of ksqlDB server (MINOR)

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
@@ -145,7 +145,6 @@ public class CommandRunner implements Closeable {
       Thread.currentThread().interrupt();
     }
     commandRunnerStatusMetric.close();
-    commandStore.close();
   }
 
   /**
@@ -284,6 +283,8 @@ public class CommandRunner implements Closeable {
         if (!closed) {
           throw wue;
         }
+      } finally {
+        commandStore.close();
       }
     }
   }


### PR DESCRIPTION
### Description 

On shutdown we're trying to close the Kafka Consumer from a different thread to the one that is using the consumer. Kafka Consumers are single threaded.
Hence we must close the consumer on the same thread as the one polling.

Fixes the following exception on shutdown:

```
[2020-02-07 15:10:44,646] ERROR Exception while waiting for CommandRunner thread to complete (io.confluent.ksql.rest.server.KsqlRestApplication:350)
    java.util.ConcurrentModificationException: KafkaConsumer is not safe for multi-threaded access
    at org.apache.kafka.clients.consumer.KafkaConsumer.acquire(KafkaConsumer.java:2422)
    at org.apache.kafka.clients.consumer.KafkaConsumer.close(KafkaConsumer.java:2305)
    at org.apache.kafka.clients.consumer.KafkaConsumer.close(KafkaConsumer.java:2260)
    at io.confluent.ksql.rest.server.CommandTopic.close(CommandTopic.java:121)
    at io.confluent.ksql.rest.server.computation.CommandStore.close(CommandStore.java:143)
    at io.confluent.ksql.rest.server.computation.CommandRunner.close(CommandRunner.java:148)
    at io.confluent.ksql.rest.server.KsqlRestApplication.triggerShutdown(KsqlRestApplication.java:348)
    at io.confluent.ksql.rest.server.ExecutableServer.triggerShutdown(ExecutableServer.java:54)
    at io.confluent.ksql.rest.server.KsqlServerMain.tryStartApp(KsqlServerMain.java:80)
    at io.confluent.ksql.rest.server.KsqlServerMain.main(KsqlServerMain.java:61)
 ```

### Testing done 

Usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

