### PR TITLE
refactor: add SessionProperties to executors

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
@@ -34,6 +34,7 @@ import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.parser.tree.InsertValues;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.DefaultSqlValueCoercer;
 import io.confluent.ksql.schema.ksql.FormatOptions;
@@ -141,7 +142,7 @@ public class InsertValuesExecutor {
 
   public void execute(
       final ConfiguredStatement<InsertValues> statement,
-      final Map<String, ?> sessionProperties,
+      final SessionProperties sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
@@ -51,6 +51,7 @@ import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.InsertValues;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
@@ -191,7 +192,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct("str"));
@@ -210,7 +211,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct("new"));
@@ -233,7 +234,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct("new"));
@@ -254,7 +255,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct("str"));
@@ -275,7 +276,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct("str"));
@@ -295,7 +296,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct("str"));
@@ -316,7 +317,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct("str"));
@@ -335,7 +336,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct("str"));
@@ -355,7 +356,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct("str"));
@@ -375,7 +376,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct("str"));
@@ -394,7 +395,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct("str"));
@@ -422,7 +423,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct("str"));
@@ -448,7 +449,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct("str"));
@@ -470,7 +471,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
 
     // Then:
     verify(valueSerializer).serialize(TOPIC_NAME, genericRow("oo"));
@@ -497,7 +498,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
 
     // Then:
     verify(valueSerializer).serialize(TOPIC_NAME, genericRow("o"));
@@ -518,7 +519,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct("str"));
@@ -553,7 +554,7 @@ public class InsertValuesExecutorTest {
         "Cannot insert values into read-only topic: _confluent-ksql-default__command-topic");
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
   }
 
   @Test
@@ -583,7 +584,7 @@ public class InsertValuesExecutorTest {
         "Cannot insert values into read-only topic: default_ksql_processing_log");
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
   }
 
   @Test
@@ -608,7 +609,7 @@ public class InsertValuesExecutorTest {
     expectedException.expectMessage("Failed to insert values into ");
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
   }
 
   @Test
@@ -629,7 +630,7 @@ public class InsertValuesExecutorTest {
     expectedException.expectCause(hasMessage(containsString("Could not serialize key")));
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
   }
 
   @Test
@@ -651,7 +652,7 @@ public class InsertValuesExecutorTest {
     expectedException.expectCause(hasMessage(containsString("Could not serialize row")));
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
   }
 
   @Test
@@ -675,7 +676,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
   }
 
   @Test
@@ -693,7 +694,7 @@ public class InsertValuesExecutorTest {
     expectedException.expectCause(hasMessage(containsString("Expected ROWKEY and COL0 to match")));
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
   }
 
   @Test
@@ -710,7 +711,7 @@ public class InsertValuesExecutorTest {
     expectedException.expectCause(hasMessage(containsString("Expected a value for each column")));
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
   }
 
   @Test
@@ -730,7 +731,7 @@ public class InsertValuesExecutorTest {
     expectedException.expectCause(hasMessage(containsString("Expected type INTEGER for field")));
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
   }
 
   @Test
@@ -747,7 +748,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct("key"));
@@ -769,7 +770,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct("key"));
@@ -790,7 +791,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct(null));
@@ -816,7 +817,7 @@ public class InsertValuesExecutorTest {
         "Failed to insert values into 'TOPIC'. Value for ROWKEY is required for tables");
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
  }
 
   @Test
@@ -836,7 +837,7 @@ public class InsertValuesExecutorTest {
         "Failed to insert values into 'TOPIC'. Value for ROWKEY is required for tables");
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
   }
 
   @Test
