### PR TITLE
chore: add 0.7 expected topologies

### DIFF
--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/TopologyFileGenerator.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/TopologyFileGenerator.java
@@ -29,13 +29,11 @@ import io.confluent.ksql.metastore.MutableMetaStore;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.TestServiceContext;
 import io.confluent.ksql.test.loader.ExpectedTopologiesTestLoader;
-import io.confluent.ksql.test.serde.SerdeSupplier;
 import io.confluent.ksql.test.tools.TestCase;
 import io.confluent.ksql.test.tools.TestExecutor;
 import io.confluent.ksql.test.tools.TestExecutorUtil;
 import io.confluent.ksql.test.tools.Topic;
 import io.confluent.ksql.test.tools.stubs.StubKafkaService;
-import io.confluent.ksql.test.utils.SerdeUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
@@ -111,7 +109,7 @@ public final class TopologyFileGenerator {
     }
 
     static void generateTopologies(final Path base) throws Exception {
-        final String formattedVersion = "0_6_0-pre";
+        final String formattedVersion = getFormattedVersionFromPomFile();
         final Path generatedTopologyPath = base.resolve(formattedVersion);
 
         System.out.println(String.format("Starting to write topology files to %s", generatedTopologyPath));

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/array_-_GENERATE_SERIES
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/array_-_GENERATE_SERIES
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<F0 INT, F1 INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 ARRAY<INT>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/array_-_GENERATE_SERIES_with_step
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/array_-_GENERATE_SERIES_with_step
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<F0 INT, F1 INT, F2 INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 ARRAY<INT>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/array_-_entries_sorted
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/array_-_entries_sorted
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<INTMAP MAP<VARCHAR, INT>, BIGINTMAP MAP<VARCHAR, BIGINT>, DOUBLEMAP MAP<VARCHAR, DOUBLE>, BOOLEANMAP MAP<VARCHAR, BOOLEAN>, STRINGMAP MAP<VARCHAR, VARCHAR>, NULLMAP MAP<VARCHAR, VARCHAR>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 ARRAY<STRUCT<K VARCHAR, V INT>>, KSQL_COL_1 ARRAY<STRUCT<K VARCHAR, V BIGINT>>, KSQL_COL_2 ARRAY<STRUCT<K VARCHAR, V DOUBLE>>, KSQL_COL_3 ARRAY<STRUCT<K VARCHAR, V BOOLEAN>>, KSQL_COL_4 ARRAY<STRUCT<K VARCHAR, V VARCHAR>>, KSQL_COL_5 ARRAY<STRUCT<K VARCHAR, V VARCHAR>>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/arraycontains_-_filter_rows_where_the_ARRAY_column_contains_a_specified_STRING
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/arraycontains_-_filter_rows_where_the_ARRAY_column_contains_a_specified_STRING
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<COLORS ARRAY<VARCHAR>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<COLORS ARRAY<VARCHAR>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/arraycontains_-_filter_rows_where_the_STRUCT-_ARRAY_column_contains_a_specified_STRING
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/arraycontains_-_filter_rows_where_the_STRUCT-_ARRAY_column_contains_a_specified_STRING
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<C1 STRUCT<COLORS ARRAY<VARCHAR>>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<COLORS ARRAY<VARCHAR>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/arrayindex_-_select_the_first_element_of_an_Array
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/arrayindex_-_select_the_first_element_of_an_Array
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<COLORS ARRAY<VARCHAR>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<C VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/arrayindex_-_select_the_last_element_of_an_Array_(-1)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/arrayindex_-_select_the_last_element_of_an_Array_(-1)
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<COLORS ARRAY<VARCHAR>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<C VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/average-udaf_-_average_double
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/average-udaf_-_average_double
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<VALUE DOUBLE> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 DOUBLE, KSQL_INTERNAL_COL_1 VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 DOUBLE, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_AGG_VARIABLE_0 STRUCT<SUM DOUBLE, COUNT BIGINT>> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<AVG DOUBLE> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/average-udaf_-_average_int
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/average-udaf_-_average_int
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<VALUE INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_AGG_VARIABLE_0 STRUCT<SUM INT, COUNT BIGINT>> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<AVG DOUBLE> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/average-udaf_-_average_long
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/average-udaf_-_average_long
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<VALUE BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_AGG_VARIABLE_0 STRUCT<SUM BIGINT, COUNT BIGINT>> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<AVG DOUBLE> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/average_-_calculate_average_in_select
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/average_-_calculate_average_in_select
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_AVG_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CTAS_AVG_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_AVG_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT, KSQL_AGG_VARIABLE_1 BIGINT> NOT NULL
+CTAS_AVG_0.AVG = STRUCT<ID BIGINT, AVG BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: AVG)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/between_-_test_BETWEEN_with_array_dereference
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/between_-_test_BETWEEN_with_array_dereference
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE ARRAY<INT>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<THING INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/between_-_test_BETWEEN_with_bigint
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/between_-_test_BETWEEN_with_bigint
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<THING BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/between_-_test_BETWEEN_with_floating_point
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/between_-_test_BETWEEN_with_floating_point
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE DOUBLE> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<THING DOUBLE> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/between_-_test_BETWEEN_with_integers
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/between_-_test_BETWEEN_with_integers
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<THING INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/between_-_test_BETWEEN_with_integers_and_expressions
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/between_-_test_BETWEEN_with_integers_and_expressions
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE INT, AVG INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<THING INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/between_-_test_BETWEEN_with_integers_and_variable_values
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/between_-_test_BETWEEN_with_integers_and_variable_values
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE INT, MIN INT, MAX INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<THING INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/between_-_test_BETWEEN_with_string_values
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/between_-_test_BETWEEN_with_string_values
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<THING VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/between_-_test_BETWEEN_with_string_values_with_substring
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/between_-_test_BETWEEN_with_string_values_with_substring
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<THING VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/between_-_test_NOT_BETWEEN_with_integers
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/between_-_test_NOT_BETWEEN_with_integers
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<THING INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/case-expression_-_searched_case_expression
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/case-expression_-_searched_case_expression
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S1_0.KsqlTopic.Source = STRUCT<ORDERUNITS DOUBLE> NOT NULL
+CSAS_S1_0.S1 = STRUCT<CASE_RESAULT VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S1)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/case-expression_-_searched_case_expression_with_structs,_multiple_expression_and_the_same_type
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/case-expression_-_searched_case_expression_with_structs,_multiple_expression_and_the_same_type
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S1_0.KsqlTopic.Source = STRUCT<ADDRESS STRUCT<CITY VARCHAR, STATE VARCHAR>, ITEMID STRUCT<NAME VARCHAR>> NOT NULL
+CSAS_S1_0.S1 = STRUCT<CASE_RESAULT VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S1)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/case-expression_-_searched_case_returning_null_in_default_branch
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/case-expression_-_searched_case_returning_null_in_default_branch
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S1_0.KsqlTopic.Source = STRUCT<ORDERUNITS DOUBLE> NOT NULL
+CSAS_S1_0.S1 = STRUCT<CASE_RESULT VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S1)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/case-expression_-_searched_case_returning_null_in_first_branch
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/case-expression_-_searched_case_returning_null_in_first_branch
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S1_0.KsqlTopic.Source = STRUCT<ORDERUNITS DOUBLE> NOT NULL
+CSAS_S1_0.S1 = STRUCT<CASE_RESULT VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S1)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/case-expression_-_searched_case_returning_null_in_later_branch
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/case-expression_-_searched_case_returning_null_in_later_branch
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S1_0.KsqlTopic.Source = STRUCT<ORDERUNITS DOUBLE> NOT NULL
+CSAS_S1_0.S1 = STRUCT<CASE_RESULT VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S1)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/case-expression_-_searched_case_with_arithmetic_expression_in_result
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/case-expression_-_searched_case_with_arithmetic_expression_in_result
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S1_0.KsqlTopic.Source = STRUCT<ORDERID BIGINT, ORDERUNITS DOUBLE> NOT NULL
+CSAS_S1_0.S1 = STRUCT<CASE_RESAULT BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S1)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/case-expression_-_searched_case_with_null_in_when
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/case-expression_-_searched_case_with_null_in_when
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S1_0.KsqlTopic.Source = STRUCT<ORDERID BIGINT, ORDERUNITS DOUBLE> NOT NULL
+CSAS_S1_0.S1 = STRUCT<CASE_RESAULT VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S1)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/cast_-_decimal_to_decimal
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/cast_-_decimal_to_decimal
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUT_0.KsqlTopic.Source = STRUCT<FOO DECIMAL(4, 2)> NOT NULL
+CSAS_OUT_0.OUT = STRUCT<KSQL_COL_0 DECIMAL(5, 3)> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/cast_-_decimal_to_other
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/cast_-_decimal_to_other
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUT_0.KsqlTopic.Source = STRUCT<VAL DECIMAL(4, 2)> NOT NULL
+CSAS_OUT_0.OUT = STRUCT<I INT, L BIGINT, D DOUBLE, S VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/cast_-_double_to_decimal
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/cast_-_double_to_decimal
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUT_0.KsqlTopic.Source = STRUCT<FOO DOUBLE> NOT NULL
+CSAS_OUT_0.OUT = STRUCT<VAL DECIMAL(2, 1)> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/cast_-_integer_to_decimal
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/cast_-_integer_to_decimal
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUT_0.KsqlTopic.Source = STRUCT<FOO INT> NOT NULL
+CSAS_OUT_0.OUT = STRUCT<VAL DECIMAL(2, 1)> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/cast_-_no_op
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/cast_-_no_op
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<B BOOLEAN, I INT, BI BIGINT, D DOUBLE, S VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BOOLEAN, KSQL_COL_1 INT, KSQL_COL_2 BIGINT, KSQL_COL_3 DOUBLE, KSQL_COL_4 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/cast_-_of_nulls
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/cast_-_of_nulls
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<IGNORED VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BOOLEAN, KSQL_COL_1 INT, KSQL_COL_2 BIGINT, KSQL_COL_3 DOUBLE, KSQL_COL_4 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/cast_-_string_to_decimal
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/cast_-_string_to_decimal
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUT_0.KsqlTopic.Source = STRUCT<FOO VARCHAR> NOT NULL
+CSAS_OUT_0.OUT = STRUCT<VAL DECIMAL(2, 1)> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/collect-list_-_collect_list_bool_map
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/collect-list_-_collect_list_bool_map
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE MAP<VARCHAR, BOOLEAN>> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 MAP<VARCHAR, BOOLEAN>, KSQL_INTERNAL_COL_2 BOOLEAN> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 MAP<VARCHAR, BOOLEAN>, KSQL_AGG_VARIABLE_0 ARRAY<BOOLEAN>> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, COLLECTED ARRAY<BOOLEAN>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/collect-list_-_collect_list_bool_map_table
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/collect-list_-_collect_list_bool_map_table
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE MAP<VARCHAR, BOOLEAN>> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 MAP<VARCHAR, BOOLEAN>, KSQL_INTERNAL_COL_2 BOOLEAN> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 MAP<VARCHAR, BOOLEAN>, KSQL_AGG_VARIABLE_0 ARRAY<BOOLEAN>> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, COLLECTED ARRAY<BOOLEAN>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/collect-list_-_collect_list_double
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/collect-list_-_collect_list_double
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, VALUE DOUBLE> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DOUBLE> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DOUBLE, KSQL_AGG_VARIABLE_0 ARRAY<DOUBLE>> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, COLLECTED ARRAY<DOUBLE>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/collect-list_-_collect_list_double_table
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/collect-list_-_collect_list_double_table
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, VALUE DOUBLE> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DOUBLE> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DOUBLE, KSQL_AGG_VARIABLE_0 ARRAY<DOUBLE>> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, COLLECTED ARRAY<DOUBLE>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/collect-list_-_collect_list_int
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/collect-list_-_collect_list_int
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, VALUE INT> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT, KSQL_AGG_VARIABLE_0 ARRAY<INT>> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, COLLECTED ARRAY<INT>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/collect-list_-_collect_list_int_table
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/collect-list_-_collect_list_int_table
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, VALUE INT> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT, KSQL_AGG_VARIABLE_0 ARRAY<INT>> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, COLLECTED ARRAY<INT>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/collect-list_-_collect_list_long
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/collect-list_-_collect_list_long
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, VALUE BIGINT> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 ARRAY<BIGINT>> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, COLLECTED ARRAY<BIGINT>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/collect-list_-_collect_list_long_table
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/collect-list_-_collect_list_long_table
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, VALUE BIGINT> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 ARRAY<BIGINT>> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, COLLECTED ARRAY<BIGINT>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/collect-list_-_collect_list_string
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/collect-list_-_collect_list_string
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, VALUE VARCHAR> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_AGG_VARIABLE_0 ARRAY<VARCHAR>> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, COLLECTED ARRAY<VARCHAR>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/collect-list_-_collect_list_string_table
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/collect-list_-_collect_list_string_table
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, VALUE VARCHAR> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_AGG_VARIABLE_0 ARRAY<VARCHAR>> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, COLLECTED ARRAY<VARCHAR>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/collect-set_-_collect_set_bool_map
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/collect-set_-_collect_set_bool_map
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE MAP<VARCHAR, BOOLEAN>> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 MAP<VARCHAR, BOOLEAN>, KSQL_INTERNAL_COL_2 BOOLEAN> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 MAP<VARCHAR, BOOLEAN>, KSQL_AGG_VARIABLE_0 ARRAY<BOOLEAN>> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, COLLECTED ARRAY<BOOLEAN>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/collect-set_-_collect_set_double
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/collect-set_-_collect_set_double
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, VALUE DOUBLE> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DOUBLE> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DOUBLE, KSQL_AGG_VARIABLE_0 ARRAY<DOUBLE>> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, COLLECTED ARRAY<DOUBLE>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/collect-set_-_collect_set_int
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/collect-set_-_collect_set_int
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, VALUE INT> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT, KSQL_AGG_VARIABLE_0 ARRAY<INT>> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, COLLECTED ARRAY<INT>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/collect-set_-_collect_set_long
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/collect-set_-_collect_set_long
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, VALUE BIGINT> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 ARRAY<BIGINT>> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, COLLECTED ARRAY<BIGINT>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/collect-set_-_collect_set_string
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/collect-set_-_collect_set_string
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, VALUE VARCHAR> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_AGG_VARIABLE_0 ARRAY<VARCHAR>> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, COLLECTED ARRAY<VARCHAR>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/concat_-_concat_fields_using_'+'_operator
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/concat_-_concat_fields_using_'+'_operator
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<THING VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/concat_-_concat_fields_using_CONCAT
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/concat_-_concat_fields_using_CONCAT
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<THING VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/count-distinct_-_count_distinct
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/count-distinct_-_count_distinct
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID VARCHAR, NAME VARCHAR> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 VARCHAR> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_AGG_VARIABLE_0 ARRAY<INT>> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID VARCHAR, COUNT BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/count_-_count
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/count_-_count
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE DOUBLE> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/count_-_count_literal
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/count_-_count_literal
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<IGNORED VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/count_-_count_star
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/count_-_count_star
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<IGNORED VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/count_-_count_table
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/count_-_count_table
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<NAME VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/count_-_should_count_back_to_zero
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/count_-_should_count_back_to_zero
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/count_-_should_support_removing_zero_counts_from_table
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/count_-_should_support_removing_zero_counts_from_table
@@ -1,0 +1,99 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT, KSQL_AGG_VARIABLE_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-HavingFilter-ApplyPredicate
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-HavingFilter-ApplyPredicate (stores: [])
+      --> Aggregate-HavingFilter-Filter
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-HavingFilter-Filter (stores: [])
+      --> Aggregate-HavingFilter-PostProcess
+      <-- Aggregate-HavingFilter-ApplyPredicate
+    Processor: Aggregate-HavingFilter-PostProcess (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-HavingFilter-Filter
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000014
+      <-- Aggregate-HavingFilter-PostProcess
+    Processor: KTABLE-TOSTREAM-0000000014 (stores: [])
+      --> KSTREAM-SINK-0000000015
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000015 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000014
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/create-struct_-_basic_struct_creation
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/create-struct_-_basic_struct_creation
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_BIG_STRUCT_0.KsqlTopic.Source = STRUCT<COL1 VARCHAR, COL2 ARRAY<VARCHAR>> NOT NULL
+CSAS_BIG_STRUCT_0.BIG_STRUCT = STRUCT<S STRUCT<F1 VARCHAR, F2 ARRAY<VARCHAR>, F3 VARCHAR>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: BIG_STRUCT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/create-struct_-_empty_struct_creation
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/create-struct_-_empty_struct_creation
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_BIG_STRUCT_0.KsqlTopic.Source = STRUCT<COL1 VARCHAR> NOT NULL
+CSAS_BIG_STRUCT_0.BIG_STRUCT = STRUCT<S STRUCT<>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: BIG_STRUCT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/create-struct_-_nested_struct_creation
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/create-struct_-_nested_struct_creation
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_BIG_STRUCT_0.KsqlTopic.Source = STRUCT<COL1 VARCHAR> NOT NULL
+CSAS_BIG_STRUCT_0.BIG_STRUCT = STRUCT<S STRUCT<F1 STRUCT<C1 VARCHAR>>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: BIG_STRUCT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/create-struct_-_quoted_identifiers
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/create-struct_-_quoted_identifiers
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_BIG_STRUCT_0.KsqlTopic.Source = STRUCT<COL1 VARCHAR> NOT NULL
+CSAS_BIG_STRUCT_0.BIG_STRUCT = STRUCT<S STRUCT<FOO VARCHAR, foo VARCHAR>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: BIG_STRUCT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/create_array_-_construct_a_list_from_null_casted_elements
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/create_array_-_construct_a_list_from_null_casted_elements
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<A INT, B INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<L ARRAY<INT>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/create_array_-_construct_a_list_from_two_elements
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/create_array_-_construct_a_list_from_two_elements
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<A INT, B INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<L ARRAY<INT>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/create_map_-_create_map_from_key_value_lists
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/create_map_-_create_map_from_key_value_lists
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<KS ARRAY<VARCHAR>, VALS ARRAY<INT>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<M MAP<VARCHAR, INT>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/create_map_-_create_map_from_named_tuples
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/create_map_-_create_map_from_named_tuples
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<K1 VARCHAR, K2 VARCHAR, V1 INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<M MAP<VARCHAR, INT>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/cube_-_cube_three_columns
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/cube_-_cube_three_columns
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<COL1 VARCHAR, COL2 VARCHAR, COL3 VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<VAL ARRAY<VARCHAR>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> FlatMap
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: FlatMap (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- FlatMap
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/cube_-_cube_two_columns_twice
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/cube_-_cube_two_columns_twice
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<COL1 VARCHAR, COL2 VARCHAR, COL3 INT, COL4 INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<VAL1 ARRAY<VARCHAR>, VAL2 ARRAY<INT>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> FlatMap
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: FlatMap (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- FlatMap
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/cube_-_cube_two_columns_with_udf_on_third
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/cube_-_cube_two_columns_with_udf_on_third
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<COL1 VARCHAR, COL2 VARCHAR, COL3 INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<VAL1 ARRAY<VARCHAR>, VAL2 INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> FlatMap
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: FlatMap (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- FlatMap
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/cube_-_cube_two_int_columns
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/cube_-_cube_two_int_columns
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<COL1 INT, COL2 INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<VAL ARRAY<INT>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> FlatMap
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: FlatMap (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- FlatMap
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/datestring_-_date_to_string
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/datestring_-_date_to_string
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_DATE_STREAM_0.KsqlTopic.Source = STRUCT<ID BIGINT, START_DATE INT, DATE_FORMAT VARCHAR> NOT NULL
+CSAS_DATE_STREAM_0.DATE_STREAM = STRUCT<ID BIGINT, CUSTOM_FORMATTED_START_DATE VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: DATE_STREAM)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_AVRO_in_out
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_AVRO_in_out
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_TEST2_0.KsqlTopic.Source = STRUCT<DEC DECIMAL(21, 19)> NOT NULL
+CSAS_TEST2_0.TEST2 = STRUCT<DEC DECIMAL(21, 19)> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TEST2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_DELIMITED_in_out
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_DELIMITED_in_out
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_TEST2_0.KsqlTopic.Source = STRUCT<DEC DECIMAL(21, 19)> NOT NULL
+CSAS_TEST2_0.TEST2 = STRUCT<DEC DECIMAL(21, 19)> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TEST2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_GEQ_-_decimal_decimal
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_GEQ_-_decimal_decimal
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_TEST2_0.KsqlTopic.Source = STRUCT<A DECIMAL(4, 2), B DECIMAL(4, 2)> NOT NULL
+CSAS_TEST2_0.TEST2 = STRUCT<RESULT BOOLEAN> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TEST2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_JSON_in_out
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_JSON_in_out
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_TEST2_0.KsqlTopic.Source = STRUCT<DEC DECIMAL(21, 19)> NOT NULL
+CSAS_TEST2_0.TEST2 = STRUCT<DEC DECIMAL(21, 19)> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TEST2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_LEQ_-_decimal_decimal
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_LEQ_-_decimal_decimal
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_TEST2_0.KsqlTopic.Source = STRUCT<A DECIMAL(4, 2), B DECIMAL(4, 2)> NOT NULL
+CSAS_TEST2_0.TEST2 = STRUCT<RESULT BOOLEAN> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TEST2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_addition
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_addition
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_TEST2_0.KsqlTopic.Source = STRUCT<A DECIMAL(4, 2), B DECIMAL(4, 2)> NOT NULL
+CSAS_TEST2_0.TEST2 = STRUCT<RESULT DECIMAL(5, 2)> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TEST2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_addition_3_columns
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_addition_3_columns
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_TEST2_0.KsqlTopic.Source = STRUCT<A DECIMAL(4, 2), B DECIMAL(4, 2)> NOT NULL
+CSAS_TEST2_0.TEST2 = STRUCT<RESULT DECIMAL(6, 2)> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TEST2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_addition_with_double
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_addition_with_double
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_TEST2_0.KsqlTopic.Source = STRUCT<A DECIMAL(4, 2), B DOUBLE> NOT NULL
+CSAS_TEST2_0.TEST2 = STRUCT<RESULT DOUBLE> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TEST2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_addition_with_int
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_addition_with_int
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_TEST2_0.KsqlTopic.Source = STRUCT<A DECIMAL(4, 2), B INT> NOT NULL
+CSAS_TEST2_0.TEST2 = STRUCT<RESULT DECIMAL(13, 2)> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TEST2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_division
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_division
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_TEST2_0.KsqlTopic.Source = STRUCT<A DECIMAL(4, 2), B DECIMAL(4, 2)> NOT NULL
+CSAS_TEST2_0.TEST2 = STRUCT<RESULT DECIMAL(11, 7)> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TEST2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_equal_-_decimal_decimal
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_equal_-_decimal_decimal
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_TEST2_0.KsqlTopic.Source = STRUCT<A DECIMAL(4, 2), B DECIMAL(4, 2)> NOT NULL
+CSAS_TEST2_0.TEST2 = STRUCT<RESULT BOOLEAN> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TEST2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_greater_than_-_decimal_decimal
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_greater_than_-_decimal_decimal
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_TEST2_0.KsqlTopic.Source = STRUCT<A DECIMAL(4, 2), B DECIMAL(4, 2)> NOT NULL
+CSAS_TEST2_0.TEST2 = STRUCT<RESULT BOOLEAN> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TEST2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_is_distinct_-_decimal_decimal
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_is_distinct_-_decimal_decimal
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_TEST2_0.KsqlTopic.Source = STRUCT<A DECIMAL(4, 2), B DECIMAL(4, 2)> NOT NULL
+CSAS_TEST2_0.TEST2 = STRUCT<RESULT BOOLEAN> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TEST2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_less_than_-_decimal_decimal
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_less_than_-_decimal_decimal
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_TEST2_0.KsqlTopic.Source = STRUCT<A DECIMAL(4, 2), B DECIMAL(4, 2)> NOT NULL
+CSAS_TEST2_0.TEST2 = STRUCT<RESULT BOOLEAN> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TEST2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_less_than_-_decimal_decimal_differing_scale
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_less_than_-_decimal_decimal_differing_scale
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_TEST2_0.KsqlTopic.Source = STRUCT<A DECIMAL(4, 2), B DECIMAL(5, 3)> NOT NULL
+CSAS_TEST2_0.TEST2 = STRUCT<RESULT BOOLEAN> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TEST2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_less_than_-_decimal_int
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_less_than_-_decimal_int
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_TEST2_0.KsqlTopic.Source = STRUCT<A DECIMAL(4, 2), B INT> NOT NULL
+CSAS_TEST2_0.TEST2 = STRUCT<RESULT BOOLEAN> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TEST2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_mod
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_mod
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_TEST2_0.KsqlTopic.Source = STRUCT<A DECIMAL(4, 2), B DECIMAL(4, 2)> NOT NULL
+CSAS_TEST2_0.TEST2 = STRUCT<RESULT DECIMAL(4, 2)> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TEST2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_multiplication
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_multiplication
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_TEST2_0.KsqlTopic.Source = STRUCT<A DECIMAL(4, 2), B DECIMAL(4, 2)> NOT NULL
+CSAS_TEST2_0.TEST2 = STRUCT<RESULT DECIMAL(9, 4)> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TEST2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_negation
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_negation
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_TEST2_0.KsqlTopic.Source = STRUCT<DEC DECIMAL(7, 5)> NOT NULL
+CSAS_TEST2_0.TEST2 = STRUCT<NEGATED DECIMAL(7, 5)> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TEST2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_not_equal_-_decimal_decimal
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_not_equal_-_decimal_decimal
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_TEST2_0.KsqlTopic.Source = STRUCT<A DECIMAL(4, 2), B DECIMAL(4, 2)> NOT NULL
+CSAS_TEST2_0.TEST2 = STRUCT<RESULT BOOLEAN> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TEST2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_subtraction
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/decimal_-_subtraction
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_TEST2_0.KsqlTopic.Source = STRUCT<A DECIMAL(4, 2), B DECIMAL(4, 2)> NOT NULL
+CSAS_TEST2_0.TEST2 = STRUCT<RESULT DECIMAL(5, 2)> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TEST2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/delimited_-_select_delimited_value_format
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/delimited_-_select_delimited_value_format
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE INT> NOT NULL
+CSAS_S2_0.S2 = STRUCT<ID BIGINT, NAME VARCHAR, VALUE INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/delimited_-_select_delimited_value_format_into_another_format
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/delimited_-_select_delimited_value_format_into_another_format
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE INT> NOT NULL
+CSAS_S2_0.S2 = STRUCT<ID BIGINT, NAME VARCHAR, VALUE INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/delimited_-_select_delimited_value_format_with_$_separated_values_using_custom_delimiter_character
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/delimited_-_select_delimited_value_format_with_$_separated_values_using_custom_delimiter_character
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE INT> NOT NULL
+CSAS_S2_0.S2 = STRUCT<ID BIGINT, NAME VARCHAR, VALUE INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/delimited_-_select_delimited_value_format_with_SPACE_separated_values_using_custom_delimiter_character
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/delimited_-_select_delimited_value_format_with_SPACE_separated_values_using_custom_delimiter_character
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE INT> NOT NULL
+CSAS_S2_0.S2 = STRUCT<ID BIGINT, NAME VARCHAR, VALUE INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/delimited_-_select_delimited_value_format_with_TAB_separated_values_using_custom_delimiter_character
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/delimited_-_select_delimited_value_format_with_TAB_separated_values_using_custom_delimiter_character
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE INT> NOT NULL
+CSAS_S2_0.S2 = STRUCT<ID BIGINT, NAME VARCHAR, VALUE INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/delimited_-_select_delimited_value_format_with_pipe_separated_values_-_should_take_source_delimiter_for_sink
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/delimited_-_select_delimited_value_format_with_pipe_separated_values_-_should_take_source_delimiter_for_sink
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE INT> NOT NULL
+CSAS_S2_0.S2 = STRUCT<ID BIGINT, NAME VARCHAR, VALUE INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_join_leaves_aliased_system_columns_in_output's_value_schema
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_join_leaves_aliased_system_columns_in_output's_value_schema
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<F0 INT> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<F1 INT> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<L_F0 INT, L_ROWTIME BIGINT, L_ROWKEY VARCHAR, L_WINDOWSTART BIGINT, L_WINDOWEND BIGINT> NOT NULL
+CSAS_OUTPUT_0.Join.Right = STRUCT<R_F1 INT, R_ROWTIME BIGINT, R_ROWKEY VARCHAR, R_WINDOWSTART BIGINT, R_WINDOWEND BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<TIME BIGINT, WSTART BIGINT, WEND BIGINT, KEY VARCHAR, F0 INT, F1 INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_join_qualified_select_star_left
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_join_qualified_select_star_left
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<F0 INT> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<F0 INT> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<I1_F0 INT, I1_ROWTIME BIGINT, I1_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.Join.Right = STRUCT<I2_F0 INT, I2_ROWTIME BIGINT, I2_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<I1_ROWTIME BIGINT, I1_ROWKEY VARCHAR, I1_F0 INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_1])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [input_2])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_join_qualified_select_star_right
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_join_qualified_select_star_right
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<F0 INT> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<F0 INT> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<I1_F0 INT, I1_ROWTIME BIGINT, I1_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.Join.Right = STRUCT<I2_F0 INT, I2_ROWTIME BIGINT, I2_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<I2_ROWTIME BIGINT, I2_ROWKEY VARCHAR, I2_F0 INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_1])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [input_2])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_join_unqualified_select_star
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_join_unqualified_select_star
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<F0 INT> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<F0 INT> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<I1_F0 INT, I1_ROWTIME BIGINT, I1_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.Join.Right = STRUCT<I2_F0 INT, I2_ROWTIME BIGINT, I2_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<I1_ROWTIME BIGINT, I1_ROWKEY VARCHAR, I1_F0 INT, I2_ROWTIME BIGINT, I2_ROWKEY VARCHAR, I2_F0 INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_1])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [input_2])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_non-join_leaves_aliased_system_columns_in_output's_value_schema
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_non-join_leaves_aliased_system_columns_in_output's_value_schema
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<F0 INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<F0 INT, TIME BIGINT, WSTART BIGINT, WEND BIGINT, KEY VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_non-join_qualified_select_star
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_non-join_qualified_select_star
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<F0 INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<F0 INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_validate_AVRO_uses_null_for_unknown_element
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_validate_AVRO_uses_null_for_unknown_element
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S_0.KsqlTopic.Source = STRUCT<C1 INT, UNKNOWN INT> NOT NULL
+CSAS_S_0.S = STRUCT<C1 INT, UNKNOWN INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_validate_array_element_OK
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_validate_array_element_OK
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<V0 ARRAY<INT>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<V0 ARRAY<INT>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_validate_bigint_elements_OK
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_validate_bigint_elements_OK
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<V0 BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<V0 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_validate_boolean_elements_OK
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_validate_boolean_elements_OK
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<V0 BOOLEAN> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<V0 BOOLEAN> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_validate_double_elements_OK
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_validate_double_elements_OK
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<V0 DOUBLE> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<V0 DOUBLE> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_validate_int_elements_OK
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_validate_int_elements_OK
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<V0 INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<V0 INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_validate_map_element_OK
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_validate_map_element_OK
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<V0 MAP<VARCHAR, INT>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<V0 MAP<VARCHAR, INT>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_validate_string_elements_OK
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_validate_string_elements_OK
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<V0 VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<V0 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_validate_struct_element_OK
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_validate_struct_element_OK
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<V0 STRUCT<F0 VARCHAR, F1 INT>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<V0 STRUCT<F0 VARCHAR, F1 INT>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_validate_with_elements_OK
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_validate_with_elements_OK
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<V0 INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<V0 INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_validate_without_elements_OK
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elements_-_validate_without_elements_OK
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<C1 INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<C1 INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elt-field_-_ELT_should_undo_FIELD
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elt-field_-_ELT_should_undo_FIELD
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<A VARCHAR, B VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<HELLO VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elt-field_-_elect_the_second_parameter
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elt-field_-_elect_the_second_parameter
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<MESSAGE VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<ELEM VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elt-field_-_field_the_correct_parameter
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/elt-field_-_field_the_correct_parameter
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<A VARCHAR, B VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<POS INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/explode_-_explode_array_with_values
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/explode_-_explode_array_with_values
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<MY_ARR ARRAY<BIGINT>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<VAL BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> FlatMap
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: FlatMap (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- FlatMap
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/explode_-_explode_different_types
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/explode_-_explode_different_types
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<F0 ARRAY<INT>, F1 ARRAY<BIGINT>, F2 ARRAY<DOUBLE>, F3 ARRAY<BOOLEAN>, F4 ARRAY<VARCHAR>, F5 ARRAY<DECIMAL(20, 10)>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 INT, KSQL_COL_1 BIGINT, KSQL_COL_2 DOUBLE, KSQL_COL_3 BOOLEAN, KSQL_COL_4 VARCHAR, KSQL_COL_5 DECIMAL(20, 10)> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> FlatMap
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: FlatMap (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- FlatMap
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/explode_-_udfs_with_table_functions_and_no_aliases,_verifies_intermediate_generated_column_names_don't_clash_with_aliases
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/explode_-_udfs_with_table_functions_and_no_aliases,_verifies_intermediate_generated_column_names_don't_clash_with_aliases
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<MY_ARR ARRAY<BIGINT>, F1 BIGINT, F2 BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BIGINT, KSQL_COL_1 BIGINT, KSQL_COL_2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> FlatMap
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: FlatMap (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- FlatMap
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/extract-json-field_-_concat_two_extracted_fields
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/extract-json-field_-_concat_two_extracted_fields
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<SOURCE VARCHAR, VERSION VARCHAR, BOTH VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/extract-json-field_-_extract_JSON_array_field
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/extract-json-field_-_extract_JSON_array_field
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ARRAY_FIELD ARRAY<VARCHAR>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<COL1 VARCHAR, COL2 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/floating-point_-_filter_by_DOUBLE
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/floating-point_-_filter_by_DOUBLE
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<ID INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/floating-point_-_with_exponent
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/floating-point_-_with_exponent
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<ID INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/geodistance_-_geo_distance_with_radius
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/geodistance_-_geo_distance_with_radius
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_DISTANCE_STREAM_0.KsqlTopic.Source = STRUCT<ID BIGINT, LAT1 DOUBLE, LON1 DOUBLE, LAT2 DOUBLE, LON2 DOUBLE, RADIUS VARCHAR> NOT NULL
+CSAS_DISTANCE_STREAM_0.DISTANCE_STREAM = STRUCT<ID BIGINT, CALCULATED_DISTANCE DOUBLE> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: DISTANCE_STREAM)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/geodistance_-_geo_distance_without_radius
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/geodistance_-_geo_distance_without_radius
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_DISTANCE_STREAM_0.KsqlTopic.Source = STRUCT<ID BIGINT, LAT1 DOUBLE, LON1 DOUBLE, LAT2 DOUBLE, LON2 DOUBLE> NOT NULL
+CSAS_DISTANCE_STREAM_0.DISTANCE_STREAM = STRUCT<ID BIGINT, CALCULATED_DISTANCE DOUBLE> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: DISTANCE_STREAM)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_ROWKEY_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_ROWKEY_(stream-_table)
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<IGNORED VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_ROWKEY_(stream-_table)_-_without_repartition
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_ROWKEY_(stream-_table)_-_without_repartition
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<IGNORED VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_ROWTIME_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_ROWTIME_(stream-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<IGNORED VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_UDAF_nested_in_UDF_in_select_expression_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_UDAF_nested_in_UDF_in_select_expression_(stream-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<D1 VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_UDAF_nested_in_UDF_in_select_expression_(table-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_UDAF_nested_in_UDF_in_select_expression_(table-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<D0 INT, D1 VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_UDF_nested_in_UDAF_in_select_expression_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_UDF_nested_in_UDAF_in_select_expression_(stream-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<D1 VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_AGG_VARIABLE_0 INT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_arithmetic_binary_expression_with_projection_in-order_&_non-commutative_group_by_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_arithmetic_binary_expression_with_projection_in-order_&_non-commutative_group_by_(stream-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<F1 INT, F2 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 INT, KSQL_INTERNAL_COL_2 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 INT, KSQL_INTERNAL_COL_2 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 INT, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_arithmetic_binary_expression_with_projection_in-order_&_non-commutative_group_by_(table-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_arithmetic_binary_expression_with_projection_in-order_&_non-commutative_group_by_(table-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<F0 INT, F1 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 INT, KSQL_INTERNAL_COL_2 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 INT, KSQL_INTERNAL_COL_2 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 INT, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_by_non-STRING_key
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_by_non-STRING_key
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<F0 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_constant_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_constant_(stream-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<IGNORED VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_constant_(table-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_constant_(table-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<USER INT, REGION VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_double_field_with_re-key_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_double_field_with_re-key_(stream-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<DATA DOUBLE> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 DOUBLE, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 DOUBLE, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<DATA DOUBLE, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_duplicate_fields_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_duplicate_fields_(stream-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<DATA VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 BIGINT, KSQL_INTERNAL_COL_2 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT, KSQL_AGG_VARIABLE_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<DATA VARCHAR, KSQL_COL_1 BIGINT, KSQL_COL_2 BIGINT, COPY VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_field_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_field_(stream-_table)
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<DATA VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<DATA VARCHAR, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_field_(stream-_table)_-_format
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_field_(stream-_table)_-_format
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<DATA VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<DATA VARCHAR, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_field_with_field_used_in_function_in_projection_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_field_with_field_used_in_function_in_projection_(stream-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<F1 VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 VARCHAR, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_field_with_field_used_in_function_in_projection_(table-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_field_with_field_used_in_function_in_projection_(table-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<USER INT, REGION VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 VARCHAR, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_field_with_re-key_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_field_with_re-key_(stream-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<DATA VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<DATA VARCHAR, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_field_with_re-key_(stream-_table)_-_format
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_field_with_re-key_(stream-_table)_-_format
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<DATA VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<DATA VARCHAR, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_field_with_re-key_(table-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_field_with_re-key_(table-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<USER INT, REGION VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_fields_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_fields_(stream-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<F1 INT, F2 VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_INTERNAL_COL_2 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_INTERNAL_COL_2 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<F1 INT, F2 VARCHAR, KSQL_COL_2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_fields_(stream-_table)_-_format
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_fields_(stream-_table)_-_format
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<F1 INT, F2 VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_INTERNAL_COL_2 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_INTERNAL_COL_2 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<F1 INT, F2 VARCHAR, KSQL_COL_2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_fields_(table-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_fields_(table-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<F1 INT, F2 VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_INTERNAL_COL_2 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_INTERNAL_COL_2 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<F1 INT, F2 VARCHAR, KSQL_COL_2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_fields_(table-_table)_-_format
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_fields_(table-_table)_-_format
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<F1 INT, F2 VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_INTERNAL_COL_2 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_INTERNAL_COL_2 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<F1 INT, F2 VARCHAR, KSQL_COL_2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_fields_used_in_expression
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_fields_used_in_expression
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<F1 INT, F2 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 INT, KSQL_INTERNAL_COL_2 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 INT, KSQL_INTERNAL_COL_2 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 INT, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_function_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_function_(stream-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 VARCHAR, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_function_(table-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_function_(table-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<USER INT, REGION VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 VARCHAR, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_int_field_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_int_field_(stream-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<ID INT, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_int_function_(table-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_int_function_(table-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<REGION VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_int_json_field_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_int_json_field_(stream-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<DATA STRUCT<FIELD INT>> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 STRUCT<FIELD INT>> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 STRUCT<FIELD INT>, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<COUNT BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_json_field_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_json_field_(stream-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<DATA STRUCT<FIELD VARCHAR>> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 STRUCT<FIELD VARCHAR>, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 STRUCT<FIELD VARCHAR>, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<FIELD VARCHAR, COUNT BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_missing_matching_projection_field_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_missing_matching_projection_field_(stream-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<DATA VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_missing_matching_projection_field_(table-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_missing_matching_projection_field_(table-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<F1 INT, F2 VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_should_exclude_any_stream_row_whose_single_GROUP_BY_expression_resolves_to_NULL
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_should_exclude_any_stream_row_whose_single_GROUP_BY_expression_resolves_to_NULL
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<STR VARCHAR, POS INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_INTERNAL_COL_2 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_INTERNAL_COL_2 INT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_should_exclude_any_stream_row_whose_single_GROUP_BY_expression_throws
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_should_exclude_any_stream_row_whose_single_GROUP_BY_expression_throws
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_should_exclude_any_table_row_whose_single_GROUP_BY_expression_resolves_to_NULL
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_should_exclude_any_table_row_whose_single_GROUP_BY_expression_resolves_to_NULL
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<STR VARCHAR, POS INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_INTERNAL_COL_2 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_INTERNAL_COL_2 INT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_should_exclude_any_table_row_whose_single_GROUP_BY_expression_throws
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_should_exclude_any_table_row_whose_single_GROUP_BY_expression_throws
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_string_concat_using_+_op_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_string_concat_using_+_op_(stream-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<F1 VARCHAR, F2 VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_INTERNAL_COL_2 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_INTERNAL_COL_2 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 VARCHAR, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_string_concat_using_+_op_(table-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_string_concat_using_+_op_(table-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<USER INT, SUBREGION VARCHAR, REGION VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_INTERNAL_COL_2 VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_INTERNAL_COL_2 VARCHAR, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_with_aggregate_arithmetic_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_with_aggregate_arithmetic_(stream-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<DATA VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<DATA VARCHAR, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_with_aggregate_arithmetic_(table-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_with_aggregate_arithmetic_(table-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<USER INT, REGION VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_with_aggregate_arithmetic_involving_source_field_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_with_aggregate_arithmetic_involving_source_field_(stream-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ITEM INT, COST INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 INT, KSQL_INTERNAL_COL_2 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 INT, KSQL_INTERNAL_COL_2 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<ITEM INT, COST INT, KSQL_COL_2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_with_aggregate_arithmetic_involving_source_field_(table-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_with_aggregate_arithmetic_involving_source_field_(table-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<F0 INT, F1 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 INT, KSQL_AGG_VARIABLE_0 INT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_with_constant_having_(stream-table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_with_constant_having_(stream-table)
@@ -1,0 +1,99 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<F1 INT, F2 VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 INT, KSQL_AGG_VARIABLE_0 INT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<F2 VARCHAR, KSQL_COL_1 INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-HavingFilter-ApplyPredicate
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-HavingFilter-ApplyPredicate (stores: [])
+      --> Aggregate-HavingFilter-Filter
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-HavingFilter-Filter (stores: [])
+      --> Aggregate-HavingFilter-PostProcess
+      <-- Aggregate-HavingFilter-ApplyPredicate
+    Processor: Aggregate-HavingFilter-PostProcess (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-HavingFilter-Filter
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000014
+      <-- Aggregate-HavingFilter-PostProcess
+    Processor: KTABLE-TOSTREAM-0000000014 (stores: [])
+      --> KSTREAM-SINK-0000000015
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000015 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000014
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_with_constants_in_the_projection_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_with_constants_in_the_projection_(stream-_table)
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<F1 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<F1 INT, F3 VARCHAR, KSQL_COL_2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_with_groupings_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_with_groupings_(stream-_table)
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<F1 INT, F2 VARCHAR, F3 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_INTERNAL_COL_2 BIGINT, KSQL_INTERNAL_COL_3 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_INTERNAL_COL_2 BIGINT, KSQL_INTERNAL_COL_3 INT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<F1 INT, F2 VARCHAR, KSQL_COL_2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_with_having_expression_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_with_having_expression_(stream-_table)
@@ -1,0 +1,84 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<F1 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT, KSQL_AGG_VARIABLE_1 INT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<F1 INT, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-HavingFilter-ApplyPredicate
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-HavingFilter-ApplyPredicate (stores: [])
+      --> Aggregate-HavingFilter-Filter
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-HavingFilter-Filter (stores: [])
+      --> Aggregate-HavingFilter-PostProcess
+      <-- Aggregate-HavingFilter-ApplyPredicate
+    Processor: Aggregate-HavingFilter-PostProcess (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-HavingFilter-Filter
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000009
+      <-- Aggregate-HavingFilter-PostProcess
+    Processor: KTABLE-TOSTREAM-0000000009 (stores: [])
+      --> KSTREAM-SINK-0000000010
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000010 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000009
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_with_having_expression_(table-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_with_having_expression_(table-_table)
@@ -1,0 +1,99 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<F0 INT, F1 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 INT, KSQL_AGG_VARIABLE_0 INT, KSQL_AGG_VARIABLE_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<F1 INT, KSQL_COL_1 INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-HavingFilter-ApplyPredicate
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-HavingFilter-ApplyPredicate (stores: [])
+      --> Aggregate-HavingFilter-Filter
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-HavingFilter-Filter (stores: [])
+      --> Aggregate-HavingFilter-PostProcess
+      <-- Aggregate-HavingFilter-ApplyPredicate
+    Processor: Aggregate-HavingFilter-PostProcess (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-HavingFilter-Filter
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000014
+      <-- Aggregate-HavingFilter-PostProcess
+    Processor: KTABLE-TOSTREAM-0000000014 (stores: [])
+      --> KSTREAM-SINK-0000000015
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000015 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000014
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_with_having_expression_on_non-group-by_field_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_with_having_expression_on_non-group-by_field_(stream-_table)
@@ -1,0 +1,99 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<F1 INT, F2 VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 BIGINT, KSQL_INTERNAL_COL_2 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 BIGINT, KSQL_INTERNAL_COL_2 INT, KSQL_AGG_VARIABLE_0 BIGINT, KSQL_AGG_VARIABLE_1 INT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<F2 VARCHAR, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-HavingFilter-ApplyPredicate
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-HavingFilter-ApplyPredicate (stores: [])
+      --> Aggregate-HavingFilter-Filter
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-HavingFilter-Filter (stores: [])
+      --> Aggregate-HavingFilter-PostProcess
+      <-- Aggregate-HavingFilter-ApplyPredicate
+    Processor: Aggregate-HavingFilter-PostProcess (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-HavingFilter-Filter
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000014
+      <-- Aggregate-HavingFilter-PostProcess
+    Processor: KTABLE-TOSTREAM-0000000014 (stores: [])
+      --> KSTREAM-SINK-0000000015
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000015 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000014
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_with_multiple_having_expressions_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/group-by_-_with_multiple_having_expressions_(stream-_table)
@@ -1,0 +1,99 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<F1 INT, F2 VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_AGG_VARIABLE_0 BIGINT, KSQL_AGG_VARIABLE_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<F1 INT, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-HavingFilter-ApplyPredicate
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-HavingFilter-ApplyPredicate (stores: [])
+      --> Aggregate-HavingFilter-Filter
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-HavingFilter-Filter (stores: [])
+      --> Aggregate-HavingFilter-PostProcess
+      <-- Aggregate-HavingFilter-ApplyPredicate
+    Processor: Aggregate-HavingFilter-PostProcess (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-HavingFilter-Filter
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000014
+      <-- Aggregate-HavingFilter-PostProcess
+    Processor: KTABLE-TOSTREAM-0000000014 (stores: [])
+      --> KSTREAM-SINK-0000000015
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000015 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000014
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/having_-_calculate_average_in_having
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/having_-_calculate_average_in_having
@@ -1,0 +1,84 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_AVG_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CTAS_AVG_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_AVG_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT, KSQL_AGG_VARIABLE_1 BIGINT, KSQL_AGG_VARIABLE_2 BIGINT, KSQL_AGG_VARIABLE_3 BIGINT> NOT NULL
+CTAS_AVG_0.AVG = STRUCT<ID BIGINT, AVG BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-HavingFilter-ApplyPredicate
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-HavingFilter-ApplyPredicate (stores: [])
+      --> Aggregate-HavingFilter-Filter
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-HavingFilter-Filter (stores: [])
+      --> Aggregate-HavingFilter-PostProcess
+      <-- Aggregate-HavingFilter-ApplyPredicate
+    Processor: Aggregate-HavingFilter-PostProcess (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-HavingFilter-Filter
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000009
+      <-- Aggregate-HavingFilter-PostProcess
+    Processor: KTABLE-TOSTREAM-0000000009 (stores: [])
+      --> KSTREAM-SINK-0000000010
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000010 (topic: AVG)
+      <-- KTABLE-TOSTREAM-0000000009
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/having_-_table_having
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/having_-_table_having
@@ -1,0 +1,87 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_T1_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CTAS_T1_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_T1_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT, KSQL_AGG_VARIABLE_1 BIGINT> NOT NULL
+CTAS_T1_0.T1 = STRUCT<ID BIGINT, SUM BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-HavingFilter-ApplyPredicate
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-HavingFilter-ApplyPredicate (stores: [])
+      --> Aggregate-HavingFilter-Filter
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: Aggregate-HavingFilter-Filter (stores: [])
+      --> Aggregate-HavingFilter-PostProcess
+      <-- Aggregate-HavingFilter-ApplyPredicate
+    Processor: Aggregate-HavingFilter-PostProcess (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-HavingFilter-Filter
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000010
+      <-- Aggregate-HavingFilter-PostProcess
+    Processor: KTABLE-TOSTREAM-0000000010 (stores: [])
+      --> KSTREAM-SINK-0000000011
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000011 (topic: T1)
+      <-- KTABLE-TOSTREAM-0000000010
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/histogram_-_histogram_on_a_table
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/histogram_-_histogram_on_a_table
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_COUNT_BY_REGION_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, REGION VARCHAR> NOT NULL
+CTAS_COUNT_BY_REGION_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 VARCHAR> NOT NULL
+CTAS_COUNT_BY_REGION_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_AGG_VARIABLE_0 MAP<VARCHAR, BIGINT>> NOT NULL
+CTAS_COUNT_BY_REGION_0.COUNT_BY_REGION = STRUCT<REGION VARCHAR, COUNTS MAP<VARCHAR, BIGINT>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: COUNT_BY_REGION)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/histogram_-_histogram_string
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/histogram_-_histogram_string
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, VALUE VARCHAR> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_AGG_VARIABLE_0 MAP<VARCHAR, BIGINT>> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, COUNTS MAP<VARCHAR, BIGINT>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/hopping-windows_-_count
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/hopping-windows_-_count
@@ -1,0 +1,78 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID INT> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_S2_0.S2 = STRUCT<COUNT BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/hopping-windows_-_import_hopping_stream
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/hopping-windows_-_import_hopping_stream
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, VALUE BIGINT> NOT NULL
+CSAS_S2_0.S2 = STRUCT<ID BIGINT, VALUE BIGINT, WSTART BIGINT, WEND BIGINT, RKEY VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/hopping-windows_-_import_hopping_stream_with_non-STRING_key
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/hopping-windows_-_import_hopping_stream_with_non-STRING_key
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, VALUE BIGINT> NOT NULL
+CSAS_S2_0.S2 = STRUCT<ID BIGINT, VALUE BIGINT, WSTART BIGINT, WEND BIGINT, KEY BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/hopping-windows_-_max_hopping
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/hopping-windows_-_max_hopping
@@ -1,0 +1,78 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/hopping-windows_-_min_hopping
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/hopping-windows_-_min_hopping
@@ -1,0 +1,78 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/hopping-windows_-_topk_hopping
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/hopping-windows_-_topk_hopping
@@ -1,0 +1,78 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE DOUBLE> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DOUBLE, KSQL_INTERNAL_COL_2 INT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DOUBLE, KSQL_AGG_VARIABLE_0 ARRAY<DOUBLE>> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, TOPK ARRAY<DOUBLE>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/hopping-windows_-_topkdistinct_hopping
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/hopping-windows_-_topkdistinct_hopping
@@ -1,0 +1,78 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE DOUBLE> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DOUBLE, KSQL_INTERNAL_COL_2 INT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DOUBLE, KSQL_AGG_VARIABLE_0 ARRAY<DOUBLE>> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, TOPK ARRAY<DOUBLE>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/identifiers_-_aliased_join_source
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/identifiers_-_aliased_join_source
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<I1_FOO INT, I1_BAR INT, I1_ROWTIME BIGINT, I1_ROWKEY INT> NOT NULL
+CSAS_OUTPUT_0.Join.Right = STRUCT<I2_FOO INT, I2_BAR INT, I2_ROWTIME BIGINT, I2_ROWKEY INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<I1_BAR INT, I2_BAR INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [t1])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [t2])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/identifiers_-_aliased_join_source_with_AS
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/identifiers_-_aliased_join_source_with_AS
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<I1_FOO INT, I1_BAR INT, I1_ROWTIME BIGINT, I1_ROWKEY INT> NOT NULL
+CSAS_OUTPUT_0.Join.Right = STRUCT<I2_FOO INT, I2_BAR INT, I2_ROWTIME BIGINT, I2_ROWKEY INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<I1_BAR INT, I2_BAR INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [t1])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [t2])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/identifiers_-_aliased_left_unaliased_right
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/identifiers_-_aliased_left_unaliased_right
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<I1_FOO INT, I1_BAR INT, I1_ROWTIME BIGINT, I1_ROWKEY INT> NOT NULL
+CSAS_OUTPUT_0.Join.Right = STRUCT<INPUT_2_FOO INT, INPUT_2_BAR INT, INPUT_2_ROWTIME BIGINT, INPUT_2_ROWKEY INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<I1_BAR INT, INPUT_2_BAR INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [t1])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [t2])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/identifiers_-_aliased_source
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/identifiers_-_aliased_source
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO INT, BAR INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/identifiers_-_aliased_source_with_AS
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/identifiers_-_aliased_source_with_AS
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO INT, BAR INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/identifiers_-_prefixed_wildcard_select_with_aliased_source
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/identifiers_-_prefixed_wildcard_select_with_aliased_source
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO INT, BAR INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/identifiers_-_unaliased_left_aliased_right
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/identifiers_-_unaliased_left_aliased_right
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<INPUT_1_FOO INT, INPUT_1_BAR INT, INPUT_1_ROWTIME BIGINT, INPUT_1_ROWKEY INT> NOT NULL
+CSAS_OUTPUT_0.Join.Right = STRUCT<I2_FOO INT, I2_BAR INT, I2_ROWTIME BIGINT, I2_ROWKEY INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<INPUT_1_BAR INT, I2_BAR INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [t1])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [t2])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/identifiers_-_wildcard_select_with_aliased_source
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/identifiers_-_wildcard_select_with_aliased_source
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO INT, BAR INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/initcap_-_do_initcap
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/initcap_-_do_initcap
@@ -1,0 +1,62 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.functions.substring.legacy.args" : "[hidden]",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<INITCAP VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/insert-into_-_convert_formats__AVRO_to_JSON
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/insert-into_-_convert_formats__AVRO_to_JSON
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+InsertQuery_0.KsqlTopic.Source = STRUCT<A BIGINT, B VARCHAR> NOT NULL
+InsertQuery_0.SINK = STRUCT<A BIGINT, B VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [source])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: sink)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/insert-into_-_convert_formats__DELIMITED_to_JSON
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/insert-into_-_convert_formats__DELIMITED_to_JSON
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+InsertQuery_1.KsqlTopic.Source = STRUCT<DATA VARCHAR> NOT NULL
+InsertQuery_1.OUTPUT = STRUCT<DATA VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [insert-source])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/insert-into_-_convert_formats__JSON_to_AVRO
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/insert-into_-_convert_formats__JSON_to_AVRO
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+InsertQuery_0.KsqlTopic.Source = STRUCT<A BIGINT, B VARCHAR> NOT NULL
+InsertQuery_0.SINK = STRUCT<A BIGINT, B VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [source])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: sink)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/insert-into_-_simple
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/insert-into_-_simple
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+InsertQuery_1.KsqlTopic.Source = STRUCT<DATA VARCHAR> NOT NULL
+InsertQuery_1.OUTPUT = STRUCT<DATA VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [insert-source])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/insert-into_-_with_custom_topic_name
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/insert-into_-_with_custom_topic_name
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+InsertQuery_1.KsqlTopic.Source = STRUCT<DATA VARCHAR> NOT NULL
+InsertQuery_1.OUTPUT = STRUCT<DATA VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [insert-source])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: custom)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/join-with-custom-timestamp_-_stream_stream_inner_join_with_ts
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/join-with-custom-timestamp_-_stream_stream_inner_join_with_ts
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S1_JOIN_S2_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, TS BIGINT> NOT NULL
+CSAS_S1_JOIN_S2_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 VARCHAR> NOT NULL
+CSAS_S1_JOIN_S2_0.Join.Left = STRUCT<S1_ID BIGINT, S1_NAME VARCHAR, S1_TS BIGINT, S1_ROWTIME BIGINT, S1_ROWKEY BIGINT> NOT NULL
+CSAS_S1_JOIN_S2_0.Join.Right = STRUCT<S2_ID BIGINT, S2_F1 VARCHAR, S2_F2 VARCHAR, S2_ROWTIME BIGINT, S2_ROWKEY BIGINT> NOT NULL
+CSAS_S1_JOIN_S2_0.S1_JOIN_S2 = STRUCT<ID BIGINT, NAME VARCHAR, TS BIGINT, F1 VARCHAR, F2 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [s1])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [s2])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: S1_JOIN_S2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/join-with-custom-timestamp_-_stream_stream_inner_join_with_ts_extractor_both_sides
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/join-with-custom-timestamp_-_stream_stream_inner_join_with_ts_extractor_both_sides
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S1_JOIN_S2_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, TS BIGINT> NOT NULL
+CSAS_S1_JOIN_S2_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 VARCHAR, RTS BIGINT> NOT NULL
+CSAS_S1_JOIN_S2_0.Join.Left = STRUCT<S1_ID BIGINT, S1_NAME VARCHAR, S1_TS BIGINT, S1_ROWTIME BIGINT, S1_ROWKEY BIGINT> NOT NULL
+CSAS_S1_JOIN_S2_0.Join.Right = STRUCT<S2_ID BIGINT, S2_F1 VARCHAR, S2_F2 VARCHAR, S2_RTS BIGINT, S2_ROWTIME BIGINT, S2_ROWKEY BIGINT> NOT NULL
+CSAS_S1_JOIN_S2_0.S1_JOIN_S2 = STRUCT<ID BIGINT, NAME VARCHAR, TS BIGINT, F1 VARCHAR, F2 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [s1])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [s2])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: S1_JOIN_S2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/join-with-custom-timestamp_-_stream_table_join_with_ts_extractor_both_sides
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/join-with-custom-timestamp_-_stream_table_join_with_ts_extractor_both_sides
@@ -1,0 +1,80 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S1_JOIN_T1_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 VARCHAR, RTS BIGINT> NOT NULL
+CSAS_S1_JOIN_T1_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, TS BIGINT> NOT NULL
+CSAS_S1_JOIN_T1_0.Join.Left = STRUCT<S1_ID BIGINT, S1_NAME VARCHAR, S1_TS BIGINT, S1_ROWTIME BIGINT, S1_ROWKEY BIGINT> NOT NULL
+CSAS_S1_JOIN_T1_0.S1_JOIN_T1 = STRUCT<ID BIGINT, NAME VARCHAR, TS BIGINT, F1 VARCHAR, F2 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [s1])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [t1])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: S1_JOIN_T1)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/join-with-custom-timestamp_-_table_table_inner_join_with_ts
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/join-with-custom-timestamp_-_table_table_inner_join_with_ts
@@ -1,0 +1,91 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S1_JOIN_S2_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, TS BIGINT> NOT NULL
+CTAS_S1_JOIN_S2_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 VARCHAR> NOT NULL
+CTAS_S1_JOIN_S2_0.S1_JOIN_S2 = STRUCT<ID BIGINT, NAME VARCHAR, TS BIGINT, F1 VARCHAR, F2 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [s1])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [s2])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: S1_JOIN_S2)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/join-with-custom-timestamp_-_table_table_inner_join_with_ts_extractor_both_sides
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/join-with-custom-timestamp_-_table_table_inner_join_with_ts_extractor_both_sides
@@ -1,0 +1,91 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S1_JOIN_S2_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, TS BIGINT> NOT NULL
+CTAS_S1_JOIN_S2_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 VARCHAR, RTS BIGINT> NOT NULL
+CTAS_S1_JOIN_S2_0.S1_JOIN_S2 = STRUCT<ID BIGINT, NAME VARCHAR, TS BIGINT, F1 VARCHAR, F2 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [s1])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [s2])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: S1_JOIN_S2)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_join_using_ROWKEY_in_the_criteria
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_join_using_ROWKEY_in_the_criteria
@@ -1,0 +1,80 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_INNER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.Join.Left = STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.INNER_JOIN = STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: INNER_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_join_using_ROWKEY_in_the_criteria_-_join_key_not_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_join_using_ROWKEY_in_the_criteria_-_join_key_not_in_projection
@@ -1,0 +1,80 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_INNER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.Join.Left = STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.INNER_JOIN = STRUCT<NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: INNER_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_join_using_ROWKEY_in_the_criteria_-_left_rowkey_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_join_using_ROWKEY_in_the_criteria_-_left_rowkey_in_projection
@@ -1,0 +1,80 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_INNER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.Join.Left = STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.INNER_JOIN = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: INNER_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_join_using_ROWKEY_in_the_criteria_-_no_source_key_fields
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_join_using_ROWKEY_in_the_criteria_-_no_source_key_fields
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CSAS_LEFT_OUTER_JOIN_0.Join.Left = STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY VARCHAR> NOT NULL
+CSAS_LEFT_OUTER_JOIN_0.Join.Right = STRUCT<TT_ID BIGINT, TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_ROWKEY VARCHAR> NOT NULL
+CSAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN = STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000009-store])
+      --> Join-outer-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-outer-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-OUTEROTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-outer-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: LEFT_OUTER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_join_using_ROWKEY_in_the_criteria_-_right_join_key_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_join_using_ROWKEY_in_the_criteria_-_right_join_key_in_projection
@@ -1,0 +1,80 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_INNER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.Join.Left = STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.INNER_JOIN = STRUCT<TT_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: INNER_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_join_using_ROWKEY_in_the_criteria_-_right_rowkey_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_join_using_ROWKEY_in_the_criteria_-_right_rowkey_in_projection
@@ -1,0 +1,80 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_INNER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.Join.Left = STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.INNER_JOIN = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: INNER_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_matching_session-windowed
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_matching_session-windowed
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<S1_ID BIGINT, S1_ROWTIME BIGINT, S1_ROWKEY INT, S1_WINDOWSTART BIGINT, S1_WINDOWEND BIGINT> NOT NULL
+CSAS_OUTPUT_0.Join.Right = STRUCT<S2_ID BIGINT, S2_ROWTIME BIGINT, S2_ROWKEY INT, S2_WINDOWSTART BIGINT, S2_WINDOWEND BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<S1_ID BIGINT, S2_ID BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_matching_time-windowed
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_matching_time-windowed
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<S1_ID BIGINT, S1_ROWTIME BIGINT, S1_ROWKEY INT, S1_WINDOWSTART BIGINT, S1_WINDOWEND BIGINT> NOT NULL
+CSAS_OUTPUT_0.Join.Right = STRUCT<S2_ID BIGINT, S2_ROWTIME BIGINT, S2_ROWKEY INT, S2_WINDOWSTART BIGINT, S2_WINDOWEND BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<S1_ROWTIME BIGINT, S1_ROWKEY INT, S1_WINDOWSTART BIGINT, S1_WINDOWEND BIGINT, S1_ID BIGINT, S2_ROWTIME BIGINT, S2_ROWKEY INT, S2_WINDOWSTART BIGINT, S2_WINDOWEND BIGINT, S2_ID BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_multiple_join_keys_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_multiple_join_keys_in_projection
@@ -1,0 +1,80 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_INNER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.Join.Left = STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.INNER_JOIN = STRUCT<ID1 BIGINT, ID2 BIGINT, ID3 BIGINT, ID4 BIGINT, ID5 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: INNER_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_on_BIGINT_column_-_KAFKA
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_on_BIGINT_column_-_KAFKA
@@ -1,0 +1,120 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<L0 BIGINT, L1 INT> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<R0 BIGINT, R1 INT> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<L_L0 BIGINT, L_L1 INT, L_ROWTIME BIGINT, L_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.Join.Right = STRUCT<R_R0 BIGINT, R_R1 INT, R_ROWTIME BIGINT, R_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<L_ROWKEY VARCHAR, L1 INT, R1 INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_on_DOUBLE_column_-_KAFKA
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_on_DOUBLE_column_-_KAFKA
@@ -1,0 +1,120 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<L0 DOUBLE, L1 INT> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<R0 DOUBLE, R1 INT> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<L_L0 DOUBLE, L_L1 INT, L_ROWTIME BIGINT, L_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.Join.Right = STRUCT<R_R0 DOUBLE, R_R1 INT, R_ROWTIME BIGINT, R_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<L_ROWKEY VARCHAR, L1 INT, R1 INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_on_INT_column_-_KAFKA
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_on_INT_column_-_KAFKA
@@ -1,0 +1,120 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<L0 INT, L1 INT> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<R0 INT, R1 INT> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<L_L0 INT, L_L1 INT, L_ROWTIME BIGINT, L_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.Join.Right = STRUCT<R_R0 INT, R_R1 INT, R_ROWTIME BIGINT, R_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<L_ROWKEY VARCHAR, L1 INT, R1 INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_on_STRING_column_-_KAFKA
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_on_STRING_column_-_KAFKA
@@ -1,0 +1,120 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<L0 VARCHAR, L1 INT> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<R0 VARCHAR, R1 INT> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<L_L0 VARCHAR, L_L1 INT, L_ROWTIME BIGINT, L_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.Join.Right = STRUCT<R_R0 VARCHAR, R_R1 INT, R_ROWTIME BIGINT, R_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<L_ROWKEY VARCHAR, L1 INT, R1 INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_on_non-STRING_key
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_on_non-STRING_key
@@ -1,0 +1,80 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<TF INT> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<SF INT> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<S_SF INT, S_ROWTIME BIGINT, S_ROWKEY BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<S_ROWTIME BIGINT, S_ROWKEY BIGINT, S_SF INT, T_ROWTIME BIGINT, T_ROWKEY BIGINT, T_TF INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [stream_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [table_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: OUTPUT)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_on_non-STRING_value_column
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_on_non-STRING_value_column
@@ -1,0 +1,95 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, TF INT> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<SF BIGINT> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<S_SF BIGINT, S_ROWTIME BIGINT, S_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<S_ROWTIME BIGINT, S_ROWKEY VARCHAR, S_SF BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT, T_ID BIGINT, T_TF INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: Join-repartition-source (topics: [Join-repartition])
+      --> Join
+    Source: KSTREAM-SOURCE-0000000000 (topics: [table_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- Join-repartition-source
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000014
+      <-- Join
+    Sink: KSTREAM-SINK-0000000014 (topic: OUTPUT)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000004 (topics: [stream_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> KSTREAM-FILTER-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KSTREAM-FILTER-0000000006 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000007
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-KEY-SELECT-0000000007 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000006
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000007
+    Processor: Join-repartition-filter (stores: [])
+      --> Join-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-repartition-sink (topic: Join-repartition)
+      <-- Join-repartition-filter
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_inner_join
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_inner_join
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_INNER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.Join.Left = STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.Join.Right = STRUCT<TT_ID BIGINT, TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_ROWKEY BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.INNER_JOIN = STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: INNER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_inner_join_-_join_key_not_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_inner_join_-_join_key_not_in_projection
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_INNER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.Join.Left = STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.Join.Right = STRUCT<TT_ID BIGINT, TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_ROWKEY BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.INNER_JOIN = STRUCT<NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: INNER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_inner_join_-_right_join_key_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_inner_join_-_right_join_key_in_projection
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_INNER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.Join.Left = STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.Join.Right = STRUCT<TT_ID BIGINT, TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_ROWKEY BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.INNER_JOIN = STRUCT<TT_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: INNER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_inner_join_all_fields
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_inner_join_all_fields
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_INNER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR> NOT NULL
+CSAS_INNER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR> NOT NULL
+CSAS_INNER_JOIN_0.Join.Left = STRUCT<TT_ID BIGINT, TT_NAME VARCHAR, TT_ROWTIME BIGINT, TT_ROWKEY BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.Join.Right = STRUCT<T_ID BIGINT, T_F1 VARCHAR, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.INNER_JOIN = STRUCT<TT_ROWTIME BIGINT, TT_ROWKEY BIGINT, TT_ID BIGINT, TT_NAME VARCHAR, T_ROWTIME BIGINT, T_ROWKEY BIGINT, T_ID BIGINT, T_F1 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: INNER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_inner_join_all_left_fields_some_right
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_inner_join_all_left_fields_some_right
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_INNER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.Join.Left = STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.Join.Right = STRUCT<TT_ID BIGINT, TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_ROWKEY BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.INNER_JOIN = STRUCT<T_ROWTIME BIGINT, T_ROWKEY BIGINT, T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, F1 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: INNER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_inner_join_all_right_fields_some_left
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_inner_join_all_right_fields_some_left
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_INNER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.Join.Left = STRUCT<TT_ID BIGINT, TT_NAME VARCHAR, TT_VALUE BIGINT, TT_ROWTIME BIGINT, TT_ROWKEY BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.Join.Right = STRUCT<T_ID BIGINT, T_F1 VARCHAR, T_F2 BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.INNER_JOIN = STRUCT<T_ROWTIME BIGINT, T_ROWKEY BIGINT, T_ID BIGINT, T_F1 VARCHAR, T_F2 BIGINT, NAME VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: INNER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_inner_join_with_different_before_and_after_windows
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_inner_join_with_different_before_and_after_windows
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_INNER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.Join.Left = STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.Join.Right = STRUCT<TT_ID BIGINT, TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_ROWKEY BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.INNER_JOIN = STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: INNER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_inner_join_with_out_of_order_messages
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_inner_join_with_out_of_order_messages
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_INNER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.Join.Left = STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.Join.Right = STRUCT<TT_ID BIGINT, TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_ROWKEY BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.INNER_JOIN = STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: INNER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_join_-_contains_CASE_expression
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_join_-_contains_CASE_expression
@@ -1,0 +1,120 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<ID INT> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<ID INT> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<T_ID INT, T_ROWTIME BIGINT, T_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.Join.Right = STRUCT<TT_ID INT, TT_ROWTIME BIGINT, TT_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<T_ID INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_join_-_contains_CAST
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_join_-_contains_CAST
@@ -1,0 +1,105 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<ID INT> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<T_ID BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL
+CSAS_OUTPUT_0.Join.Right = STRUCT<TT_ID INT, TT_ROWTIME BIGINT, TT_ROWKEY INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<T_ID BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000014-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000013-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000013-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000014-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000017
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000017 (topic: OUTPUT)
+      <-- Project
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> KSTREAM-FILTER-0000000005
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: KSTREAM-FILTER-0000000005 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000006
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-KEY-SELECT-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000005
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000006
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_join_-_contains_CAST_double_to_int
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_join_-_contains_CAST_double_to_int
@@ -1,0 +1,120 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<ID INT> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<ID DOUBLE> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<L_ID INT, L_ROWTIME BIGINT, L_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.Join.Right = STRUCT<R_ID DOUBLE, R_ROWTIME BIGINT, R_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<L_ID INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_join_-_contains_arithmetic_binary_expression
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_join_-_contains_arithmetic_binary_expression
@@ -1,0 +1,120 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<T_ID BIGINT, T_ROWTIME BIGINT, T_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.Join.Right = STRUCT<TT_ID BIGINT, TT_ROWTIME BIGINT, TT_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<T_ID BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_join_-_contains_arithmetic_unary_expression
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_join_-_contains_arithmetic_unary_expression
@@ -1,0 +1,120 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<T_ID BIGINT, T_ROWTIME BIGINT, T_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.Join.Right = STRUCT<TT_ID BIGINT, TT_ROWTIME BIGINT, TT_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<T_ID BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_join_-_contains_arithmetic_unary_expression_flipped_sides
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_join_-_contains_arithmetic_unary_expression_flipped_sides
@@ -1,0 +1,120 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<T_ID BIGINT, T_ROWTIME BIGINT, T_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.Join.Right = STRUCT<TT_ID BIGINT, TT_ROWTIME BIGINT, TT_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<T_ID BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_join_-_contains_function
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_join_-_contains_function
@@ -1,0 +1,120 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<ID VARCHAR> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<ID VARCHAR> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<T_ID VARCHAR, T_ROWTIME BIGINT, T_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.Join.Right = STRUCT<TT_ID VARCHAR, TT_ROWTIME BIGINT, TT_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<T_ID VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_join_-_contains_subscript
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_join_-_contains_subscript
@@ -1,0 +1,120 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<ID ARRAY<BIGINT>> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<T_ID BIGINT, T_ROWTIME BIGINT, T_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.Join.Right = STRUCT<TT_ID ARRAY<BIGINT>, TT_ROWTIME BIGINT, TT_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<T_ID BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_left_join
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_left_join
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CSAS_LEFT_OUTER_JOIN_0.Join.Left = STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL
+CSAS_LEFT_OUTER_JOIN_0.Join.Right = STRUCT<TT_ID BIGINT, TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_ROWKEY BIGINT> NOT NULL
+CSAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN = STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000009-store])
+      --> Join-outer-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-outer-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-OUTEROTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-outer-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: LEFT_OUTER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_left_join_-_join_key_not_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_left_join_-_join_key_not_in_projection
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CSAS_LEFT_OUTER_JOIN_0.Join.Left = STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL
+CSAS_LEFT_OUTER_JOIN_0.Join.Right = STRUCT<TT_ID BIGINT, TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_ROWKEY BIGINT> NOT NULL
+CSAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN = STRUCT<NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000009-store])
+      --> Join-outer-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-outer-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-OUTEROTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-outer-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: LEFT_OUTER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_outer_join
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_outer_join
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CSAS_LEFT_OUTER_JOIN_0.Join.Left = STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL
+CSAS_LEFT_OUTER_JOIN_0.Join.Right = STRUCT<TT_ID BIGINT, TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_ROWKEY BIGINT> NOT NULL
+CSAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN = STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000009-store])
+      --> Join-outer-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-OUTERTHIS-0000000008-store])
+      --> Join-outer-this-join
+      <-- PrependAliasLeft
+    Processor: Join-outer-other-join (stores: [KSTREAM-OUTERTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-outer-this-join (stores: [KSTREAM-OUTEROTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-outer-this-join, Join-outer-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: LEFT_OUTER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_outer_join_-_right_join_key_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_stream_outer_join_-_right_join_key_in_projection
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CSAS_LEFT_OUTER_JOIN_0.Join.Left = STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL
+CSAS_LEFT_OUTER_JOIN_0.Join.Right = STRUCT<TT_ID BIGINT, TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_ROWKEY BIGINT> NOT NULL
+CSAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN = STRUCT<TT_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000009-store])
+      --> Join-outer-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-OUTERTHIS-0000000008-store])
+      --> Join-outer-this-join
+      <-- PrependAliasLeft
+    Processor: Join-outer-other-join (stores: [KSTREAM-OUTERTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-outer-this-join (stores: [KSTREAM-OUTEROTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-outer-this-join, Join-outer-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: LEFT_OUTER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_table_inner_join
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_table_inner_join
@@ -1,0 +1,80 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_INNER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.Join.Left = STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.INNER_JOIN = STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: INNER_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_table_inner_join_-_join_key_not_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_table_inner_join_-_join_key_not_in_projection
@@ -1,0 +1,80 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_INNER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.Join.Left = STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.INNER_JOIN = STRUCT<NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: INNER_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_table_inner_join_-_right_join_key_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_table_inner_join_-_right_join_key_in_projection
@@ -1,0 +1,80 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_INNER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.Join.Left = STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL
+CSAS_INNER_JOIN_0.INNER_JOIN = STRUCT<TT_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: INNER_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_table_left_join
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_table_left_join
@@ -1,0 +1,80 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_LEFT_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CSAS_LEFT_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CSAS_LEFT_JOIN_0.Join.Left = STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL
+CSAS_LEFT_JOIN_0.LEFT_JOIN = STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: LEFT_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_table_left_join_-_join_key_not_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_table_left_join_-_join_key_not_in_projection
@@ -1,0 +1,80 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_LEFT_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CSAS_LEFT_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CSAS_LEFT_JOIN_0.Join.Left = STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL
+CSAS_LEFT_JOIN_0.LEFT_JOIN = STRUCT<NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: LEFT_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_table_left_join_-_right_join_key_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_table_left_join_-_right_join_key_in_projection
@@ -1,0 +1,80 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_LEFT_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CSAS_LEFT_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CSAS_LEFT_JOIN_0.Join.Left = STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL
+CSAS_LEFT_JOIN_0.LEFT_JOIN = STRUCT<TT_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: LEFT_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_to_stream_unwrapped_single_field_value_schema_on_inputs
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_to_stream_unwrapped_single_field_value_schema_on_inputs
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = BIGINT
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = BIGINT
+CSAS_OUTPUT_0.Join.Left = STRUCT<S1_ID BIGINT, S1_ROWTIME BIGINT, S1_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.Join.Right = STRUCT<S2_ID BIGINT, S2_ROWTIME BIGINT, S2_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<ID1 BIGINT, ID2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [S1])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [S2])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_to_stream_unwrapped_single_field_value_schema_on_inputs_and_output
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_to_stream_unwrapped_single_field_value_schema_on_inputs_and_output
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = BIGINT
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = BIGINT
+CSAS_OUTPUT_0.Join.Left = STRUCT<S1_ID BIGINT, S1_ROWTIME BIGINT, S1_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.Join.Right = STRUCT<S2_ID BIGINT, S2_ROWTIME BIGINT, S2_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = BIGINT
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [S1])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [S2])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_to_stream_wrapped_single_field_value_schema_on_inputs
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_to_stream_wrapped_single_field_value_schema_on_inputs
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<S1_ID BIGINT, S1_ROWTIME BIGINT, S1_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.Join.Right = STRUCT<S2_ID BIGINT, S2_ROWTIME BIGINT, S2_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<ID1 BIGINT, ID2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [S1])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [S2])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_to_table_unwrapped_single_field_value_schema_on_inputs
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_to_table_unwrapped_single_field_value_schema_on_inputs
@@ -1,0 +1,80 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = BIGINT
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = BIGINT
+CSAS_OUTPUT_0.Join.Left = STRUCT<S_ID BIGINT, S_ROWTIME BIGINT, S_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<ID1 BIGINT, ID2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [S])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [T])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: OUTPUT)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_to_table_unwrapped_single_field_value_schema_on_inputs_and_output
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_to_table_unwrapped_single_field_value_schema_on_inputs_and_output
@@ -1,0 +1,80 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = BIGINT
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = BIGINT
+CSAS_OUTPUT_0.Join.Left = STRUCT<S_ID BIGINT, S_ROWTIME BIGINT, S_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = BIGINT
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [S])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [T])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: OUTPUT)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_to_table_when_table_does_not_have_key_field_and_joining_by_table_ROWKEY
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_to_table_when_table_does_not_have_key_field_and_joining_by_table_ROWKEY
@@ -1,0 +1,80 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, NAME VARCHAR> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<S_ID BIGINT, S_ROWTIME BIGINT, S_ROWKEY BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<S_ID BIGINT, NAME VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [S])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [NO_KEY])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: OUTPUT)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_to_table_wrapped_single_field_value_schema_on_inputs
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_stream_to_table_wrapped_single_field_value_schema_on_inputs
@@ -1,0 +1,80 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<S_ID BIGINT, S_ROWTIME BIGINT, S_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<ID1 BIGINT, ID2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [S])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [T])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: OUTPUT)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_table_join_pipeline
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_table_join_pipeline
@@ -1,0 +1,91 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_INNER_JOIN_2_1.KafkaTopic_Left.Source = STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CTAS_INNER_JOIN_2_1.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F3 VARCHAR> NOT NULL
+CTAS_INNER_JOIN_2_1.INNER_JOIN_2 = STRUCT<T_ID BIGINT, NAME VARCHAR, F1 VARCHAR, F3 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [INNER_JOIN])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic_2])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: INNER_JOIN_2)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_table_table_inner_join
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_table_table_inner_join
@@ -1,0 +1,91 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_INNER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CTAS_INNER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CTAS_INNER_JOIN_0.INNER_JOIN = STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: INNER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_table_table_inner_join_-_join_key_not_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_table_table_inner_join_-_join_key_not_in_projection
@@ -1,0 +1,91 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_INNER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CTAS_INNER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CTAS_INNER_JOIN_0.INNER_JOIN = STRUCT<NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: INNER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_table_table_inner_join_-_right_join_key_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_table_table_inner_join_-_right_join_key_in_projection
@@ -1,0 +1,91 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_INNER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CTAS_INNER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CTAS_INNER_JOIN_0.INNER_JOIN = STRUCT<TT_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: INNER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_table_table_join_with_where_clause
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_table_table_join_with_where_clause
@@ -1,0 +1,100 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CTAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<T_ID BIGINT, NAME VARCHAR, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> WhereFilter-ApplyPredicate
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: WhereFilter-ApplyPredicate (stores: [])
+      --> WhereFilter-Filter
+      <-- KTABLE-MERGE-0000000008
+    Processor: WhereFilter-Filter (stores: [])
+      --> WhereFilter-PostProcess
+      <-- WhereFilter-ApplyPredicate
+    Processor: WhereFilter-PostProcess (stores: [])
+      --> Project
+      <-- WhereFilter-Filter
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000015
+      <-- WhereFilter-PostProcess
+    Processor: KTABLE-TOSTREAM-0000000015 (stores: [])
+      --> KSTREAM-SINK-0000000016
+      <-- Project
+    Sink: KSTREAM-SINK-0000000016 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000015
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_table_table_left_join
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_table_table_left_join
@@ -1,0 +1,91 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CTAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CTAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN = STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: LEFT_OUTER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_table_table_left_join_-_both_join_keys_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_table_table_left_join_-_both_join_keys_in_projection
@@ -1,0 +1,91 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CTAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CTAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN = STRUCT<T_ID BIGINT, TT_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: LEFT_OUTER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_table_table_left_join_-_join_key_not_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_table_table_left_join_-_join_key_not_in_projection
@@ -1,0 +1,91 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CTAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CTAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN = STRUCT<NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: LEFT_OUTER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_table_table_left_join_-_right_join_key_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_table_table_left_join_-_right_join_key_in_projection
@@ -1,0 +1,91 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CTAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CTAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN = STRUCT<TT_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: LEFT_OUTER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_table_table_outer_join
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_table_table_outer_join
@@ -1,0 +1,91 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CTAS_OUTER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CTAS_OUTER_JOIN_0.OUTER_JOIN = STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: OUTER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_table_table_outer_join_-_right_join_key_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_table_table_outer_join_-_right_join_key_in_projection
@@ -1,0 +1,91 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTER_JOIN_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CTAS_OUTER_JOIN_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+CTAS_OUTER_JOIN_0.OUTER_JOIN = STRUCT<TT_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: OUTER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_table_to_table_unwrapped_single_field_value_schema_on_inputs
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_table_to_table_unwrapped_single_field_value_schema_on_inputs
@@ -1,0 +1,91 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KafkaTopic_Left.Source = BIGINT
+CTAS_OUTPUT_0.KafkaTopic_Right.Source = BIGINT
+CTAS_OUTPUT_0.OUTPUT = STRUCT<ID1 BIGINT, ID2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [T1])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [T2])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_table_to_table_unwrapped_single_field_value_schema_on_inputs_and_output
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_table_to_table_unwrapped_single_field_value_schema_on_inputs_and_output
@@ -1,0 +1,91 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KafkaTopic_Left.Source = BIGINT
+CTAS_OUTPUT_0.KafkaTopic_Right.Source = BIGINT
+CTAS_OUTPUT_0.OUTPUT = BIGINT
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [T1])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [T2])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_table_to_table_wrapped_single_field_value_schema_on_inputs
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_table_to_table_wrapped_single_field_value_schema_on_inputs
@@ -1,0 +1,91 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT> NOT NULL
+CTAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<ID1 BIGINT, ID2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [T1])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [T2])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_unqualified_join_criteria
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/joins_-_unqualified_join_criteria
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source = STRUCT<LEFT_ID BIGINT, NAME VARCHAR> NOT NULL
+CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source = STRUCT<RIGHT_ID BIGINT, F1 VARCHAR> NOT NULL
+CSAS_LEFT_OUTER_JOIN_0.Join.Left = STRUCT<T_LEFT_ID BIGINT, T_NAME VARCHAR, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL
+CSAS_LEFT_OUTER_JOIN_0.Join.Right = STRUCT<TT_RIGHT_ID BIGINT, TT_F1 VARCHAR, TT_ROWTIME BIGINT, TT_ROWKEY BIGINT> NOT NULL
+CSAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN = STRUCT<LEFT_ID BIGINT, NAME VARCHAR, F1 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000009-store])
+      --> Join-outer-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-outer-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-OUTEROTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-outer-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: LEFT_OUTER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/json_array_contains_-_filter_rows_where_the_ARRAY_column_contains_a_specified_STRING
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/json_array_contains_-_filter_rows_where_the_ARRAY_column_contains_a_specified_STRING
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<COLORS VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<COLORS VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_multiple_copies_of_key_field_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_multiple_copies_of_key_field_in_projection
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO0 INT, FOO1 INT, FOO2 INT, FOO3 INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_null___group_by_(-)___key_in_value___aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_null___group_by_(-)___key_in_value___aliasing
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<ALIASED INT, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_null___group_by_(-)___key_in_value___no_aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_null___group_by_(-)___key_in_value___no_aliasing
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<FOO INT, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_null___group_by_(-)___key_not_in_value___-
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_null___group_by_(-)___key_not_in_value___-
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_null___no_key_change___-___-
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_null___no_key_change___-___-
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO INT, BAR INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_null___partition_by_(-)___key_in_value___no_aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_null___partition_by_(-)___key_in_value___no_aliasing
@@ -1,0 +1,67 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO INT, BAR INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> Project
+      <-- KSTREAM-FILTER-0000000002
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Sink: KSTREAM-SINK-0000000005 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_null___partition_by_(-)___key_not_in_value___-
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_null___partition_by_(-)___key_not_in_value___-
@@ -1,0 +1,67 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<BAR INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> Project
+      <-- KSTREAM-FILTER-0000000002
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Sink: KSTREAM-SINK-0000000005 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___group_by_(different)___key_in_value___aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___group_by_(different)___key_in_value___aliasing
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<ALIASED INT, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___group_by_(different)___key_in_value___no_aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___group_by_(different)___key_in_value___no_aliasing
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<BAR INT, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___group_by_(different)___key_not_in_value___-
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___group_by_(different)___key_not_in_value___-
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___group_by_(same)___key_in_value___aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___group_by_(same)___key_in_value___aliasing
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<ALIASED INT, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___group_by_(same)___key_in_value___no_aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___group_by_(same)___key_in_value___no_aliasing
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<FOO INT, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___group_by_(same)___key_not_in_value___-
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___group_by_(same)___key_not_in_value___-
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___group_by_expression___key_in_value___no_aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___group_by_expression___key_in_value___no_aliasing
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 INT, KSQL_INTERNAL_COL_2 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 INT, KSQL_INTERNAL_COL_2 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 INT, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___group_by_multiple___key_in_value___no_aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___group_by_multiple___key_in_value___no_aliasing
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 INT, KSQL_INTERNAL_COL_2 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 INT, KSQL_INTERNAL_COL_2 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<FOO INT, BAR INT, KSQL_COL_2 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___no_key_change___key_in_value___aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___no_key_change___key_in_value___aliasing
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<ALIASED INT, BAR INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___no_key_change___key_in_value___aliasing_+_duplicate
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___no_key_change___key_in_value___aliasing_+_duplicate
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<ALIASED INT, FOO INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___no_key_change___key_in_value___no_aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___no_key_change___key_in_value___no_aliasing
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO INT, BAR INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___no_key_change___key_not_in_value___-
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___no_key_change___key_not_in_value___-
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<BAR INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___partition_by_(different)___key_in_value___no_aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___partition_by_(different)___key_in_value___no_aliasing
@@ -1,0 +1,67 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO INT, BAR INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> Project
+      <-- KSTREAM-FILTER-0000000002
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Sink: KSTREAM-SINK-0000000005 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___partition_by_(different)___key_not_in_value___-
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___partition_by_(different)___key_not_in_value___-
@@ -1,0 +1,67 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> Project
+      <-- KSTREAM-FILTER-0000000002
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Sink: KSTREAM-SINK-0000000005 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___partition_by_(same)___key_in_value___no_aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___partition_by_(same)___key_in_value___no_aliasing
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO INT, BAR INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___partition_by_(same)___key_not_in_value___-
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___partition_by_(same)___key_not_in_value___-
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<BAR INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___partition_by_expression___key_in_value___no_aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_stream___initially_set___partition_by_expression___key_in_value___no_aliasing
@@ -1,0 +1,67 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> Project
+      <-- KSTREAM-FILTER-0000000002
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Sink: KSTREAM-SINK-0000000005 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_table___initially_null___group_by_(-)___key_in_value___aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_table___initially_null___group_by_(-)___key_in_value___aliasing
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<ALIASED INT, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_table___initially_null___group_by_(-)___key_in_value___no_aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_table___initially_null___group_by_(-)___key_in_value___no_aliasing
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<FOO INT, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_table___initially_null___no_key_change___-___-
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_table___initially_null___no_key_change___-___-
@@ -1,0 +1,67 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<BAR INT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<BAR INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Project
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-TOSTREAM-0000000004 (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- Project
+    Sink: KSTREAM-SINK-0000000005 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000004
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_table___initially_set___group_by_(different)___key_in_value___aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_table___initially_set___group_by_(different)___key_in_value___aliasing
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<ALIASED INT, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_table___initially_set___group_by_(different)___key_in_value___no_aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_table___initially_set___group_by_(different)___key_in_value___no_aliasing
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<BAR INT, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_table___initially_set___group_by_(different)___key_not_in_value___-
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_table___initially_set___group_by_(different)___key_not_in_value___-
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_table___initially_set___group_by_(same)___key_in_value___aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_table___initially_set___group_by_(same)___key_in_value___aliasing
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<ALIASED INT, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_table___initially_set___group_by_(same)___key_in_value___no_aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_table___initially_set___group_by_(same)___key_in_value___no_aliasing
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<FOO INT, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_table___initially_set___group_by_(same)___key_not_in_value___-
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_table___initially_set___group_by_(same)___key_not_in_value___-
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_table___initially_set___no_key_change___key_in_value___aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_table___initially_set___no_key_change___key_in_value___aliasing
@@ -1,0 +1,67 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<ALIASED INT, BAR INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Project
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-TOSTREAM-0000000004 (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- Project
+    Sink: KSTREAM-SINK-0000000005 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000004
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_table___initially_set___no_key_change___key_in_value___no_aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_table___initially_set___no_key_change___key_in_value___no_aliasing
@@ -1,0 +1,67 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<FOO INT, BAR INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Project
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-TOSTREAM-0000000004 (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- Project
+    Sink: KSTREAM-SINK-0000000005 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000004
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_table___initially_set___no_key_change___key_not_in_value___-
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_table___initially_set___no_key_change___key_not_in_value___-
@@ -1,0 +1,67 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<BAR INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Project
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-TOSTREAM-0000000004 (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- Project
+    Sink: KSTREAM-SINK-0000000005 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000004
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_using_full_source_name_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_using_full_source_name_in_projection
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_using_source_alias_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_using_source_alias_in_projection
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_where_clause
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_where_clause
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_where_clause_with_alias
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_where_clause_with_alias
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<BOO INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_where_only_rowkey_is_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-field_-_where_only_rowkey_is_in_projection
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT, BAR INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<ID INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-schemas_-_KEY_value_field_name
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-schemas_-_KEY_value_field_name
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<KEY VARCHAR, ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<KEY VARCHAR, ID BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-schemas_-_filter_by_non-STRING_ROWKEY
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-schemas_-_filter_by_non-STRING_ROWKEY
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<ID BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-schemas_-_filter_by_non-STRING_ROWKEY_in_UDF
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-schemas_-_filter_by_non-STRING_ROWKEY_in_UDF
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<ID BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-schemas_-_stream_explicit_KAFKA_BIGINT_ROWKEY
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-schemas_-_stream_explicit_KAFKA_BIGINT_ROWKEY
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<ID BIGINT, KEY BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-schemas_-_stream_explicit_KAFKA_DOUBLE_ROWKEY
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-schemas_-_stream_explicit_KAFKA_DOUBLE_ROWKEY
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<ID BIGINT, KEY DOUBLE> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-schemas_-_stream_explicit_KAFKA_INT_ROWKEY
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-schemas_-_stream_explicit_KAFKA_INT_ROWKEY
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<ID BIGINT, KEY INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-schemas_-_stream_explicit_KAFKA_STRING_ROWKEY
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-schemas_-_stream_explicit_KAFKA_STRING_ROWKEY
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<ID BIGINT, KEY VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-schemas_-_stream_implicit_KAFKA_STRING_ROWKEY
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-schemas_-_stream_implicit_KAFKA_STRING_ROWKEY
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<ID BIGINT, KEY VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-schemas_-_table_explicit_KAFKA_BIGINT_ROWKEY
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-schemas_-_table_explicit_KAFKA_BIGINT_ROWKEY
@@ -1,0 +1,67 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<ID BIGINT, KEY BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Project
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-TOSTREAM-0000000004 (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- Project
+    Sink: KSTREAM-SINK-0000000005 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000004
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-schemas_-_table_explicit_KAFKA_DOUBLE_ROWKEY
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-schemas_-_table_explicit_KAFKA_DOUBLE_ROWKEY
@@ -1,0 +1,67 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<ID BIGINT, KEY DOUBLE> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Project
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-TOSTREAM-0000000004 (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- Project
+    Sink: KSTREAM-SINK-0000000005 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000004
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-schemas_-_table_explicit_KAFKA_INT_ROWKEY
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-schemas_-_table_explicit_KAFKA_INT_ROWKEY
@@ -1,0 +1,67 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<ID BIGINT, KEY INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Project
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-TOSTREAM-0000000004 (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- Project
+    Sink: KSTREAM-SINK-0000000005 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000004
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-schemas_-_table_explicit_KAFKA_STRING_ROWKEY
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-schemas_-_table_explicit_KAFKA_STRING_ROWKEY
@@ -1,0 +1,67 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<ID BIGINT, KEY VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Project
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-TOSTREAM-0000000004 (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- Project
+    Sink: KSTREAM-SINK-0000000005 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000004
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-schemas_-_table_implicit_KAFKA_STRING_ROWKEY
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-schemas_-_table_implicit_KAFKA_STRING_ROWKEY
@@ -1,0 +1,67 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<ID BIGINT, KEY VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Project
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-TOSTREAM-0000000004 (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- Project
+    Sink: KSTREAM-SINK-0000000005 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000004
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-schemas_-_windowed_table_explicit_non-STRING_ROWKEY
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-schemas_-_windowed_table_explicit_non-STRING_ROWKEY
@@ -1,0 +1,78 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<VALUE BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<ID BIGINT, MAX BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-schemas_-_windowed_table_explicit_non-STRING_ROWKEY_udf
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/key-schemas_-_windowed_table_explicit_non-STRING_ROWKEY_udf
@@ -1,0 +1,78 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<VALUE BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<EXP DOUBLE, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/literals_-_BIGINT_literal_min_max
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/literals_-_BIGINT_literal_min_max
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<ID BIGINT, MIN BIGINT, MAX BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/literals_-_BOOLEAN_literal
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/literals_-_BOOLEAN_literal
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<ID BIGINT, KSQL_COL_1 BOOLEAN, KSQL_COL_2 BOOLEAN, KSQL_COL_3 BOOLEAN, KSQL_COL_4 BOOLEAN, KSQL_COL_5 BOOLEAN, KSQL_COL_6 BOOLEAN> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/literals_-_DECIMAL_literal
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/literals_-_DECIMAL_literal
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<ID BIGINT, KSQL_COL_1 DECIMAL(4, 3)> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/literals_-_DOUBLE_literal_min_max
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/literals_-_DOUBLE_literal_min_max
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<ID BIGINT, MIN_VALUE DOUBLE, NEG_MIN_VALUE DOUBLE, MIN_NORMAL DOUBLE, NEG_MIN_NORMAL DOUBLE, MAX_VALUE DOUBLE, NEG_MAX_VALUE DOUBLE> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/literals_-_INT_literal_min_max
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/literals_-_INT_literal_min_max
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<ID BIGINT, MIN INT, MAX INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/magic-timestamp-conversion_-_between_predicate_on_BIGINT_ROWTIME_in_WHERE
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/magic-timestamp-conversion_-_between_predicate_on_BIGINT_ROWTIME_in_WHERE
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<THING INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/magic-timestamp-conversion_-_between_predicate_on_STRING_ROWTIME_in_WHERE
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/magic-timestamp-conversion_-_between_predicate_on_STRING_ROWTIME_in_WHERE
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<THING INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/magic-timestamp-conversion_-_between_predicate_on_STRING_WINDOWSTART_in_WHERE
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/magic-timestamp-conversion_-_between_predicate_on_STRING_WINDOWSTART_in_WHERE
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<SOURCE INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/magic-timestamp-conversion_-_comparison_predicate_on_BIGINT_ROWTIME_in_WHERE
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/magic-timestamp-conversion_-_comparison_predicate_on_BIGINT_ROWTIME_in_WHERE
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<THING INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/magic-timestamp-conversion_-_comparison_predicate_on_BIGINT_window_bounds_in_WHERE
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/magic-timestamp-conversion_-_comparison_predicate_on_BIGINT_window_bounds_in_WHERE
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<SOURCE INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/magic-timestamp-conversion_-_comparison_predicate_on_STRING_ROWTIME_in_WHERE
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/magic-timestamp-conversion_-_comparison_predicate_on_STRING_ROWTIME_in_WHERE
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<THING INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/magic-timestamp-conversion_-_comparison_predicate_on_STRING_window_bounds_in_WHERE
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/magic-timestamp-conversion_-_comparison_predicate_on_STRING_window_bounds_in_WHERE
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<SOURCE INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/magic-timestamp-conversion_-_comparison_predicate_with_STRING_ROWTIME_containing_TZ_in_WHERE
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/magic-timestamp-conversion_-_comparison_predicate_with_STRING_ROWTIME_containing_TZ_in_WHERE
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<THING INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/magic-timestamp-conversion_-_nested_comparison_expression_on_STRING_ROWTIME_in_WHERE
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/magic-timestamp-conversion_-_nested_comparison_expression_on_STRING_ROWTIME_in_WHERE
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<THING INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/magic-timestamp-conversion_-_partial_STRING_ROWTIME
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/magic-timestamp-conversion_-_partial_STRING_ROWTIME
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<THING INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/math_-_abs
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/math_-_abs
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<I INT, L BIGINT, D DOUBLE, B DECIMAL(2, 1)> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<I INT, L BIGINT, D DOUBLE, B DECIMAL(2, 1)> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/math_-_calculate_CEIL_function
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/math_-_calculate_CEIL_function
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<I INT, L BIGINT, D DOUBLE, B DECIMAL(2, 1)> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<I INT, L BIGINT, D DOUBLE, B DECIMAL(2, 1)> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/math_-_exp
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/math_-_exp
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<I INT, L BIGINT, D DOUBLE> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<I DOUBLE, L DOUBLE, D DOUBLE> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/math_-_floor
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/math_-_floor
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<I INT, L BIGINT, D DOUBLE, B DECIMAL(2, 1)> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<I INT, L BIGINT, D DOUBLE, B DECIMAL(2, 1)> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/math_-_ln
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/math_-_ln
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<I INT, L BIGINT, D DOUBLE> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<I DOUBLE, L DOUBLE, D DOUBLE> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/math_-_round
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/math_-_round
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<V DOUBLE> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<R0 BIGINT, R00 DOUBLE, R1 DOUBLE, R2 DOUBLE, R10 DOUBLE, 1R DOUBLE, 2R DOUBLE> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/math_-_round_with_large_DECIMAL_values
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/math_-_round_with_large_DECIMAL_values
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<V DECIMAL(33, 16)> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<R0 DECIMAL(17, 0), R00 DECIMAL(33, 16), R1 DECIMAL(33, 16), R2 DECIMAL(33, 16), R10 DECIMAL(33, 16), 1R DECIMAL(33, 16), 2R DECIMAL(33, 16)> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/math_-_sign
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/math_-_sign
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<I INT, L BIGINT, D DOUBLE> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<I INT, L INT, D INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/math_-_sqrt
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/math_-_sqrt
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<I INT, L BIGINT, D DOUBLE> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<I DOUBLE, L DOUBLE, D DOUBLE> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/max-group-by_-_max_decimal_group_by
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/max-group-by_-_max_decimal_group_by
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, VALUE DECIMAL(4, 2)> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DECIMAL(4, 2)> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DECIMAL(4, 2), KSQL_AGG_VARIABLE_0 DECIMAL(4, 2)> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, VALUE DECIMAL(4, 2)> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/max-group-by_-_max_double_group_by
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/max-group-by_-_max_double_group_by
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, VALUE DOUBLE> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DOUBLE> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DOUBLE, KSQL_AGG_VARIABLE_0 DOUBLE> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, VALUE DOUBLE> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/max-group-by_-_max_integer_group_by
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/max-group-by_-_max_integer_group_by
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, VALUE INT> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT, KSQL_AGG_VARIABLE_0 INT> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, VALUE INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/max-group-by_-_max_long_group_by
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/max-group-by_-_max_long_group_by
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, VALUE BIGINT> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, VALUE BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/min-group-by_-_min_decimal_group_by
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/min-group-by_-_min_decimal_group_by
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, VALUE DECIMAL(4, 2)> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DECIMAL(4, 2)> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DECIMAL(4, 2), KSQL_AGG_VARIABLE_0 DECIMAL(4, 2)> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, MIN DECIMAL(4, 2)> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/min-group-by_-_min_double_group_by
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/min-group-by_-_min_double_group_by
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, VALUE DOUBLE> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DOUBLE> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DOUBLE, KSQL_AGG_VARIABLE_0 DOUBLE> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, MIN DOUBLE> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/min-group-by_-_min_integer_group_by
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/min-group-by_-_min_integer_group_by
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, VALUE INT> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT, KSQL_AGG_VARIABLE_0 INT> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, MIN INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/min-group-by_-_min_long_group_by
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/min-group-by_-_min_long_group_by
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, VALUE BIGINT> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, MIN BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/more-complex-struct_-_complex_struct_select_array,_map,_map_value_struct
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/more-complex-struct_-_complex_struct_select_array,_map,_map_value_struct
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S2_0.KsqlTopic.Source = STRUCT<NESTED_STRUCT_FIELD STRUCT<SL1_STRUCT STRUCT<SL2_STRUCT STRUCT<SL3_STRUCT STRUCT<SL4_STRING VARCHAR, SL4_INT INT, SL4_DOUBLE_ARRAY ARRAY<DOUBLE>>, SL3_DOUBLE_ARRAY ARRAY<DOUBLE>, SL3_STRING VARCHAR>, SL2_STRUCT_MAP MAP<VARCHAR, STRUCT<SL2_3_STRING VARCHAR, SL2_3_DOUBLE DOUBLE>>, SL2_DOUBLE DOUBLE, SL2_BOOLEAN BOOLEAN>, SL1_STRING VARCHAR, SL1_STRUCT_ARRAY ARRAY<STRUCT<SL1_2_STRING VARCHAR, SL1_2_DOUBLE DOUBLE>>>, COL1 BIGINT, COL2 VARCHAR> NOT NULL
+CSAS_S2_0.S2 = STRUCT<NESTED_STRUCT_FIELD__SL1_STRUCT__SL2_STRUCT__SL3_STRUCT__SL4_DOUBLE_ARRAY ARRAY<DOUBLE>, NESTED_STRUCT_FIELD__SL1_STRUCT__SL2_STRUCT_MAP MAP<VARCHAR, STRUCT<SL2_3_STRING VARCHAR, SL2_3_DOUBLE DOUBLE>>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/more-complex-struct_-_complex_struct_select_array_and_map_items
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/more-complex-struct_-_complex_struct_select_array_and_map_items
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S3_0.KsqlTopic.Source = STRUCT<NESTED_STRUCT_FIELD STRUCT<SL1_STRUCT STRUCT<SL2_STRUCT STRUCT<SL3_STRUCT STRUCT<SL4_STRING VARCHAR, SL4_INT INT, SL4_DOUBLE_ARRAY ARRAY<DOUBLE>>, SL3_DOUBLE_ARRAY ARRAY<DOUBLE>, SL3_STRING VARCHAR>, SL2_STRUCT_MAP MAP<VARCHAR, STRUCT<SL2_3_STRING VARCHAR, SL2_3_DOUBLE DOUBLE>>, SL2_DOUBLE DOUBLE, SL2_BOOLEAN BOOLEAN>, SL1_STRING VARCHAR, SL1_STRUCT_ARRAY ARRAY<STRUCT<SL1_2_STRING VARCHAR, SL1_2_DOUBLE DOUBLE>>>, COL1 BIGINT, COL2 VARCHAR> NOT NULL
+CSAS_S3_0.S3 = STRUCT<COL1 DOUBLE, COL2 STRUCT<SL2_3_STRING VARCHAR, SL2_3_DOUBLE DOUBLE>, COL3 DOUBLE, COL4 DOUBLE> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S3)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/more-complex-struct_-_complex_struct_select_star
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/more-complex-struct_-_complex_struct_select_star
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S1_0.KsqlTopic.Source = STRUCT<NESTED_STRUCT_FIELD STRUCT<SL1_STRUCT STRUCT<SL2_STRUCT STRUCT<SL3_STRUCT STRUCT<SL4_STRING VARCHAR, SL4_INT INT, SL4_DOUBLE_ARRAY ARRAY<DOUBLE>>, SL3_DOUBLE_ARRAY ARRAY<DOUBLE>, SL3_STRING VARCHAR>, SL2_STRUCT_MAP MAP<VARCHAR, STRUCT<SL2_3_STRING VARCHAR, SL2_3_DOUBLE DOUBLE>>, SL2_DOUBLE DOUBLE, SL2_BOOLEAN BOOLEAN>, SL1_STRING VARCHAR, SL1_STRUCT_ARRAY ARRAY<STRUCT<SL1_2_STRING VARCHAR, SL1_2_DOUBLE DOUBLE>>>, COL1 BIGINT, COL2 VARCHAR> NOT NULL
+CSAS_S1_0.S1 = STRUCT<NESTED_STRUCT_FIELD STRUCT<SL1_STRUCT STRUCT<SL2_STRUCT STRUCT<SL3_STRUCT STRUCT<SL4_STRING VARCHAR, SL4_INT INT, SL4_DOUBLE_ARRAY ARRAY<DOUBLE>>, SL3_DOUBLE_ARRAY ARRAY<DOUBLE>, SL3_STRING VARCHAR>, SL2_STRUCT_MAP MAP<VARCHAR, STRUCT<SL2_3_STRING VARCHAR, SL2_3_DOUBLE DOUBLE>>, SL2_DOUBLE DOUBLE, SL2_BOOLEAN BOOLEAN>, SL1_STRING VARCHAR, SL1_STRUCT_ARRAY ARRAY<STRUCT<SL1_2_STRING VARCHAR, SL1_2_DOUBLE DOUBLE>>>, COL1 BIGINT, COL2 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S1)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/multiple-avro-maps_-_project_multiple_avro_maps
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/multiple-avro-maps_-_project_multiple_avro_maps
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_SINK_0.KsqlTopic.Source = STRUCT<M1 MAP<VARCHAR, INT>, M2 MAP<VARCHAR, VARCHAR>> NOT NULL
+CSAS_SINK_0.SINK = STRUCT<M1 MAP<VARCHAR, INT>, M2 MAP<VARCHAR, VARCHAR>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: SINK)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_aliased_key_field_-_same_name
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_aliased_key_field_-_same_name
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_REPARTITIONED_0.KsqlTopic.Source = STRUCT<ID VARCHAR, NAME VARCHAR> NOT NULL
+CSAS_REPARTITIONED_0.REPARTITIONED = STRUCT<ID VARCHAR, NAME VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: REPARTITIONED)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_bigint_key_field
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_bigint_key_field
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<ID BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_int_column
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_int_column
@@ -1,0 +1,67 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<ID BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> Project
+      <-- KSTREAM-FILTER-0000000002
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Sink: KSTREAM-SINK-0000000005 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_partition_by
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_partition_by
@@ -1,0 +1,67 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<ID INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> Project
+      <-- KSTREAM-FILTER-0000000002
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Sink: KSTREAM-SINK-0000000005 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_partition_by_ROWKEY
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_partition_by_ROWKEY
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<ID BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_partition_by_ROWKEY_in_join_on_ROWKEY
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_partition_by_ROWKEY_in_join_on_ROWKEY
@@ -1,0 +1,96 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<A VARCHAR, B VARCHAR> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<C VARCHAR, D VARCHAR> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<L_A VARCHAR, L_B VARCHAR, L_ROWTIME BIGINT, L_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.Join.Right = STRUCT<R_C VARCHAR, R_D VARCHAR, R_ROWTIME BIGINT, R_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<L_ROWKEY VARCHAR, R_ROWKEY VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [LEFT])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [RIGHT])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> KSTREAM-FILTER-0000000011
+      <-- Join-this-join, Join-other-join
+    Processor: KSTREAM-FILTER-0000000011 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000012
+      <-- Join-merge
+    Processor: KSTREAM-KEY-SELECT-0000000012 (stores: [])
+      --> Project
+      <-- KSTREAM-FILTER-0000000011
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000014
+      <-- KSTREAM-KEY-SELECT-0000000012
+    Sink: KSTREAM-SINK-0000000014 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_partition_by_ROWKEY_in_join_on_ROWKEY_ALIASED
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_partition_by_ROWKEY_in_join_on_ROWKEY_ALIASED
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<A VARCHAR, B VARCHAR> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<C VARCHAR, D VARCHAR> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<L_A VARCHAR, L_B VARCHAR, L_ROWTIME BIGINT, L_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.Join.Right = STRUCT<R_C VARCHAR, R_D VARCHAR, R_ROWTIME BIGINT, R_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<L_ROWKEY VARCHAR, R_ROWKEY VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [LEFT])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [RIGHT])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_partition_by_ROWKEY_in_join_on_non-ROWKEY
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_partition_by_ROWKEY_in_join_on_non-ROWKEY
@@ -1,0 +1,126 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<A VARCHAR, B VARCHAR> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<C VARCHAR, D VARCHAR> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<L_A VARCHAR, L_B VARCHAR, L_ROWTIME BIGINT, L_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.Join.Right = STRUCT<R_C VARCHAR, R_D VARCHAR, R_ROWTIME BIGINT, R_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<L_ROWKEY VARCHAR, R_ROWKEY VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [LEFT])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [RIGHT])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> KSTREAM-FILTER-0000000021
+      <-- Join-this-join, Join-other-join
+    Processor: KSTREAM-FILTER-0000000021 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000022
+      <-- Join-merge
+    Processor: KSTREAM-KEY-SELECT-0000000022 (stores: [])
+      --> Project
+      <-- KSTREAM-FILTER-0000000021
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000024
+      <-- KSTREAM-KEY-SELECT-0000000022
+    Sink: KSTREAM-SINK-0000000024 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_partition_by_ROWTIME
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_partition_by_ROWTIME
@@ -1,0 +1,67 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<ID BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> Project
+      <-- KSTREAM-FILTER-0000000002
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Sink: KSTREAM-SINK-0000000005 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_partition_by_non-ROWKEY_in_join_on_ROWKEY
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_partition_by_non-ROWKEY_in_join_on_ROWKEY
@@ -1,0 +1,96 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<A VARCHAR, B VARCHAR> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<C VARCHAR, D VARCHAR> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<L_A VARCHAR, L_B VARCHAR, L_ROWTIME BIGINT, L_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.Join.Right = STRUCT<R_C VARCHAR, R_D VARCHAR, R_ROWTIME BIGINT, R_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<L_ROWKEY VARCHAR, R_ROWKEY VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [LEFT])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [RIGHT])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> KSTREAM-FILTER-0000000011
+      <-- Join-this-join, Join-other-join
+    Processor: KSTREAM-FILTER-0000000011 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000012
+      <-- Join-merge
+    Processor: KSTREAM-KEY-SELECT-0000000012 (stores: [])
+      --> Project
+      <-- KSTREAM-FILTER-0000000011
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000014
+      <-- KSTREAM-KEY-SELECT-0000000012
+    Sink: KSTREAM-SINK-0000000014 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_partition_by_non-ROWKEY_in_join_on_non-ROWKEY
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_partition_by_non-ROWKEY_in_join_on_non-ROWKEY
@@ -1,0 +1,120 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<A VARCHAR, B VARCHAR> NOT NULL
+CSAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<C VARCHAR, D VARCHAR> NOT NULL
+CSAS_OUTPUT_0.Join.Left = STRUCT<L_A VARCHAR, L_B VARCHAR, L_ROWTIME BIGINT, L_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.Join.Right = STRUCT<R_C VARCHAR, R_D VARCHAR, R_ROWTIME BIGINT, R_ROWKEY VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<L_ROWKEY VARCHAR, R_ROWKEY VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [LEFT])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [RIGHT])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_partition_by_project_ROWKEY
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_partition_by_project_ROWKEY
@@ -1,0 +1,67 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<OLDKEY VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> Project
+      <-- KSTREAM-FILTER-0000000002
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Sink: KSTREAM-SINK-0000000005 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_partition_by_with_null_partition_by_value
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_partition_by_with_null_partition_by_value
@@ -1,0 +1,67 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_REPARTITIONED_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CSAS_REPARTITIONED_0.REPARTITIONED = STRUCT<NAME VARCHAR, ID BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> Project
+      <-- KSTREAM-FILTER-0000000002
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Sink: KSTREAM-SINK-0000000005 (topic: REPARTITIONED)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_partition_by_with_null_value
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_partition_by_with_null_value
@@ -1,0 +1,67 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_REPARTITIONED_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CSAS_REPARTITIONED_0.REPARTITIONED = STRUCT<NAME VARCHAR, ID BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> Project
+      <-- KSTREAM-FILTER-0000000002
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Sink: KSTREAM-SINK-0000000005 (topic: REPARTITIONED)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_partition_by_with_projection_select_all
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_partition_by_with_projection_select_all
@@ -1,0 +1,67 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_REPARTITIONED_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CSAS_REPARTITIONED_0.REPARTITIONED = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> Project
+      <-- KSTREAM-FILTER-0000000002
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Sink: KSTREAM-SINK-0000000005 (topic: REPARTITIONED)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_partition_by_with_projection_select_some
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/partition-by_-_partition_by_with_projection_select_some
@@ -1,0 +1,67 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_REPARTITIONED_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CSAS_REPARTITIONED_0.REPARTITIONED = STRUCT<NAME VARCHAR, ID BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> Project
+      <-- KSTREAM-FILTER-0000000002
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Sink: KSTREAM-SINK-0000000005 (topic: REPARTITIONED)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_CSAS_with_custom_Kafka_topic_name
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_CSAS_with_custom_Kafka_topic_name
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S1_0.KsqlTopic.Source = STRUCT<C1 BIGINT, C2 INT, C3 VARCHAR> NOT NULL
+CSAS_S1_0.S1 = STRUCT<C1 BIGINT, C2 INT, C3 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: topic_s)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Filter_on_BETWEEN
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Filter_on_BETWEEN
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S1_0.KsqlTopic.Source = STRUCT<C1 BIGINT, C2 INT, C3 VARCHAR> NOT NULL
+CSAS_S1_0.S1 = STRUCT<C1 BIGINT, C2 INT, C3 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: S1)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Filter_on_IS_DISTINCT_FROM
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Filter_on_IS_DISTINCT_FROM
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S1_0.KsqlTopic.Source = STRUCT<C1 BIGINT, C2 INT> NOT NULL
+CSAS_S1_0.S1 = STRUCT<C1 BIGINT, C2 INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: S1)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Filter_on_IS_NOT_DISTINCT_FROM
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Filter_on_IS_NOT_DISTINCT_FROM
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S1_0.KsqlTopic.Source = STRUCT<C1 BIGINT, C2 INT> NOT NULL
+CSAS_S1_0.S1 = STRUCT<C1 BIGINT, C2 INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: S1)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Filter_on_NOT_BETWEEN
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Filter_on_NOT_BETWEEN
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S1_0.KsqlTopic.Source = STRUCT<C1 BIGINT, C2 INT, C3 VARCHAR> NOT NULL
+CSAS_S1_0.S1 = STRUCT<C1 BIGINT, C2 INT, C3 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: S1)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Filter_on_NOT_NULL
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Filter_on_NOT_NULL
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S1_0.KsqlTopic.Source = STRUCT<C1 BIGINT, C2 INT, C3 VARCHAR> NOT NULL
+CSAS_S1_0.S1 = STRUCT<C1 BIGINT, C2 INT, C3 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: S1)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Filter_on_NULL
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Filter_on_NULL
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S1_0.KsqlTopic.Source = STRUCT<C1 BIGINT, C2 INT, C3 VARCHAR> NOT NULL
+CSAS_S1_0.S1 = STRUCT<C1 BIGINT, C2 INT, C3 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: S1)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Filter_on_like_pattern
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Filter_on_like_pattern
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S1_0.KsqlTopic.Source = STRUCT<C1 BIGINT, C2 INT, C3 VARCHAR> NOT NULL
+CSAS_S1_0.S1 = STRUCT<C1 BIGINT, C2 INT, C3 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: S1)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Filter_on_like_pattern_without_wildcards
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Filter_on_like_pattern_without_wildcards
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S1_0.KsqlTopic.Source = STRUCT<C1 BIGINT, C2 INT, C3 VARCHAR> NOT NULL
+CSAS_S1_0.S1 = STRUCT<C1 BIGINT, C2 INT, C3 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: S1)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Filter_on_long_literal
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Filter_on_long_literal
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S1_0.KsqlTopic.Source = STRUCT<C1 BIGINT, C2 INT, C3 VARCHAR> NOT NULL
+CSAS_S1_0.S1 = STRUCT<C1 BIGINT, C2 INT, C3 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: S1)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Filter_on_non-STRING_ROWKEY
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Filter_on_non-STRING_ROWKEY
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<C1 BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<C1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Filter_on_not_like_pattern
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Filter_on_not_like_pattern
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S1_0.KsqlTopic.Source = STRUCT<C1 BIGINT, C2 INT, C3 VARCHAR> NOT NULL
+CSAS_S1_0.S1 = STRUCT<C1 BIGINT, C2 INT, C3 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: S1)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Filter_on_string_literal
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Filter_on_string_literal
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S1_0.KsqlTopic.Source = STRUCT<C1 BIGINT, C2 INT, C3 VARCHAR> NOT NULL
+CSAS_S1_0.S1 = STRUCT<C1 BIGINT, C2 INT, C3 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: S1)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Json_Map_filter
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Json_Map_filter
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S1_0.KsqlTopic.Source = STRUCT<ID BIGINT, THING MAP<VARCHAR, VARCHAR>> NOT NULL
+CSAS_S1_0.S1 = STRUCT<ID BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: S1)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Json_Multi_Dimensional_Array
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Json_Multi_Dimensional_Array
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S3_0.KsqlTopic.Source = STRUCT<ID BIGINT, ARRAY_COL ARRAY<ARRAY<ARRAY<VARCHAR>>>> NOT NULL
+CSAS_S3_0.S3 = STRUCT<ID BIGINT, ARRAY_ITEM VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S3)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Json_Multi_Dimensional_Array_2
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Json_Multi_Dimensional_Array_2
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S3_0.KsqlTopic.Source = STRUCT<ID BIGINT, ARRAY_COL ARRAY<ARRAY<VARCHAR>>> NOT NULL
+CSAS_S3_0.S3 = STRUCT<ID BIGINT, ARRAY_ITEM VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S3)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Null_row_filter
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Null_row_filter
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S3_0.KsqlTopic.Source = STRUCT<ID BIGINT, THING MAP<VARCHAR, VARCHAR>> NOT NULL
+CSAS_S3_0.S3 = STRUCT<ID BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: S3)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Project_fields_with_reserved_name
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Project_fields_with_reserved_name
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S1_0.KsqlTopic.Source = STRUCT<START VARCHAR, END VARCHAR> NOT NULL
+CSAS_S1_0.S1 = STRUCT<END VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S1)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Project_struct_fields_with_reserved_name
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_Project_struct_fields_with_reserved_name
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S1_0.KsqlTopic.Source = STRUCT<S STRUCT<START VARCHAR, END VARCHAR>> NOT NULL
+CSAS_S1_0.S1 = STRUCT<S__END VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S1)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_WHERE_with_many_comparisons._This_tests_the_fix_for_#1784
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_WHERE_with_many_comparisons._This_tests_the_fix_for_#1784
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_EVENTSTEST_0.KsqlTopic.Source = STRUCT<ID INT, FIELD0 VARCHAR> NOT NULL
+CSAS_EVENTSTEST_0.EVENTSTEST = STRUCT<ID INT, FIELD1 VARCHAR, FIELD0 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [events])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: EVENTSTEST)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_project_and_filter
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_project_and_filter
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S1_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE DOUBLE> NOT NULL
+CSAS_S1_0.S1 = STRUCT<NAME VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: S1)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_project_and_negative_filter
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_project_and_negative_filter
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE DOUBLE> NOT NULL
+CSAS_S2_0.S2 = STRUCT<NAME VARCHAR, ID BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: S2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_project_string_with_embedded_code
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/project-filter_-_project_string_with_embedded_code
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S1_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_S1_0.S1 = STRUCT<X VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S1)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/quoted-identifiers_-_create_table_with_key_that_is_quoted
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/quoted-identifiers_-_create_table_with_key_that_is_quoted
@@ -1,0 +1,67 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<some.key VARCHAR> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<some.key VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Project
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-TOSTREAM-0000000004 (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- Project
+    Sink: KSTREAM-SINK-0000000005 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000004
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/quoted-identifiers_-_joins_using_fields_that_require_quotes
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/quoted-identifiers_-_joins_using_fields_that_require_quotes
@@ -1,0 +1,95 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_JOINED_0.KafkaTopic_Right.Source = STRUCT<with.dot VARCHAR> NOT NULL
+CSAS_JOINED_0.KafkaTopic_Left.Source = STRUCT<SELECT VARCHAR, field! VARCHAR> NOT NULL
+CSAS_JOINED_0.Join.Left = STRUCT<L_SELECT VARCHAR, L_field! VARCHAR, L_ROWTIME BIGINT, L_ROWKEY VARCHAR> NOT NULL
+CSAS_JOINED_0.JOINED = STRUCT<field! VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: Join-repartition-source (topics: [Join-repartition])
+      --> Join
+    Source: KSTREAM-SOURCE-0000000000 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- Join-repartition-source
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000014
+      <-- Join
+    Sink: KSTREAM-SINK-0000000014 (topic: JOINED)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000004 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> KSTREAM-FILTER-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KSTREAM-FILTER-0000000006 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000007
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-KEY-SELECT-0000000007 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000006
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000007
+    Processor: Join-repartition-filter (stores: [])
+      --> Join-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-repartition-sink (topic: Join-repartition)
+      <-- Join-repartition-filter
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/quoted-identifiers_-_literals_with_quotes_galore
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/quoted-identifiers_-_literals_with_quotes_galore
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 VARCHAR, KSQL_COL_1 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/quoted-identifiers_-_math_using_fields_that_require_quotes
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/quoted-identifiers_-_math_using_fields_that_require_quotes
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SELECT INT, with.dot INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/quoted-identifiers_-_partition_by_quoted_field
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/quoted-identifiers_-_partition_by_quoted_field
@@ -1,0 +1,67 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<some.key VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<some.key VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> Project
+      <-- KSTREAM-FILTER-0000000002
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Sink: KSTREAM-SINK-0000000005 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/quoted-identifiers_-_sink_fields_that_require_quotes
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/quoted-identifiers_-_sink_fields_that_require_quotes
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<A VARCHAR, B VARCHAR, C VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<with.dot VARCHAR, *bad!chars* VARCHAR, SELECT VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/quoted-identifiers_-_source_fields_that_require_quotes
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/quoted-identifiers_-_source_fields_that_require_quotes
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<with.dot VARCHAR, *bad!chars* VARCHAR, SELECT VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<with.dot VARCHAR, *bad!chars* VARCHAR, SELECT VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/quoted-identifiers_-_source_names_requiring_quotes
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/quoted-identifiers_-_source_names_requiring_quotes
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_foo-too_0.KsqlTopic.Source = STRUCT<ID VARCHAR> NOT NULL
+CSAS_foo-too_0.foo-too = STRUCT<ID VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [foo-source])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: foo-too)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/quoted-identifiers_-_udf_using_fields_that_require_quotes
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/quoted-identifiers_-_udf_using_fields_that_require_quotes
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SELECT INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/replace_-_replace
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/replace_-_replace
@@ -1,0 +1,62 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.functions.substring.legacy.args" : "[hidden]",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<REPLACE VARCHAR, REPLACE_NULL VARCHAR, REPLACE_W_NULL VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/scratch_-_deserialize_anonymous_primitive_by_default_-_value
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/scratch_-_deserialize_anonymous_primitive_by_default_-_value
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_deserialization_should_default_to_wrapped_values
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_deserialization_should_default_to_wrapped_values
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_deserialization_should_pick_up_value_wrapping_from_config
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_deserialization_should_pick_up_value_wrapping_from_config
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "false",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = VARCHAR
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO VARCHAR, FOO2 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_deserialize_anonymous_array_-_value
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_deserialize_anonymous_array_-_value
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = ARRAY<VARCHAR>
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO ARRAY<VARCHAR>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_deserialize_anonymous_array_-_value_-_non-nullable
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_deserialize_anonymous_array_-_value_-_non-nullable
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = ARRAY<VARCHAR>
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO ARRAY<VARCHAR>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_deserialize_anonymous_array_-_value_-_with_coercion
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_deserialize_anonymous_array_-_value_-_with_coercion
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = ARRAY<VARCHAR>
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO ARRAY<VARCHAR>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_deserialize_anonymous_map_-_value
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_deserialize_anonymous_map_-_value
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = MAP<VARCHAR, INT>
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO MAP<VARCHAR, INT>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_deserialize_anonymous_map_-_value_-_non-nullable
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_deserialize_anonymous_map_-_value_-_non-nullable
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = MAP<VARCHAR, INT>
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO MAP<VARCHAR, INT>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_deserialize_anonymous_map_-_value_-_with_coercion
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_deserialize_anonymous_map_-_value_-_with_coercion
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = MAP<VARCHAR, VARCHAR>
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO MAP<VARCHAR, VARCHAR>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_deserialize_anonymous_primitive_-_value
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_deserialize_anonymous_primitive_-_value
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = INT
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_deserialize_anonymous_primitive_-_value_-_with_coercion
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_deserialize_anonymous_primitive_-_value_-_with_coercion
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = VARCHAR
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_deserialize_anonymous_primitive_by_default_-_value
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_deserialize_anonymous_primitive_by_default_-_value
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_deserialize_nested_array_-_value
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_deserialize_nested_array_-_value
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO ARRAY<VARCHAR>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO ARRAY<VARCHAR>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_deserialize_nested_map_-_value
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_deserialize_nested_map_-_value
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO MAP<VARCHAR, INT>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO MAP<VARCHAR, INT>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_deserialize_nested_primitive_-_value
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_deserialize_nested_primitive_-_value
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_serialization_should_default_to_wrapped_values
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_serialization_should_default_to_wrapped_values
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_serialization_should_pick_up_value_wrapping_from_config
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_serialization_should_pick_up_value_wrapping_from_config
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "false",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO VARCHAR, FOO2 VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = VARCHAR
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_serialize_anonymous_array_-_value
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_serialize_anonymous_array_-_value
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO ARRAY<BIGINT>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = ARRAY<BIGINT>
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_serialize_anonymous_map_-_value
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_serialize_anonymous_map_-_value
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO MAP<VARCHAR, DOUBLE>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = MAP<VARCHAR, DOUBLE>
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_serialize_anonymous_primitive_-_value
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_serialize_anonymous_primitive_-_value
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO BOOLEAN> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = BOOLEAN
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_serialize_anonymous_struct_-_value
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_serialize_anonymous_struct_-_value
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO STRUCT<F0 INT>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<F0 INT>
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_serialize_nested_array_-_value
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_serialize_nested_array_-_value
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO ARRAY<BIGINT>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO ARRAY<BIGINT>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_serialize_nested_map_-_value
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_serialize_nested_map_-_value
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO MAP<VARCHAR, DOUBLE>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO MAP<VARCHAR, DOUBLE>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_serialize_nested_primitive_-_value
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_serialize_nested_primitive_-_value
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO BOOLEAN> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO BOOLEAN> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_serialize_nested_struct_-_value
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/serdes_-_serialize_nested_struct_-_value
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO STRUCT<F0 INT>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FOO STRUCT<F0 INT>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/session-windows_-_import_session_stream
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/session-windows_-_import_session_stream
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, VALUE BIGINT> NOT NULL
+CSAS_S2_0.S2 = STRUCT<ID BIGINT, VALUE BIGINT, KEY VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/session-windows_-_import_session_stream_with_non-STRING_key
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/session-windows_-_import_session_stream_with_non-STRING_key
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_S2_0.S2 = STRUCT<ID BIGINT, WSTART BIGINT, WEND BIGINT, KEY INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/session-windows_-_max_session
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/session-windows_-_max_session
@@ -1,0 +1,78 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/simple-struct_-_simple_struct_read_struct_as_json_string
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/simple-struct_-_simple_struct_read_struct_as_json_string
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S1_0.KsqlTopic.Source = STRUCT<ORDERTIME BIGINT, ORDERID BIGINT, ITEMID VARCHAR, ORDERUNITS DOUBLE, ARRAYCOL ARRAY<DOUBLE>, MAPCOL MAP<VARCHAR, DOUBLE>, ADDRESS STRUCT<NUMBER BIGINT, STREET VARCHAR, CITY VARCHAR, STATE VARCHAR, ZIPCODE BIGINT>> NOT NULL
+CSAS_S1_0.S1 = STRUCT<ITEMID VARCHAR, KSQL_COL_1 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S1)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/simple-struct_-_simple_struct_select_filter
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/simple-struct_-_simple_struct_select_filter
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S2_0.KsqlTopic.Source = STRUCT<ORDERTIME BIGINT, ORDERID BIGINT, ITEMID STRUCT<ITEMID BIGINT, NAME VARCHAR, CATEGORY STRUCT<ID BIGINT, NAME VARCHAR>>, ORDERUNITS DOUBLE, ARRAYCOL ARRAY<DOUBLE>, MAPCOL MAP<VARCHAR, DOUBLE>, ADDRESS STRUCT<NUMBER BIGINT, STREET VARCHAR, CITY VARCHAR, STATE VARCHAR, ZIPCODE BIGINT>> NOT NULL
+CSAS_S2_0.S2 = STRUCT<ITEMID__NAME VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: S2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/simple-struct_-_simple_struct_select_filter_2
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/simple-struct_-_simple_struct_select_filter_2
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S3_0.KsqlTopic.Source = STRUCT<ORDERTIME BIGINT, ORDERID BIGINT, ITEMID STRUCT<ITEMID BIGINT, NAME VARCHAR, CATEGORY STRUCT<ID BIGINT, NAME VARCHAR>>, ORDERUNITS DOUBLE, ARRAYCOL ARRAY<DOUBLE>, MAPCOL MAP<VARCHAR, DOUBLE>, ADDRESS STRUCT<NUMBER BIGINT, STREET VARCHAR, CITY VARCHAR, STATE VARCHAR, ZIPCODE BIGINT>> NOT NULL
+CSAS_S3_0.S3 = STRUCT<ITEMID__CATEGORY__ID BIGINT, ADDRESS__STREET VARCHAR, ZIPCODE BIGINT, STATE VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: S3)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/simple-struct_-_simple_struct_select_filter_4
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/simple-struct_-_simple_struct_select_filter_4
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S5_0.KsqlTopic.Source = STRUCT<ORDERTIME BIGINT, ORDERID BIGINT, ITEMID STRUCT<ITEMID BIGINT, NAME VARCHAR, CATEGORY STRUCT<ID BIGINT, NAME VARCHAR>>, ORDERUNITS DOUBLE, ARRAYCOL ARRAY<DOUBLE>, MAPCOL MAP<VARCHAR, DOUBLE>, ADDRESS STRUCT<NUMBER BIGINT, STREET VARCHAR, CITY VARCHAR, STATE VARCHAR, ZIPCODE BIGINT>> NOT NULL
+CSAS_S5_0.S5 = STRUCT<ITEMID BIGINT, CNAME VARCHAR, STATE_LENGTH INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: S5)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/simple-struct_-_simple_struct_select_for_ambiguity
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/simple-struct_-_simple_struct_select_for_ambiguity
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S7_0.KsqlTopic.Source = STRUCT<S STRUCT<S VARCHAR>> NOT NULL
+CSAS_S7_0.S7 = STRUCT<S1 STRUCT<S VARCHAR>, S2 STRUCT<S VARCHAR>, S3 VARCHAR, S4 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S7)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/simple-struct_-_simple_struct_select_star
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/simple-struct_-_simple_struct_select_star
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S1_0.KsqlTopic.Source = STRUCT<ORDERTIME BIGINT, ORDERID BIGINT, ITEMID STRUCT<ITEMID BIGINT, NAME VARCHAR, CATEGORY STRUCT<ID BIGINT, NAME VARCHAR>>, ORDERUNITS DOUBLE, ARRAYCOL ARRAY<DOUBLE>, MAPCOL MAP<VARCHAR, DOUBLE>, ADDRESS STRUCT<NUMBER BIGINT, STREET VARCHAR, CITY VARCHAR, STATE VARCHAR, ZIPCODE BIGINT>> NOT NULL
+CSAS_S1_0.S1 = STRUCT<ORDERTIME BIGINT, ORDERID BIGINT, ITEMID STRUCT<ITEMID BIGINT, NAME VARCHAR, CATEGORY STRUCT<ID BIGINT, NAME VARCHAR>>, ORDERUNITS DOUBLE, ARRAYCOL ARRAY<DOUBLE>, MAPCOL MAP<VARCHAR, DOUBLE>, ADDRESS STRUCT<NUMBER BIGINT, STREET VARCHAR, CITY VARCHAR, STATE VARCHAR, ZIPCODE BIGINT>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S1)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/simple-struct_-_simple_struct_select_with_nulls
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/simple-struct_-_simple_struct_select_with_nulls
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S6_0.KsqlTopic.Source = STRUCT<ORDERTIME BIGINT, ORDERID BIGINT, ITEMID STRUCT<ITEMID BIGINT, NAME VARCHAR, CATEGORY STRUCT<ID BIGINT, NAME VARCHAR>>, ORDERUNITS DOUBLE, ARRAYCOL ARRAY<DOUBLE>, MAPCOL MAP<VARCHAR, DOUBLE>, ADDRESS STRUCT<NUMBER BIGINT, STREET VARCHAR, CITY VARCHAR, STATE VARCHAR, ZIPCODE BIGINT>> NOT NULL
+CSAS_S6_0.S6 = STRUCT<ITEMID BIGINT, CATID BIGINT, CAT STRUCT<ID BIGINT, NAME VARCHAR>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S6)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/simple-struct_-_simples_struct_select_filter_3
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/simple-struct_-_simples_struct_select_filter_3
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S4_0.KsqlTopic.Source = STRUCT<ORDERTIME BIGINT, ORDERID BIGINT, ITEMID STRUCT<ITEMID BIGINT, NAME VARCHAR, CATEGORY STRUCT<ID BIGINT, NAME VARCHAR>>, ORDERUNITS DOUBLE, ARRAYCOL ARRAY<DOUBLE>, MAPCOL MAP<VARCHAR, DOUBLE>, ADDRESS STRUCT<NUMBER BIGINT, STREET VARCHAR, CITY VARCHAR, STATE VARCHAR, ZIPCODE BIGINT>> NOT NULL
+CSAS_S4_0.S4 = STRUCT<ITEMID__ITEMID BIGINT, IID STRUCT<ITEMID BIGINT, NAME VARCHAR, CATEGORY STRUCT<ID BIGINT, NAME VARCHAR>>, CATNAME VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: S4)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sink-partitions-replicas_-_Use_the_legacy_default_sink_properties_for_the_sink_topic_if_default_partitions_and_replicas_were_set
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sink-partitions-replicas_-_Use_the_legacy_default_sink_properties_for_the_sink_topic_if_default_partitions_and_replicas_were_set
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S_0.KsqlTopic.Source = STRUCT<C1 INT> NOT NULL
+CSAS_S_0.S = STRUCT<C1 INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sink-partitions-replicas_-_should_copy_partition_and_replica_count_from_source_topic
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sink-partitions-replicas_-_should_copy_partition_and_replica_count_from_source_topic
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S_0.KsqlTopic.Source = STRUCT<C1 INT> NOT NULL
+CSAS_S_0.S = STRUCT<C1 INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sink-topic-naming_-_sink-topic-naming__default_topic_name_is_stream_name,_in_upper-case
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sink-topic-naming_-_sink-topic-naming__default_topic_name_is_stream_name,_in_upper-case
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<SOURCE VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sink-topic-naming_-_sink-topic-naming__use_prefixed_default_topic_name_when_property_set
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sink-topic-naming_-_sink-topic-naming__use_prefixed_default_topic_name_when_property_set
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "some-prefix-",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<SOURCE VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: some-prefix-OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sink-topic-naming_-_sink-topic-naming__use_supplied_topic_name,_when_supplied
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sink-topic-naming_-_sink-topic-naming__use_supplied_topic_name,_when_supplied
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "some-prefix-",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<SOURCE VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: Fred)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/slice_-_sublist_for_list_of_lists
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/slice_-_sublist_for_list_of_lists
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<L ARRAY<ARRAY<VARCHAR>>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<SUB ARRAY<ARRAY<VARCHAR>>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/slice_-_sublist_for_list_of_maps
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/slice_-_sublist_for_list_of_maps
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<L ARRAY<MAP<VARCHAR, VARCHAR>>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<SUB ARRAY<MAP<VARCHAR, VARCHAR>>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/slice_-_sublist_for_string_list
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/slice_-_sublist_for_string_list
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<L ARRAY<VARCHAR>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<SUB ARRAY<VARCHAR>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/split_-_split_a_message_by_commas_and_display_pos_0_and_2_of_the_returned_array
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/split_-_split_a_message_by_commas_and_display_pos_0_and_2_of_the_returned_array
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<MESSAGE VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<S1 VARCHAR, S2 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/split_-_split_a_message_by_using_the_'$$'_delimiter
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/split_-_split_a_message_by_using_the_'$$'_delimiter
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<MESSAGE VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<SPLIT_MSG ARRAY<VARCHAR>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/split_-_split_a_message_by_using_the_'.'_delimiter
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/split_-_split_a_message_by_using_the_'.'_delimiter
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<MESSAGE VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<SPLIT_MSG ARRAY<VARCHAR>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/split_-_split_all_characters_by_using_the_''_delimiter
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/split_-_split_all_characters_by_using_the_''_delimiter
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<MESSAGE VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<SPLIT_MSG ARRAY<VARCHAR>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/string_-___operator
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/string_-___operator
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<TEXT VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<TEXT VARCHAR, KSQL_COL_1 BOOLEAN> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/stringdate_-_string_to_date
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/stringdate_-_string_to_date
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_TS_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, DATE VARCHAR, FORMAT VARCHAR> NOT NULL
+CSAS_TS_0.TS = STRUCT<ID BIGINT, TS INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TS)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/stringtimestamp_-_string_to_timestamp
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/stringtimestamp_-_string_to_timestamp
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_TS_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, TIMESTAMP VARCHAR> NOT NULL
+CSAS_TS_0.TS = STRUCT<ID BIGINT, TS BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TS)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/struct-udfs_-_Create_a_struct_from_a_string
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/struct-udfs_-_Create_a_struct_from_a_string
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<VALUE VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<VALUE STRUCT<A VARCHAR>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/struct-udfs_-_Extract_value_from_struct
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/struct-udfs_-_Extract_value_from_struct
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<VALUE STRUCT<A VARCHAR>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<VALUE VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/substring_-_do_substring_with_just_pos
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/substring_-_do_substring_with_just_pos
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<SUBSTRING VARCHAR, NULL_STR VARCHAR, NULL_POS VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/substring_-_do_substring_with_pos_and_length
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/substring_-_do_substring_with_pos_and_length
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<SUBSTRING VARCHAR, NULL_STR VARCHAR, NULL_POS VARCHAR, NULL_LEN VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/substring_-_in_group_by
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/substring_-_in_group_by
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<THING VARCHAR, SUBSTRING BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/substring_-_should_default_to_current_mode_for_new_queries
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/substring_-_should_default_to_current_mode_for_new_queries
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<SOURCE VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<SUBSTRING VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sum_-_sum_decimal
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sum_-_sum_decimal
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, VALUE DECIMAL(4, 1)> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DECIMAL(4, 1)> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DECIMAL(4, 1), KSQL_AGG_VARIABLE_0 DECIMAL(4, 1)> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, SUM DECIMAL(4, 1)> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sum_-_sum_double
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sum_-_sum_double
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, VALUE DOUBLE> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DOUBLE> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DOUBLE, KSQL_AGG_VARIABLE_0 DOUBLE> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, SUM DOUBLE> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sum_-_sum_double_map
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sum_-_sum_double_map
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE MAP<VARCHAR, DOUBLE>> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 MAP<VARCHAR, DOUBLE>, KSQL_INTERNAL_COL_2 DOUBLE> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 MAP<VARCHAR, DOUBLE>, KSQL_AGG_VARIABLE_0 DOUBLE> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, SUM_VAL DOUBLE> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sum_-_sum_int
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sum_-_sum_int
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, VALUE INT> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT, KSQL_AGG_VARIABLE_0 INT> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, SUM INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sum_-_sum_int_left_join_of_table
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sum_-_sum_int_left_join_of_table
@@ -1,0 +1,114 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KafkaTopic_Left.Source = STRUCT<ID BIGINT, TOTAL INT> NOT NULL
+CTAS_OUTPUT_0.KafkaTopic_Right.Source = STRUCT<ID BIGINT, TOTAL INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT, KSQL_AGG_VARIABLE_0 INT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<ID BIGINT, SUM INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [T1])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [T2])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-FILTER-0000000012 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000014
+      <-- KTABLE-FILTER-0000000012
+    Sink: KSTREAM-SINK-0000000014 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000015 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000016
+    Processor: KTABLE-AGGREGATE-0000000016 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000015
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000016
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000019
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000019 (stores: [])
+      --> KSTREAM-SINK-0000000020
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000020 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000019
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sum_-_sum_list_of_doubles_into_a_single_double
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sum_-_sum_list_of_doubles_into_a_single_double
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<VALUE ARRAY<DOUBLE>> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 ARRAY<DOUBLE>, KSQL_INTERNAL_COL_1 VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 ARRAY<DOUBLE>, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_AGG_VARIABLE_0 DOUBLE> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<SUM_VAL DOUBLE> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sum_-_sum_list_of_ints_into_a_single_int
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sum_-_sum_list_of_ints_into_a_single_int
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<VALUE ARRAY<INT>> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 ARRAY<INT>, KSQL_INTERNAL_COL_1 VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 ARRAY<INT>, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_AGG_VARIABLE_0 INT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<SUM_VAL INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sum_-_sum_list_of_longs_into_a_single_long
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sum_-_sum_list_of_longs_into_a_single_long
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<VALUE ARRAY<BIGINT>> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 ARRAY<BIGINT>, KSQL_INTERNAL_COL_1 VARCHAR> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 ARRAY<BIGINT>, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<SUM_VAL BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sum_-_sum_long
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sum_-_sum_long
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, VALUE BIGINT> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, SUM BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sum_-_sum_with_constant_double_arg
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sum_-_sum_with_constant_double_arg
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE MAP<VARCHAR, DOUBLE>> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DOUBLE> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_AGG_VARIABLE_0 DOUBLE> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, SUM_VAL DOUBLE> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sum_-_sum_with_constant_int_arg
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sum_-_sum_with_constant_int_arg
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE MAP<VARCHAR, DOUBLE>> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_AGG_VARIABLE_0 INT> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, SUM_VAL INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sum_-_sum_with_constant_long_arg
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/sum_-_sum_with_constant_long_arg
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE MAP<VARCHAR, DOUBLE>> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, SUM_VAL BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table-functions_-_multiple_table_functions
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table-functions_-_multiple_table_functions
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<MY_ARR1 ARRAY<BIGINT>, MY_ARR2 ARRAY<BIGINT>, BAR BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BIGINT, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> FlatMap
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: FlatMap (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- FlatMap
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table-functions_-_table_function_as_first_select
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table-functions_-_table_function_as_first_select
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID BIGINT, MY_ARR ARRAY<BIGINT>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<VAL BIGINT, ID BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> FlatMap
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: FlatMap (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- FlatMap
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table-functions_-_table_function_as_last_select
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table-functions_-_table_function_as_last_select
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID BIGINT, MY_ARR ARRAY<BIGINT>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<ID BIGINT, VAL BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> FlatMap
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: FlatMap (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- FlatMap
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table-functions_-_table_function_with_no_alias
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table-functions_-_table_function_with_no_alias
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO BIGINT, ID BIGINT, MY_ARR ARRAY<BIGINT>, BAR BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> FlatMap
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: FlatMap (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- FlatMap
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table-functions_-_table_function_with_no_other_selected_columns
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table-functions_-_table_function_with_no_other_selected_columns
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO BIGINT, ID BIGINT, MY_ARR ARRAY<BIGINT>, BAR BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<VAL BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> FlatMap
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: FlatMap (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- FlatMap
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table-functions_-_table_function_with_non_selected_columns
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table-functions_-_table_function_with_non_selected_columns
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<FOO BIGINT, ID BIGINT, MY_ARR ARRAY<BIGINT>, BAR BIGINT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<VAL BIGINT, ID BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> FlatMap
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: FlatMap (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- FlatMap
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table-functions_-_table_function_with_where_clause
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table-functions_-_table_function_with_where_clause
@@ -1,0 +1,67 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<F0 INT, F1 ARRAY<INT>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<F0 INT, VAL INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> FlatMap
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: FlatMap (stores: [])
+      --> Project
+      <-- WhereFilter
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- FlatMap
+    Sink: KSTREAM-SINK-0000000005 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table-functions_-_table_functions_with_complex_expressions
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table-functions_-_table_functions_with_complex_expressions
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<F0 INT, F1 INT, F2 INT, F3 INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<F0 INT, KSQL_COL_1 INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> FlatMap
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: FlatMap (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- FlatMap
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table-functions_-_test_udtf_-_array_params
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table-functions_-_test_udtf_-_array_params
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<F0 ARRAY<INT>, F1 ARRAY<BIGINT>, F2 ARRAY<DOUBLE>, F3 ARRAY<BOOLEAN>, F4 ARRAY<VARCHAR>, F5 ARRAY<DECIMAL(20, 10)>, F6 ARRAY<STRUCT<A VARCHAR>>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> FlatMap
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: FlatMap (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- FlatMap
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table-functions_-_test_udtf_-_map_params
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table-functions_-_test_udtf_-_map_params
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<F0 MAP<VARCHAR, INT>, F1 MAP<VARCHAR, BIGINT>, F2 MAP<VARCHAR, DOUBLE>, F3 MAP<VARCHAR, BOOLEAN>, F4 MAP<VARCHAR, VARCHAR>, F5 MAP<VARCHAR, DECIMAL(20, 10)>, F6 MAP<VARCHAR, STRUCT<A VARCHAR>>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> FlatMap
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: FlatMap (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- FlatMap
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table-functions_-_test_udtf_-_return_vals
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table-functions_-_test_udtf_-_return_vals
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<F0 INT, F1 BIGINT, F2 DOUBLE, F3 BOOLEAN, F4 VARCHAR, F5 DECIMAL(20, 10), F6 STRUCT<A VARCHAR>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 INT, KSQL_COL_1 BIGINT, KSQL_COL_2 DOUBLE, KSQL_COL_3 BOOLEAN, KSQL_COL_4 VARCHAR, KSQL_COL_5 DECIMAL(30, 10), KSQL_COL_6 STRUCT<A VARCHAR>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> FlatMap
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: FlatMap (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- FlatMap
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table-functions_-_test_udtf_-_simple_params
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table-functions_-_test_udtf_-_simple_params
@@ -1,0 +1,64 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<F0 INT, F1 BIGINT, F2 DOUBLE, F3 BOOLEAN, F4 VARCHAR, F5 DECIMAL(20, 10), F6 STRUCT<A VARCHAR>> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> FlatMap
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: FlatMap (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- FlatMap
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table_-_should_NOT_reuse_source_topic_for_change_log_if_topology_optimizations_are_off
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table_-_should_NOT_reuse_source_topic_for_change_log_if_topology_optimizations_are_off
@@ -1,0 +1,67 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "none",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_T1_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CTAS_T1_0.T1 = STRUCT<ID BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Project
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-TOSTREAM-0000000004 (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- Project
+    Sink: KSTREAM-SINK-0000000005 (topic: T1)
+      <-- KTABLE-TOSTREAM-0000000004
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table_-_should_forward_nulls_in_changelog_when_table_not_materialized
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table_-_should_forward_nulls_in_changelog_when_table_not_materialized
@@ -1,0 +1,67 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<ID BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Project
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-TOSTREAM-0000000004 (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- Project
+    Sink: KSTREAM-SINK-0000000005 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000004
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table_-_should_not_blow_up_on_null_key
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table_-_should_not_blow_up_on_null_key
@@ -1,0 +1,67 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<ID BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Project
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-TOSTREAM-0000000004 (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- Project
+    Sink: KSTREAM-SINK-0000000005 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000004
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table_-_should_reuse_source_topic_for_change_log_by_default
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table_-_should_reuse_source_topic_for_change_log_by_default
@@ -1,0 +1,67 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_T1_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CTAS_T1_0.T1 = STRUCT<ID BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Project
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-TOSTREAM-0000000004 (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- Project
+    Sink: KSTREAM-SINK-0000000005 (topic: T1)
+      <-- KTABLE-TOSTREAM-0000000004
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table_-_update-delete
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/table_-_update-delete
@@ -1,0 +1,67 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_T1_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE INT> NOT NULL
+CTAS_T1_0.T1 = STRUCT<NAME VARCHAR, VALUE INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Project
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-TOSTREAM-0000000004 (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- Project
+    Sink: KSTREAM-SINK-0000000005 (topic: T1)
+      <-- KTABLE-TOSTREAM-0000000004
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/test-custom-udaf_-_test_udaf_group_by
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/test-custom-udaf_-_test_udaf_group_by
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE INT> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/test-custom-udaf_-_test_udaf_on_a_table
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/test-custom-udaf_-_test_udaf_on_a_table
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_SUM_ID_BY_REGION_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, REGION VARCHAR> NOT NULL
+CTAS_SUM_ID_BY_REGION_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_SUM_ID_BY_REGION_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_SUM_ID_BY_REGION_0.SUM_ID_BY_REGION = STRUCT<REGION VARCHAR, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: SUM_ID_BY_REGION)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/test-custom-udaf_-_test_udaf_with_struct
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/test-custom-udaf_-_test_udaf_with_struct
@@ -1,0 +1,90 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_RESULT_0.KsqlTopic.Source = STRUCT<ID VARCHAR, VAL STRUCT<A INT, B INT>> NOT NULL
+CTAS_RESULT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 STRUCT<A INT, B INT>> NOT NULL
+CTAS_RESULT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 STRUCT<A INT, B INT>, KSQL_AGG_VARIABLE_0 STRUCT<A INT, B INT>> NOT NULL
+CTAS_RESULT_0.RESULT = STRUCT<ID VARCHAR, RESULT STRUCT<A INT, B INT>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: RESULT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/timestamp-extractor_-_KSQL_default_timestamp_extractor
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/timestamp-extractor_-_KSQL_default_timestamp_extractor
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_TS_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_TS_0.TS = STRUCT<ID BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TS)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/timestamp-extractor_-_KSQL_override_timestamp_extractor
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/timestamp-extractor_-_KSQL_override_timestamp_extractor
@@ -1,0 +1,62 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647",
+  "ksql.streams.default.timestamp.extractor" : "org.apache.kafka.streams.processor.LogAndSkipOnInvalidTimestamp"
+}
+CONFIGS_END
+CSAS_TS_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_TS_0.TS = STRUCT<ID BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TS)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/timestamp-to-string_-_with_valid_zone
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/timestamp-to-string_-_with_valid_zone
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<IGNORED INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<KSQL_COL_0 VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/timestampformat_-_timestamp_format
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/timestampformat_-_timestamp_format
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_TS_0.KsqlTopic.Source = STRUCT<ID BIGINT, EVENT_TIMESTAMP VARCHAR> NOT NULL
+CSAS_TS_0.TS = STRUCT<ID BIGINT, ETS BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TS)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/timestampformat_-_with_single_digit_ms_and_numeric_tz
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/timestampformat_-_with_single_digit_ms_and_numeric_tz
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_TS_0.KsqlTopic.Source = STRUCT<EVENT_TIMESTAMP VARCHAR> NOT NULL
+CSAS_TS_0.TS = STRUCT<ETS BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TS)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/topk-distinct_-_topk_distinct_decimal
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/topk-distinct_-_topk_distinct_decimal
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE DECIMAL(2, 1)> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DECIMAL(2, 1), KSQL_INTERNAL_COL_2 INT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DECIMAL(2, 1), KSQL_AGG_VARIABLE_0 ARRAY<DECIMAL(2, 1)>> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, TOPK ARRAY<DECIMAL(2, 1)>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/topk-distinct_-_topk_distinct_integer
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/topk-distinct_-_topk_distinct_integer
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE INT> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT, KSQL_INTERNAL_COL_2 INT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT, KSQL_AGG_VARIABLE_0 ARRAY<INT>> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, TOPK ARRAY<INT>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/topk-distinct_-_topk_distinct_long
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/topk-distinct_-_topk_distinct_long
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_INTERNAL_COL_2 INT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 ARRAY<BIGINT>> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, TOPK ARRAY<BIGINT>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/topk-distinct_-_topk_distinct_string
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/topk-distinct_-_topk_distinct_string
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE VARCHAR> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_INTERNAL_COL_2 INT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_AGG_VARIABLE_0 ARRAY<VARCHAR>> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, TOPK ARRAY<VARCHAR>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/topk-group-by_-_topk_double
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/topk-group-by_-_topk_double
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE DOUBLE> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DOUBLE, KSQL_INTERNAL_COL_2 INT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DOUBLE, KSQL_AGG_VARIABLE_0 ARRAY<DOUBLE>> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, TOPK ARRAY<DOUBLE>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/topk-group-by_-_topk_integer
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/topk-group-by_-_topk_integer
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE INT> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT, KSQL_INTERNAL_COL_2 INT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT, KSQL_AGG_VARIABLE_0 ARRAY<INT>> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, TOPK ARRAY<INT>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/topk-group-by_-_topk_long
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/topk-group-by_-_topk_long
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_INTERNAL_COL_2 INT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 ARRAY<BIGINT>> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, TOPK ARRAY<BIGINT>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/topk-group-by_-_topk_string
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/topk-group-by_-_topk_string
@@ -1,0 +1,75 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE VARCHAR> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_INTERNAL_COL_2 INT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 VARCHAR, KSQL_AGG_VARIABLE_0 ARRAY<VARCHAR>> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, TOPK ARRAY<VARCHAR>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/tumbling-windows_-_import_tumbling_stream
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/tumbling-windows_-_import_tumbling_stream
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, VALUE BIGINT> NOT NULL
+CSAS_S2_0.S2 = STRUCT<ID BIGINT, VALUE BIGINT, KEY VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/tumbling-windows_-_import_tumbling_stream_with_non-STRING_key
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/tumbling-windows_-_import_tumbling_stream_with_non-STRING_key
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CSAS_S2_0.S2 = STRUCT<ID BIGINT, WSTART BIGINT, WEND BIGINT, KEY INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: S2)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/tumbling-windows_-_max_tumbling
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/tumbling-windows_-_max_tumbling
@@ -1,0 +1,78 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/tumbling-windows_-_min_tumbling
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/tumbling-windows_-_min_tumbling
@@ -1,0 +1,78 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, KSQL_COL_1 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/tumbling-windows_-_topk_tumbling
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/tumbling-windows_-_topk_tumbling
@@ -1,0 +1,78 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE DOUBLE> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DOUBLE, KSQL_INTERNAL_COL_2 INT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DOUBLE, KSQL_AGG_VARIABLE_0 ARRAY<DOUBLE>> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, TOPK ARRAY<DOUBLE>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/tumbling-windows_-_topkdistinct_tumbling
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/tumbling-windows_-_topkdistinct_tumbling
@@ -1,0 +1,78 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT, NAME VARCHAR, VALUE DOUBLE> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DOUBLE, KSQL_INTERNAL_COL_2 INT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 DOUBLE, KSQL_AGG_VARIABLE_0 ARRAY<DOUBLE>> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, TOPK ARRAY<DOUBLE>> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/udf-implicit-cast_-_choose_the_exact_match_first
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/udf-implicit-cast_-_choose_the_exact_match_first
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<ID INT> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<ID INT, FOO VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/udf-implicit-cast_-_decimal_field_-__double
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/udf-implicit-cast_-_decimal_field_-__double
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_DISTANCE_STREAM_0.KsqlTopic.Source = STRUCT<ID BIGINT, LAT1 DOUBLE, LON1 DOUBLE, LAT2 DECIMAL(3, 1)> NOT NULL
+CSAS_DISTANCE_STREAM_0.DISTANCE_STREAM = STRUCT<ID BIGINT, CALCULATED_DISTANCE DOUBLE> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: DISTANCE_STREAM)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/udf-implicit-cast_-_decimal_literal_-__double
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/udf-implicit-cast_-_decimal_literal_-__double
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_DISTANCE_STREAM_0.KsqlTopic.Source = STRUCT<ID BIGINT, LAT1 DOUBLE, LON1 DOUBLE> NOT NULL
+CSAS_DISTANCE_STREAM_0.DISTANCE_STREAM = STRUCT<ID BIGINT, CALCULATED_DISTANCE DOUBLE> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: DISTANCE_STREAM)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/udf-implicit-cast_-_int_field_-__double
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/udf-implicit-cast_-_int_field_-__double
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_DISTANCE_STREAM_0.KsqlTopic.Source = STRUCT<ID BIGINT, LAT1 DOUBLE, LON1 DOUBLE, LAT2 INT> NOT NULL
+CSAS_DISTANCE_STREAM_0.DISTANCE_STREAM = STRUCT<ID BIGINT, CALCULATED_DISTANCE DOUBLE> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: DISTANCE_STREAM)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/udf-implicit-cast_-_int_literal_-__double
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/udf-implicit-cast_-_int_literal_-__double
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_DISTANCE_STREAM_0.KsqlTopic.Source = STRUCT<ID BIGINT, LAT1 DOUBLE, LON1 DOUBLE> NOT NULL
+CSAS_DISTANCE_STREAM_0.DISTANCE_STREAM = STRUCT<ID BIGINT, CALCULATED_DISTANCE DOUBLE> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: DISTANCE_STREAM)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/udf-implicit-cast_-_long_field_-__double
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/udf-implicit-cast_-_long_field_-__double
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_DISTANCE_STREAM_0.KsqlTopic.Source = STRUCT<ID BIGINT, LAT1 DOUBLE, LON1 DOUBLE, LAT2 BIGINT> NOT NULL
+CSAS_DISTANCE_STREAM_0.DISTANCE_STREAM = STRUCT<ID BIGINT, CALCULATED_DISTANCE DOUBLE> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: DISTANCE_STREAM)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/url_-_chain_a_call_to_URL_EXTRACT_PARAMETER_with_URL_DECODE_PARAM
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/url_-_chain_a_call_to_URL_EXTRACT_PARAMETER_with_URL_DECODE_PARAM
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<URL VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<PARAM VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/url_-_decode_a_url_parameter_using_DECODE_URL_PARAM
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/url_-_decode_a_url_parameter_using_DECODE_URL_PARAM
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<URL VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<DECODED VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/url_-_encode_a_url_parameter_using_ENCODE_URL_PARAM
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/url_-_encode_a_url_parameter_using_ENCODE_URL_PARAM
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<URL VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<ENCODED VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/url_-_extract_a_fragment_from_a_URL_using_URL_EXTRACT_FRAGMENT
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/url_-_extract_a_fragment_from_a_URL_using_URL_EXTRACT_FRAGMENT
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<URL VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<FRAGMENT VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/url_-_extract_a_host_from_a_URL_using_URL_EXTRACT_HOST
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/url_-_extract_a_host_from_a_URL_using_URL_EXTRACT_HOST
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<URL VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<HOST VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/url_-_extract_a_parameter_from_a_URL_using_URL_EXTRACT_PARAMETER
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/url_-_extract_a_parameter_from_a_URL_using_URL_EXTRACT_PARAMETER
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<URL VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<PARAM_A VARCHAR, PARAM_B VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/url_-_extract_a_path_from_a_URL_using_URL_EXTRACT_PATH
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/url_-_extract_a_path_from_a_URL_using_URL_EXTRACT_PATH
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<URL VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<PATH VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/url_-_extract_a_port_from_a_URL_using_URL_EXTRACT_PORT
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/url_-_extract_a_port_from_a_URL_using_URL_EXTRACT_PORT
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<URL VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<PORT INT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/url_-_extract_a_protocol_from_a_URL_using_URL_EXTRACT_PROTOCOL
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/url_-_extract_a_protocol_from_a_URL_using_URL_EXTRACT_PROTOCOL
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<URL VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<PROTOCOL VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/url_-_extract_a_query_from_a_URL_using_URL_EXTRACT_QUERY
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/url_-_extract_a_query_from_a_URL_using_URL_EXTRACT_QUERY
@@ -1,0 +1,61 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_OUTPUT_0.KsqlTopic.Source = STRUCT<URL VARCHAR> NOT NULL
+CSAS_OUTPUT_0.OUTPUT = STRUCT<Q VARCHAR> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/window-bounds_-_in_expressions
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/window-bounds_-_in_expressions
@@ -1,0 +1,78 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, KSQL_COL_1 BIGINT, KSQL_COL_2 BIGINT, COUNT BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/window-bounds_-_table_hopping
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/window-bounds_-_table_hopping
@@ -1,0 +1,78 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, WSTART BIGINT, WEND BIGINT, COUNT BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/window-bounds_-_table_session
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/window-bounds_-_table_session
@@ -1,0 +1,78 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, WSTART BIGINT, WEND BIGINT, COUNT BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/window-bounds_-_table_tumbling
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/window-bounds_-_table_tumbling
@@ -1,0 +1,78 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<ID BIGINT> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_S2_0.S2 = STRUCT<ID BIGINT, WSTART BIGINT, WEND BIGINT, COUNT BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/window-bounds_-_windowed_group_by_-_non-aggregate_window_bounds_in_SELECT
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/window-bounds_-_windowed_group_by_-_non-aggregate_window_bounds_in_SELECT
@@ -1,0 +1,78 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_OUTPUT_0.KsqlTopic.Source = STRUCT<IGNORED INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_OUTPUT_0.OUTPUT = STRUCT<COUNT BIGINT, WSTART BIGINT, WEND BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/window-bounds_-_windowed_group_by_-_window_bounds_used_in_expression_with_aggregate_in_SELECT
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_7_0/window-bounds_-_windowed_group_by_-_window_bounds_used_in_expression_with_aggregate_in_SELECT
@@ -1,0 +1,78 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.security.extension.class" : null,
+  "ksql.transient.prefix" : "transient_",
+  "ksql.persistence.wrap.single.values" : "true",
+  "ksql.authorization.cache.expiry.time.secs" : "30",
+  "ksql.schema.registry.url" : "",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.query.pull.enable.standby.reads" : "false",
+  "ksql.connect.url" : "http://localhost:8083",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.internal.topic.min.insync.replicas" : "1",
+  "ksql.streams.shutdown.timeout.ms" : "300000",
+  "ksql.new.api.enabled" : "false",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.insert.into.values.enabled" : "true",
+  "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.access.validator.enable" : "auto",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.metric.reporters" : "",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.metrics.extension" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.execution.plan.enable" : "false",
+  "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+  "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.authorization.cache.max.entries" : "10000",
+  "ksql.metrics.tags.custom" : "",
+  "ksql.pull.queries.enable" : "true",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.connect.worker.config" : "",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CTAS_S2_0.KsqlTopic.Source = STRUCT<IGNORED INT> NOT NULL
+CTAS_S2_0.Aggregate.GroupBy = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 INT> NOT NULL
+CTAS_S2_0.Aggregate.Aggregate.Materialize = STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL
+CTAS_S2_0.S2 = STRUCT<KSQL_COL_0 BIGINT> NOT NULL
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/joins.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/joins.json
@@ -1738,15 +1738,16 @@
     {
       "name": "stream stream join - contains CAST",
       "statements": [
-        "CREATE STREAM TEST1 (ID bigint) WITH (kafka_topic='left_topic', value_format='JSON');",
-        "CREATE STREAM TEST2 (ID int) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE STREAM TEST1 (ROWKEY bigint KEY, ID bigint) WITH (kafka_topic='left_topic', value_format='JSON', key='ID');",
+        "CREATE STREAM TEST2 (ROWKEY int KEY, ID int) WITH (kafka_topic='right_topic', value_format='JSON', key='ID');",
         "CREATE STREAM OUTPUT as SELECT t.ID FROM test1 t JOIN test2 tt WITHIN 30 seconds ON t.id = CAST(tt.id AS BIGINT);"
       ],
       "inputs": [
-        {"topic": "left_topic", "value": {"id": 1}, "timestamp": 10},
-        {"topic": "right_topic", "value": {"id": 1}, "timestamp": 10}
+        {"topic": "left_topic", "key": 1, "value": {"id": 1}, "timestamp": 10},
+        {"topic": "right_topic", "key": 1, "value": {"id": 1}, "timestamp": 10}
       ],
       "outputs": [
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-right-repartition", "key": 1, "value": {"TT_ID": 1, "TT_ROWTIME": 10, "TT_ROWKEY": 1}, "timestamp": 10},
         {"topic": "OUTPUT", "key": 1, "value": {"T_ID": 1}, "timestamp": 10}
       ]
     },


### PR DESCRIPTION
### Description 

Add expected topologies files for the 0.7.0 release. 

Built off commit d9aabf358f8e6b3c73e6f518fdc667b59cd6bb12

Note: the commit also includes a slight change to `joins.json`, which is just there to test that joins on expressions force repartition of the data.

### Testing done 

Test only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

