### PR TITLE
chore: Primitive Keys comes to PRINT TOPIC

### DIFF
--- a/docs-md/developer-guide/create-a-stream.md
+++ b/docs-md/developer-guide/create-a-stream.md
@@ -282,13 +282,14 @@ PRINT pageviews_intro;
 Your output should resemble:
 
 ```
-Format:STRING
-10/30/18 10:15:51 PM UTC , 294851 , 1540937751186,User_8,Page_12
-10/30/18 10:15:55 PM UTC , 295051 , 1540937755255,User_1,Page_15
-10/30/18 10:15:57 PM UTC , 295111 , 1540937757265,User_8,Page_10
-10/30/18 10:15:59 PM UTC , 295221 , 1540937759330,User_4,Page_15
-10/30/18 10:15:59 PM UTC , 295231 , 1540937759699,User_1,Page_12
-10/30/18 10:15:59 PM UTC , 295241 , 1540937759990,User_6,Page_15
+Key format: KAFKA (BIGINT or DOUBLE)
+Value format: KAFKA (STRING)
+rowtime: 10/30/18 10:15:51 PM GMT, key: 294851, value: 1540937751186,User_8,Page_12
+rowtime: 10/30/18 10:15:55 PM GMT, key: 295051, value: 1540937755255,User_1,Page_15
+rowtime: 10/30/18 10:15:57 PM GMT, key: 295111, value: 1540937757265,User_8,Page_10
+rowtime: 10/30/18 10:15:59 PM GMT, key: 295221, value: 1540937759330,User_4,Page_15
+rowtime: 10/30/18 10:15:59 PM GMT, key: 295231, value: 1540937759699,User_1,Page_12
+rowtime: 10/30/18 10:15:59 PM GMT, key: 295241, value: 1540937759990,User_6,Page_15
 ^CTopic printing ceased
 ```
 

--- a/docs-md/developer-guide/create-a-table.md
+++ b/docs-md/developer-guide/create-a-table.md
@@ -218,10 +218,11 @@ PRINT users_female;
 Your output should resemble:
 
 ```
-Format:JSON
-{"ROWTIME":1541458112639,"ROWKEY":"User_5","USERID":"User_5","GENDER":"FEMALE","REGIONID":"Region_4"}
-{"ROWTIME":1541458112857,"ROWKEY":"User_2","USERID":"User_2","GENDER":"FEMALE","REGIONID":"Region_7"}
-{"ROWTIME":1541458112838,"ROWKEY":"User_9","USERID":"User_9","GENDER":"FEMALE","REGIONID":"Region_4"}
+Key format: KAFKA (STRING)
+Value format: JSON
+rowTime: 12/21/18 23:58:42 PM PSD, key: User_5, value: {"USERID":"User_5","GENDER":"FEMALE","REGIONID":"Region_4"}
+rowTime: 12/21/18 23:58:42 PM PSD, key: User_2, value: {"USERID":"User_2","GENDER":"FEMALE","REGIONID":"Region_7"}
+rowTime: 12/21/18 23:58:42 PM PSD, key: User_9, value: {"USERID":"User_9","GENDER":"FEMALE","REGIONID":"Region_4"}
 ^CTopic printing ceased
 ```
 

--- a/docs-md/developer-guide/ksqldb-reference/print.md
+++ b/docs-md/developer-guide/ksqldb-reference/print.md
@@ -39,13 +39,14 @@ The following statement shows how to print all of the records in a topic named
 PRINT ksql__commands FROM BEGINNING;
 ```
 
-ksqlDB will attempt to determine the format of the data in the topic and wil output what its thinks is
+ksqlDB attempts to determine the format of the data in the topic and outputs what it thinks are
 the key and value formats at the top of the output.
 
 !!! note
    Attempting to determine a data format from only the serialized bytes is not an exact science!
-   For example, it is not possible to distinguish between serialized `BIGINT` and `DOUBLE`s, as
-   they both occupy 8 bytes. Short strings can also be mistaken for serialized numbers.
+   For example, it is not possible to distinguish between serialized `BIGINT` and `DOUBLE` values,
+   because they both occupy eight bytes. Short strings can also be mistaken for serialized numbers.
+   Where it appears different records are using different formats ksqlDB will state the format is `MIXED`.
 
 Your output should resemble:
 

--- a/docs-md/developer-guide/ksqldb-reference/print.md
+++ b/docs-md/developer-guide/ksqldb-reference/print.md
@@ -39,13 +39,24 @@ The following statement shows how to print all of the records in a topic named
 PRINT ksql__commands FROM BEGINNING;
 ```
 
+ksqlDB will attempt to determine the format of the data in the topic and wil output what its thinks is
+the key and value formats at the top of the output.
+
+!!! note
+   Attempting to determine a data format from only the serialized bytes is not an exact science!
+   For example, it is not possible to distinguish between serialized `BIGINT` and `DOUBLE`s, as
+   they both occupy 8 bytes. Short strings can also be mistaken for serialized numbers.
+
 Your output should resemble:
 
