### PR TITLE
refactor: rename `ExpressionAnalyzer` -> `ColumnReferenceValidator` (Minor)

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -303,21 +303,21 @@ class Analyzer {
 
     private void throwOnUnknownColumnReference() {
 
-      final ExpressionAnalyzer expressionAnalyzer =
-          new ExpressionAnalyzer(analysis.getFromSourceSchemas(true));
+      final ColumnReferenceValidator columnValidator =
+          new ColumnReferenceValidator(analysis.getFromSourceSchemas(true));
 
       analysis.getWhereExpression()
-          .ifPresent(expressionAnalyzer::analyzeExpression);
+          .ifPresent(columnValidator::analyzeExpression);
 
       analysis.getGroupByExpressions()
-          .forEach(expressionAnalyzer::analyzeExpression);
+          .forEach(columnValidator::analyzeExpression);
 
       analysis.getHavingExpression()
-          .ifPresent(expressionAnalyzer::analyzeExpression);
+          .ifPresent(columnValidator::analyzeExpression);
 
       analysis.getSelectExpressions().stream()
           .map(SelectExpression::getExpression)
-          .forEach(expressionAnalyzer::analyzeExpression);
+          .forEach(columnValidator::analyzeExpression);
     }
 
     @Override
@@ -340,13 +340,13 @@ class Analyzer {
         throw new KsqlException("Only equality join criteria is supported.");
       }
 
-      final ExpressionAnalyzer expressionAnalyzer =
-          new ExpressionAnalyzer(analysis.getFromSourceSchemas(false));
+      final ColumnReferenceValidator columnValidator =
+          new ColumnReferenceValidator(analysis.getFromSourceSchemas(false));
 
-      final Set<SourceName> srcsUsedInLeft = expressionAnalyzer
+      final Set<SourceName> srcsUsedInLeft = columnValidator
           .analyzeExpression(comparisonExpression.getLeft());
 
-      final Set<SourceName> srcsUsedInRight = expressionAnalyzer
+      final Set<SourceName> srcsUsedInRight = columnValidator
           .analyzeExpression(comparisonExpression.getRight());
 
       final SourceName leftSourceName = getOnlySourceForJoin(

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/ColumnReferenceValidator.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/ColumnReferenceValidator.java
@@ -34,11 +34,11 @@ import java.util.stream.Collectors;
 /**
  * Searches through the AST for any column references and throws if they are unknown or ambiguous.
  */
-class ExpressionAnalyzer {
+class ColumnReferenceValidator {
 
   private final SourceSchemas sourceSchemas;
 
-  ExpressionAnalyzer(final SourceSchemas sourceSchemas) {
+  ColumnReferenceValidator(final SourceSchemas sourceSchemas) {
     this.sourceSchemas = Objects.requireNonNull(sourceSchemas, "sourceSchemas");
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/ColumnReferenceValidatorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/ColumnReferenceValidatorTest.java
@@ -44,7 +44,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ExpressionAnalyzerTest {
+public class ColumnReferenceValidatorTest {
 
   private static final Expression WINDOW_START_EXP = new UnqualifiedColumnReferenceExp(
       SchemaUtil.WINDOWSTART_NAME
@@ -57,11 +57,11 @@ public class ExpressionAnalyzerTest {
 
   @Mock
   private SourceSchemas sourceSchemas;
-  private ExpressionAnalyzer analyzer;
+  private ColumnReferenceValidator analyzer;
 
   @Before
   public void setUp() {
-    analyzer = new ExpressionAnalyzer(sourceSchemas);
+    analyzer = new ColumnReferenceValidator(sourceSchemas);
   }
 
   @Test


### PR DESCRIPTION
### Description 

As all it does is validate columns exist and aren't ambiguous.

Name's been confusing / bugging me for a while.


### Testing done 

Non-functional change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

