### PR TITLE
fix: print root cause in error message

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
@@ -31,6 +31,7 @@ import io.confluent.ksql.schema.ksql.inference.TopicSchemaSupplier.SchemaAndId;
 import io.confluent.ksql.schema.ksql.inference.TopicSchemaSupplier.SchemaResult;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.statement.Injector;
+import io.confluent.ksql.util.ErrorMessageUtil;
 import io.confluent.ksql.util.IdentifierUtil;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlStatementException;
@@ -79,7 +80,10 @@ public class DefaultSchemaInjector implements Injector {
     } catch (final KsqlStatementException e) {
       throw e;
     } catch (final KsqlException e) {
-      throw new KsqlStatementException(e.getMessage(), statement.getStatementText(), e.getCause());
+      throw new KsqlStatementException(
+          ErrorMessageUtil.buildErrorMessage(e), 
+          statement.getStatementText(), 
+          e.getCause());
     }
   }
 


### PR DESCRIPTION
### Description 
Lost the root cause for an error during recent refactors. Using the `ErrorMessageUtil.buildErrorMessage(`) to get back the specificity of the error message.

### Testing done 
before
```
ksql> CREATE STREAM KS_ORDERS WITH (KAFKA_TOPIC='KS_ORDERS', VALUE_FORMAT='AVRO');
Schema registry fetch for topic KS_ORDERS request failed.
```
after
```
ksql> CREATE STREAM KS_ORDERS WITH (KAFKA_TOPIC='KS_ORDERS', VALUE_FORMAT='AVRO');
Schema registry fetch for topic KS_ORDERS request failed.
Caused by: KSQL is not configured to use a schema registry. To enable it, please
        set ksql.schema.registry.url
```
### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