@@ -851,7 +852,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
 
     // Then:
     verify(keySerdeFactory).create(

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/HeartbeatAgent.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/HeartbeatAgent.java
@@ -27,6 +27,7 @@ import io.confluent.ksql.rest.util.DiscoverRemoteHostsUtil;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.HostStatus;
 import io.confluent.ksql.util.KsqlHostInfo;
+import io.confluent.ksql.util.PersistentQueryMetadata;
 import java.net.URI;
 import java.net.URL;
 import java.time.Clock;
@@ -42,8 +43,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
-import io.confluent.ksql.util.PersistentQueryMetadata;
 import org.apache.kafka.streams.state.HostInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ConnectExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ConnectExecutor.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Maps;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.connect.supported.Connectors;
 import io.confluent.ksql.parser.tree.CreateConnector;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.CreateConnectorEntity;
 import io.confluent.ksql.rest.entity.ErrorEntity;
 import io.confluent.ksql.rest.entity.KsqlEntity;
@@ -26,7 +27,6 @@ import io.confluent.ksql.services.ConnectClient;
 import io.confluent.ksql.services.ConnectClient.ConnectResponse;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
-import java.util.Map;
 import java.util.Optional;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
 
@@ -36,7 +36,7 @@ public final class ConnectExecutor {
 
   public static Optional<KsqlEntity> execute(
       final ConfiguredStatement<CreateConnector> statement,
-      final Map<String, ?> sessionProperties,
+      final SessionProperties sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/CustomExecutors.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/CustomExecutors.java
@@ -36,6 +36,7 @@ import io.confluent.ksql.parser.tree.SetProperty;
 import io.confluent.ksql.parser.tree.ShowColumns;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.UnsetProperty;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
@@ -104,11 +105,11 @@ public enum CustomExecutors {
 
   public Optional<KsqlEntity> execute(
       final ConfiguredStatement<?> statement,
-      final Map<String, Object> mutableScopedProperties,
+      final SessionProperties sessionProperties,
       final KsqlExecutionContext executionCtx,
       final ServiceContext serviceCtx
   ) {
-    return executor.execute(statement, mutableScopedProperties, executionCtx, serviceCtx);
+    return executor.execute(statement, sessionProperties, executionCtx, serviceCtx);
   }
 
   private static StatementExecutor insertValuesExecutor() {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutor.java
@@ -21,6 +21,7 @@ import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.connect.Connector;
 import io.confluent.ksql.connect.supported.Connectors;
 import io.confluent.ksql.parser.tree.DescribeConnector;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.ConnectorDescription;
 import io.confluent.ksql.rest.entity.ErrorEntity;
 import io.confluent.ksql.rest.entity.KsqlEntity;
@@ -31,7 +32,6 @@ import io.confluent.ksql.services.ConnectClient.ConnectResponse;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -61,7 +61,7 @@ public final class DescribeConnectorExecutor {
   @SuppressWarnings("OptionalGetWithoutIsPresent")
   public Optional<KsqlEntity> execute(
       final ConfiguredStatement<DescribeConnector> configuredStatement,
-      final Map<String, ?> sessionProperties,
+      final SessionProperties sessionProperties,
       final KsqlExecutionContext ksqlExecutionContext,
       final ServiceContext serviceContext
   ) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeFunctionExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeFunctionExecutor.java
@@ -26,6 +26,7 @@ import io.confluent.ksql.function.types.ParamType;
 import io.confluent.ksql.function.udf.UdfMetadata;
 import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.parser.tree.DescribeFunction;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.ArgumentInfo;
 import io.confluent.ksql.rest.entity.FunctionDescriptionList;
 import io.confluent.ksql.rest.entity.FunctionInfo;
@@ -37,7 +38,6 @@ import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.IdentifierUtil;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 public final class DescribeFunctionExecutor {
@@ -49,7 +49,7 @@ public final class DescribeFunctionExecutor {
 
   public static Optional<KsqlEntity> execute(
       final ConfiguredStatement<DescribeFunction> statement,
-      final Map<String, ?> sessionProperties,
+      final SessionProperties sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DropConnectorExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DropConnectorExecutor.java
@@ -17,13 +17,13 @@ package io.confluent.ksql.rest.server.execution;
 
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.parser.tree.DropConnector;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.DropConnectorEntity;
 import io.confluent.ksql.rest.entity.ErrorEntity;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.services.ConnectClient.ConnectResponse;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
-import java.util.Map;
 import java.util.Optional;
 
 public final class DropConnectorExecutor {
@@ -32,7 +32,7 @@ public final class DropConnectorExecutor {
 
   public static Optional<KsqlEntity> execute(
       final ConfiguredStatement<DropConnector> statement,
-      final Map<String, ?> sessionProperties,
+      final SessionProperties sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ExplainExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ExplainExecutor.java
@@ -22,6 +22,7 @@ import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.QueryContainer;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.QueryDescription;
 import io.confluent.ksql.rest.entity.QueryDescriptionEntity;
@@ -32,7 +33,6 @@ import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
-import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -45,7 +45,7 @@ public final class ExplainExecutor {
 
   public static Optional<KsqlEntity> execute(
       final ConfiguredStatement<Explain> statement,
-      final Map<String, ?> sessionProperties,
+      final SessionProperties sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListConnectorsExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListConnectorsExecutor.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.rest.server.execution;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.parser.tree.ListConnectors;
 import io.confluent.ksql.parser.tree.ListConnectors.Scope;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.ConnectorList;
 import io.confluent.ksql.rest.entity.ErrorEntity;
 import io.confluent.ksql.rest.entity.KsqlEntity;
@@ -29,7 +30,6 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import org.apache.kafka.connect.runtime.AbstractStatus.State;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
@@ -45,7 +45,7 @@ public final class ListConnectorsExecutor {
   @SuppressWarnings("OptionalGetWithoutIsPresent")
   public static Optional<KsqlEntity> execute(
       final ConfiguredStatement<ListConnectors> configuredStatement,
-      final Map<String, ?> sessionProperties,
+      final SessionProperties sessionProperties,
       final KsqlExecutionContext ksqlExecutionContext,
       final ServiceContext serviceContext
   ) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListFunctionsExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListFunctionsExecutor.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.rest.server.execution;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.parser.tree.ListFunctions;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.FunctionNameList;
 import io.confluent.ksql.rest.entity.FunctionType;
 import io.confluent.ksql.rest.entity.KsqlEntity;
@@ -25,7 +26,6 @@ import io.confluent.ksql.rest.entity.SimpleFunctionInfo;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -35,7 +35,7 @@ public final class ListFunctionsExecutor {
 
   public static Optional<KsqlEntity> execute(
       final ConfiguredStatement<ListFunctions> statement,
-      final Map<String, ?> sessionProperties,
+      final SessionProperties sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutor.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.rest.server.execution;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.config.KsqlConfigResolver;
 import io.confluent.ksql.parser.tree.ListProperties;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.PropertiesList;
 import io.confluent.ksql.rest.entity.PropertiesList.Property;
@@ -41,7 +42,7 @@ public final class ListPropertiesExecutor {
 
   public static Optional<KsqlEntity> execute(
       final ConfiguredStatement<ListProperties> statement,
-      final Map<String, ?> sessionProperties,
+      final SessionProperties sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutor.java
@@ -18,13 +18,13 @@ package io.confluent.ksql.rest.server.execution;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.parser.tree.ListQueries;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.QueryDescriptionFactory;
 import io.confluent.ksql.rest.entity.QueryDescriptionList;
 import io.confluent.ksql.rest.entity.RunningQuery;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -34,7 +34,7 @@ public final class ListQueriesExecutor {
 
   public static Optional<KsqlEntity> execute(
       final ConfiguredStatement<ListQueries> statement,
-      final Map<String, ?> sessionProperties,
+      final SessionProperties sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {
@@ -52,12 +52,12 @@ public final class ListQueriesExecutor {
         executionContext.getPersistentQueries()
             .stream()
             .map(q -> new RunningQuery(
-                    q.getStatementString(),
-                    ImmutableSet.of(q.getSinkName().name()),
-                    ImmutableSet.of(q.getResultTopic().getKafkaTopicName()),
-                    q.getQueryId(),
-                    Optional.of(q.getState())
-                ))
+                q.getStatementString(),
+                ImmutableSet.of(q.getSinkName().name()),
+                ImmutableSet.of(q.getResultTopic().getKafkaTopicName()),
+                q.getQueryId(),
+                Optional.of(q.getState())
+            ))
             .collect(Collectors.toList())));
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
@@ -25,6 +25,7 @@ import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.tree.ListStreams;
 import io.confluent.ksql.parser.tree.ListTables;
 import io.confluent.ksql.parser.tree.ShowColumns;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.KsqlWarning;
 import io.confluent.ksql.rest.entity.RunningQuery;
@@ -43,7 +44,6 @@ import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -82,7 +82,7 @@ public final class ListSourceExecutor {
 
   public static Optional<KsqlEntity> streams(
       final ConfiguredStatement<ListStreams> statement,
-      final Map<String, ?> sessionProperties,
+      final SessionProperties sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {
@@ -107,7 +107,7 @@ public final class ListSourceExecutor {
 
   public static Optional<KsqlEntity> tables(
       final ConfiguredStatement<ListTables> statement,
-      final Map<String, ?> sessionProperties,
+      final SessionProperties sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {
@@ -131,7 +131,7 @@ public final class ListSourceExecutor {
 
   public static Optional<KsqlEntity> columns(
       final ConfiguredStatement<ShowColumns> statement,
-      final Map<String, ?> sessionProperties,
+      final SessionProperties sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutor.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.rest.server.execution;
 
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.parser.tree.ListTopics;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.KafkaTopicInfo;
 import io.confluent.ksql.rest.entity.KafkaTopicInfoExtended;
 import io.confluent.ksql.rest.entity.KafkaTopicsList;
@@ -52,7 +53,7 @@ public final class ListTopicsExecutor {
 
   public static Optional<KsqlEntity> execute(
       final ConfiguredStatement<ListTopics> statement,
-      final Map<String, ?> sessionProperties,
+      final SessionProperties sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListTypesExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListTypesExecutor.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.metastore.TypeRegistry.CustomType;
 import io.confluent.ksql.parser.tree.ListTypes;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.SchemaInfo;
 import io.confluent.ksql.rest.entity.TypeList;
@@ -26,7 +27,6 @@ import io.confluent.ksql.rest.util.EntityUtil;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.Optional;
 
 public final class ListTypesExecutor {
@@ -35,7 +35,7 @@ public final class ListTypesExecutor {
 
   public static Optional<KsqlEntity> execute(
       final ConfiguredStatement<ListTypes> configuredStatement,
-      final Map<String, ?> sessionProperties,
+      final SessionProperties sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PropertyExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PropertyExecutor.java
@@ -19,10 +19,10 @@ import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.parser.tree.SetProperty;
 import io.confluent.ksql.parser.tree.UnsetProperty;
 import io.confluent.ksql.properties.PropertyOverrider;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
-import java.util.Map;
 import java.util.Optional;
 
 public final class PropertyExecutor {
@@ -31,21 +31,21 @@ public final class PropertyExecutor {
 
   public static Optional<KsqlEntity> set(
       final ConfiguredStatement<SetProperty> statement,
-      final Map<String, Object> mutableScopedProperties,
+      final SessionProperties sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {
-    PropertyOverrider.set(statement, mutableScopedProperties);
+    PropertyOverrider.set(statement, sessionProperties.getMutableScopedProperties());
     return Optional.empty();
   }
 
   public static Optional<KsqlEntity> unset(
       final ConfiguredStatement<UnsetProperty> statement,
-      final Map<String, Object> mutableScopedProperties,
+      final SessionProperties sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {
-    PropertyOverrider.unset(statement, mutableScopedProperties);
+    PropertyOverrider.unset(statement, sessionProperties.getMutableScopedProperties());
     return Optional.empty();
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PullQueryExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PullQueryExecutor.java
@@ -69,6 +69,7 @@ import io.confluent.ksql.parser.tree.Select;
 import io.confluent.ksql.parser.tree.SelectItem;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.Errors;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.client.RestResponse;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.rest.entity.StreamedRow.Header;
@@ -141,7 +142,7 @@ public final class PullQueryExecutor {
 
   public static void validate(
       final ConfiguredStatement<Query> statement,
-      final Map<String, ?> sessionProperties,
+      final SessionProperties sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/RequestHandler.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/RequestHandler.java
@@ -19,13 +19,13 @@ import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.server.computation.DistributingExecutor;
 import io.confluent.ksql.security.KsqlSecurityContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -69,19 +69,18 @@ public class RequestHandler {
   public KsqlEntityList execute(
       final KsqlSecurityContext securityContext,
       final List<ParsedStatement> statements,
-      final Map<String, Object> propertyOverrides
+      final SessionProperties sessionProperties
   ) {
-    final Map<String, Object> scopedPropertyOverrides = new HashMap<>(propertyOverrides);
     final KsqlEntityList entities = new KsqlEntityList();
     for (final ParsedStatement parsed : statements) {
       final PreparedStatement<?> prepared = ksqlEngine.prepare(parsed);
       final ConfiguredStatement<?> configured = ConfiguredStatement.of(
-          prepared, scopedPropertyOverrides, ksqlConfig);
+          prepared, sessionProperties.getMutableScopedProperties(), ksqlConfig);
 
       executeStatement(
           securityContext,
           configured,
-          scopedPropertyOverrides,
+          sessionProperties,
           entities
       ).ifPresent(entities::add);
     }
@@ -92,7 +91,7 @@ public class RequestHandler {
   private <T extends Statement> Optional<KsqlEntity> executeStatement(
       final KsqlSecurityContext securityContext,
       final ConfiguredStatement<T> configured,
-      final Map<String, Object> mutableScopedProperties,
+      final SessionProperties sessionProperties,
       final KsqlEntityList entities
   ) {
     final Class<? extends Statement> statementClass = configured.getStatement().getClass();
@@ -106,7 +105,7 @@ public class RequestHandler {
 
     return executor.execute(
         configured,
-        mutableScopedProperties,
+        sessionProperties,
         ksqlEngine,
         securityContext.getServiceContext()
     );

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/StatementExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/StatementExecutor.java
@@ -17,10 +17,10 @@ package io.confluent.ksql.rest.server.execution;
 
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
-import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -33,14 +33,14 @@ public interface StatementExecutor<T extends Statement> {
    * Executes the query against the parameterized {@code ksqlEngine}.
    *
    * @param statement the statement to execute
-   * @param mutableScopedProperties the session properties
+   * @param sessionProperties the session properties
    * @param executionContext the context in which to execute it
    * @param serviceContext the services to use to execute it
    * @return the execution result, if present, else {@link Optional#empty()}
    */
   Optional<KsqlEntity> execute(
       ConfiguredStatement<T> statement,
-      Map<String, Object> mutableScopedProperties,
+      SessionProperties sessionProperties,
       KsqlExecutionContext executionContext,
       ServiceContext serviceContext
   );

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -72,7 +72,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import org.apache.commons.collections4.map.HashedMap;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.state.HostInfo;
 import org.slf4j.Logger;
@@ -168,8 +167,8 @@ public class KsqlResource implements KsqlConfigurable {
       this.localUrl = new URL(applicationServer);
     } catch (final Exception e) {
       throw new IllegalStateException("Failed to convert remote host info to URL."
-              + " remoteInfo: " + localHost.host() + ":"
-              + localHost.host());
+          + " remoteInfo: " + localHost.host() + ":"
+          + localHost.host());
     }
 
     this.validator = new RequestValidator(
@@ -217,7 +216,7 @@ public class KsqlResource implements KsqlConfigurable {
           securityContext,
           TERMINATE_CLUSTER,
               new SessionProperties(
-                  new HashedMap<>(request.getStreamsProperties()),
+                  request.getStreamsProperties(),
                   localHost,
                   localUrl
               )
@@ -251,7 +250,7 @@ public class KsqlResource implements KsqlConfigurable {
           SandboxedServiceContext.create(securityContext.getServiceContext()),
           statements,
           new SessionProperties(
-              new HashedMap<>(request.getStreamsProperties()),
+              request.getStreamsProperties(),
               localHost, 
               localUrl
           ),
@@ -262,7 +261,7 @@ public class KsqlResource implements KsqlConfigurable {
           securityContext,
           statements,
           new SessionProperties(
-              new HashedMap<>(request.getStreamsProperties()),
+              request.getStreamsProperties(),
               localHost,
               localUrl
           )

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -215,11 +215,11 @@ public class KsqlResource implements KsqlConfigurable {
       final KsqlEntityList entities = handler.execute(
           securityContext,
           TERMINATE_CLUSTER,
-              new SessionProperties(
-                  request.getStreamsProperties(),
-                  localHost,
-                  localUrl
-              )
+          new SessionProperties(
+              request.getStreamsProperties(),
+              localHost,
+              localUrl
+          )
       );
       return Response.ok(entities).build();
     } catch (final Exception e) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/CustomValidators.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/CustomValidators.java
@@ -38,6 +38,7 @@ import io.confluent.ksql.parser.tree.SetProperty;
 import io.confluent.ksql.parser.tree.ShowColumns;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.UnsetProperty;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.server.execution.DescribeConnectorExecutor;
 import io.confluent.ksql.rest.server.execution.DescribeFunctionExecutor;
 import io.confluent.ksql.rest.server.execution.ExplainExecutor;
@@ -112,9 +113,9 @@ public enum CustomValidators {
 
   public void validate(
       final ConfiguredStatement<?> statement,
-      final Map<String, Object> mutableScopedProperties,
+      final SessionProperties sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext) throws KsqlException {
-    validator.validate(statement, mutableScopedProperties, executionContext, serviceContext);
+    validator.validate(statement, sessionProperties, executionContext, serviceContext);
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/PrintTopicValidator.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/PrintTopicValidator.java
@@ -17,10 +17,10 @@ package io.confluent.ksql.rest.server.validation;
 
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.rest.Errors;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.server.resources.KsqlRestException;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
-import java.util.Map;
 
 public final class PrintTopicValidator {
 
@@ -28,7 +28,7 @@ public final class PrintTopicValidator {
 
   public static void validate(
       final ConfiguredStatement<?> statement,
-      final Map<String, ?> sessionProperties,
+      final SessionProperties sessionProperties,
       final KsqlExecutionContext context,
       final ServiceContext serviceContext) {
     throw new KsqlRestException(Errors.queryEndpoint(statement.getStatementText()));

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/RequestValidator.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/RequestValidator.java
@@ -26,6 +26,7 @@ import io.confluent.ksql.parser.tree.CreateAsSelect;
 import io.confluent.ksql.parser.tree.InsertInto;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.TerminateQuery;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.server.computation.ValidatedCommandFactory;
 import io.confluent.ksql.rest.util.QueryCapacityUtil;
 import io.confluent.ksql.services.ServiceContext;
@@ -34,7 +35,6 @@ import io.confluent.ksql.statement.Injector;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlStatementException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
@@ -80,7 +80,7 @@ public class RequestValidator {
    * Validates the messages against a snapshot in time of the KSQL engine.
    *
    * @param statements          the list of statements to validate
-   * @param propertyOverrides   a map of properties to override for this validation
+   * @param sessionProperties   session properties for this validation
    * @param sql                 the sql that generated the list of statements, used for
    *                            generating more useful debugging information
    *
@@ -93,12 +93,11 @@ public class RequestValidator {
   public int validate(
       final ServiceContext serviceContext,
       final List<ParsedStatement> statements,
-      final Map<String, Object> propertyOverrides,
+      final SessionProperties sessionProperties,
       final String sql
   ) {
     requireSandbox(serviceContext);
 
-    final Map<String, Object> scopedPropertyOverrides = new HashMap<>(propertyOverrides);
     final KsqlExecutionContext ctx = requireSandbox(snapshotSupplier.apply(serviceContext));
     final Injector injector = injectorFactory.apply(ctx, serviceContext);
 
@@ -106,10 +105,10 @@ public class RequestValidator {
     for (final ParsedStatement parsed : statements) {
       final PreparedStatement<?> prepared = ctx.prepare(parsed);
       final ConfiguredStatement<?> configured = ConfiguredStatement.of(
-          prepared, scopedPropertyOverrides, ksqlConfig);
+          prepared, sessionProperties.getMutableScopedProperties(), ksqlConfig);
 
       numPersistentQueries +=
-          validate(serviceContext, configured, scopedPropertyOverrides, ctx, injector);
+          validate(serviceContext, configured, sessionProperties, ctx, injector);
     }
 
     if (QueryCapacityUtil.exceedsPersistentQueryCapacity(ctx, ksqlConfig, numPersistentQueries)) {
@@ -128,7 +127,7 @@ public class RequestValidator {
   private <T extends Statement> int validate(
       final ServiceContext serviceContext,
       final ConfiguredStatement<T> configured,
-      final Map<String, Object> mutableScopedProperties,
+      final SessionProperties sessionProperties,
       final KsqlExecutionContext executionContext,
       final Injector injector
   ) throws KsqlStatementException  {
@@ -139,7 +138,7 @@ public class RequestValidator {
 
     if (customValidator != null) {
       customValidator
-          .validate(configured, mutableScopedProperties, executionContext, serviceContext);
+          .validate(configured, sessionProperties, executionContext, serviceContext);
     } else if (KsqlEngine.isExecutableStatement(configured.getStatement())
         || configured.getStatement() instanceof TerminateQuery) {
       final ConfiguredStatement<?> statementInjected = injector.inject(configured);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/StatementValidator.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/StatementValidator.java
@@ -17,10 +17,10 @@ package io.confluent.ksql.rest.server.validation;
 
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlException;
-import java.util.Map;
 
 /**
  * An interface that allows for arbitrary validation code of a prepared statement
@@ -43,7 +43,7 @@ public interface StatementValidator<T extends Statement> {
    */
   void validate(
       ConfiguredStatement<T> statement,
-      Map<String, Object> mutableScopedProperties,
+      SessionProperties sessionProperties,
       KsqlExecutionContext executionContext,
       ServiceContext serviceContext) throws KsqlException;
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/DiscoverRemoteHostsUtil.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/DiscoverRemoteHostsUtil.java
@@ -15,12 +15,10 @@
 
 package io.confluent.ksql.rest.util;
 
-import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.util.KsqlHostInfo;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/DiscoverRemoteHostsUtil.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/DiscoverRemoteHostsUtil.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.util;
+
+import io.confluent.ksql.engine.KsqlEngine;
+import io.confluent.ksql.util.KsqlHostInfo;
+import io.confluent.ksql.util.PersistentQueryMetadata;
+import io.confluent.ksql.util.QueryMetadata;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.kafka.streams.state.HostInfo;
+import org.apache.kafka.streams.state.StreamsMetadata;
+
+public final class DiscoverRemoteHostsUtil {
+
+  private DiscoverRemoteHostsUtil() {}
+
+  public static Set<HostInfo> getRemoteHosts(
+      final List<PersistentQueryMetadata> currentQueries, 
+      final KsqlHostInfo localHost
+  ) {
+    return currentQueries.stream()
+        .map(QueryMetadata::getAllMetadata)
+        .filter(Objects::nonNull)
+        .flatMap(Collection::stream)
+        .filter(streamsMetadata -> streamsMetadata != StreamsMetadata.NOT_AVAILABLE)
+        .map(StreamsMetadata::hostInfo)
+        .filter(hostInfo -> !(hostInfo.host().equals(localHost.host())
+            && hostInfo.port() == (localHost.port())))
+        .collect(Collectors.toSet());
+  }
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ConnectExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ConnectExecutorTest.java
@@ -16,12 +16,12 @@
 package io.confluent.ksql.rest.server.execution;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
@@ -32,6 +32,7 @@ import io.confluent.ksql.execution.expression.tree.StringLiteral;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.CreateConnector;
 import io.confluent.ksql.parser.tree.CreateConnector.Type;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.CreateConnectorEntity;
 import io.confluent.ksql.rest.entity.ErrorEntity;
 import io.confluent.ksql.rest.entity.KsqlEntity;
@@ -48,7 +49,6 @@ import org.apache.kafka.connect.runtime.rest.entities.ConnectorType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -85,7 +85,7 @@ public class ConnectExecutorTest {
     givenSuccess();
 
     // When:
-    ConnectExecutor.execute(CREATE_CONNECTOR_CONFIGURED, ImmutableMap.of(), null, serviceContext);
+    ConnectExecutor.execute(CREATE_CONNECTOR_CONFIGURED, mock(SessionProperties.class), null, serviceContext);
 
     // Then:
     verify(connectClient).create(eq("foo"), (Map<String, String>) argThat(hasEntry("foo", "bar")));
@@ -98,7 +98,7 @@ public class ConnectExecutorTest {
 
     // When:
     final Optional<KsqlEntity> entity = ConnectExecutor
-        .execute(CREATE_CONNECTOR_CONFIGURED, ImmutableMap.of(), null, serviceContext);
+        .execute(CREATE_CONNECTOR_CONFIGURED, mock(SessionProperties.class), null, serviceContext);
 
     // Then:
     assertThat("Expected non-empty response", entity.isPresent());
@@ -112,7 +112,7 @@ public class ConnectExecutorTest {
 
     // When:
     final Optional<KsqlEntity> entity = ConnectExecutor
-        .execute(CREATE_CONNECTOR_CONFIGURED, ImmutableMap.of(), null, serviceContext);
+        .execute(CREATE_CONNECTOR_CONFIGURED, mock(SessionProperties.class), null, serviceContext);
 
     // Then:
     assertThat("Expected non-empty response", entity.isPresent());

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutorTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -40,6 +41,7 @@ import io.confluent.ksql.parser.tree.DescribeConnector;
 import io.confluent.ksql.rest.entity.ConnectorDescription;
 import io.confluent.ksql.rest.entity.ErrorEntity;
 import io.confluent.ksql.rest.entity.KsqlEntity;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SqlBaseType;
 import io.confluent.ksql.schema.ksql.types.SqlPrimitiveType;
@@ -162,7 +164,7 @@ public class DescribeConnectorExecutorTest {
   public void shouldDescribeKnownConnector() {
     // When:
     final Optional<KsqlEntity> entity = executor
-        .execute(describeStatement, ImmutableMap.of(), engine, serviceContext);
+        .execute(describeStatement, mock(SessionProperties.class), engine, serviceContext);
 
     // Then:
     assertThat("Expected a response", entity.isPresent());
@@ -187,7 +189,7 @@ public class DescribeConnectorExecutorTest {
 
     // When:
     final Optional<KsqlEntity> entity = executor
-        .execute(describeStatement, ImmutableMap.of(), engine, serviceContext);
+        .execute(describeStatement, mock(SessionProperties.class), engine, serviceContext);
 
     // Then:
     assertThat("Expected a response", entity.isPresent());
@@ -206,7 +208,7 @@ public class DescribeConnectorExecutorTest {
 
     // When:
     final Optional<KsqlEntity> entity = executor
-        .execute(describeStatement, ImmutableMap.of(), engine, serviceContext);
+        .execute(describeStatement, mock(SessionProperties.class), engine, serviceContext);
 
     // Then:
     verify(connectClient).status("connector");
@@ -222,7 +224,7 @@ public class DescribeConnectorExecutorTest {
 
     // When:
     final Optional<KsqlEntity> entity = executor
-        .execute(describeStatement, ImmutableMap.of(), engine, serviceContext);
+        .execute(describeStatement, mock(SessionProperties.class), engine, serviceContext);
 
     // Then:
     verify(connectClient).status("connector");
@@ -240,7 +242,7 @@ public class DescribeConnectorExecutorTest {
 
     // When:
     final Optional<KsqlEntity> entity = executor
-        .execute(describeStatement, ImmutableMap.of(), engine, serviceContext);
+        .execute(describeStatement, mock(SessionProperties.class), engine, serviceContext);
 
     // Then:
     assertThat("Expected a response", entity.isPresent());

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeFunctionExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeFunctionExecutorTest.java
@@ -16,8 +16,9 @@
 package io.confluent.ksql.rest.server.execution;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
 
-import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.FunctionDescriptionList;
 import io.confluent.ksql.rest.entity.FunctionType;
 import io.confluent.ksql.rest.server.TemporaryEngine;
@@ -39,7 +40,7 @@ public class DescribeFunctionExecutorTest {
     final FunctionDescriptionList functionList = (FunctionDescriptionList)
         CustomExecutors.DESCRIBE_FUNCTION.execute(
             engine.configure("DESCRIBE FUNCTION CONCAT;"),
-            ImmutableMap.of(),
+            mock(SessionProperties.class),
             engine.getEngine(),
             engine.getServiceContext()
         ).orElseThrow(IllegalStateException::new);
@@ -65,7 +66,7 @@ public class DescribeFunctionExecutorTest {
     final FunctionDescriptionList functionList = (FunctionDescriptionList)
         CustomExecutors.DESCRIBE_FUNCTION.execute(
             engine.configure("DESCRIBE FUNCTION MAX;"),
-            ImmutableMap.of(),
+            mock(SessionProperties.class),
             engine.getEngine(),
             engine.getServiceContext()
         ).orElseThrow(IllegalStateException::new);
@@ -91,7 +92,7 @@ public class DescribeFunctionExecutorTest {
     final FunctionDescriptionList functionList = (FunctionDescriptionList)
         CustomExecutors.DESCRIBE_FUNCTION.execute(
             engine.configure("DESCRIBE FUNCTION TEST_UDTF1;"),
-            ImmutableMap.of(),
+            mock(SessionProperties.class),
             engine.getEngine(),
             engine.getServiceContext()
         ).orElseThrow(IllegalStateException::new);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DropConnectorExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DropConnectorExecutorTest.java
@@ -19,12 +19,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.DropConnector;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.DropConnectorEntity;
 import io.confluent.ksql.rest.entity.ErrorEntity;
 import io.confluent.ksql.rest.entity.KsqlEntity;
@@ -74,7 +76,7 @@ public class DropConnectorExecutorTest {
         .thenReturn(ConnectResponse.success("foo", HttpStatus.SC_OK));
 
     // When:
-    DropConnectorExecutor.execute(DROP_CONNECTOR_CONFIGURED, ImmutableMap.of(),null, serviceContext);
+    DropConnectorExecutor.execute(DROP_CONNECTOR_CONFIGURED, mock(SessionProperties.class),null, serviceContext);
 
     // Then:
     verify(connectClient).delete("foo");
@@ -88,7 +90,7 @@ public class DropConnectorExecutorTest {
 
     // When:
     final Optional<KsqlEntity> response = DropConnectorExecutor
-        .execute(DROP_CONNECTOR_CONFIGURED, ImmutableMap.of(),null, serviceContext);
+        .execute(DROP_CONNECTOR_CONFIGURED, mock(SessionProperties.class),null, serviceContext);
 
     // Then:
     assertThat("expected response", response.isPresent());
@@ -103,7 +105,7 @@ public class DropConnectorExecutorTest {
 
     // When:
     final Optional<KsqlEntity> entity = DropConnectorExecutor
-        .execute(DROP_CONNECTOR_CONFIGURED, ImmutableMap.of(),null, serviceContext);
+        .execute(DROP_CONNECTOR_CONFIGURED, mock(SessionProperties.class), null, serviceContext);
 
     // Then:
     assertThat("Expected non-empty response", entity.isPresent());

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ExplainExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ExplainExecutorTest.java
@@ -24,11 +24,11 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.QueryDescriptionEntity;
 import io.confluent.ksql.rest.entity.QueryDescriptionFactory;
 import io.confluent.ksql.rest.server.TemporaryEngine;
@@ -65,7 +65,7 @@ public class ExplainExecutorTest {
     // When:
     final QueryDescriptionEntity query = (QueryDescriptionEntity) CustomExecutors.EXPLAIN.execute(
         explain,
-        ImmutableMap.of(),
+        mock(SessionProperties.class),
         engine,
         this.engine.getServiceContext()
     ).orElseThrow(IllegalStateException::new);
@@ -84,7 +84,7 @@ public class ExplainExecutorTest {
     // When:
     final QueryDescriptionEntity query = (QueryDescriptionEntity) CustomExecutors.EXPLAIN.execute(
         explain,
-        ImmutableMap.of(),
+        mock(SessionProperties.class),
         engine.getEngine(),
         engine.getServiceContext()
     ).orElseThrow(IllegalStateException::new);
@@ -105,7 +105,7 @@ public class ExplainExecutorTest {
     // When:
     final QueryDescriptionEntity query = (QueryDescriptionEntity) CustomExecutors.EXPLAIN.execute(
         explain,
-        ImmutableMap.of(),
+        mock(SessionProperties.class),
         engine.getEngine(),
         engine.getServiceContext()
     ).orElseThrow(IllegalStateException::new);
@@ -125,7 +125,7 @@ public class ExplainExecutorTest {
     // When:
     final QueryDescriptionEntity query = (QueryDescriptionEntity) CustomExecutors.EXPLAIN.execute(
         explain,
-        ImmutableMap.of(),
+        mock(SessionProperties.class),
         engine.getEngine(),
         engine.getServiceContext()
     ).orElseThrow(IllegalStateException::new);
@@ -144,7 +144,7 @@ public class ExplainExecutorTest {
     // When:
     CustomExecutors.EXPLAIN.execute(
         engine.configure("Explain SHOW TOPICS;"),
-        ImmutableMap.of(),
+        mock(SessionProperties.class),
         engine.getEngine(),
         engine.getServiceContext()
     );

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListConnectorsExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListConnectorsExecutorTest.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.rest.server.execution;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
@@ -25,6 +26,7 @@ import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.ListConnectors;
 import io.confluent.ksql.parser.tree.ListConnectors.Scope;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.ConnectorList;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.KsqlWarning;
@@ -112,7 +114,7 @@ public class ListConnectorsExecutorTest {
 
     // When:
     final Optional<KsqlEntity> entity = ListConnectorsExecutor
-        .execute(statement, ImmutableMap.of(), engine, serviceContext);
+        .execute(statement, mock(SessionProperties.class), engine, serviceContext);
 
     // Then:
     assertThat("expected response!", entity.isPresent());
@@ -142,7 +144,7 @@ public class ListConnectorsExecutorTest {
 
     // When:
     final Optional<KsqlEntity> entity = ListConnectorsExecutor
-        .execute(statement, ImmutableMap.of(), engine, serviceContext);
+        .execute(statement, mock(SessionProperties.class), engine, serviceContext);
 
     // Then:
     assertThat("expected response!", entity.isPresent());
@@ -171,7 +173,7 @@ public class ListConnectorsExecutorTest {
 
     // When:
     final Optional<KsqlEntity> entity = ListConnectorsExecutor
-        .execute(statement, ImmutableMap.of(), engine, serviceContext);
+        .execute(statement, mock(SessionProperties.class), engine, serviceContext);
 
     // Then:
     assertThat("expected response!", entity.isPresent());
@@ -197,7 +199,7 @@ public class ListConnectorsExecutorTest {
 
     // When:
     final Optional<KsqlEntity> entity = ListConnectorsExecutor
-        .execute(statement, ImmutableMap.of(), engine, serviceContext);
+        .execute(statement, mock(SessionProperties.class), engine, serviceContext);
 
     // Then:
     assertThat("expected response!", entity.isPresent());

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListFunctionsExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListFunctionsExecutorTest.java
@@ -19,8 +19,9 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.mock;
 
-import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.FunctionNameList;
 import io.confluent.ksql.rest.entity.FunctionType;
 import io.confluent.ksql.rest.entity.SimpleFunctionInfo;
@@ -42,7 +43,7 @@ public class ListFunctionsExecutorTest {
     // When:
     final FunctionNameList functionList = (FunctionNameList) CustomExecutors.LIST_FUNCTIONS.execute(
         engine.configure("LIST FUNCTIONS;"),
-        ImmutableMap.of(),
+        mock(SessionProperties.class),
         engine.getEngine(),
         engine.getServiceContext()
     ).orElseThrow(IllegalStateException::new);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutorTest.java
@@ -23,8 +23,10 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isIn;
 import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.PropertiesList;
 import io.confluent.ksql.rest.entity.PropertiesList.Property;
 import io.confluent.ksql.rest.server.TemporaryEngine;
@@ -46,7 +48,7 @@ public class ListPropertiesExecutorTest {
     // When:
     final PropertiesList properties = (PropertiesList) CustomExecutors.LIST_PROPERTIES.execute(
         engine.configure("LIST PROPERTIES;"),
-        ImmutableMap.of(),
+        mock(SessionProperties.class),
         engine.getEngine(),
         engine.getServiceContext()
     ).orElseThrow(IllegalStateException::new);
@@ -72,7 +74,7 @@ public class ListPropertiesExecutorTest {
     final PropertiesList properties = (PropertiesList) CustomExecutors.LIST_PROPERTIES.execute(
         engine.configure("LIST PROPERTIES;")
             .withProperties(ImmutableMap.of("ksql.streams.auto.offset.reset", "latest")),
-        ImmutableMap.of(),
+        mock(SessionProperties.class),
         engine.getEngine(),
         engine.getServiceContext()
     ).orElseThrow(IllegalStateException::new);
@@ -89,7 +91,7 @@ public class ListPropertiesExecutorTest {
     // When:
     final PropertiesList properties = (PropertiesList) CustomExecutors.LIST_PROPERTIES.execute(
         engine.configure("LIST PROPERTIES;"),
-        ImmutableMap.of(),
+        mock(SessionProperties.class),
         engine.getEngine(),
         engine.getServiceContext()
     ).orElseThrow(IllegalStateException::new);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
@@ -33,6 +32,7 @@ import io.confluent.ksql.rest.entity.Queries;
 import io.confluent.ksql.rest.entity.QueryDescriptionFactory;
 import io.confluent.ksql.rest.entity.QueryDescriptionList;
 import io.confluent.ksql.rest.entity.RunningQuery;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.server.TemporaryEngine;
 import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
@@ -55,7 +55,7 @@ public class ListQueriesExecutorTest {
     // When
     final Queries queries = (Queries) CustomExecutors.LIST_QUERIES.execute(
         engine.configure("SHOW QUERIES;"),
-        ImmutableMap.of(),
+            mock(SessionProperties.class),
         engine.getEngine(),
         engine.getServiceContext()
     ).orElseThrow(IllegalStateException::new);
@@ -75,7 +75,7 @@ public class ListQueriesExecutorTest {
     // When
     final Queries queries = (Queries) CustomExecutors.LIST_QUERIES.execute(
         showQueries,
-        ImmutableMap.of(),
+        mock(SessionProperties.class),
         engine,
         this.engine.getServiceContext()
     ).orElseThrow(IllegalStateException::new);
@@ -103,7 +103,7 @@ public class ListQueriesExecutorTest {
     // When
     final QueryDescriptionList queries = (QueryDescriptionList) CustomExecutors.LIST_QUERIES.execute(
         showQueries,
-        ImmutableMap.of(),
+        mock(SessionProperties.class),
         engine,
         this.engine.getServiceContext()
     ).orElseThrow(IllegalStateException::new);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
@@ -38,6 +38,7 @@ import io.confluent.ksql.metastore.model.KsqlTable;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.ShowColumns;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.KsqlWarning;
 import io.confluent.ksql.rest.entity.RunningQuery;
@@ -99,7 +100,7 @@ public class ListSourceExecutorTest {
     final StreamsList descriptionList = (StreamsList)
         CustomExecutors.LIST_STREAMS.execute(
             engine.configure("SHOW STREAMS;"),
-            ImmutableMap.of(),
+            mock(SessionProperties.class),
             engine.getEngine(),
             engine.getServiceContext()
         ).orElseThrow(IllegalStateException::new);
@@ -130,7 +131,7 @@ public class ListSourceExecutorTest {
     final SourceDescriptionList descriptionList = (SourceDescriptionList)
         CustomExecutors.LIST_STREAMS.execute(
             engine.configure("SHOW STREAMS EXTENDED;"),
-            ImmutableMap.of(),
+            mock(SessionProperties.class),
             engine.getEngine(),
             engine.getServiceContext()
         ).orElseThrow(IllegalStateException::new);
@@ -163,7 +164,7 @@ public class ListSourceExecutorTest {
     final TablesList descriptionList = (TablesList)
         CustomExecutors.LIST_TABLES.execute(
             engine.configure("LIST TABLES;"),
-            ImmutableMap.of(),
+            mock(SessionProperties.class),
             engine.getEngine(),
             engine.getServiceContext()
         ).orElseThrow(IllegalStateException::new);
@@ -196,7 +197,7 @@ public class ListSourceExecutorTest {
     final SourceDescriptionList descriptionList = (SourceDescriptionList)
         CustomExecutors.LIST_TABLES.execute(
             engine.configure("LIST TABLES EXTENDED;"),
-            ImmutableMap.of(),
+            mock(SessionProperties.class),
             engine.getEngine(),
             engine.getServiceContext()
         ).orElseThrow(IllegalStateException::new);
@@ -243,7 +244,7 @@ public class ListSourceExecutorTest {
                 ImmutableMap.of(),
                 engine.getKsqlConfig()
             ),
-            ImmutableMap.of(),
+            mock(SessionProperties.class),
             engine.getEngine(),
             engine.getServiceContext()
         ).orElseThrow(IllegalStateException::new);
@@ -273,7 +274,7 @@ public class ListSourceExecutorTest {
     // When:
     CustomExecutors.SHOW_COLUMNS.execute(
         engine.configure("DESCRIBE S;"),
-        ImmutableMap.of(),
+        mock(SessionProperties.class),
         engine.getEngine(),
         engine.getServiceContext()
     );
@@ -295,7 +296,7 @@ public class ListSourceExecutorTest {
     // When:
     CustomExecutors.LIST_STREAMS.execute(
         engine.configure("SHOW STREAMS;"),
-        ImmutableMap.of(),
+        mock(SessionProperties.class),
         engine.getEngine(),
         serviceContext
     ).orElseThrow(IllegalStateException::new);
@@ -351,7 +352,7 @@ public class ListSourceExecutorTest {
     // When:
     final KsqlEntity entity = CustomExecutors.LIST_STREAMS.execute(
         engine.configure("SHOW STREAMS EXTENDED;"),
-        ImmutableMap.of(),
+        mock(SessionProperties.class),
         engine.getEngine(),
         serviceContext
     ).orElseThrow(IllegalStateException::new);
@@ -371,7 +372,7 @@ public class ListSourceExecutorTest {
     // When:
     final KsqlEntity entity = CustomExecutors.LIST_TABLES.execute(
         engine.configure("SHOW TABLES EXTENDED;"),
-        ImmutableMap.of(),
+        mock(SessionProperties.class),
         engine.getEngine(),
         serviceContext
     ).orElseThrow(IllegalStateException::new);
@@ -390,7 +391,7 @@ public class ListSourceExecutorTest {
     // When:
     final KsqlEntity entity = CustomExecutors.SHOW_COLUMNS.execute(
         engine.configure("DESCRIBE EXTENDED STREAM1;"),
-        ImmutableMap.of(),
+        mock(SessionProperties.class),
         engine.getEngine(),
         serviceContext
     ).orElseThrow(IllegalStateException::new);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutorTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.KafkaTopicInfo;
 import io.confluent.ksql.rest.entity.KafkaTopicInfoExtended;
 import io.confluent.ksql.rest.entity.KafkaTopicsList;
@@ -72,7 +72,7 @@ public class ListTopicsExecutorTest {
     final KafkaTopicsList topicsList =
         (KafkaTopicsList) CustomExecutors.LIST_TOPICS.execute(
             engine.configure("LIST TOPICS;"),
-            ImmutableMap.of(),
+            mock(SessionProperties.class),
             engine.getEngine(),
             serviceContext
         ).orElseThrow(IllegalStateException::new);
@@ -95,7 +95,7 @@ public class ListTopicsExecutorTest {
     final KafkaTopicsList topicsList =
         (KafkaTopicsList) CustomExecutors.LIST_TOPICS.execute(
             engine.configure("LIST ALL TOPICS;"),
-            ImmutableMap.of(),
+            mock(SessionProperties.class),
             engine.getEngine(),
             serviceContext
         ).orElseThrow(IllegalStateException::new);
@@ -118,7 +118,7 @@ public class ListTopicsExecutorTest {
     final KafkaTopicsList topicsList =
         (KafkaTopicsList) CustomExecutors.LIST_TOPICS.execute(
             engine.configure("LIST TOPICS;"),
-            ImmutableMap.of(),
+            mock(SessionProperties.class),
             engine.getEngine(),
             serviceContext
         ).orElseThrow(IllegalStateException::new);
@@ -147,7 +147,7 @@ public class ListTopicsExecutorTest {
     final KafkaTopicsListExtended topicsList =
         (KafkaTopicsListExtended) CustomExecutors.LIST_TOPICS.execute(
             engine.configure("LIST TOPICS EXTENDED;"),
-            ImmutableMap.of(),
+            mock(SessionProperties.class),
             engine.getEngine(),
             serviceContext
         ).orElseThrow(IllegalStateException::new);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListTypesExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListTypesExecutorTest.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.rest.server.execution;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
@@ -26,6 +27,7 @@ import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.TypeRegistry.CustomType;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.ListTypes;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.TypeList;
 import io.confluent.ksql.rest.util.EntityUtil;
@@ -69,7 +71,7 @@ public class ListTypesExecutorTest {
             ImmutableMap.of(),
             KSQL_CONFIG
         ),
-        ImmutableMap.of(),
+        mock(SessionProperties.class),
         context,
         null);
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PropertyExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PropertyExecutorTest.java
@@ -20,10 +20,16 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.mock;
 
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.server.TemporaryEngine;
+
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+
+import io.confluent.ksql.util.KsqlHostInfo;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.junit.Rule;
 import org.junit.Test;
@@ -40,11 +46,13 @@ public class PropertyExecutorTest {
     // Given:
     engine.givenSource(DataSourceType.KSTREAM, "stream");
     final Map<String, Object> properties = new HashMap<>();
+    final SessionProperties sessionProperties =
+        new SessionProperties(properties, mock(KsqlHostInfo.class), mock(URL.class));
 
     // When:
     CustomExecutors.SET_PROPERTY.execute(
         engine.configure("SET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "' = 'none';"),
-        properties,
+        sessionProperties,
         engine.getEngine(),
         engine.getServiceContext()
     );
@@ -59,11 +67,13 @@ public class PropertyExecutorTest {
     engine.givenSource(DataSourceType.KSTREAM, "stream");
     final Map<String, Object> properties = new HashMap<>();
     properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "none");
+    final SessionProperties sessionProperties =
+        new SessionProperties(properties, mock(KsqlHostInfo.class), mock(URL.class));
 
     // When:
     CustomExecutors.UNSET_PROPERTY.execute(
         engine.configure("UNSET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "';"),
-        properties,
+        sessionProperties,
         engine.getEngine(),
         engine.getServiceContext()
     );

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PropertyExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PropertyExecutorTest.java
@@ -26,6 +26,7 @@ import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.server.TemporaryEngine;
 
 import java.net.URL;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -44,10 +45,9 @@ public class PropertyExecutorTest {
   @Test
   public void shouldSetProperty() {
     // Given:
-    engine.givenSource(DataSourceType.KSTREAM, "stream");
-    final Map<String, Object> properties = new HashMap<>();
     final SessionProperties sessionProperties =
-        new SessionProperties(properties, mock(KsqlHostInfo.class), mock(URL.class));
+        new SessionProperties(new HashMap<>(), mock(KsqlHostInfo.class), mock(URL.class));
+    final Map<String, Object> properties = sessionProperties.getMutableScopedProperties();
 
     // When:
     CustomExecutors.SET_PROPERTY.execute(
@@ -65,10 +65,12 @@ public class PropertyExecutorTest {
   public void shouldUnSetProperty() {
     // Given:
     engine.givenSource(DataSourceType.KSTREAM, "stream");
-    final Map<String, Object> properties = new HashMap<>();
-    properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "none");
     final SessionProperties sessionProperties =
-        new SessionProperties(properties, mock(KsqlHostInfo.class), mock(URL.class));
+        new SessionProperties(
+            Collections.singletonMap(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "none"),
+            mock(KsqlHostInfo.class),
+            mock(URL.class));
+    final Map<String, Object> properties = sessionProperties.getMutableScopedProperties();
 
     // When:
     CustomExecutors.UNSET_PROPERTY.execute(

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PullQueryExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PullQueryExecutorTest.java
@@ -30,6 +30,7 @@ import io.confluent.ksql.execution.streams.RoutingFilter.RoutingFilterFactory;
 import io.confluent.ksql.execution.streams.RoutingFilters;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.Query;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.server.TemporaryEngine;
 import io.confluent.ksql.rest.server.resources.KsqlRestException;
 import io.confluent.ksql.rest.server.validation.CustomValidators;
@@ -111,7 +112,7 @@ public class PullQueryExecutorTest {
       // When:
       CustomValidators.QUERY_ENDPOINT.validate(
           query,
-          ImmutableMap.of(),
+          mock(SessionProperties.class),
           engine.getEngine(),
           engine.getServiceContext()
       );

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -199,7 +199,8 @@ public class KsqlResourceTest {
   private static final KsqlRequest VALID_EXECUTABLE_REQUEST = new KsqlRequest(
       "CREATE STREAM S AS SELECT * FROM test_stream;",
       ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"),
-      0L);
+      0L
+  );
   private static final LogicalSchema SINGLE_FIELD_SCHEMA = LogicalSchema.builder()
       .valueColumn(ColumnName.of("val"), SqlTypes.STRING)
       .build();

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/PrintTopicValidatorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/PrintTopicValidatorTest.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.PrintTopic;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.server.resources.KsqlRestException;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
@@ -74,7 +75,7 @@ public class PrintTopicValidatorTest {
     // When:
     CustomValidators.PRINT_TOPIC.validate(
         query,
-        ImmutableMap.of(),
+        mock(SessionProperties.class),
         ksqlEngine,
         serviceContext
     );

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/PropertyOverriderTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/PropertyOverriderTest.java
@@ -19,14 +19,19 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.SetProperty;
 import io.confluent.ksql.parser.tree.UnsetProperty;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.server.TemporaryEngine;
 import io.confluent.ksql.statement.ConfiguredStatement;
+import io.confluent.ksql.util.KsqlHostInfo;
 import io.confluent.ksql.util.KsqlStatementException;
+
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -58,7 +63,7 @@ public class PropertyOverriderTest {
             new HashMap<>(),
             engine.getKsqlConfig()
         ),
-        ImmutableMap.of(),
+        mock(SessionProperties.class),
         engine.getEngine(),
         engine.getServiceContext()
     );
@@ -68,6 +73,8 @@ public class PropertyOverriderTest {
   public void shouldAllowSetKnownProperty() {
     // Given:
     final Map<String, Object> properties = new HashMap<>();
+    final SessionProperties sessionProperties = 
+        new SessionProperties(properties, mock(KsqlHostInfo.class), mock(URL.class));
 
     // When:
     CustomValidators.SET_PROPERTY.validate(
@@ -78,7 +85,7 @@ public class PropertyOverriderTest {
             ImmutableMap.of(),
             engine.getKsqlConfig()
         ),
-        properties,
+        sessionProperties,
         engine.getEngine(),
         engine.getServiceContext()
     );
@@ -90,6 +97,11 @@ public class PropertyOverriderTest {
 
   @Test
   public void shouldFailOnInvalidSetPropertyValue() {
+    // Given:
+    final Map<String, Object> properties = new HashMap<>();
+    final SessionProperties sessionProperties =
+        new SessionProperties(properties, mock(KsqlHostInfo.class), mock(URL.class));
+
     // Expect:
     expectedException.expect(KsqlStatementException.class);
     expectedException.expectMessage("Invalid value invalid");
@@ -103,7 +115,7 @@ public class PropertyOverriderTest {
             ImmutableMap.of(),
             engine.getKsqlConfig()
         ),
-        new HashMap<>(),
+        sessionProperties,
         engine.getEngine(),
         engine.getServiceContext()
     );
@@ -111,6 +123,11 @@ public class PropertyOverriderTest {
 
   @Test
   public void shouldFailOnUnknownUnsetProperty() {
+    // Given:
+    final Map<String, Object> properties = new HashMap<>();
+    final SessionProperties sessionProperties =
+        new SessionProperties(properties, mock(KsqlHostInfo.class), mock(URL.class));
+
     // Expect:
     expectedException.expect(KsqlStatementException.class);
     expectedException.expectMessage("Unknown property: consumer.invalid");
@@ -124,7 +141,7 @@ public class PropertyOverriderTest {
             new HashMap<>(),
             engine.getKsqlConfig()
         ),
-        ImmutableMap.of(),
+        sessionProperties,
         engine.getEngine(),
         engine.getServiceContext()
     );
@@ -135,6 +152,8 @@ public class PropertyOverriderTest {
     // Given:
     final Map<String, Object> properties = new HashMap<>();
     properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    final SessionProperties sessionProperties =
+        new SessionProperties(properties, mock(KsqlHostInfo.class), mock(URL.class));
 
     // When:
     CustomValidators.UNSET_PROPERTY.validate(
@@ -145,7 +164,7 @@ public class PropertyOverriderTest {
             ImmutableMap.of(),
             engine.getKsqlConfig()
         ),
-        properties,
+        sessionProperties,
         engine.getEngine(),
         engine.getServiceContext()
     );

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/PropertyOverriderTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/PropertyOverriderTest.java
@@ -32,9 +32,12 @@ import io.confluent.ksql.util.KsqlHostInfo;
 import io.confluent.ksql.util.KsqlStatementException;
 
 import java.net.URL;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+
+import org.apache.commons.collections4.map.HashedMap;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.junit.Rule;
 import org.junit.Test;
@@ -72,9 +75,9 @@ public class PropertyOverriderTest {
   @Test
   public void shouldAllowSetKnownProperty() {
     // Given:
-    final Map<String, Object> properties = new HashMap<>();
     final SessionProperties sessionProperties = 
-        new SessionProperties(properties, mock(KsqlHostInfo.class), mock(URL.class));
+        new SessionProperties(new HashedMap<>(), mock(KsqlHostInfo.class), mock(URL.class));
+    final Map<String, Object> properties = sessionProperties.getMutableScopedProperties();
 
     // When:
     CustomValidators.SET_PROPERTY.validate(
@@ -98,9 +101,8 @@ public class PropertyOverriderTest {
   @Test
   public void shouldFailOnInvalidSetPropertyValue() {
     // Given:
-    final Map<String, Object> properties = new HashMap<>();
     final SessionProperties sessionProperties =
-        new SessionProperties(properties, mock(KsqlHostInfo.class), mock(URL.class));
+        new SessionProperties(new HashedMap<>(), mock(KsqlHostInfo.class), mock(URL.class));
 
     // Expect:
     expectedException.expect(KsqlStatementException.class);
@@ -150,10 +152,12 @@ public class PropertyOverriderTest {
   @Test
   public void shouldAllowUnsetKnownProperty() {
     // Given:
-    final Map<String, Object> properties = new HashMap<>();
-    properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
     final SessionProperties sessionProperties =
-        new SessionProperties(properties, mock(KsqlHostInfo.class), mock(URL.class));
+        new SessionProperties(
+            Collections.singletonMap(
+                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"),
+                mock(KsqlHostInfo.class), mock(URL.class));
+    final Map<String, Object> properties = sessionProperties.getMutableScopedProperties();
 
     // When:
     CustomValidators.UNSET_PROPERTY.validate(

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/RequestValidatorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/RequestValidatorTest.java
@@ -42,6 +42,7 @@ import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.tree.CreateStream;
 import io.confluent.ksql.parser.tree.Explain;
 import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.server.computation.ValidatedCommandFactory;
 import io.confluent.ksql.services.SandboxedServiceContext;
 import io.confluent.ksql.services.ServiceContext;
@@ -82,6 +83,8 @@ public class RequestValidatorTest {
   private Injector topicInjector;
   @Mock
   private ValidatedCommandFactory distributedStatementValidator;
+  @Mock
+  private SessionProperties sessionProperties;
 
   private ServiceContext serviceContext;
   private MutableMetaStore metaStore;
@@ -124,12 +127,12 @@ public class RequestValidatorTest {
         givenParsed(SOME_STREAM_SQL);
 
     // When:
-    validator.validate(serviceContext, statements, ImmutableMap.of(), "sql");
+    validator.validate(serviceContext, statements, sessionProperties, "sql");
 
     // Then:
     verify(statementValidator, times(1)).validate(
         argThat(is(configured(preparedStatement(instanceOf(CreateStream.class))))),
-        eq(ImmutableMap.of()),
+        eq(sessionProperties),
         eq(executionContext),
         any()
     );
@@ -142,7 +145,7 @@ public class RequestValidatorTest {
         givenParsed("CREATE STREAM foo WITH (kafka_topic='foo', value_format='json');");
 
     // When:
-    validator.validate(serviceContext, statements, ImmutableMap.of(), "sql");
+    validator.validate(serviceContext, statements, sessionProperties, "sql");
 
     // Then:
     verify(distributedStatementValidator).create(
@@ -169,7 +172,7 @@ public class RequestValidatorTest {
     expectedException.expectMessage("Fail");
 
     // When:
-    validator.validate(serviceContext, statements, ImmutableMap.of(), "sql");
+    validator.validate(serviceContext, statements, sessionProperties, "sql");
   }
 
   @Test
@@ -183,7 +186,7 @@ public class RequestValidatorTest {
     expectedException.expectMessage("Do not know how to validate statement");
 
     // When:
-    validator.validate(serviceContext, statements, ImmutableMap.of(), "sql");
+    validator.validate(serviceContext, statements, sessionProperties, "sql");
   }
 
   @Test
@@ -202,7 +205,7 @@ public class RequestValidatorTest {
     expectedException.expectMessage("persistent queries to exceed the configured limit");
 
     // When:
-    validator.validate(serviceContext, statements, ImmutableMap.of(), "sql");
+    validator.validate(serviceContext, statements, sessionProperties, "sql");
   }
 
   @Test
@@ -223,7 +226,7 @@ public class RequestValidatorTest {
 
     // Expect Nothing:
     // When:
-    validator.validate(serviceContext, statements, ImmutableMap.of(), "sql");
+    validator.validate(serviceContext, statements, sessionProperties, "sql");
   }
 
   @Test
@@ -237,7 +240,7 @@ public class RequestValidatorTest {
     expectedException.expectMessage("Expected sandbox");
 
     // When:
-    validator.validate(serviceContext, ImmutableList.of(), ImmutableMap.of(), "sql");
+    validator.validate(serviceContext, ImmutableList.of(), sessionProperties, "sql");
   }
 
   @Test
@@ -251,7 +254,7 @@ public class RequestValidatorTest {
     expectedException.expectMessage("Expected sandbox");
 
     // When:
-    validator.validate(serviceContext, ImmutableList.of(), ImmutableMap.of(), "sql");
+    validator.validate(serviceContext, ImmutableList.of(), sessionProperties, "sql");
   }
 
   @Test
@@ -262,7 +265,7 @@ public class RequestValidatorTest {
         SandboxedServiceContext.create(TestServiceContext.create());
 
     // When:
-    validator.validate(otherServiceContext, statements, ImmutableMap.of(), "sql");
+    validator.validate(otherServiceContext, statements, sessionProperties, "sql");
 
     // Then:
     verify(distributedStatementValidator).create(

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/SessionProperties.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/SessionProperties.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.rest;
 import io.confluent.ksql.util.KsqlHostInfo;
 
 import java.net.URL;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -28,11 +29,11 @@ public class SessionProperties {
   private final URL localUrl;
 
   public SessionProperties(
-          final Map<String, Object> mutableScopedProperties,
-          final KsqlHostInfo ksqlHostInfo,
-          final URL localUrl) {
+      final Map<String, Object> mutableScopedProperties,
+      final KsqlHostInfo ksqlHostInfo,
+      final URL localUrl) {
     this.mutableScopedProperties = 
-        Objects.requireNonNull(mutableScopedProperties, "mutableScopedProperties");
+        new HashMap<>(Objects.requireNonNull(mutableScopedProperties, "mutableScopedProperties"));
     this.ksqlHostInfo = Objects.requireNonNull(ksqlHostInfo, "ksqlHostInfo");
     this.localUrl = Objects.requireNonNull(localUrl, "localUrl");
   }

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/SessionProperties.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/SessionProperties.java
@@ -22,12 +22,22 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+/**
+ * Wraps the incoming {@link io.confluent.ksql.rest.entity.KsqlRequest} streamsProperties 
+ * in a object withthe {@link KsqlHostInfo} and URL of the server that handles the request.
+ * This should be created in the Rest Resource that receives the request.
+ */
 public class SessionProperties {
   
   private final Map<String, Object> mutableScopedProperties;
   private final KsqlHostInfo ksqlHostInfo;
   private final URL localUrl;
 
+  /**
+   * @param mutableScopedProperties   The streamsProperties of the incoming request
+   * @param ksqlHostInfo              The ksqlHostInfo of the server that handles the request 
+   * @param localUrl                  The url of the server that handles the request
+   */
   public SessionProperties(
       final Map<String, Object> mutableScopedProperties,
       final KsqlHostInfo ksqlHostInfo,

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/SessionProperties.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/SessionProperties.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest;
+
+import io.confluent.ksql.util.KsqlHostInfo;
+
+import java.net.URL;
+import java.util.Map;
+import java.util.Objects;
+
+public class SessionProperties {
+  
+  private final Map<String, Object> mutableScopedProperties;
+  private final KsqlHostInfo ksqlHostInfo;
+  private final URL localUrl;
+
+  public SessionProperties(
+          final Map<String, Object> mutableScopedProperties,
+          final KsqlHostInfo ksqlHostInfo,
+          final URL localUrl) {
+    this.mutableScopedProperties = 
+        Objects.requireNonNull(mutableScopedProperties, "mutableScopedProperties");
+    this.ksqlHostInfo = Objects.requireNonNull(ksqlHostInfo, "ksqlHostInfo");
+    this.localUrl = Objects.requireNonNull(localUrl, "localUrl");
+  }
+
+  public Map<String, Object> getMutableScopedProperties() {
+    return mutableScopedProperties;
+  }
+
+  public KsqlHostInfo getKsqlHostInfo() {
+    return ksqlHostInfo;
+  }
+
+  public URL getLocalUrl() {
+    return localUrl;
+  }
+}

--- a/ksql-rest-model/src/test/java/io/confluent/ksql/rest/entity/KsqlRequestTest.java
+++ b/ksql-rest-model/src/test/java/io/confluent/ksql/rest/entity/KsqlRequestTest.java
@@ -176,7 +176,8 @@ public class KsqlRequestTest {
         ImmutableMap.of(
             ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "not-parsable"
         ),
-        null);
+        null
+    );
 
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage(containsString(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG));
@@ -194,7 +195,8 @@ public class KsqlRequestTest {
         Collections.singletonMap(
             ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"
         ),
-        null);
+        null
+    );
 
     // When:
     final Map<String, Object> props = request.getStreamsProperties();


### PR DESCRIPTION
### Description 
Modifies the StatementExecutor interface by wrapping the mutableScopedProperties in a SessionProperties object. KsqlResource will create SessionProperty objects and pass them to RequestValidator and RequestHandler.

This provides more information in the executors when processing requests (can also add additional parameters if necessary in the future)

The motivation for this PR is here https://github.com/confluentinc/ksql/pull/4572

Also, moved discovery of remote hosts from Persistent Queries in HeartbeatAgent to a generic utility function.


### Testing done 
Only refactor change, update function calls so build can pass.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