-```json
-    Format:JSON
-    {"ROWTIME":1516010696273,"ROWKEY":"\"stream/CLICKSTREAM/create\"","statement":"CREATE STREAM clickstream (_time bigint,time varchar, ip varchar, request varchar, status int, userid int, bytes bigint, agent varchar) with (kafka_topic = 'clickstream', value_format = 'json');","streamsProperties":{}}
-    {"ROWTIME":1516010709492,"ROWKEY":"\"table/EVENTS_PER_MIN/create\"","statement":"create table events_per_min as select userid, count(*) as events from clickstream window  TUMBLING (size 10 second) group by userid EMIT CHANGES;","streamsProperties":{}}
+```
+    Key format: KAFKA (INTEGER)
+    Value format: JSON
+    rowtime: 12/21/18 23:58:42 PM PSD, key: stream/CLICKSTREAM/create, value: {statement":"CREATE STREAM clickstream (_time bigint,time varchar, ip varchar, request varchar, status int, userid int, bytes bigint, agent varchar) with (kafka_topic = 'clickstream', value_format = 'json');","streamsProperties":{}}
+    rowtime: 12/21/18 23:58:42 PM PSD, key: table/EVENTS_PER_MIN/create, value: {"statement":"create table events_per_min as select userid, count(*) as events from clickstream window  TUMBLING (size 10 second) group by userid EMIT CHANGES;","streamsProperties":{}}
     ^CTopic printing ceased
 ```
+
+
 
 Page last revised on: {{ git_revision_date }}

--- a/docs-md/developer-guide/query-with-structured-data.md
+++ b/docs-md/developer-guide/query-with-structured-data.md
@@ -144,11 +144,12 @@ PRINT 'raw-topic' FROM BEGINNING;
 Your output should resemble:
 
 ```json
-    Format:JSON
-    {"ROWTIME":1544042630406,"ROWKEY":"1","type":"key1","data":{"timestamp":"2018-12-21 23:58:42.1","field-a":1,"field-b":"first-value-for-key1"}}
-    {"ROWTIME":1544042630406,"ROWKEY":"2","type":"key2","data":{"timestamp":"2018-12-21 23:58:42.2","field-a":1,"field-c":11,"field-d":"first-value-for-key2"}}
-    {"ROWTIME":1544042630406,"ROWKEY":"3","type":"key1","data":{"timestamp":"2018-12-21 23:58:42.3","field-a":2,"field-b":"updated-value-for-key1"}}
-    {"ROWTIME":1544042630406,"ROWKEY":"4","type":"key2","data":{"timestamp":"2018-12-21 23:58:42.4","field-a":3,"field-c":22,"field-d":"updated-value-for-key2"}}
+    Key format: KAFKA (STRING)
+    Value format: JSON
+    rowtime: 12/21/18 23:58:42 PM PSD, key: 1, value: {"type":"key1","data":{"timestamp":"2018-12-21 23:58:42.1","field-a":1,"field-b":"first-value-for-key1"}}
+    rowtime: 12/21/18 23:58:42 PM PSD, key: 2, value: {"type":"key2","data":{"timestamp":"2018-12-21 23:58:42.2","field-a":1,"field-c":11,"field-d":"first-value-for-key2"}}
+    rowtime: 12/21/18 23:58:42 PM PSD, key: 3, value: {"type":"key1","data":{"timestamp":"2018-12-21 23:58:42.3","field-a":2,"field-b":"updated-value-for-key1"}}
+    rowtime: 12/21/18 23:58:42 PM PSD, key: 4, value: {"type":"key2","data":{"timestamp":"2018-12-21 23:58:42.4","field-a":3,"field-c":22,"field-d":"updated-value-for-key2"}}
     ^CTopic printing ceased
 ```
 

--- a/docs-md/tutorials/basics-docker.md
+++ b/docs-md/tutorials/basics-docker.md
@@ -184,11 +184,12 @@ PRINT users;
 Your output should resemble:
 
 ```json
-    Format:AVRO
-    {"ROWTIME":1540254230041,"ROWKEY":"User_1","registertime":1516754966866,"userid":"User_1","regionid":"Region_9","gender":"MALE"}
-    {"ROWTIME":1540254230081,"ROWKEY":"User_3","registertime":1491558386780,"userid":"User_3","regionid":"Region_2","gender":"MALE"}
-    {"ROWTIME":1540254230091,"ROWKEY":"User_7","registertime":1514374073235,"userid":"User_7","regionid":"Region_2","gender":"OTHER"}
-    ^C{"ROWTIME":1540254232442,"ROWKEY":"User_4","registertime":1510034151376,"userid":"User_4","regionid":"Region_8","gender":"FEMALE"}
+    Key format: KAFKA (STRING)
+    Value format: AVRO
+    rowtime: 10/30/18 10:15:51 PM GMT, key: User_1, value: {registertime":1516754966866,"userid":"User_1","regionid":"Region_9","gender":"MALE"}
+    rowtime: 10/30/18 10:15:51 PM GMT, key: User_3, value: {registertime":1491558386780,"userid":"User_3","regionid":"Region_2","gender":"MALE"}
+    rowtime: 10/30/18 10:15:53 PM GMT, key: User_7, value: {registertime":1514374073235,"userid":"User_7","regionid":"Region_2","gender":"OTHER"}
+    rowtime: 10/30/18 10:15:59 PM GMT, key: User_4, value: {registertime":1510034151376,"userid":"User_4","regionid":"Region_8","gender":"FEMALE"}
     Topic printing ceased
 ```
 
@@ -203,13 +204,13 @@ PRINT pageviews;
 Your output should resemble:
 
 ```
-    Format:STRING
-    10/23/18 12:24:03 AM UTC , 1540254243183 , 1540254243183,User_9,Page_20
-    10/23/18 12:24:03 AM UTC , 1540254243617 , 1540254243617,User_7,Page_47
-    10/23/18 12:24:03 AM UTC , 1540254243888 , 1540254243888,User_4,Page_27
-    ^C10/23/18 12:24:05 AM UTC , 1540254245161 , 1540254245161,User_9,Page_62
+    Key format: KAFKA (INTEGER)
+    Format: KAFKA (STRING)
+    rowtime: 10/23/18 12:24:03 AM PSD, key: 1540254243183, value: 1540254243183,User_9,Page_20
+    rowtime: 10/23/18 12:24:03 AM PSD, key: 1540254243617, value: 1540254243617,User_7,Page_47
+    rowtime: 10/23/18 12:24:03 AM PSD, key: 1540254243888, value: 1540254243888,User_4,Page_27
+    ^Crowtime: 10/23/18 12:24:05 AM PSD, key: 1540254245161, value: 1540254245161,User_9,Page_62
     Topic printing ceased
-    ksql>
 ```
 
 Press Ctrl+C to stop printing messages.

--- a/docs-md/tutorials/basics-docker.md
+++ b/docs-md/tutorials/basics-docker.md
@@ -186,10 +186,10 @@ Your output should resemble:
 ```json
     Key format: KAFKA (STRING)
     Value format: AVRO
-    rowtime: 10/30/18 10:15:51 PM GMT, key: User_1, value: {registertime":1516754966866,"userid":"User_1","regionid":"Region_9","gender":"MALE"}
-    rowtime: 10/30/18 10:15:51 PM GMT, key: User_3, value: {registertime":1491558386780,"userid":"User_3","regionid":"Region_2","gender":"MALE"}
-    rowtime: 10/30/18 10:15:53 PM GMT, key: User_7, value: {registertime":1514374073235,"userid":"User_7","regionid":"Region_2","gender":"OTHER"}
-    rowtime: 10/30/18 10:15:59 PM GMT, key: User_4, value: {registertime":1510034151376,"userid":"User_4","regionid":"Region_8","gender":"FEMALE"}
+    rowtime: 10/30/18 10:15:51 PM GMT, key: User_1, value: {"registertime":1516754966866,"userid":"User_1","regionid":"Region_9","gender":"MALE"}
+    rowtime: 10/30/18 10:15:51 PM GMT, key: User_3, value: {"registertime":1491558386780,"userid":"User_3","regionid":"Region_2","gender":"MALE"}
+    rowtime: 10/30/18 10:15:53 PM GMT, key: User_7, value: {"registertime":1514374073235,"userid":"User_7","regionid":"Region_2","gender":"OTHER"}
+    rowtime: 10/30/18 10:15:59 PM GMT, key: User_4, value: {"registertime":1510034151376,"userid":"User_4","regionid":"Region_8","gender":"FEMALE"}
     Topic printing ceased
 ```
 

--- a/docs-md/tutorials/basics-local.md
+++ b/docs-md/tutorials/basics-local.md
@@ -164,10 +164,10 @@ Your output should resemble:
 ```json
 Key format: KAFKA (STRING)
 Value format: AVRO
-rowtime: 10/30/18 10:15:51 PM GMT, key: User_1, value: {registertime":1516754966866,"userid":"User_1","regionid":"Region_9","gender":"MALE"}
-rowtime: 10/30/18 10:15:51 PM GMT, key: User_3, value: {registertime":1491558386780,"userid":"User_3","regionid":"Region_2","gender":"MALE"}
-rowtime: 10/30/18 10:15:53 PM GMT, key: User_7, value: {registertime":1514374073235,"userid":"User_7","regionid":"Region_2","gender":"OTHER"}
-^Crowtime: 10/30/18 10:15:59 PM GMT, key: User_4, value: {registertime":1510034151376,"userid":"User_4","regionid":"Region_8","gender":"FEMALE"}
+rowtime: 10/30/18 10:15:51 PM GMT, key: User_1, value: {"registertime":1516754966866,"userid":"User_1","regionid":"Region_9","gender":"MALE"}
+rowtime: 10/30/18 10:15:51 PM GMT, key: User_3, value: {"registertime":1491558386780,"userid":"User_3","regionid":"Region_2","gender":"MALE"}
+rowtime: 10/30/18 10:15:53 PM GMT, key: User_7, value: {"registertime":1514374073235,"userid":"User_7","regionid":"Region_2","gender":"OTHER"}
+^Crowtime: 10/30/18 10:15:59 PM GMT, key: User_4, value: {"registertime":1510034151376,"userid":"User_4","regionid":"Region_8","gender":"FEMALE"}
 Topic printing ceased
 ```
 

--- a/docs-md/tutorials/basics-local.md
+++ b/docs-md/tutorials/basics-local.md
@@ -162,11 +162,12 @@ PRINT users;
 Your output should resemble:
 
 ```json
-Format:AVRO
-{"ROWTIME":1540254230041,"ROWKEY":"User_1","registertime":1516754966866,"userid":"User_1","regionid":"Region_9","gender":"MALE"}
-{"ROWTIME":1540254230081,"ROWKEY":"User_3","registertime":1491558386780,"userid":"User_3","regionid":"Region_2","gender":"MALE"}
-{"ROWTIME":1540254230091,"ROWKEY":"User_7","registertime":1514374073235,"userid":"User_7","regionid":"Region_2","gender":"OTHER"}
-^C{"ROWTIME":1540254232442,"ROWKEY":"User_4","registertime":1510034151376,"userid":"User_4","regionid":"Region_8","gender":"FEMALE"}
+Key format: KAFKA (STRING)
+Value format: AVRO
+rowtime: 10/30/18 10:15:51 PM GMT, key: User_1, value: {registertime":1516754966866,"userid":"User_1","regionid":"Region_9","gender":"MALE"}
+rowtime: 10/30/18 10:15:51 PM GMT, key: User_3, value: {registertime":1491558386780,"userid":"User_3","regionid":"Region_2","gender":"MALE"}
+rowtime: 10/30/18 10:15:53 PM GMT, key: User_7, value: {registertime":1514374073235,"userid":"User_7","regionid":"Region_2","gender":"OTHER"}
+^Crowtime: 10/30/18 10:15:59 PM GMT, key: User_4, value: {registertime":1510034151376,"userid":"User_4","regionid":"Region_8","gender":"FEMALE"}
 Topic printing ceased
 ```
 
@@ -181,13 +182,13 @@ PRINT pageviews;
 Your output should resemble:
 
 ```
-Format:STRING
-10/23/18 12:24:03 AM UTC , 1540254243183 , 1540254243183,User_9,Page_20
-10/23/18 12:24:03 AM UTC , 1540254243617 , 1540254243617,User_7,Page_47
-10/23/18 12:24:03 AM UTC , 1540254243888 , 1540254243888,User_4,Page_27
-^C10/23/18 12:24:05 AM UTC , 1540254245161 , 1540254245161,User_9,Page_62
+Key format: KAFKA (INTEGER)
+Format: KAFKA (STRING)
+rowtime: 10/23/18 12:24:03 AM PSD, key: 1540254243183, value: 1540254243183,User_9,Page_20
+rowtime: 10/23/18 12:24:03 AM PSD, key: 1540254243617, value: 1540254243617,User_7,Page_47
+rowtime: 10/23/18 12:24:03 AM PSD, key: 1540254243888, value: 1540254243888,User_4,Page_27
+^Crowtime: 10/23/18 12:24:05 AM PSD, key: 1540254245161, value: 1540254245161,User_9,Page_62
 Topic printing ceased
-ksql>
 ```
 
 Press Ctrl+C to stop printing messages.

--- a/docs/includes/ksql-includes.rst
+++ b/docs/includes/ksql-includes.rst
@@ -144,11 +144,12 @@ Your output should resemble:
 
 ::
 
-    Format:JSON
-    {"ROWTIME":1540254230041,"ROWKEY":"User_1","registertime":1516754966866,"userid":"User_1","regionid":"Region_9","gender":"MALE"}
-    {"ROWTIME":1540254230081,"ROWKEY":"User_3","registertime":1491558386780,"userid":"User_3","regionid":"Region_2","gender":"MALE"}
-    {"ROWTIME":1540254230091,"ROWKEY":"User_7","registertime":1514374073235,"userid":"User_7","regionid":"Region_2","gender":"OTHER"}
-    ^C{"ROWTIME":1540254232442,"ROWKEY":"User_4","registertime":1510034151376,"userid":"User_4","regionid":"Region_8","gender":"FEMALE"}
+    Key format: KAFKA (STRING)
+    Value format: AVRO
+    rowtime: 10/30/18 10:15:51 PM GMT, key: User_1, value: {registertime":1516754966866,"userid":"User_1","regionid":"Region_9","gender":"MALE"}
+    rowtime: 10/30/18 10:15:51 PM GMT, key: User_3, value: {registertime":1491558386780,"userid":"User_3","regionid":"Region_2","gender":"MALE"}
+    rowtime: 10/30/18 10:15:53 PM GMT, key: User_7, value: {registertime":1514374073235,"userid":"User_7","regionid":"Region_2","gender":"OTHER"}
+    ^Crowtime: 10/30/18 10:15:59 PM GMT, key: User_4, value: {registertime":1510034151376,"userid":"User_4","regionid":"Region_8","gender":"FEMALE"}
     Topic printing ceased
 
 Press CTRL+C to stop printing messages.
@@ -163,13 +164,13 @@ Your output should resemble:
 
 ::
 
-    Format:STRING
-    10/23/18 12:24:03 AM UTC , 9461 , 1540254243183,User_9,Page_20
-    10/23/18 12:24:03 AM UTC , 9471 , 1540254243617,User_7,Page_47
-    10/23/18 12:24:03 AM UTC , 9481 , 1540254243888,User_4,Page_27
-    ^C10/23/18 12:24:05 AM UTC , 9521 , 1540254245161,User_9,Page_62
+    Key format: KAFKA (INTEGER)
+    Format: KAFKA (STRING)
+    rowtime: 10/23/18 12:24:03 AM PSD, key: 1540254243183, value: 1540254243183,User_9,Page_20
+    rowtime: 10/23/18 12:24:03 AM PSD, key: 1540254243617, value: 1540254243617,User_7,Page_47
+    rowtime: 10/23/18 12:24:03 AM PSD, key: 1540254243888, value: 1540254243888,User_4,Page_27
+    ^Crowtime: 10/23/18 12:24:05 AM PSD, key: 1540254245161, value: 1540254245161,User_9,Page_62
     Topic printing ceased
-    ksql>
 
 Press CTRL+C to stop printing messages.
 

--- a/docs/includes/ksql-includes.rst
+++ b/docs/includes/ksql-includes.rst
@@ -146,10 +146,10 @@ Your output should resemble:
 
     Key format: KAFKA (STRING)
     Value format: AVRO
-    rowtime: 10/30/18 10:15:51 PM GMT, key: User_1, value: {registertime":1516754966866,"userid":"User_1","regionid":"Region_9","gender":"MALE"}
-    rowtime: 10/30/18 10:15:51 PM GMT, key: User_3, value: {registertime":1491558386780,"userid":"User_3","regionid":"Region_2","gender":"MALE"}
-    rowtime: 10/30/18 10:15:53 PM GMT, key: User_7, value: {registertime":1514374073235,"userid":"User_7","regionid":"Region_2","gender":"OTHER"}
-    ^Crowtime: 10/30/18 10:15:59 PM GMT, key: User_4, value: {registertime":1510034151376,"userid":"User_4","regionid":"Region_8","gender":"FEMALE"}
+    rowtime: 10/30/18 10:15:51 PM GMT, key: User_1, value: {"registertime":1516754966866,"userid":"User_1","regionid":"Region_9","gender":"MALE"}
+    rowtime: 10/30/18 10:15:51 PM GMT, key: User_3, value: {"registertime":1491558386780,"userid":"User_3","regionid":"Region_2","gender":"MALE"}
+    rowtime: 10/30/18 10:15:53 PM GMT, key: User_7, value: {"registertime":1514374073235,"userid":"User_7","regionid":"Region_2","gender":"OTHER"}
+    ^Crowtime: 10/30/18 10:15:59 PM GMT, key: User_4, value: {"registertime":1510034151376,"userid":"User_4","regionid":"Region_8","gender":"FEMALE"}
     Topic printing ceased
 
 Press CTRL+C to stop printing messages.

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -403,9 +403,9 @@ public class CliTest {
 
     // Then:
     assertThatEventually(() -> terminal.getOutputString(), containsString("Value-Format:JSON"));
-    // Todo(ac): assertThat(terminal.getOutputString(), containsString("Key-Format:KAFKA (BIGINT)"));
+    assertThat(terminal.getOutputString(), containsString("Key-Format:STRING")); // Todo(ac): Kafka BIGINT
     assertThat(terminal.getOutputString(), containsString(","
-        + " key: \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001, " // Todo(ac):
+        + " key: \\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x01, " // Todo(ac):
         + "value: {"
         + "\"ORDERTIME\":1,"
         + "\"ORDERID\":" + "\"ORDER_1\","
@@ -424,7 +424,7 @@ public class CliTest {
 
     // Then:
     assertThatEventually(() -> terminal.getOutputString(), containsString("Value-Format:STRING"));
-    // Todo(ac): assertThat(terminal.getOutputString(), containsString("Key-Format:KAFKA (STRING)"));
+    assertThat(terminal.getOutputString(), containsString("Key-Format:STRING")); // Todo(ac): Kafka STRING
     assertThat(terminal.getOutputString(), containsString(", key: <null>, value: <null>"));
     assertThat(terminal.getOutputString(), containsString(", key: ITEM_1, value: ITEM_1,home cinema"));
   }

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -402,8 +402,8 @@ public class CliTest {
     run("print " + JSON_TOPIC + " FROM BEGINNING INTERVAL 1 LIMIT 1;", localCli);
 
     // Then:
-    assertThatEventually(() -> terminal.getOutputString(), containsString("Value-Format: JSON"));
-    assertThat(terminal.getOutputString(), containsString("Key-Format: KAFKA (BIGINT or DOUBLE)"));
+    assertThatEventually(() -> terminal.getOutputString(), containsString("Value format: JSON"));
+    assertThat(terminal.getOutputString(), containsString("Key format: KAFKA (BIGINT or DOUBLE)"));
     assertThat(terminal.getOutputString(), containsString(","
         + " key: 1, "
         + "value: {"
@@ -423,8 +423,8 @@ public class CliTest {
     run("print " + DELIMITED_TOPIC + " FROM BEGINNING INTERVAL 1 LIMIT 2;", localCli);
 
     // Then:
-    assertThatEventually(() -> terminal.getOutputString(), containsString("Value-Format: KAFKA (STRING)"));
-    assertThat(terminal.getOutputString(), containsString("Key-Format: KAFKA (STRING)"));
+    assertThatEventually(() -> terminal.getOutputString(), containsString("Value format: KAFKA (STRING)"));
+    assertThat(terminal.getOutputString(), containsString("Key format: KAFKA (STRING)"));
     assertThat(terminal.getOutputString(), containsString(", key: <null>, value: <null>"));
     assertThat(terminal.getOutputString(), containsString(", key: ITEM_1, value: ITEM_1,home cinema"));
   }

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -402,10 +402,10 @@ public class CliTest {
     run("print " + JSON_TOPIC + " FROM BEGINNING INTERVAL 1 LIMIT 1;", localCli);
 
     // Then:
-    assertThatEventually(() -> terminal.getOutputString(), containsString("Value-Format:JSON"));
-    assertThat(terminal.getOutputString(), containsString("Key-Format:STRING")); // Todo(ac): Kafka BIGINT
+    assertThatEventually(() -> terminal.getOutputString(), containsString("Value-Format: JSON"));
+    assertThat(terminal.getOutputString(), containsString("Key-Format: KAFKA (BIGINT or DOUBLE)"));
     assertThat(terminal.getOutputString(), containsString(","
-        + " key: \\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x01, " // Todo(ac):
+        + " key: 1, "
         + "value: {"
         + "\"ORDERTIME\":1,"
         + "\"ORDERID\":" + "\"ORDER_1\","
@@ -423,8 +423,8 @@ public class CliTest {
     run("print " + DELIMITED_TOPIC + " FROM BEGINNING INTERVAL 1 LIMIT 2;", localCli);
 
     // Then:
-    assertThatEventually(() -> terminal.getOutputString(), containsString("Value-Format:STRING"));
-    assertThat(terminal.getOutputString(), containsString("Key-Format:STRING")); // Todo(ac): Kafka STRING
+    assertThatEventually(() -> terminal.getOutputString(), containsString("Value-Format: KAFKA (STRING)"));
+    assertThat(terminal.getOutputString(), containsString("Key-Format: KAFKA (STRING)"));
     assertThat(terminal.getOutputString(), containsString(", key: <null>, value: <null>"));
     assertThat(terminal.getOutputString(), containsString(", key: ITEM_1, value: ITEM_1,home cinema"));
   }

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/SslFunctionalTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/SslFunctionalTest.java
@@ -103,7 +103,7 @@ public class SslFunctionalTest {
   @BeforeClass
   public static void classSetUp() {
     final OrderDataProvider dataProvider = new OrderDataProvider();
-    TEST_HARNESS.getKafkaCluster().createTopic(TOPIC_NAME);
+    TEST_HARNESS.getKafkaCluster().createTopics(TOPIC_NAME);
     TEST_HARNESS.produceRows(dataProvider.topicName(), dataProvider, JSON);
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
@@ -21,7 +21,6 @@ import static io.confluent.ksql.test.util.MapMatchers.mapHasSize;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-import com.google.common.collect.ImmutableMap;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.GenericRow;
@@ -163,7 +162,7 @@ public final class IntegrationTestHarness extends ExternalResource {
   public void produceRecord(final String topicName, final String key, final String data) {
     kafkaCluster.produceRows(
         topicName,
-        ImmutableMap.of(key, data),
+        Collections.singletonMap(key, data),
         new StringSerializer(),
         new StringSerializer(),
         DEFAULT_TS_SUPPLIER

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/ItemDataProvider.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/ItemDataProvider.java
@@ -29,9 +29,11 @@ import java.util.Map;
 public class ItemDataProvider extends TestDataProvider<String> {
 
   private static final LogicalSchema LOGICAL_SCHEMA = LogicalSchema.builder()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("ID"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("DESCRIPTION"), SqlTypes.STRING)
       .build();
+
   private static final PhysicalSchema PHYSICAL_SCHEMA = PhysicalSchema
       .from(LOGICAL_SCHEMA, SerdeOption.none());
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/KafkaTopicClientImplIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/KafkaTopicClientImplIntegrationTest.java
@@ -71,7 +71,7 @@ public class KafkaTopicClientImplIntegrationTest {
   @Before
   public void setUp() {
     testTopic = UUID.randomUUID().toString();
-    KAFKA.createTopic(testTopic);
+    KAFKA.createTopics(testTopic);
 
     adminClient = AdminClient.create(ImmutableMap.of(
         AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA.bootstrapServers()));

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PrintPublisher.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PrintPublisher.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.rest.server.resources.streaming;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
@@ -31,7 +33,6 @@ import java.util.AbstractCollection;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -56,15 +57,15 @@ public class PrintPublisher implements Flow.Publisher<Collection<String>> {
       final ServiceContext serviceContext,
       final Map<String, Object> consumerProperties,
       final PrintTopic printTopic) {
-    this.exec = exec;
-    this.serviceContext = Objects.requireNonNull(serviceContext, "serviceContext");
-    this.consumerProperties = Objects.requireNonNull(consumerProperties, "consumerProperties");
-    this.printTopic = Objects.requireNonNull(printTopic, "printTopic");
+    this.exec = requireNonNull(exec, "exec");
+    this.serviceContext = requireNonNull(serviceContext, "serviceContext");
+    this.consumerProperties = requireNonNull(consumerProperties, "consumerProperties");
+    this.printTopic = requireNonNull(printTopic, "printTopic");
   }
 
   @Override
   public void subscribe(final Flow.Subscriber<Collection<String>> subscriber) {
-    final KafkaConsumer<String, Bytes> topicConsumer =
+    final KafkaConsumer<Bytes, Bytes> topicConsumer =
         PrintTopicUtil.createTopicConsumer(serviceContext, consumerProperties, printTopic);
 
     subscriber.onSubscribe(
@@ -84,7 +85,7 @@ public class PrintPublisher implements Flow.Publisher<Collection<String>> {
   static class PrintSubscription extends PollingSubscription<Collection<String>> {
 
     private final PrintTopic printTopic;
-    private final KafkaConsumer<String, Bytes> topicConsumer;
+    private final KafkaConsumer<Bytes, Bytes> topicConsumer;
     private final RecordFormatter formatter;
     private boolean closed = false;
 
@@ -95,19 +96,19 @@ public class PrintPublisher implements Flow.Publisher<Collection<String>> {
         final ListeningScheduledExecutorService exec,
         final PrintTopic printTopic,
         final Subscriber<Collection<String>> subscriber,
-        final KafkaConsumer<String, Bytes> topicConsumer,
+        final KafkaConsumer<Bytes, Bytes> topicConsumer,
         final RecordFormatter formatter
     ) {
       super(exec, subscriber, null);
-      this.printTopic = Objects.requireNonNull(printTopic, "printTopic");
-      this.topicConsumer = Objects.requireNonNull(topicConsumer, "topicConsumer");
-      this.formatter = Objects.requireNonNull(formatter, "formatter");
+      this.printTopic = requireNonNull(printTopic, "printTopic");
+      this.topicConsumer = requireNonNull(topicConsumer, "topicConsumer");
+      this.formatter = requireNonNull(formatter, "formatter");
     }
 
     @Override
     public Collection<String> poll() {
       try {
-        final ConsumerRecords<String, Bytes> records = topicConsumer.poll(Duration.ZERO);
+        final ConsumerRecords<Bytes, Bytes> records = topicConsumer.poll(Duration.ZERO);
         if (records.isEmpty()) {
           return null;
         }
@@ -163,7 +164,7 @@ public class PrintPublisher implements Flow.Publisher<Collection<String>> {
       Preconditions.checkArgument(interval > 0, "interval must be greater than 0");
       Preconditions.checkArgument(start >= 0, "start must be greater than or equal to 0");
       Preconditions.checkArgument(limit >= 0, "limit must be greater than or equal to 0");
-      Objects.requireNonNull(source, "source");
+      requireNonNull(source, "source");
 
       this.source = Iterables.skip(source, start);
       this.size = Math.min(

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PrintTopicUtil.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PrintTopicUtil.java
@@ -24,7 +24,6 @@ import java.util.stream.Collectors;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.BytesDeserializer;
-import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KafkaClientSupplier;
 
@@ -33,19 +32,19 @@ final class PrintTopicUtil {
   private PrintTopicUtil() {
   }
 
-  static KafkaConsumer<String, Bytes> createTopicConsumer(
+  static KafkaConsumer<Bytes, Bytes> createTopicConsumer(
       final ServiceContext serviceContext,
       final Map<String, Object> consumerProperties,
       final PrintTopic printTopic
   ) {
-    final KafkaConsumer<String, Bytes> topicConsumer = new KafkaConsumer<>(
+    final KafkaConsumer<Bytes, Bytes> topicConsumer = new KafkaConsumer<>(
         injectSupplierProperties(serviceContext, consumerProperties),
-        new StringDeserializer(),
+        new BytesDeserializer(),
         new BytesDeserializer()
     );
 
     final List<TopicPartition> topicPartitions =
-        topicConsumer.partitionsFor(printTopic.getTopic().toString())
+        topicConsumer.partitionsFor(printTopic.getTopic())
             .stream()
             .map(partitionInfo ->
                 new TopicPartition(partitionInfo.topic(), partitionInfo.partition()))

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStream.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStream.java
@@ -121,15 +121,11 @@ public final class TopicStream {
               + ", " + "key: " + rowKey
               + ", value: " + value;
         } catch (IOException e) {
-          // Todo(ac): If this throws... try other formats? Output format at start of row?
           log.warn("Exception formatting record", e);
           return "Failed to parse row";
         }
       };
     }
-
-    // Todo(ac): Detect windwowed key?
-    // Todo(ac): Look in SR
 
     public String getKeyFormat() {
       return keyFormatter
@@ -233,7 +229,6 @@ public final class TopicStream {
           final KafkaAvroDeserializer avroDeserializer
       ) {
         try {
-          // Todo(ac): Include details that schema is registered?
           avroDeserializer.deserialize(topicName, data.get());
           return Optional.of(createFormatter(topicName, avroDeserializer));
         } catch (final Exception t) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriter.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriter.java
@@ -109,8 +109,8 @@ public class TopicStreamWriter implements StreamingOutput {
         for (final Supplier<String> value : values) {
           if (printFormat) {
             printFormat = false;
-            out.write(("Key-Format:" + formatter.getKeyFormat().name() + "\n").getBytes(UTF_8));
-            out.write(("Value-Format:" + formatter.getValueFormat().name() + "\n").getBytes(UTF_8));
+            out.write(("Key-Format: " + formatter.getKeyFormat() + "\n").getBytes(UTF_8));
+            out.write(("Value-Format: " + formatter.getValueFormat() + "\n").getBytes(UTF_8));
           }
 
           if (messagesPolled++ % interval == 0) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriter.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriter.java
@@ -109,8 +109,8 @@ public class TopicStreamWriter implements StreamingOutput {
         for (final Supplier<String> value : values) {
           if (printFormat) {
             printFormat = false;
-            out.write(("Key-Format: " + formatter.getKeyFormat() + "\n").getBytes(UTF_8));
-            out.write(("Value-Format: " + formatter.getValueFormat() + "\n").getBytes(UTF_8));
+            out.write(("Key format: " + formatter.getKeyFormat() + "\n").getBytes(UTF_8));
+            out.write(("Value format: " + formatter.getValueFormat() + "\n").getBytes(UTF_8));
           }
 
           if (messagesPolled++ % interval == 0) {

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PrintSubscriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PrintSubscriptionTest.java
@@ -27,6 +27,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+@SuppressWarnings("UnstableApiUsage")
 @RunWith(MockitoJUnitRunner.class)
 public class PrintSubscriptionTest {
 
@@ -64,9 +65,9 @@ public class PrintSubscriptionTest {
 
     // Then:
     assertThat(results, contains(Lists.newArrayList(
-        containsString("key0 , value0"),
-        containsString("key1 , value1"),
-        containsString("key2 , value2"))
+        containsString("key: key0, value: value0"),
+        containsString("key: key1, value: value1"),
+        containsString("key: key2, value: value2"))
     ));
   }
 
@@ -88,8 +89,8 @@ public class PrintSubscriptionTest {
 
     // Then:
     assertThat(results, contains(Lists.newArrayList(
-        containsString("key0 , value0"),
-        containsString("key1 , value1"))
+        containsString("key0, value: value0"),
+        containsString("key1, value: value1"))
     ));
     assertThat(results2, empty());
   }
@@ -112,13 +113,13 @@ public class PrintSubscriptionTest {
 
     // Then:
     assertThat(results, contains(Lists.newArrayList(
-        containsString("key0 , value0"),
-        containsString("key1 , value1"),
-        containsString("key2 , value2"))
+        containsString("key: key0, value: value0"),
+        containsString("key: key1, value: value1"),
+        containsString("key: key2, value: value2"))
     ));
     assertThat(results2, contains(Lists.newArrayList(
-        containsString("key3 , value3"),
-        containsString("key4 , value4"))
+        containsString("key: key3, value: value3"),
+        containsString("key: key4, value: value4"))
     ));
   }
 
@@ -140,11 +141,11 @@ public class PrintSubscriptionTest {
 
     // Then:
     assertThat(results, contains(Lists.newArrayList(
-        containsString("key0 , value0"),
-        containsString("key2 , value2"))
+        containsString("key: key0, value: value0"),
+        containsString("key: key2, value: value2"))
     ));
     assertThat(results2, contains(
-        containsString("key4 , value4")
+        containsString("key: key4, value: value4")
     ));
   }
 
@@ -168,14 +169,14 @@ public class PrintSubscriptionTest {
 
     // Then:
     assertThat(results, contains(Lists.newArrayList(
-        containsString("key0 , value0"),
-        containsString("key2 , value2"))
+        containsString("key: key0, value: value0"),
+        containsString("key: key2, value: value2"))
     ));
     assertThat(results2, contains(
-        containsString("key4 , value4")
+        containsString("key: key4, value: value4")
     ));
     assertThat(results3, contains(
-        containsString("key6 , value6")
+        containsString("key: key6, value: value6")
     ));
     assertThat(results4, empty());
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PrintSubscriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PrintSubscriptionTest.java
@@ -31,17 +31,17 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class PrintSubscriptionTest {
 
-  @Mock public KafkaConsumer<String, Bytes> kafkaConsumer;
+  @Mock public KafkaConsumer<Bytes, Bytes> kafkaConsumer;
   @Mock public SchemaRegistryClient schemaRegistry;
 
   @Before
   public void setup() {
-    final Iterator<ConsumerRecords<String, Bytes>> records = StreamingTestUtils.generate(
+    final Iterator<ConsumerRecords<Bytes, Bytes>> records = StreamingTestUtils.generate(
         "topic",
-        i -> "key" + i,
+        i -> new Bytes(("key" + i).getBytes(Charsets.UTF_8)),
         i -> new Bytes(("value" + i).getBytes(Charsets.UTF_8)));
 
-    final Iterator<ConsumerRecords<String, Bytes>> partitioned =
+    final Iterator<ConsumerRecords<Bytes, Bytes>> partitioned =
         StreamingTestUtils.partition(records, 3);
 
     when(kafkaConsumer.poll(any(Duration.class)))

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PrintSubscriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PrintSubscriptionTest.java
@@ -38,8 +38,8 @@ public class PrintSubscriptionTest {
   public void setup() {
     final Iterator<ConsumerRecords<Bytes, Bytes>> records = StreamingTestUtils.generate(
         "topic",
-        i -> new Bytes(("key" + i).getBytes(Charsets.UTF_8)),
-        i -> new Bytes(("value" + i).getBytes(Charsets.UTF_8)));
+        i -> new Bytes(("key-" + i).getBytes(Charsets.UTF_8)),
+        i -> new Bytes(("value-" + i).getBytes(Charsets.UTF_8)));
 
     final Iterator<ConsumerRecords<Bytes, Bytes>> partitioned =
         StreamingTestUtils.partition(records, 3);
@@ -65,9 +65,9 @@ public class PrintSubscriptionTest {
 
     // Then:
     assertThat(results, contains(Lists.newArrayList(
-        containsString("key: key0, value: value0"),
-        containsString("key: key1, value: value1"),
-        containsString("key: key2, value: value2"))
+        containsString("key: key-0, value: value-0"),
+        containsString("key: key-1, value: value-1"),
+        containsString("key: key-2, value: value-2"))
     ));
   }
 
@@ -89,8 +89,8 @@ public class PrintSubscriptionTest {
 
     // Then:
     assertThat(results, contains(Lists.newArrayList(
-        containsString("key0, value: value0"),
-        containsString("key1, value: value1"))
+        containsString("key-0, value: value-0"),
+        containsString("key-1, value: value-1"))
     ));
     assertThat(results2, empty());
   }
@@ -113,13 +113,13 @@ public class PrintSubscriptionTest {
 
     // Then:
     assertThat(results, contains(Lists.newArrayList(
-        containsString("key: key0, value: value0"),
-        containsString("key: key1, value: value1"),
-        containsString("key: key2, value: value2"))
+        containsString("key: key-0, value: value-0"),
+        containsString("key: key-1, value: value-1"),
+        containsString("key: key-2, value: value-2"))
     ));
     assertThat(results2, contains(Lists.newArrayList(
-        containsString("key: key3, value: value3"),
-        containsString("key: key4, value: value4"))
+        containsString("key: key-3, value: value-3"),
+        containsString("key: key-4, value: value-4"))
     ));
   }
 
@@ -141,11 +141,11 @@ public class PrintSubscriptionTest {
 
     // Then:
     assertThat(results, contains(Lists.newArrayList(
-        containsString("key: key0, value: value0"),
-        containsString("key: key2, value: value2"))
+        containsString("key: key-0, value: value-0"),
+        containsString("key: key-2, value: value-2"))
     ));
     assertThat(results2, contains(
-        containsString("key: key4, value: value4")
+        containsString("key: key-4, value: value-4")
     ));
   }
 
@@ -169,17 +169,16 @@ public class PrintSubscriptionTest {
 
     // Then:
     assertThat(results, contains(Lists.newArrayList(
-        containsString("key: key0, value: value0"),
-        containsString("key: key2, value: value2"))
+        containsString("key: key-0, value: value-0"),
+        containsString("key: key-2, value: value-2"))
     ));
     assertThat(results2, contains(
-        containsString("key: key4, value: value4")
+        containsString("key: key-4, value: value-4")
     ));
     assertThat(results3, contains(
-        containsString("key: key6, value: value6")
+        containsString("key: key-6, value: value-6")
     ));
     assertThat(results4, empty());
   }
-
 }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamingTestUtils.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamingTestUtils.java
@@ -39,27 +39,28 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Bytes;
 
+@SuppressWarnings("UnstableApiUsage")
 final class StreamingTestUtils {
 
   private StreamingTestUtils() { /* private constructor for utility class */ }
 
-  static Iterator<ConsumerRecords<String, Bytes>> generate(
+  static Iterator<ConsumerRecords<Bytes, Bytes>> generate(
       final String topic,
-      final Function<Integer, String> keyMapper,
+      final Function<Integer, Bytes> keyMapper,
       final Function<Integer, Bytes> valueMapper) {
     return IntStream.iterate(0, i -> i + 1)
         .mapToObj(
             i -> new ConsumerRecord<>(topic, 0, i, keyMapper.apply(i), valueMapper.apply(i)))
         .map(Lists::newArrayList)
-        .map(crs -> (List<ConsumerRecord<String, Bytes>>) crs)
+        .map(crs -> (List<ConsumerRecord<Bytes, Bytes>>) crs)
         .map(crs -> ImmutableMap.of(new TopicPartition("topic", 0), crs))
-        .map(map -> (Map<TopicPartition, List<ConsumerRecord<String, Bytes>>>) map)
+        .map(map -> (Map<TopicPartition, List<ConsumerRecord<Bytes, Bytes>>>) map)
         .map(ConsumerRecords::new)
         .iterator();
   }
 
-  static Iterator<ConsumerRecords<String, Bytes>> partition(
-      final Iterator<ConsumerRecords<String, Bytes>> source,
+  static Iterator<ConsumerRecords<Bytes, Bytes>> partition(
+      final Iterator<ConsumerRecords<Bytes, Bytes>> source,
       final int partitions) {
     return Streams.stream(Iterators.partition(source, partitions))
         .map(StreamingTestUtils::combine)

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -544,7 +545,7 @@ public class TopicStreamTest {
       when(schemaRegistryClient.getSchemaById(anyInt()))
           .thenReturn(new AvroSchema(AVRO_SCHEMA));
     } catch (final Exception e) {
-      // meh.
+      fail("invalid test");
     }
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamTest.java
@@ -584,6 +584,3 @@ public class TopicStreamTest {
     return avroSerializer.serialize("topic", avroRecord);
   }
 }
-
-// Todo(ac): Could output _possible_ formats, e.g. "23" could be JSON number, or delimited.
-// Todo(ac): over multiple lines, it could narrow this down.

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriterTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriterTest.java
@@ -148,5 +148,3 @@ public class TopicStreamWriterTest {
     }
   }
 }
-
-// Todo(ac): Doccs - call out limitations DOUBLE/BIGINT, 4 char, 8 char STRINGS.

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriterTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriterTest.java
@@ -78,8 +78,8 @@ public class TopicStreamWriterTest {
 
     // Then:
     final List<String> expected = ImmutableList.of(
-        "Key-Format:STRING",
-        "Value-Format:STRING",
+        "Key-Format: STRING",
+        "Value-Format: STRING",
         "rowtime: N/A, key: key0, value: value0",
         System.lineSeparator(),
         "rowtime: N/A, key: key1, value: value1",
@@ -107,8 +107,8 @@ public class TopicStreamWriterTest {
 
     // Then:
     final List<String> expected = ImmutableList.of(
-        "Key-Format:STRING",
-        "Value-Format:STRING",
+        "Key-Format: STRING",
+        "Value-Format: STRING",
         "rowtime: N/A, key: key0, value: value0",
         System.lineSeparator(),
         "rowtime: N/A, key: key2, value: value2",

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriterTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriterTest.java
@@ -42,8 +42,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class TopicStreamWriterTest {
 
-  @Mock public KafkaConsumer<String, Bytes> kafkaConsumer;
-  @Mock public SchemaRegistryClient schemaRegistry;
+  @Mock
+  public KafkaConsumer<String, Bytes> kafkaConsumer;
+  @Mock
+  public SchemaRegistryClient schemaRegistry;
   private ValidatingOutputStream out;
 
   @Before
@@ -52,13 +54,15 @@ public class TopicStreamWriterTest {
         "topic",
         i -> "key" + i,
         i -> new Bytes(("value" + i).getBytes(Charsets.UTF_8)));
+
     when(kafkaConsumer.poll(any(Duration.class)))
         .thenAnswer(invocation -> records.next());
+
     out = new ValidatingOutputStream();
   }
 
   @Test
-  public void testIntervalOneAndLimitTwo() {
+  public void shouldIntervalOneAndLimitTwo() {
     // Given:
     final TopicStreamWriter writer = new TopicStreamWriter(
         schemaRegistry,
@@ -74,15 +78,18 @@ public class TopicStreamWriterTest {
 
     // Then:
     final List<String> expected = ImmutableList.of(
-        "Format:STRING",
-        "key0 , value0",
-        "key1 , value1"
+        "Value-Format:STRING",
+        "rowtime: N/A, key: key0, value: value0",
+        System.lineSeparator(),
+        "rowtime: N/A, key: key1, value: value1",
+        System.lineSeparator()
     );
     out.assertWrites(expected);
   }
 
+
   @Test
-  public void testIntervalTwoAndLimitTwo() {
+  public void shouldIntervalTwoAndLimitTwo() {
     // Given:
     final TopicStreamWriter writer = new TopicStreamWriter(
         schemaRegistry,
@@ -99,9 +106,11 @@ public class TopicStreamWriterTest {
 
     // Then:
     final List<String> expected = ImmutableList.of(
-        "Format:STRING",
-        "key0 , value0",
-        "key2 , value2"
+        "Value-Format:STRING",
+        "rowtime: N/A, key: key0, value: value0",
+        System.lineSeparator(),
+        "rowtime: N/A, key: key2, value: value2",
+        System.lineSeparator()
     );
     out.assertWrites(expected);
   }
@@ -117,8 +126,8 @@ public class TopicStreamWriterTest {
     @Override public void write(final int b) { /* not called*/ }
 
     @Override
-    public void write(final byte[] b) {
-      recordedWrites.add(b);
+    public void write(final byte[] bytes) {
+      recordedWrites.add(bytes);
     }
 
     void assertWrites(final List<String> expected) {
@@ -131,5 +140,4 @@ public class TopicStreamWriterTest {
       }
     }
   }
-
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriterTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriterTest.java
@@ -52,8 +52,8 @@ public class TopicStreamWriterTest {
   public void setup() {
     final Iterator<ConsumerRecords<Bytes, Bytes>> records = StreamingTestUtils.generate(
         "topic",
-        i -> new Bytes(("key" + i).getBytes(Charsets.UTF_8)),
-        i -> new Bytes(("value" + i).getBytes(Charsets.UTF_8)));
+        i -> new Bytes(("key-" + i).getBytes(Charsets.UTF_8)),
+        i -> new Bytes(("value-" + i).getBytes(Charsets.UTF_8)));
 
     when(kafkaConsumer.poll(any(Duration.class)))
         .thenAnswer(invocation -> records.next());
@@ -78,16 +78,15 @@ public class TopicStreamWriterTest {
 
     // Then:
     final List<String> expected = ImmutableList.of(
-        "Key-Format: STRING",
-        "Value-Format: STRING",
-        "rowtime: N/A, key: key0, value: value0",
+        "Key format: KAFKA (STRING)",
+        "Value format: KAFKA (STRING)",
+        "rowtime: N/A, key: key-0, value: value-0",
         System.lineSeparator(),
-        "rowtime: N/A, key: key1, value: value1",
+        "rowtime: N/A, key: key-1, value: value-1",
         System.lineSeparator()
     );
     out.assertWrites(expected);
   }
-
 
   @Test
   public void shouldIntervalTwoAndLimitTwo() {
@@ -107,11 +106,11 @@ public class TopicStreamWriterTest {
 
     // Then:
     final List<String> expected = ImmutableList.of(
-        "Key-Format: STRING",
-        "Value-Format: STRING",
-        "rowtime: N/A, key: key0, value: value0",
+        "Key format: KAFKA (STRING)",
+        "Value format: KAFKA (STRING)",
+        "rowtime: N/A, key: key-0, value: value-0",
         System.lineSeparator(),
-        "rowtime: N/A, key: key2, value: value2",
+        "rowtime: N/A, key: key-2, value: value-2",
         System.lineSeparator()
     );
     out.assertWrites(expected);
@@ -149,3 +148,5 @@ public class TopicStreamWriterTest {
     }
   }
 }
+
+// Todo(ac): Doccs - call out limitations DOUBLE/BIGINT, 4 char, 8 char STRINGS.

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/kafka/KafkaSerdeFactory.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/kafka/KafkaSerdeFactory.java
@@ -22,6 +22,7 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.schema.connect.SqlSchemaFormatter;
 import io.confluent.ksql.schema.connect.SqlSchemaFormatter.Option;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
+import io.confluent.ksql.schema.ksql.SqlBaseType;
 import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.KsqlSerdeFactory;
 import io.confluent.ksql.util.DecimalUtil;
@@ -44,10 +45,17 @@ import org.apache.kafka.connect.data.Struct;
 public class KafkaSerdeFactory implements KsqlSerdeFactory {
 
   private static final ImmutableMap<Type, Serde<?>> SERDE = ImmutableMap.of(
-      Type.STRING, Serdes.String(),
       Type.INT32, Serdes.Integer(),
       Type.INT64, Serdes.Long(),
-      Type.FLOAT64, Serdes.Double()
+      Type.FLOAT64, Serdes.Double(),
+      Type.STRING, Serdes.String()
+  );
+
+  public static final ImmutableMap<SqlBaseType, Serde<?>> SQL_SERDE = ImmutableMap.of(
+      SqlBaseType.INTEGER, Serdes.Integer(),
+      SqlBaseType.BIGINT, Serdes.Long(),
+      SqlBaseType.DOUBLE, Serdes.Double(),
+      SqlBaseType.STRING, Serdes.String()
   );
 
   @Override

--- a/ksql-test-util/src/main/java/io/confluent/ksql/test/util/EmbeddedSingleNodeKafkaCluster.java
+++ b/ksql-test-util/src/main/java/io/confluent/ksql/test/util/EmbeddedSingleNodeKafkaCluster.java
@@ -263,17 +263,17 @@ public final class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
   /**
    * Create a Kafka topic with 1 partition and a replication factor of 1.
    *
-   * @param topic The name of the topic.
+   * @param topics The name of the topics to create.
    */
-  public void createTopic(final String topic) {
-    broker.createTopic(topic, 1, 1);
+  public void createTopics(final String... topics) {
+    Arrays.stream(topics).forEach(topic -> broker.createTopic(topic, 1, 1));
   }
 
   /**
    * Create a Kafka topic with the given parameters.
    *
-   * @param topic       The name of the topic.
-   * @param partitions  The number of partitions for this topic.
+   * @param topic The name of the topic.
+   * @param partitions The number of partitions for this topic.
    * @param replication The replication factor for (the partitions of) this topic.
    */
   public void createTopic(final String topic, final int partitions, final int replication) {
@@ -283,16 +283,17 @@ public final class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
   /**
    * Create a Kafka topic with the given parameters.
    *
-   * @param topic       The name of the topic.
-   * @param partitions  The number of partitions for this topic.
+   * @param topic The name of the topic.
+   * @param partitions The number of partitions for this topic.
    * @param replication The replication factor for (partitions of) this topic.
    * @param topicConfig Additional topic-level configuration settings.
    */
   public void createTopic(
       final String topic,
-                          final int partitions,
-                          final int replication,
-                          final Map<String, String> topicConfig) {
+      final int partitions,
+      final int replication,
+      final Map<String, String> topicConfig
+  ) {
     broker.createTopic(topic, partitions, replication, topicConfig);
   }
 


### PR DESCRIPTION
### Description 

Fixes: https://github.com/confluentinc/ksql/issues/4258

This change makes `PRINT TOPIC` output not just the format of the value, but also the key.

Output used to look like:

```
    Format:JSON
    {"ROWTIME":1544042630406,"ROWKEY":"1","type":"key1","data":{"timestamp":"2018-12-21 23:58:42.1","field-a":1,"field-b":"first-value-for-key1"}}
    ...
```

The old version tried to represent the whole row as a JSON Object, or Avro record, etc.  Going forward this doesn't make sense as there are two formats at play: key and value, and they are generally different. 

It now looks like:

```
    Key format: KAFKA (STRING)
    Value format: JSON
    rowtime: 02/10/2020 20:26:44 GMT, key: "1", value: {"type":"key1","data":{"timestamp":"2018-12-21 23:58:42.1","field-a":1,"field-b":"first-value-for-key1"}}
    ...
```

Note: the 'Key format' and 'Value format' a the top.
Note: row format is now `rowtime: <string timestamp>, key: <key>, value: <value>`. Where:
   - `<string timestamp>` is the timestamp of the record, formatted as string in local tz. (All formats but JSON already did this - now its standard)
   - `<key>` is the formatted key output.
   - `<value`> is the formatted value output.

There is also very basic mixed mode detection: it no longer just checks one record to determine formats. It now checks the whole batch and if the formats vary it displays them as `MIXED` and formats them as strings.  

### Limitations:

* There is no way to distinguish between a serialized `DOUBLE` vs `BIGINT` vs an 8-char `STRING`.
* There is no way to distinguish between a serialized `INT` vs 4-char `STRING`.

There's not much we can do about the `DOUBLE`/`BIGINT` thing - it just defaults to formatting them as `BIGINT`, as that'll be way more common, and the format is displayed as `KAFKA (BIGINT or DOUBLE)`.

The overlap with certain length `STRING` values is more of an issue. This likely needs more work. Ideally, PRINT would track the set of possible formats and narrow that down as it sees more records, e.g. if it repeatedly saw 4 bytes of data, it's probably an `INT`, where as if the first 5 records have 4 bytes, but then it changes to 7, then 1, then it's probably a `STRING`. etc.

Not sure how the UX would work here though.   We could output 'possible formats per row' and narrow this down as we go.  Thoughts welcome.

### How to review:

Commits:
1. Refactors PRINT TOPIC to:
    - prep for key formats
    - standardized output, regardless of format, to: `rowkey: <ts>, key: <key>, value: <value>`.
    - format is no longer determined from first record: first batch is inspected
    - added MIXED format, where format varies per-row.  This defaults to formatting as a string.
    - PRINT TOPIC no longer filters out null values. Each record in the topic results in a output row, which will help highlight data issues.
    - outputs a message if it failed to deserialize a record, which will help highlight data issues.
    - formatting is now lazy, meaning we avoid the formatting cost where INTERVAL != 1
2. Outputs the key's format as well as the existing value's format.
3. Adds KAFKA format
4. Changes some text layout and fixes some tests.

### Testing done 

Tests enhanced, added + manual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

