### PR TITLE
fix: Fixes the single host lag reporting case

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/HeartbeatAgent.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/HeartbeatAgent.java
@@ -223,6 +223,9 @@ public final class HeartbeatAgent {
           }
           return status;
         });
+        for (HostStatusListener listener : hostStatusListeners) {
+          listener.onHostStatusUpdated(getHostsStatus());
+        }
         return;
       }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/HeartbeatAgent.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/HeartbeatAgent.java
@@ -223,9 +223,7 @@ public final class HeartbeatAgent {
           }
           return status;
         });
-        for (HostStatusListener listener : hostStatusListeners) {
-          listener.onHostStatusUpdated(getHostsStatus());
-        }
+        notifyListeners();
         return;
       }
 
@@ -256,8 +254,16 @@ public final class HeartbeatAgent {
               .withHostAlive(isAlive).withLastStatusUpdateMs(windowEnd));
         }
       }
+      notifyListeners();
+    }
+
+    private void notifyListeners() {
       for (HostStatusListener listener : hostStatusListeners) {
-        listener.onHostStatusUpdated(getHostsStatus());
+        try {
+          listener.onHostStatusUpdated(getHostsStatus());
+        } catch (Throwable t) {
+          LOG.error("Error while notifying listener", t);
+        }
       }
     }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/MaximumLagFilter.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/MaximumLagFilter.java
@@ -66,8 +66,8 @@ public final class MaximumLagFilter implements RoutingFilter {
           final long offsetLag = Math.max(endOffset - hostLag.getCurrentOffsetPosition(), 0);
           return offsetLag <= allowedOffsetLag;
         })
-        // If we don't have lag info, we'll be conservative and not include the host
-        .orElse(false);
+        // If we don't have lag info, we'll be conservative and include the host
+        .orElse(true);
   }
 
   /**

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/MaximumLagFilterTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/MaximumLagFilterTest.java
@@ -94,7 +94,7 @@ public class MaximumLagFilterTest {
         PARTITION).get();
 
     // Then:
-    assertFalse(filter.filter(HOST1));
+    assertTrue(filter.filter(HOST1));
   }
 
   @Test


### PR DESCRIPTION
### Description 
Currently, when a single host exists, lag doesn't get reported.  This ensures lag always gets reported.  Also changes the default to not filter if there is no lag data.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

