### PR TITLE
test: fix flaky insert API tests (MINOR)

### DIFF
--- a/ksql-api/src/test/java/io/confluent/ksql/api/ApiTest.java
+++ b/ksql-api/src/test/java/io/confluent/ksql/api/ApiTest.java
@@ -486,7 +486,7 @@ public class ApiTest {
     assertThat(response.statusCode(), is(200));
     assertThat(response.statusMessage(), is("OK"));
     assertThatEventually(() -> testEndpoints.getInsertsSubscriber().getRowsInserted(), is(rows));
-    assertThat(testEndpoints.getInsertsSubscriber().isCompleted(), is(true));
+    assertThatEventually(() -> testEndpoints.getInsertsSubscriber().isCompleted(), is(true));
     assertThat(testEndpoints.getLastTarget(), is("test-stream"));
   }
 
@@ -511,7 +511,7 @@ public class ApiTest {
     String responseBody = response.bodyAsString();
     InsertsResponse insertsResponse = new InsertsResponse(responseBody);
     assertThat(insertsResponse.acks, hasSize(rows.size()));
-    assertThat(testEndpoints.getInsertsSubscriber().getRowsInserted(), is(rows));
+    assertThatEventually(() -> testEndpoints.getInsertsSubscriber().getRowsInserted(), is(rows));
     assertThatEventually(() -> testEndpoints.getInsertsSubscriber().isCompleted(), is(true));
     assertThat(testEndpoints.getLastTarget(), is("test-stream"));
   }
@@ -563,8 +563,9 @@ public class ApiTest {
     assertThat(insertsResponse.acks, hasSize(rows.size()));
 
     // Make sure all inserts made it to the server
-    assertThat(testEndpoints.getInsertsSubscriber().getRowsInserted(), is(rows));
-    assertThat(testEndpoints.getInsertsSubscriber().isCompleted(), is(true));
+    TestInsertsSubscriber insertsSubscriber = testEndpoints.getInsertsSubscriber();
+    assertThatEventually(insertsSubscriber::getRowsInserted, is(rows));
+    assertThatEventually(insertsSubscriber::isCompleted, is(true));
 
     // Ensure we received at least some of the response before all the request body was written
     // Yay HTTP2!


### PR DESCRIPTION
### Description 

We saw a flaky failure of `ApiTest#shouldStreamInserts()` at the following assertion: https://github.com/confluentinc/ksql/blob/75bf29aa5582849f229d8effad87e5fa8362993f/ksql-api/src/test/java/io/confluent/ksql/api/ApiTest.java#L552

This PR attempts to fix the flakiness by switching to `assertThatEventually`, since `InsertSubscriber` methods are async. The corresponding changes are made in a couple other tests as well.

### Testing done 

Will wait to get a clean build once Jenkins is unblocked.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

