### PR TITLE
chore: update contributing test command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ drop the `-daemon` switch, and start the CLI in a second console.
 To build and test changes locally, run the following commands:
 
 ```shell
-$ mvn clean install checkstyle:check integration-test
+$ mvn clean checkstyle:check integration-test
 ```
 
 ### Testing docker image


### PR DESCRIPTION
### Description 
The command we instruct contributors to use for testing local builds fails as of 2559b2fd, which added the `ksql-docker` project.

`mvn clean install checkstyle:check integration-test`

This fails with:
`Failed to execute goal org.apache.maven.plugins:maven-jar-plugin:3.0.2:jar (default-jar) on project ksql-docker: You have to use a classifier to attach supplemental artifacts to the project instead of replacing them`

[The below is copied from a similar change in an internal project]

I believe there are two factors leading to the error. The first is addressed by this PR. The second, related factor explains why the command was working until the `ksql-docker `project was added.

#### Factor 1
Including both the `install` and `integration-test` commands causes the `package` phase to execute twice. This happens because `install` and `integration-test` execute all dependent phases in the maven lifecycle, including package. There is no deduplication between the two implicit calls to package.

#### Factor 2
The `ksql-docker` project has no sources, i.e. src/main is empty. This is fine if the package phase is run once: Maven warns `[WARNING] JAR will be empty - no content was marked for inclusion!`. I assume Maven also generates and inserts an empty marker in place of the artifact.

But, when the package phase runs a second time as part of `integration-test`, it seems that Maven creates a fresh empty marker. Then, when it compares the empty marker with the second, redundant package phase with the first package phase, the empty markers don't match, throwing the error above because Maven thinks you're trying to insert two different artifacts at the same coordinates.

On the other hand, when there are sources, I assume the duplicate artifacts are compared based on a content hash, allowing the build to continue without exception because the hashes match for non-empty artifacts. This is why it was working before the addition of `ksql-docker`.


The fix is simply to elide the extra `install` phase.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

