### PR TITLE
test: data providers should be ordered (MINOR)

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/util/ItemDataProvider.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/ItemDataProvider.java
@@ -16,9 +16,9 @@
 
 package io.confluent.ksql.util;
 
+import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.GenericRow;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -37,25 +37,24 @@ public class ItemDataProvider extends TestDataProvider {
       .field("ID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
       .field("DESCRIPTION", SchemaBuilder.OPTIONAL_STRING_SCHEMA).build();
 
-  private static final Map<String, GenericRow> data = new ItemDataProvider().buildData();
+  private static final Map<String, GenericRow> data = buildData();
 
   public ItemDataProvider() {
     super(namePrefix, ksqlSchemaString, key, schema, data);
   }
 
-  private Map<String, GenericRow> buildData() {
+  private static Map<String, GenericRow> buildData() {
 
-    final Map<String, GenericRow> dataMap = new HashMap<>();
-    dataMap.put("ITEM_1", new GenericRow(Arrays.asList("ITEM_1",  "home cinema")));
-    dataMap.put("ITEM_2", new GenericRow(Arrays.asList("ITEM_2",  "clock radio")));
-    dataMap.put("ITEM_3", new GenericRow(Arrays.asList("ITEM_3",  "road bike")));
-    dataMap.put("ITEM_4", new GenericRow(Arrays.asList("ITEM_4",  "mountain bike")));
-    dataMap.put("ITEM_5", new GenericRow(Arrays.asList("ITEM_5",  "snowboard")));
-    dataMap.put("ITEM_6", new GenericRow(Arrays.asList("ITEM_6",  "iphone 10")));
-    dataMap.put("ITEM_7", new GenericRow(Arrays.asList("ITEM_7",  "gopro")));
-    dataMap.put("ITEM_8", new GenericRow(Arrays.asList("ITEM_8",  "cat")));
-
-    return dataMap;
+    return ImmutableMap.<String, GenericRow>builder()
+        .put("ITEM_1", new GenericRow(Arrays.asList("ITEM_1",  "home cinema")))
+        .put("ITEM_2", new GenericRow(Arrays.asList("ITEM_2",  "clock radio")))
+        .put("ITEM_3", new GenericRow(Arrays.asList("ITEM_3",  "road bike")))
+        .put("ITEM_4", new GenericRow(Arrays.asList("ITEM_4",  "mountain bike")))
+        .put("ITEM_5", new GenericRow(Arrays.asList("ITEM_5",  "snowboard")))
+        .put("ITEM_6", new GenericRow(Arrays.asList("ITEM_6",  "iphone 10")))
+        .put("ITEM_7", new GenericRow(Arrays.asList("ITEM_7",  "gopro")))
+        .put("ITEM_8", new GenericRow(Arrays.asList("ITEM_8",  "cat")))
+        .build();
   }
 
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/OrderDataProvider.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/OrderDataProvider.java
@@ -16,6 +16,7 @@
 
 package io.confluent.ksql.util;
 
+import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.GenericRow;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -42,92 +43,85 @@ public class OrderDataProvider extends TestDataProvider {
       .field("PRICEARRAY", SchemaBuilder.array(SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA).optional().build())
       .field("KEYVALUEMAP", SchemaBuilder.map(SchemaBuilder.OPTIONAL_STRING_SCHEMA, SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA)).optional().build();
 
-  private static final Map<String, GenericRow> data = new OrderDataProvider().buildData();
+  private static final Map<String, GenericRow> data = buildData();
 
   public OrderDataProvider() {
     super(namePrefix, ksqlSchemaString, key, schema, data);
   }
 
-  private Map<String, GenericRow> buildData() {
+  private static Map<String, GenericRow> buildData() {
 
     final Map<String, Double> mapField = new HashMap<>();
     mapField.put("key1", 1.0);
     mapField.put("key2", 2.0);
     mapField.put("key3", 3.0);
 
-    final Map<String, GenericRow> dataMap = new HashMap<>();
-    dataMap.put("1", new GenericRow(Arrays.asList(
-        1L,
-        "ORDER_1",
-        "ITEM_1",
-        10.0,
-        "2018-01-01",
-        Arrays.asList(100.0, 110.99, 90.0 ),
-        mapField)));
-    dataMap.put("2", new GenericRow(Arrays.asList(
-        2L,
-        "ORDER_2",
-        "ITEM_2",
-        20.0,
-        "2018-01-02",
-        Arrays.asList(10.0, 10.99, 9.0),
-        mapField)));
-
-    dataMap.put("3", new GenericRow(Arrays.asList(
-        3L,
-        "ORDER_3",
-        "ITEM_3",
-        30.0,
-        "2018-01-03",
-        Arrays.asList(10.0, 10.99, 91.0),
-        mapField)));
-
-    dataMap.put("4", new GenericRow(Arrays.asList(
-        4L,
-        "ORDER_4",
-        "ITEM_4",
-        40.0,
-        "2018-01-04",
-        Arrays.asList(10.0, 140.99, 94.0),
-        mapField)));
-
-    dataMap.put("5", new GenericRow(Arrays.asList(
-        5L,
-        "ORDER_5",
-        "ITEM_5",
-        50.0,
-        "2018-01-05",
-        Arrays.asList(160.0, 160.99, 98.0),
-        mapField)));
-
-    dataMap.put("6", new GenericRow(Arrays.asList(
-        6L,
-        "ORDER_6",
-        "ITEM_6",
-        60.0,
-        "2018-01-06",
-        Arrays.asList(1000.0, 1100.99, 900.0),
-        mapField)));
-
-    dataMap.put("7", new GenericRow(Arrays.asList(
-        7L,
-        "ORDER_6",
-        "ITEM_7",
-        70.0,
-        "2018-01-07",
-        Arrays.asList(1100.0, 1110.99, 190.0),
-        mapField)));
-
-    dataMap.put("8", new GenericRow(Arrays.asList(
-        8L,
-        "ORDER_6",
-        "ITEM_8",
-        80.0,
-        "2018-01-08",
-        Arrays.asList(1100.0, 1110.99, 970.0),
-        mapField)));
-
-    return dataMap;
+    return ImmutableMap.<String, GenericRow>builder()
+        .put("1", new GenericRow(Arrays.asList(
+            1L,
+            "ORDER_1",
+            "ITEM_1",
+            10.0,
+            "2018-01-01",
+            Arrays.asList(100.0, 110.99, 90.0 ),
+            mapField)))
+        .put("2", new GenericRow(Arrays.asList(
+            2L,
+            "ORDER_2",
+            "ITEM_2",
+            20.0,
+            "2018-01-02",
+            Arrays.asList(10.0, 10.99, 9.0),
+            mapField)))
+        .put("3", new GenericRow(Arrays.asList(
+            3L,
+            "ORDER_3",
+            "ITEM_3",
+            30.0,
+            "2018-01-03",
+            Arrays.asList(10.0, 10.99, 91.0),
+            mapField)))
+        .put("4", new GenericRow(Arrays.asList(
+            4L,
+            "ORDER_4",
+            "ITEM_4",
+            40.0,
+            "2018-01-04",
+            Arrays.asList(10.0, 140.99, 94.0),
+            mapField)))
+        .put("5", new GenericRow(Arrays.asList(
+            5L,
+            "ORDER_5",
+            "ITEM_5",
+            50.0,
+            "2018-01-05",
+            Arrays.asList(160.0, 160.99, 98.0),
+            mapField)))
+        .put("6", new GenericRow(Arrays.asList(
+            6L,
+            "ORDER_6",
+            "ITEM_6",
+            60.0,
+            "2018-01-06",
+            Arrays.asList(1000.0, 1100.99, 900.0),
+            mapField)))
+        .put("7", new GenericRow(Arrays.asList(
+            7L,
+            "ORDER_6",
+            "ITEM_7",
+            70.0,
+            "2018-01-07",
+            Arrays.asList(1100.0, 1110.99, 190.0),
+            mapField)))
+        .put("8", new GenericRow(Arrays.asList(
+            8L,
+            "ORDER_6",
+            "ITEM_8",
+            80.0,
+            "2018-01-08",
+            Arrays.asList(1100.0, 1110.99, 970.0),
+            mapField)))
+        .build();
   }
 
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/PageViewDataProvider.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/PageViewDataProvider.java
@@ -15,9 +15,9 @@
  **/
 package io.confluent.ksql.util;
 
+import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.GenericRow;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -36,29 +36,26 @@ public class PageViewDataProvider extends TestDataProvider {
       .field("USERID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
       .field("PAGEID", SchemaBuilder.OPTIONAL_STRING_SCHEMA).build();
 
-  private static final Map<String, GenericRow> data = new PageViewDataProvider().buildData();
+  private static final Map<String, GenericRow> data = buildData();
 
   public PageViewDataProvider() {
     super(namePrefix, ksqlSchemaString, key, schema, data);
   }
 
-  private Map<String, GenericRow> buildData() {
-    final Map<String, GenericRow> dataMap = new HashMap<>();
-
+  private static Map<String, GenericRow> buildData() {
     // Create page view records with:
     // key = page_id
     // value = (view time, user_id, page_id)
-    dataMap.put("1", new GenericRow(Arrays.asList(1L, "USER_1", "PAGE_1")));
-    dataMap.put("2", new GenericRow(Arrays.asList(2L, "USER_2", "PAGE_2")));
-    dataMap.put("3", new GenericRow(Arrays.asList(3L, "USER_4", "PAGE_3")));
-    dataMap.put("4", new GenericRow(Arrays.asList(4L, "USER_3", "PAGE_4")));
-    dataMap.put("5", new GenericRow(Arrays.asList(5L, "USER_0", "PAGE_5")));
-
-    // Duplicate page views from different users.
-    dataMap.put("6", new GenericRow(Arrays.asList(6L, "USER_2", "PAGE_5")));
-    dataMap.put("7", new GenericRow(Arrays.asList(7L, "USER_3", "PAGE_5")));
-
-    return dataMap;
+    return ImmutableMap.<String, GenericRow>builder()
+        .put("1", new GenericRow(Arrays.asList(1L, "USER_1", "PAGE_1")))
+        .put("2", new GenericRow(Arrays.asList(2L, "USER_2", "PAGE_2")))
+        .put("3", new GenericRow(Arrays.asList(3L, "USER_4", "PAGE_3")))
+        .put("4", new GenericRow(Arrays.asList(4L, "USER_3", "PAGE_4")))
+        .put("5", new GenericRow(Arrays.asList(5L, "USER_0", "PAGE_5")))
+        // Duplicate page views from different users.
+        .put("6", new GenericRow(Arrays.asList(6L, "USER_2", "PAGE_5")))
+        .put("7", new GenericRow(Arrays.asList(7L, "USER_3", "PAGE_5")))
+        .build();
   }
 
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/UserDataProvider.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/UserDataProvider.java
@@ -15,9 +15,9 @@
  **/
 package io.confluent.ksql.util;
 
+import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.GenericRow;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -35,24 +35,23 @@ public class UserDataProvider extends TestDataProvider {
       .field("REGIONID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
       .field("USERID", SchemaBuilder.OPTIONAL_STRING_SCHEMA).build();
 
-  private static final Map<String, GenericRow> data = new UserDataProvider().buildData();
+  private static final Map<String, GenericRow> data = buildData();
 
   public UserDataProvider() {
     super(namePrefix, ksqlSchemaString, key, schema, data);
   }
 
-  private Map<String, GenericRow> buildData() {
-    final Map<String, GenericRow> dataMap = new HashMap<>();
+  private static Map<String, GenericRow> buildData() {
     // create a records with:
     // key == user_id
     // value = (creation_time, gender, region, user_id)
-    dataMap.put("USER_0", new GenericRow(Arrays.asList(0L, "FEMALE", "REGION_0", "USER_0")));
-    dataMap.put("USER_1", new GenericRow(Arrays.asList(1L, "MALE", "REGION_1", "USER_1")));
-    dataMap.put("USER_2", new GenericRow(Arrays.asList(2L, "FEMALE", "REGION_1", "USER_2")));
-    dataMap.put("USER_3", new GenericRow(Arrays.asList(3L, "MALE", "REGION_0", "USER_3")));
-    dataMap.put("USER_4", new GenericRow(Arrays.asList(4L, "MALE", "REGION_4", "USER_4")));
-
-    return dataMap;
+    return ImmutableMap.<String, GenericRow>builder()
+        .put("USER_0", new GenericRow(Arrays.asList(0L, "FEMALE", "REGION_0", "USER_0")))
+        .put("USER_1", new GenericRow(Arrays.asList(1L, "MALE", "REGION_1", "USER_1")))
+        .put("USER_2", new GenericRow(Arrays.asList(2L, "FEMALE", "REGION_1", "USER_2")))
+        .put("USER_3", new GenericRow(Arrays.asList(3L, "MALE", "REGION_0", "USER_3")))
+        .put("USER_4", new GenericRow(Arrays.asList(4L, "MALE", "REGION_4", "USER_4")))
+        .build();
   }
 
 


### PR DESCRIPTION
### Description 

Tests that rely on the `TestDataProvider`s assume the provided data are ordered according to the order specified in the data providers, but this guarantee is not provided by `HashMap`. This leads to flaky failures such as this one from `5.2.x`:
```
testInsertIntoAvro
A test failure has occurred at Tue Feb 11 20:21:01 2020 UTC.

Module: io.confluent.ksql.integration.StreamsSelectAndProjectIntTest

org.junit.ComparisonFailure: expected:<ITEM_[1]> but was:<ITEM_[2]>
	at io.confluent.ksql.integration.StreamsSelectAndProjectIntTest.testInsertIntoAvro(StreamsSelectAndProjectIntTest.java:381)
```
where the test was expecting the first record to be `ITEM_1` but received `ITEM_2` instead.

This PR fixes such flaky failures by switching to a map implementation that does guarantee order.

### Testing done 

`mvn package`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

