### PR TITLE
feat: better error message when transaction to command topic fails to initialize by timeout

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/DistributingExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/DistributingExecutor.java
@@ -19,6 +19,7 @@ import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.parser.tree.InsertInto;
 import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.rest.Errors;
 import io.confluent.ksql.rest.entity.CommandId;
 import io.confluent.ksql.rest.entity.CommandStatus;
 import io.confluent.ksql.rest.entity.CommandStatusEntity;
@@ -56,6 +57,7 @@ public class DistributingExecutor {
   private final ValidatedCommandFactory validatedCommandFactory;
   private final CommandIdAssigner commandIdAssigner;
   private final ReservedInternalTopics internalTopics;
+  private final Errors errorHandler;
 
   public DistributingExecutor(
       final KsqlConfig ksqlConfig,
@@ -63,7 +65,8 @@ public class DistributingExecutor {
       final Duration distributedCmdResponseTimeout,
       final BiFunction<KsqlExecutionContext, ServiceContext, Injector> injectorFactory,
       final Optional<KsqlAuthorizationValidator> authorizationValidator,
-      final ValidatedCommandFactory validatedCommandFactory
+      final ValidatedCommandFactory validatedCommandFactory,
+      final Errors errorHandler
   ) {
     this.commandQueue = Objects.requireNonNull(commandQueue, "commandQueue");
     this.distributedCmdResponseTimeout =
@@ -78,6 +81,7 @@ public class DistributingExecutor {
     this.commandIdAssigner = new CommandIdAssigner();
     this.internalTopics =
         new ReservedInternalTopics(Objects.requireNonNull(ksqlConfig, "ksqlConfig"));
+    this.errorHandler = Objects.requireNonNull(errorHandler, "errorHandler");
   }
 
   /**
@@ -113,18 +117,12 @@ public class DistributingExecutor {
 
     try {
       transactionalProducer.initTransactions();
+    } catch (final TimeoutException e) {
+      throw new KsqlServerException(errorHandler.transactionInitTimeoutErrorMessage(e), e);
     } catch (final Exception e) {
       throw new KsqlServerException(String.format(
-          "Failed to initialize transactional producer to the KSQL command topic. "
-              + "This may be a result of having misconfigured Kafka."
-              + System.lineSeparator()
-              + "If you're running a single Kafka broker, ensure that the following Kafka configs are set to 1:" 
-              + System.lineSeparator() 
-              + "- transaction.state.log.replication.factor"
-              + System.lineSeparator()
-              + "- transaction.state.log.min.isr"
-              + System.lineSeparator()
-              + "- offsets.topic.replication.factor", e));
+          "Could not write the statement '%s' into the command topic: " + e.getMessage(),
+          statement.getStatementText()), e);
     }
     
     try {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -167,7 +167,8 @@ public class KsqlResource implements KsqlConfigurable {
             distributedCmdResponseTimeout,
             injectorFactory,
             authorizationValidator,
-            new ValidatedCommandFactory(config)
+            new ValidatedCommandFactory(config),
+            errorHandler
         ),
         ksqlEngine,
         config,

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/DistributingExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/DistributingExecutorTest.java
@@ -45,6 +45,7 @@ import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.TableElements;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
+import io.confluent.ksql.rest.Errors;
 import io.confluent.ksql.rest.entity.CommandId;
 import io.confluent.ksql.rest.entity.CommandId.Action;
 import io.confluent.ksql.rest.entity.CommandId.Type;
@@ -130,6 +131,8 @@ public class DistributingExecutorTest {
   private Producer<CommandId, Command> transactionalProducer;
   @Mock
   private Command command;
+  @Mock
+  private Errors errorHandler;
 
   private DistributingExecutor distributor;
   private AtomicLong scnCounter;
@@ -159,7 +162,8 @@ public class DistributingExecutorTest {
         DURATION_10_MS,
         (ec, sc) -> InjectorChain.of(schemaInjector, topicInjector),
         Optional.of(authorizationValidator),
-        validatedCommandFactory
+        validatedCommandFactory,
+        errorHandler
     );
   }
 

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/DefaultErrorMessages.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/DefaultErrorMessages.java
@@ -25,6 +25,20 @@ public class DefaultErrorMessages implements ErrorMessages {
   }
 
   @Override
+  public String transactionInitTimeoutErrorMessage(final Exception e) {
+    return "Timeout while initializing transaction to the KSQL command topic."
+        + System.lineSeparator()
+        + "If you're running a single Kafka broker, " 
+        + "ensure that the following Kafka configs are set to 1:"
+        + System.lineSeparator()
+        + "- transaction.state.log.replication.factor"
+        + System.lineSeparator()
+        + "- transaction.state.log.min.isr"
+        + System.lineSeparator()
+        + "- offsets.topic.replication.factor";
+  }
+
+  @Override
   public String schemaRegistryUnconfiguredErrorMessage(final Exception e) {
     return ErrorMessageUtil.buildErrorMessage(e);
   }

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/ErrorMessages.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/ErrorMessages.java
@@ -19,5 +19,7 @@ public interface ErrorMessages {
   
   String kafkaAuthorizationErrorMessage(Exception e);
 
+  String transactionInitTimeoutErrorMessage(Exception e);
+  
   String schemaRegistryUnconfiguredErrorMessage(Exception e);
 }

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/Errors.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/Errors.java
@@ -225,6 +225,10 @@ public final class Errors {
     return errorMessages.kafkaAuthorizationErrorMessage(e);
   }
 
+  public String transactionInitTimeoutErrorMessage(final Exception e) {
+    return errorMessages.transactionInitTimeoutErrorMessage(e);
+  }
+
   public Response generateResponse(
       final Exception e,
       final Response defaultResponse


### PR DESCRIPTION
### Description 
Addresses https://github.com/confluentinc/ksql/issues/4453

Moved `transactionalProducer.initTransactions()` out of the same try catch block as the rest of the transaction operations. 
Added more specific error message. (added as a pluggable one for scenarios where it doesn't make sense to advise the user to set their Kafka configs)

This isn't ideal currently as there are other reasons for a TimeoutException to be returned from `initTransaction` but until https://issues.apache.org/jira/browse/KAFKA-9511 is worked on, I think this is the best we can  do.


### Testing done 
Unit test
Spun up a Kafka without setting the required configs, got the error message when issuing a DDL to the server.
```
ksql> CREATE STREAM source_ab (myFixedField1 varchar, eventPayload varchar) WITH (kafka_topic='topic_a', PARTITIONS = 1, value_format='json');
Timeout while initializing transaction to the KSQL command topic.
If you're running a single Kafka broker, ensure that the following Kafka configs are set to 1:
- transaction.state.log.replication.factor
- transaction.state.log.min.isr
- offsets.topic.replication.factor
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

