### PR TITLE
feat: display errors in CLI in red text

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/Cli.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/Cli.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.cli;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-
 import io.confluent.ksql.cli.console.Console;
 import io.confluent.ksql.cli.console.KsqlTerminal.StatusClosable;
 import io.confluent.ksql.cli.console.OutputFormat;
@@ -175,7 +174,8 @@ public class Cli implements KsqlRequestExecutor, Closeable {
         eof = true;
       } catch (final Exception exception) {
         LOGGER.error("", exception);
-        terminal.writer().println(ErrorMessageUtil.buildErrorMessage(exception));
+        terminal.printError(ErrorMessageUtil.buildErrorMessage(exception),
+            exception.toString());
       }
       terminal.flush();
     }

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/Cli.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/Cli.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.cli;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+
 import io.confluent.ksql.cli.console.Console;
 import io.confluent.ksql.cli.console.KsqlTerminal.StatusClosable;
 import io.confluent.ksql.cli.console.OutputFormat;

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.cli.console;
 
 import static io.confluent.ksql.util.CmdLineUtil.splitByUnquotedWhitespace;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -322,7 +321,7 @@ public class Console implements Closeable {
 
   public void printError(final String shortMsg, final String fullMsg) {
     log.error(fullMsg);
-    writer().println(shortMsg);
+    terminal.printError(shortMsg);
   }
 
   public void printStreamedRow(final StreamedRow row) {

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.cli.console;
 
 import static io.confluent.ksql.util.CmdLineUtil.splitByUnquotedWhitespace;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/JLineTerminal.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/JLineTerminal.java
@@ -153,6 +153,13 @@ class JLineTerminal implements KsqlTerminal {
     return () -> updateStatusBar(DEFAULT_STATUS_MSG);
   }
 
+  @Override
+  public void printError(final String message) {
+    writer().println(
+        new AttributedString(message, AttributedStyle.DEFAULT.foreground(AttributedStyle.RED))
+            .toAnsi());
+  }
+
   @VisibleForTesting
   Terminal getTerminal() {
     return terminal;

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/KsqlTerminal.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/KsqlTerminal.java
@@ -45,6 +45,7 @@ public interface KsqlTerminal {
   @FunctionalInterface
   interface StatusClosable extends Closeable {
 
+    @Override
     void close();
   }
 
@@ -57,6 +58,8 @@ public interface KsqlTerminal {
    * @return the closable that will remove the status message.
    */
   StatusClosable setStatusMessage(String message);
+
+  void printError(String message);
 
   void close();
 

--- a/ksql-cli/src/test/java/io/confluent/ksql/TestTerminal.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/TestTerminal.java
@@ -97,6 +97,6 @@ public class TestTerminal implements KsqlTerminal {
 
   @Override
   public void printError(final String message) {
-    // Ignore
+    writer().println(message);
   }
 }

--- a/ksql-cli/src/test/java/io/confluent/ksql/TestTerminal.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/TestTerminal.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql;
 
 import io.confluent.ksql.cli.console.KsqlTerminal;
-import java.io.File;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.Writer;
@@ -94,5 +93,10 @@ public class TestTerminal implements KsqlTerminal {
   @Override
   public StatusClosable setStatusMessage(final String message) {
     return () -> {};
+  }
+
+  @Override
+  public void printError(final String message) {
+    // Ignore
   }
 }


### PR DESCRIPTION

Simply renders error messages displayed in the CLI in red (see #892 ). 
@rmoff - this is for you ;-)