### PR TITLE
test: fix flaky RestApiTest#shouldExecutePushQueryOverRest (MINOR)

### DIFF
--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -59,6 +59,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import javax.websocket.CloseReason.CloseCodes;
 import javax.ws.rs.core.MediaType;
 import org.eclipse.jetty.websocket.api.Session;
@@ -206,13 +207,15 @@ public class RestApiTest {
     );
 
     // Then:
-    final String[] messages = response.split(System.lineSeparator());
-    assertThat(messages.length, is(HEADER + LIMIT + FOOTER));
-    assertThat(messages[0],
+    final List<String> messages = Arrays.stream(response.split(System.lineSeparator()))
+        .filter(s -> !s.isEmpty())
+        .collect(Collectors.toList());
+    assertThat(messages, hasSize(HEADER + LIMIT + FOOTER));
+    assertThat(messages.get(0),
         is("{\"header\":{\"queryId\":\"none\",\"schema\":\"`USERID` STRING, `PAGEID` STRING, `VIEWTIME` BIGINT, `ROWKEY` STRING\"}}"));
-    assertThat(messages[1], is("{\"row\":{\"columns\":[\"USER_1\",\"PAGE_1\",1,\"1\"]}}"));
-    assertThat(messages[2], is("{\"row\":{\"columns\":[\"USER_2\",\"PAGE_2\",2,\"2\"]}}"));
-    assertThat(messages[3], is("{\"finalMessage\":\"Limit Reached\"}"));
+    assertThat(messages.get(1), is("{\"row\":{\"columns\":[\"USER_1\",\"PAGE_1\",1,\"1\"]}}"));
+    assertThat(messages.get(2), is("{\"row\":{\"columns\":[\"USER_2\",\"PAGE_2\",2,\"2\"]}}"));
+    assertThat(messages.get(3), is("{\"finalMessage\":\"Limit Reached\"}"));
   }
 
   @Test


### PR DESCRIPTION
### Description 

We've seen three flaky failures for the test `RestApiTest#shouldExecutePushQueryOverRest` over the past two days, each with the following stacktrace:
```
java.lang.AssertionError: 

Expected: is "{\"finalMessage\":\"Limit Reached\"}]"
     but: was ""
	at io.confluent.ksql.rest.integration.RestApiTest.shouldExecutePushQueryOverRest(RestApiTest.java:234)
```
The [test](https://github.com/confluentinc/ksql/blob/31e75acb161f82e8ea14babed0acfe80b604bee0/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java#L220) issues a push query with `LIMIT` clause to the HTTP streaming endpoint and expects four rows to be returned: a header row, two rows of data, and a footer indicating that the limit has been reached. The test first parses the JSON response to check that four rows are returned, then splits the (un-parsed) response string on newline and checks that the first four lines correspond to the four expected rows. Interestingly, only the check for the fourth line of the response fails: the test expects the fourth line to be the footer but in the flaky failures the fourth line is empty.

I think this is happening because the QueryStreamWriter sometimes writes empty lines into the response: https://github.com/confluentinc/ksql/blob/31e75acb161f82e8ea14babed0acfe80b604bee0/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriter.java#L78-L80

If this were to happen after the two data rows were written but before the final `Limit Reached` message was written, then the test `RestApiTest#shouldExecutePushQueryOverRest` would fail in the way we've observed: the output would contain four messages when parsed as JSON, but the fourth row of the raw response would be an empty line.

The exact circumstances that would cause such a newline to be written after the two data rows would be:
- The last (second) row of data is polled from the row queue: https://github.com/confluentinc/ksql/blob/31e75acb161f82e8ea14babed0acfe80b604bee0/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriter.java#L71
- `limitReached` has not been updated yet, so a new iteration of this while-loop is entered: https://github.com/confluentinc/ksql/blob/31e75acb161f82e8ea14babed0acfe80b604bee0/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriter.java#L70
- This time, the attempted `poll()` times out since no new rows have been written to the queue.
- By now, `limitReached` has been set so the footer is written: https://github.com/confluentinc/ksql/blob/31e75acb161f82e8ea14babed0acfe80b604bee0/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriter.java#L89
and the response is returned.

However, this seems very unlikely since `limitReached` is updated immediately after rows are added to the row queue: https://github.com/confluentinc/ksql/blob/31e75acb161f82e8ea14babed0acfe80b604bee0/ksql-engine/src/main/java/io/confluent/ksql/query/TransientQueryQueue.java#L106-L107
but I don't currently have a better explanation -- thoughts appreciated!

This PR updates the test to remove empty lines from the un-parsed response before the comparison, which fixes the flakiness if my hypothesis is correct.

### Testing done 

`mvn package`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

