### PR TITLE
fix: ConcurrentModificationException in ClusterStatusResource

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/ClusterStatusResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/ClusterStatusResource.java
@@ -102,14 +102,14 @@ public class ClusterStatusResource {
   private Map<String, ActiveStandbyEntity> getActiveStandbyInformation(
       final KsqlHostInfo ksqlHostInfo
   ) {
-    Map<String, ActiveStandbyEntity> perQueryMap = new HashMap<>();
+    final Map<String, ActiveStandbyEntity> perQueryMap = new HashMap<>();
     for (PersistentQueryMetadata persistentQueryMetadata: engine.getPersistentQueries()) {
       for (StreamsMetadata streamsMetadata: persistentQueryMetadata.getAllMetadata()) {
         if (streamsMetadata == StreamsMetadata.NOT_AVAILABLE
             || !streamsMetadata.hostInfo().equals(asHostInfo(ksqlHostInfo))) {
           continue;
         }
-        QueryIdAndStreamsMetadata queryIdAndStreamsMetadata = new QueryIdAndStreamsMetadata(
+        final QueryIdAndStreamsMetadata queryIdAndStreamsMetadata = new QueryIdAndStreamsMetadata(
             persistentQueryMetadata.getQueryId().toString(),
             streamsMetadata
         );

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/ClusterStatusResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/ClusterStatusResource.java
@@ -106,7 +106,7 @@ public class ClusterStatusResource {
     for (PersistentQueryMetadata persistentQueryMetadata: engine.getPersistentQueries()) {
       for (StreamsMetadata streamsMetadata: persistentQueryMetadata.getAllMetadata()) {
         if (streamsMetadata == StreamsMetadata.NOT_AVAILABLE
-            || streamsMetadata.hostInfo().equals(asHostInfo(ksqlHostInfo))) {
+            || !streamsMetadata.hostInfo().equals(asHostInfo(ksqlHostInfo))) {
           continue;
         }
         QueryIdAndStreamsMetadata queryIdAndStreamsMetadata = new QueryIdAndStreamsMetadata(


### PR DESCRIPTION
### Description 
Fix flaky test in master. Changed streams api to nested loops to make reasoning about the code easier.

### Testing done 
Ran `HeartbeatAgentFunctionalTest` 60 times.

