### PR TITLE
docs: copy new serialization content to 5.5.x branch (DOCS-3399)

### DIFF
--- a/docs-md/concepts/schemas.md
+++ b/docs-md/concepts/schemas.md
@@ -1,17 +1,189 @@
 ---
 layout: page
 title: Schemas in ksqlDB
-tagline: Use schemas in your queries 
+tagline: Defining the structure of your data
 description: Learn how schemas work with ksqlDB
 keywords: ksqldb, schema, evolution, avro
 ---
 
+Data sources like streams and tables have an associated schema. This schema defines the columns
+available in the data, just like a the columns in a traditional SQL database table.
+
+## Key vs Value columns
+
+KsqlDB supports both key and value columns. These map to the data held in the keys and values of the
+underlying {{ site.ak }} topic.
+
+A column is defined by a combination of its [name](#valid-identifiers), its [SQL data type](#sql-data-type),
+and possibly a namespace.
+
+Key columns have a `KEY` namespace suffix. Key columns have the following restrictions:
+  * The can only be a single key column, currently.
+  * The key column must be named `ROWKEY` in the KSQL schema.
+
+Value columns have no namespace suffix. There can be one or more value columns amd the value columns
+can have any name.
+
+For example, the following declares a schema with a single `INT` key column and several value
+columns:
+
+```sql
+ROWKEY INT KEY, ID BIGINT, STRING NAME, ADDRESS ADDRESS_TYPE
+```
+
+## Valid Identifiers
+
+Column and field names must be valid identifiers.
+
+Unquoted identifiers will be treated as upper-case, for example `col0` is equivalent to `COL0`, and
+must contain only alpha-numeric and underscore characters.
+
+Identifiers containing invalid character, or where case needs to be preserved, can be quoted using
+back-tick quotes, for example ``col0``.
+
+## SQL data types
+
+The following SQL types are supported by ksqlDB:
+
+ * [Primitive types](#primitive-types)
+ * [Decimal type](#decimal-type)
+ * [Array type](#array-type)
+ * [Map type](#map-type)
+ * [Struct type](#struct-type)
+ * [Custom types](#custom-types)
+
+### Primitive types
+
+Supported primitive types are:
+
+  * `BOOLEAN`: a binary value
+  * `INT`: 32-bit signed integer
+  * `BIGINT`: 64-bit signed integer
+  * `DOUBLE`: double precision (64-bit) IEEE 754 floating-point number
+  * `STRING`: a unicode character sequence (UTF8)
+
+### Decimal type
+
+The `DECIMAL` type can store numbers with a very large number of digits and perform calculations exactly.
+It is recommended for storing monetary amounts and other quantities where exactness is required.
+However, arithmetic on decimals is slow compared to integer and floating point types.
+
+`DECIMAL` types have a _precision_ and _scale_.
+The scale is the number of digits in the fractional part, to the right of the decimal point.
+The precision is the total number of significant digits in the whole number, that is,
+the number of digits on both sides of the decimal point.
+For example, the number `765.937500` has a precision of 9 and a scale of 6.
+
+To declare a column of type `DECIMAL` use the syntax:
+
+```sql
+DECIMAL(precision, scale)
+```
+
+The precision must be positive, the scale zero or positive.
+
+### Array type
+
+The `ARRAY` type defines a variable-length array of elements. All elements in the array must be of
+the same type.
+
+To declare an `ARRAY` use the syntax:
+
+```
+ARRAY<element-type>
+```
+
+The _element-type_ of an another [SQL data type](#sql-data-types).
+
+For example, the following creates an array of `STRING`s:
+
+```sql
+ARRAY<STRING>
+```
+
+Instances of an array can be created using the syntax:
+
+```
+ARRAY[value [, value]*]
+```
+
+For example, the following creates an array with three `INT` elements:
+
+```sql
+ARRAY[2, 4, 6]
+```
+
+### Map type
+
+The `MAP` type defines a variable-length collection of key-value pairs. All keys in the map must be
+of the same type. All values in the map must be of the same type.
+
+To declare a `MAP` use the syntax:
+
+```
+MAP<key-type, element-type>
+```
+
+The _key-type_ must currently be `STRING` while the _value-type_ can an any other [SQL data type](#sql-data-types).
+
+For example, the following creates a map with `STRING` keys and values:
+
+```sql
+MAP<STRING, STRING>
+```
+
+Instances of a map can be created using the syntax:
+
+```
+MAP(key := value [, key := value]*)
+```
+
+For example, the following creates a map with three key-value pairs:
+
+```sql
+MAP('a' := 1, 'b' := 2, 'c' := 3)
+```
+
+### Struct type
+
+The `STRUCT` type defines a list of named fields, where each field can have any [SQL data type](#sql-data-types).
+
+To declare a `STRUCT` use the syntax:
+
+```
+STRUCT<field-name field-type [, field-name field-type]*>
+```
+
+The _field-name_ can be any [valid identifier](#valid-identifiers). The _field-type_ can be any
+valid [SQL data type](#sql-data-types).
+
+For example, the following creates a struct with an `INT` field called `FOO` and a `BOOLEAN` field
+call `BAR`:
+
+```sql
+STRUCT<FOO INT, BAR BOOLEAN>
+```
+
+Instances of a struct can be created using the syntax:
+
+```
+STRUCT(field-name := field-value [, field-name := field-value]*)
+```
+
+For example, the following creates a struct with fields called `FOO` and `BAR` and sets their values
+to `10` and `true`, respectively:
+
+```sql
+STRUCT('FOO' := 10, 'BAR' := true)
+```
+
+### Custom types
+
+KsqlDB supports custom types using the `CREATE TYPE` statements.
+See the [`CREATE TYPE` docs](../developer-guide/ksqldb-reference/create-type) for more information.
+
 TODO:
 
-- overview of how schemas work in ksqlDB
-- overview of data types
-- overview of serialization
 - schema evolution with ksqlDB and Avro
-
 
 Page last revised on: {{ git_revision_date }}

--- a/docs-md/concepts/schemas.md
+++ b/docs-md/concepts/schemas.md
@@ -186,4 +186,5 @@ TODO:
 
 - schema evolution with ksqlDB and Avro
 
+
 Page last revised on: {{ git_revision_date }}

--- a/docs-md/developer-guide/joins/partition-data.md
+++ b/docs-md/developer-guide/joins/partition-data.md
@@ -48,7 +48,7 @@ the resulting table is determined as follows:
     - When grouping by a single column or expression, the type of `ROWKEY` in the
     resulting stream matches the type of the column or expression.
     - When grouping by multiple columns or expressions, the type of `ROWKEY` in the
-    resulting stream is a `STRING`.
+    resulting stream is an [SQL `STRING`](../../concepts/schemas).
 - If the FROM clause contains only tables and no GROUP BY clause, the key is
   copied over from the key of the table(s) in the FROM clause.
 - If the FROM clause contains only tables and has a GROUP BY clause, the
@@ -56,7 +56,7 @@ the resulting table is determined as follows:
     - When grouping by a single column or expression, the type of `ROWKEY` in the
     resulting stream matches the type of the column or expression.
     - When grouping by multiple columns or expressions, the type of `ROWKEY` in the
-    resulting stream is a `STRING`.
+    resulting stream is an [SQL `STRING`](../../concepts/schemas).
 
 The following example shows a `users` table joined with a `clicks` stream
 on the `userId` column. The `users` table has the correct primary key
@@ -105,8 +105,8 @@ processing.
 
 For a join to work, the keys from both sides must have the same SQL type.
 
-For example, you can join a stream of user clicks that's keyed on a `VARCHAR`
-user id with a table of user profiles that's also keyed on a `VARCHAR` user id.
+For example, you can join a stream of user clicks that's keyed on a `STRING`
+user id with a table of user profiles that's also keyed on a `STRING` user id.
 Records with the exact same user id on both sides will be joined.
 
 If the schema of the columns you wish to join on don't match, it may be possible

--- a/docs-md/developer-guide/ksqldb-reference/print.md
+++ b/docs-md/developer-guide/ksqldb-reference/print.md
@@ -21,6 +21,9 @@ Description
 
 Print the contents of Kafka topics to the ksqlDB CLI.
 
+The _topicName_ is case sensitive. Quote the name if it contains invalid characters.
+See [Valid Identifiers](../../concepts/schemas#valid-identifiers) for more information.
+
 The PRINT statement supports the following properties:
 
 |     Property      |                                                   Description                                                    |
@@ -33,11 +36,21 @@ Example
 -------
 
 The following statement shows how to print all of the records in a topic named
-`ksql__commands`.
+`_confluent-ksql-default__command_topic`, (the default name for the topic ksqlDB stores your submitted command in).
+Note, the topic name has been quoted as it contains the invalid dash character.
 
 ```sql
-PRINT ksql__commands FROM BEGINNING;
+PRINT '_confluent-ksql-default__command_topic' FROM BEGINNING;
 ```
+
+ksqlDB attempts to determine the format of the data in the topic and outputs what it thinks are
+the key and value formats at the top of the output.
+
+!!! note
+   Attempting to determine a data format from only the serialized bytes is not an exact science!
+   For example, it is not possible to distinguish between serialized `BIGINT` and `DOUBLE` values,
+   because they both occupy eight bytes. Short strings can also be mistaken for serialized numbers.
+   Where it appears different records are using different formats ksqlDB will state the format is `MIXED`.
 
 Your output should resemble:
 

--- a/docs-md/developer-guide/ksqldb-reference/select-push-query.md
+++ b/docs-md/developer-guide/ksqldb-reference/select-push-query.md
@@ -48,7 +48,7 @@ In the previous statements, `from_item` is one of the following:
 -   `from_item LEFT JOIN from_item ON join_condition`
 
 The WHERE clause can refer to any column defined for a stream or table,
-including the system columns `ROWTIME` and `ROWKEY`.
+including the `ROWTIME` and `ROWKEY` system columns.
 
 Example
 -------
@@ -114,7 +114,7 @@ or joins. Windows are tracked per record key.
 Windowing adds two additional system columns to the data, which provide
 the window bounds: `WINDOWSTART` and `WINDOWEND`.
 
-KsqlDB supports the following WINDOW types.
+ksqlDB supports the following WINDOW types:
 
 **TUMBLING**: Tumbling windows group input records into fixed-sized,
 non-overlapping windows based on the records' timestamps. You must


### PR DESCRIPTION
This PR copies over the new serialization content from PR #4478 that belongs in v0.7.0 docs, which are published out of the `5.5.x` branch (for tools support). The content that hasn't been copied stays in `master` and will be published in v0.8.0.