### PR TITLE
feat: show queries and show queries extended return results for all nodes in the cluster

### DIFF
--- a/docs-md/developer-guide/ksqldb-reference/show-queries.md
+++ b/docs-md/developer-guide/ksqldb-reference/show-queries.md
@@ -21,9 +21,9 @@ Description
 
 List the running persistent queries.
 
-`SHOW QUERIES` lists queries running in the cluster
+`SHOW QUERIES` lists queries running in the cluster.
 
-`SHOW QUERIES EXTENDED` Lists queries running in the cluster in more detail
+`SHOW QUERIES EXTENDED` lists queries running in the cluster in more detail.
 
 Example
 -------

--- a/docs-md/developer-guide/ksqldb-reference/show-queries.md
+++ b/docs-md/developer-guide/ksqldb-reference/show-queries.md
@@ -13,7 +13,7 @@ Synopsis
 --------
 
 ```sql
-SHOW | LIST [ALL] QUERIES [EXTENDED];
+SHOW | LIST QUERIES [EXTENDED];
 ```
 
 Description
@@ -21,11 +21,9 @@ Description
 
 List the running persistent queries.
 
-`SHOW QUERIES` lists queries running on the node that receives the request
+`SHOW QUERIES` lists queries running in the cluster
 
-`SHOW QUERIES EXTENDED` Lists queries running on the node that receives the request in more detail
-
-`SHOW ALL QUERIES` lists all queries running across all nodes in the cluster
+`SHOW QUERIES EXTENDED` Lists queries running in the cluster in more detail
 
 Example
 -------

--- a/docs-md/developer-guide/ksqldb-reference/show-queries.md
+++ b/docs-md/developer-guide/ksqldb-reference/show-queries.md
@@ -13,13 +13,19 @@ Synopsis
 --------
 
 ```sql
-SHOW QUERIES;
+SHOW | LIST [ALL] QUERIES [EXTENDED];
 ```
 
 Description
 -----------
 
 List the running persistent queries.
+
+`SHOW QUERIES` lists queries running on the node that receives the request
+
+`SHOW QUERIES EXTENDED` Lists queries running on the node that receives the request in more detail
+
+`SHOW ALL QUERIES` lists all queries running across all nodes in the cluster
 
 Example
 -------

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -659,6 +659,9 @@ public class Console implements Closeable {
     if (query.getState().isPresent()) {
       writer().println(String.format("%-20s : %s", "Status", query.getState().get()));
     }
+    if (query.getKsqlHostInfo().isPresent()) {
+      writer().println(String.format("%-20s : %s", "Host Info", query.getKsqlHostInfo().get()));
+    }
     writer().println();
     printSchema(query.getWindowType(), query.getFields(), "");
     printQuerySources(query);

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/QueriesTableBuilder.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/QueriesTableBuilder.java
@@ -25,7 +25,14 @@ import java.util.stream.Stream;
 public class QueriesTableBuilder implements TableBuilder<Queries> {
 
   private static final List<String> HEADERS =
-      ImmutableList.of("Query ID", "Status", "Sink Name", "Sink Kafka Topic", "Query String");
+      ImmutableList.of(
+          "Query ID", 
+          "Status", 
+          "Host Info",
+          "Sink Name",
+          "Sink Kafka Topic",
+          "Query String"
+      );
 
   @Override
   public Table buildTable(final Queries entity) {
@@ -33,6 +40,7 @@ public class QueriesTableBuilder implements TableBuilder<Queries> {
         .map(r -> ImmutableList.of(
             r.getId().getId(),
             r.getState().orElse("N/A"),
+            r.getKsqlHostInfo().orElse(null) == null ? "N/A" : r.getKsqlHostInfo().get().toString(),
             String.join(",", r.getSinks()),
             String.join(",", r.getSinkKafkaTopics()),
             r.getQuerySingleLine()

--- a/ksql-execution/src/main/java/io/confluent/ksql/services/DisabledKsqlClient.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/services/DisabledKsqlClient.java
@@ -43,6 +43,14 @@ public final class DisabledKsqlClient implements SimpleKsqlClient {
   }
 
   @Override
+  public RestResponse<KsqlEntityList> makeInternalKsqlRequest(
+      final URI serverEndPoint,
+      final String sql
+  ) {
+    throw new UnsupportedOperationException("KSQL client is disabled");
+  }
+
+  @Override
   public RestResponse<List<StreamedRow>> makeQueryRequest(
       final URI serverEndPoint,
       final String sql,

--- a/ksql-execution/src/main/java/io/confluent/ksql/services/SimpleKsqlClient.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/services/SimpleKsqlClient.java
@@ -35,8 +35,8 @@ public interface SimpleKsqlClient {
   );
 
   RestResponse<KsqlEntityList> makeInternalKsqlRequest(
-    URI serverEndPoint,
-    String sql
+      URI serverEndPoint,
+      String sql
   );
 
   /**

--- a/ksql-execution/src/main/java/io/confluent/ksql/services/SimpleKsqlClient.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/services/SimpleKsqlClient.java
@@ -34,6 +34,11 @@ public interface SimpleKsqlClient {
       String sql
   );
 
+  RestResponse<KsqlEntityList> makeInternalKsqlRequest(
+    URI serverEndPoint,
+    String sql
+  );
+
   /**
    * Send pull query request to remote Ksql server.
    * @param serverEndPoint the remote destination

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutorUtil.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutorUtil.java
@@ -333,7 +333,8 @@ public final class TestExecutorUtil {
           new SessionProperties(
               requireNonNull(overrides, "overrides"),
               new KsqlHostInfo("host", 50),
-              buildUrl());
+              buildURL(),
+              false);
       this.ksqlConfig = requireNonNull(ksqlConfig, "ksqlConfig");
       this.stubKafkaService = requireNonNull(stubKafkaService, "stubKafkaService");
       this.schemaInjector = requireNonNull(schemaInjector, "schemaInjector");

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutorUtil.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutorUtil.java
@@ -333,7 +333,7 @@ public final class TestExecutorUtil {
           new SessionProperties(
               requireNonNull(overrides, "overrides"),
               new KsqlHostInfo("host", 50),
-              buildURL(),
+              TestExecutorUtil.buildUrl(),
               false);
       this.ksqlConfig = requireNonNull(ksqlConfig, "ksqlConfig");
       this.stubKafkaService = requireNonNull(stubKafkaService, "stubKafkaService");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -580,7 +580,7 @@ public class AstBuilder {
     @Override
     public Node visitListTopics(final SqlBaseParser.ListTopicsContext context) {
       return new ListTopics(getLocation(context),
-          context.ALL() != null, context.EXTENDED() != null);
+      context.ALL() != null, context.EXTENDED() != null);
     }
 
     @Override
@@ -597,8 +597,8 @@ public class AstBuilder {
 
     @Override
     public Node visitListQueries(final SqlBaseParser.ListQueriesContext context) {
-      return new ListQueries(
-          getLocation(context), context.EXTENDED() != null);
+      return new ListQueries(getLocation(context),
+      context.ALL() != null, context.EXTENDED() != null);
     }
 
     @Override

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -579,8 +579,8 @@ public class AstBuilder {
 
     @Override
     public Node visitListTopics(final SqlBaseParser.ListTopicsContext context) {
-      return new ListTopics(getLocation(context),
-      context.ALL() != null, context.EXTENDED() != null);
+      return new ListTopics(getLocation(context), 
+          context.ALL() != null, context.EXTENDED() != null);
     }
 
     @Override
@@ -597,8 +597,8 @@ public class AstBuilder {
 
     @Override
     public Node visitListQueries(final SqlBaseParser.ListQueriesContext context) {
-      return new ListQueries(getLocation(context),
-      context.ALL() != null, context.EXTENDED() != null);
+      return new ListQueries(
+          getLocation(context), context.EXTENDED() != null);
     }
 
     @Override

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListQueries.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListQueries.java
@@ -25,14 +25,21 @@ import java.util.Optional;
 @Immutable
 public class ListQueries extends Statement {
 
+  private final boolean showAll;
   private final boolean showExtended;
 
   public ListQueries(
       final Optional<NodeLocation> location,
+      final boolean showAll,
       final boolean showExtended
   ) {
     super(location);
     this.showExtended = showExtended;
+    this.showAll = showAll;
+  }
+
+  public boolean getShowAll() {
+    return showAll;
   }
 
   public boolean getShowExtended() {
@@ -48,17 +55,18 @@ public class ListQueries extends Statement {
       return false;
     }
     final ListQueries that = (ListQueries) o;
-    return showExtended == that.showExtended;
+    return showAll == that.showAll && showExtended == that.showExtended;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(showExtended);
+    return Objects.hash(showExtended, showAll);
   }
 
   @Override
   public String toString() {
     return toStringHelper(this)
+        .add("showAll", showAll)
         .add("showExtended", showExtended)
         .toString();
   }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListQueries.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListQueries.java
@@ -25,21 +25,14 @@ import java.util.Optional;
 @Immutable
 public class ListQueries extends Statement {
 
-  private final boolean showAll;
   private final boolean showExtended;
 
   public ListQueries(
       final Optional<NodeLocation> location,
-      final boolean showAll,
       final boolean showExtended
   ) {
     super(location);
     this.showExtended = showExtended;
-    this.showAll = showAll;
-  }
-
-  public boolean getShowAll() {
-    return showAll;
   }
 
   public boolean getShowExtended() {
@@ -55,18 +48,17 @@ public class ListQueries extends Statement {
       return false;
     }
     final ListQueries that = (ListQueries) o;
-    return showAll == that.showAll && showExtended == that.showExtended;
+    return showExtended == that.showExtended;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(showExtended, showAll);
+    return Objects.hash(showExtended);
   }
 
   @Override
   public String toString() {
     return toStringHelper(this)
-        .add("showAll", showAll)
         .add("showExtended", showExtended)
         .toString();
   }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -709,6 +709,18 @@ public class KsqlParserTest {
     assertThat(statement, instanceOf(ListQueries.class));
     final ListQueries listQueries = (ListQueries)statement;
     assertThat(listQueries.getShowExtended(), is(false));
+    assertThat(listQueries.getShowAll(), is(false));
+  }
+
+  @Test
+  public void shouldSetShowAllForShowQueries() {
+    final String statementString = "SHOW ALL QUERIES;";
+    final Statement statement = KsqlParserTestUtil.buildSingleAst(statementString, metaStore)
+            .getStatement();
+    assertThat(statement, instanceOf(ListQueries.class));
+    final ListQueries listQueries = (ListQueries)statement;
+    assertThat(listQueries.getShowExtended(), is(false));
+    assertThat(listQueries.getShowAll(), is(true));
   }
 
   @Test
@@ -850,7 +862,18 @@ public class KsqlParserTest {
     final ListQueries listQueries = (ListQueries)statement;
     assertThat(listQueries.getShowExtended(), is(true));
   }
-  
+
+  @Test
+  public void shouldSetShowALLForShowQueriesDescriptions() {
+    final String statementString = "SHOW ALL QUERIES EXTENDED;";
+    final Statement statement = KsqlParserTestUtil.buildSingleAst(statementString, metaStore)
+            .getStatement();
+    assertThat(statement, instanceOf(ListQueries.class));
+    final ListQueries listQueries = (ListQueries)statement;
+    assertThat(listQueries.getShowExtended(), is(true));
+    assertThat(listQueries.getShowAll(), is(true));
+  }
+
   private void assertQuerySucceeds(final String sql) {
     final Statement statement = KsqlParserTestUtil.buildSingleAst(sql, metaStore).getStatement();
     assertThat(statement, instanceOf(Query.class));

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -709,18 +709,6 @@ public class KsqlParserTest {
     assertThat(statement, instanceOf(ListQueries.class));
     final ListQueries listQueries = (ListQueries)statement;
     assertThat(listQueries.getShowExtended(), is(false));
-    assertThat(listQueries.getShowAll(), is(false));
-  }
-
-  @Test
-  public void shouldSetShowAllForShowQueries() {
-    final String statementString = "SHOW ALL QUERIES;";
-    final Statement statement = KsqlParserTestUtil.buildSingleAst(statementString, metaStore)
-            .getStatement();
-    assertThat(statement, instanceOf(ListQueries.class));
-    final ListQueries listQueries = (ListQueries)statement;
-    assertThat(listQueries.getShowExtended(), is(false));
-    assertThat(listQueries.getShowAll(), is(true));
   }
 
   @Test
@@ -861,17 +849,6 @@ public class KsqlParserTest {
     assertThat(statement, instanceOf(ListQueries.class));
     final ListQueries listQueries = (ListQueries)statement;
     assertThat(listQueries.getShowExtended(), is(true));
-  }
-
-  @Test
-  public void shouldSetShowALLForShowQueriesDescriptions() {
-    final String statementString = "SHOW ALL QUERIES EXTENDED;";
-    final Statement statement = KsqlParserTestUtil.buildSingleAst(statementString, metaStore)
-            .getStatement();
-    assertThat(statement, instanceOf(ListQueries.class));
-    final ListQueries listQueries = (ListQueries)statement;
-    assertThat(listQueries.getShowExtended(), is(true));
-    assertThat(listQueries.getShowAll(), is(true));
   }
 
   private void assertQuerySucceeds(final String sql) {

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/ListQueriesTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/ListQueriesTest.java
@@ -30,11 +30,11 @@ public class ListQueriesTest {
     new EqualsTester()
         .addEqualityGroup(
             // Note: At the moment location does not take part in equality testing
-            new ListQueries(Optional.of(SOME_LOCATION), true),
-            new ListQueries(Optional.of(OTHER_LOCATION), true)
+            new ListQueries(Optional.of(SOME_LOCATION), true, true),
+            new ListQueries(Optional.of(OTHER_LOCATION), true, true)
         )
         .addEqualityGroup(
-            new ListQueries(Optional.of(SOME_LOCATION), false)
+            new ListQueries(Optional.of(SOME_LOCATION), false, false)
         )
         .testEquals();
   }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/ListQueriesTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/ListQueriesTest.java
@@ -30,11 +30,11 @@ public class ListQueriesTest {
     new EqualsTester()
         .addEqualityGroup(
             // Note: At the moment location does not take part in equality testing
-            new ListQueries(Optional.of(SOME_LOCATION), true, true),
-            new ListQueries(Optional.of(OTHER_LOCATION), true, true)
+            new ListQueries(Optional.of(SOME_LOCATION), true),
+            new ListQueries(Optional.of(OTHER_LOCATION), true)
         )
         .addEqualityGroup(
-            new ListQueries(Optional.of(SOME_LOCATION), false, false)
+            new ListQueries(Optional.of(SOME_LOCATION), false)
         )
         .testEquals();
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescriptionFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescriptionFactory.java
@@ -32,7 +32,10 @@ public final class QueryDescriptionFactory {
   private QueryDescriptionFactory() {
   }
 
-  public static QueryDescription forQueryMetadata(final QueryMetadata queryMetadata) {
+  public static QueryDescription forQueryMetadata(
+      final QueryMetadata queryMetadata,
+      final Optional<KsqlHostInfoEntity> ksqlHostInfo
+  ) {
     if (queryMetadata instanceof PersistentQueryMetadata) {
       final PersistentQueryMetadata persistentQuery = (PersistentQueryMetadata) queryMetadata;
       return create(
@@ -40,7 +43,8 @@ public final class QueryDescriptionFactory {
           persistentQuery,
           persistentQuery.getResultTopic().getKeyFormat().getWindowType(),
           ImmutableSet.of(persistentQuery.getSinkName()),
-          Optional.of(persistentQuery.getState())
+          Optional.of(persistentQuery.getState()),
+          ksqlHostInfo
       );
     }
 
@@ -49,6 +53,7 @@ public final class QueryDescriptionFactory {
         queryMetadata,
         Optional.empty(),
         Collections.emptySet(),
+        Optional.empty(),
         Optional.empty()
     );
   }
@@ -58,7 +63,8 @@ public final class QueryDescriptionFactory {
       final QueryMetadata queryMetadata,
       final Optional<WindowType> windowType,
       final Set<SourceName> sinks,
-      final Optional<String> state
+      final Optional<String> state,
+      final Optional<KsqlHostInfoEntity> ksqlHostInfo
   ) {
     return new QueryDescription(
         id,
@@ -70,7 +76,8 @@ public final class QueryDescriptionFactory {
         queryMetadata.getTopologyDescription(),
         queryMetadata.getExecutionPlan(),
         queryMetadata.getOverriddenProperties(),
-        state
+        state,
+        ksqlHostInfo
     );
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/ServerUtil.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/ServerUtil.java
@@ -69,7 +69,11 @@ public final class ServerUtil {
    * @param remotePort The remote port
    * @return uri
    */
-  static URI buildRemoteUri(final URL localHost, final String remoteHost, final int remotePort) {
+  public static URI buildRemoteUri(
+      final URL localHost, 
+      final String remoteHost, 
+      final int remotePort
+  ) {
     try {
       return new URL(localHost.getProtocol(), remoteHost, remotePort, "/").toURI();
     } catch (final Exception e) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ExplainExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ExplainExecutor.java
@@ -118,7 +118,7 @@ public final class ExplainExecutor {
               new IllegalStateException("The provided statement did not run a ksql query"));
     }
 
-    return QueryDescriptionFactory.forQueryMetadata(metadata);
+    return QueryDescriptionFactory.forQueryMetadata(metadata, Optional.empty());
   }
 
   private static QueryDescription explainQuery(
@@ -131,7 +131,7 @@ public final class ExplainExecutor {
             "Query with id:" + queryId + " does not exist, "
                 + "use SHOW QUERIES to view the full set of queries."));
 
-    return QueryDescriptionFactory.forQueryMetadata(metadata);
+    return QueryDescriptionFactory.forQueryMetadata(metadata, Optional.empty());
   }
 
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutor.java
@@ -71,14 +71,14 @@ public final class ListQueriesExecutor {
         ))
         .collect(Collectors.toList()));
     
-    if (listQueries.getShowAll()) {
+    if (!sessionProperties.getIsInternalRequest()) {
       final Set<HostInfo> hosts =
           DiscoverRemoteHostsUtil.getRemoteHosts(
               executionContext.getPersistentQueries(),
               sessionProperties.getKsqlHostInfo());
 
       hosts.forEach(hostInfo -> {
-        final KsqlEntityList response = serviceContext.getKsqlClient().makeKsqlRequest(
+        final KsqlEntityList response = serviceContext.getKsqlClient().makeInternalKsqlRequest(
             ServerUtil.buildRemoteUri(
                 sessionProperties.getLocalUrl(),
                 hostInfo.host(),
@@ -114,14 +114,14 @@ public final class ListQueriesExecutor {
             ))
         .collect(Collectors.toList()));
 
-    if (listQueries.getShowAll()) {
+    if (!sessionProperties.getIsInternalRequest()) {
       final Set<HostInfo> hosts =
           DiscoverRemoteHostsUtil.getRemoteHosts(
               executionContext.getPersistentQueries(),
               sessionProperties.getKsqlHostInfo());
 
       hosts.forEach(hostInfo -> {
-        final KsqlEntityList response = serviceContext.getKsqlClient().makeKsqlRequest(
+        final KsqlEntityList response = serviceContext.getKsqlClient().makeInternalKsqlRequest(
             ServerUtil.buildRemoteUri(
                 sessionProperties.getLocalUrl(),
                 hostInfo.host(),

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutor.java
@@ -84,7 +84,7 @@ public final class ListQueriesExecutor {
                 hostInfo.host(),
                 hostInfo.port()
             ),
-            "show queries;"
+            statement.getStatementText()
         ).getResponse();
         response.forEach(queries -> {
           runningQueries.addAll(((Queries) queries).getQueries());
@@ -104,8 +104,8 @@ public final class ListQueriesExecutor {
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {
-    final List<QueryDescription> queryDescriptionList = new ArrayList<>();
-    queryDescriptionList.addAll(
+    final List<QueryDescription> queryDesrciptions = new ArrayList<>();
+    queryDesrciptions.addAll(
         executionContext.getPersistentQueries().stream()
         .map(query ->
             QueryDescriptionFactory.forQueryMetadata(
@@ -127,16 +127,16 @@ public final class ListQueriesExecutor {
                 hostInfo.host(),
                 hostInfo.port()
             ),
-            "show queries extended;"
+            statement.getStatementText()
         ).getResponse();
 
         response.forEach(queries -> {
-          queryDescriptionList.addAll(((QueryDescriptionList) queries).getQueryDescriptions());
+          queryDesrciptions.addAll(((QueryDescriptionList) queries).getQueryDescriptions());
         });
       });
     }
     return Optional.of(new QueryDescriptionList(
         statement.getStatementText(),
-        queryDescriptionList));
+        queryDesrciptions));
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutor.java
@@ -63,7 +63,7 @@ public final class ListQueriesExecutor {
         .stream()
         .map(q -> new RunningQuery(
             q.getStatementString(),
-            ImmutableSet.of(q.getSinkName().name()),
+            ImmutableSet.of(q.getSinkName().text()),
             ImmutableSet.of(q.getResultTopic().getKafkaTopicName()),
             q.getQueryId(),
             Optional.of(q.getState()),

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
@@ -224,7 +224,8 @@ public final class ListSourceExecutor {
             ImmutableSet.of(q.getSinkName().text()),
             ImmutableSet.of(q.getResultTopic().getKafkaTopicName()),
             q.getQueryId(),
-            Optional.of(q.getState())
+            Optional.of(q.getState()),
+            Optional.empty()
         ))
         .collect(Collectors.toList());
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -254,7 +254,7 @@ public class KsqlResource implements KsqlConfigurable {
               request.getConfigOverrides(),
               localHost, 
               localUrl,
-              request.getIsInternalRequest().orElse(false)
+              request.getInternalRequest()
           ),
           request.getKsql()
       );
@@ -266,7 +266,7 @@ public class KsqlResource implements KsqlConfigurable {
               request.getConfigOverrides(),
               localHost,
               localUrl,
-              request.getIsInternalRequest().orElse(false)
+              request.getInternalRequest()
           )
       );
       return Response.ok(entities).build();

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -218,7 +218,8 @@ public class KsqlResource implements KsqlConfigurable {
           new SessionProperties(
               request.getStreamsProperties(),
               localHost,
-              localUrl
+              localUrl,
+              false
           )
       );
       return Response.ok(entities).build();
@@ -252,7 +253,8 @@ public class KsqlResource implements KsqlConfigurable {
           new SessionProperties(
               request.getConfigOverrides(),
               localHost, 
-              localUrl
+              localUrl,
+              request.getIsInternalRequest().orElse(false)
           ),
           request.getKsql()
       );
@@ -263,7 +265,8 @@ public class KsqlResource implements KsqlConfigurable {
           new SessionProperties(
               request.getConfigOverrides(),
               localHost,
-              localUrl
+              localUrl,
+              request.getIsInternalRequest().orElse(false)
           )
       );
       return Response.ok(entities).build();

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/services/DefaultKsqlClient.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/services/DefaultKsqlClient.java
@@ -74,6 +74,17 @@ final class DefaultKsqlClient implements SimpleKsqlClient {
   }
 
   @Override
+  public RestResponse<KsqlEntityList> makeInternalKsqlRequest(
+      final URI serverEndPoint,
+      final String sql
+  ) {
+    final KsqlTarget target = sharedClient
+        .target(serverEndPoint);
+
+    return getTarget(target, authHeader).postInternalKsqlRequest(sql);
+  }
+
+  @Override
   public RestResponse<List<StreamedRow>> makeQueryRequest(
       final URI serverEndPoint,
       final String sql,

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/services/ServerInternalKsqlClient.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/services/ServerInternalKsqlClient.java
@@ -61,7 +61,7 @@ public class ServerInternalKsqlClient implements SimpleKsqlClient {
       final String sql
   ) {
     final KsqlRequest request = new KsqlRequest(
-        sql, Collections.emptyMap(), Collections.emptyMap(), null);
+        sql, Collections.emptyMap(), Collections.emptyMap(), null, true);
     final Response response = ksqlResource.handleKsqlStatements(securityContext, request);
 
     final Code statusCode = HttpStatus.getCode(response.getStatus());
@@ -71,6 +71,14 @@ public class ServerInternalKsqlClient implements SimpleKsqlClient {
     }
 
     return RestResponse.successful(statusCode, (KsqlEntityList) response.getEntity());
+  }
+
+  @Override
+  public RestResponse<KsqlEntityList> makeInternalKsqlRequest(
+      final URI serverEndpoint,
+      final String sql
+  ) {
+    return makeKsqlRequest(serverEndpoint, sql);
   }
 
   @Override

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/DiscoverRemoteHostsUtil.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/DiscoverRemoteHostsUtil.java
@@ -38,9 +38,7 @@ public final class DiscoverRemoteHostsUtil {
         .map(QueryMetadata::getAllMetadata)
         .filter(Objects::nonNull)
         .flatMap(Collection::stream)
-        .filter(streamsMetadata -> {
-          return streamsMetadata != StreamsMetadata.NOT_AVAILABLE;
-        })
+        .filter(streamsMetadata -> streamsMetadata != StreamsMetadata.NOT_AVAILABLE)
         .map(StreamsMetadata::hostInfo)
         .filter(hostInfo -> !(hostInfo.host().equals(localHost.host())
             && hostInfo.port() == (localHost.port())))

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/DiscoverRemoteHostsUtil.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/DiscoverRemoteHostsUtil.java
@@ -38,7 +38,9 @@ public final class DiscoverRemoteHostsUtil {
         .map(QueryMetadata::getAllMetadata)
         .filter(Objects::nonNull)
         .flatMap(Collection::stream)
-        .filter(streamsMetadata -> streamsMetadata != StreamsMetadata.NOT_AVAILABLE)
+        .filter(streamsMetadata -> {
+          return streamsMetadata != StreamsMetadata.NOT_AVAILABLE;
+        })
         .map(StreamsMetadata::hostInfo)
         .filter(hostInfo -> !(hostInfo.host().equals(localHost.host())
             && hostInfo.port() == (localHost.port())))

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
@@ -79,6 +79,7 @@ public class QueryDescriptionFactoryTest {
   private static final String SQL_TEXT = "test statement";
   private static final String TOPOLOGY_TEXT = "Topology Text";
   private static final Long closeTimeout = KsqlConfig.KSQL_SHUTDOWN_TIMEOUT_MS_DEFAULT;
+  private static final Optional<KsqlHostInfoEntity> LOCAL_HOST = Optional.of(new KsqlHostInfoEntity("localhost", 50));
 
   @Mock
   private Consumer<QueryMetadata> queryCloseCallback;
@@ -117,7 +118,7 @@ public class QueryDescriptionFactoryTest {
         queryCloseCallback,
         closeTimeout);
 
-    transientQueryDescription = QueryDescriptionFactory.forQueryMetadata(transientQuery);
+    transientQueryDescription = QueryDescriptionFactory.forQueryMetadata(transientQuery, Optional.empty());
 
     final PersistentQueryMetadata persistentQuery = new PersistentQueryMetadata(
         SQL_TEXT,
@@ -138,7 +139,7 @@ public class QueryDescriptionFactoryTest {
         queryCloseCallback,
         closeTimeout);
 
-    persistentQueryDescription = QueryDescriptionFactory.forQueryMetadata(persistentQuery);
+    persistentQueryDescription = QueryDescriptionFactory.forQueryMetadata(persistentQuery, LOCAL_HOST);
   }
 
   @Test
@@ -231,7 +232,7 @@ public class QueryDescriptionFactoryTest {
         closeTimeout);
 
     // When:
-    transientQueryDescription = QueryDescriptionFactory.forQueryMetadata(transientQuery);
+    transientQueryDescription = QueryDescriptionFactory.forQueryMetadata(transientQuery, Optional.empty());
 
     // Then:
     assertThat(transientQueryDescription.getFields(), contains(
@@ -264,7 +265,7 @@ public class QueryDescriptionFactoryTest {
         closeTimeout);
 
     // When:
-    transientQueryDescription = QueryDescriptionFactory.forQueryMetadata(transientQuery);
+    transientQueryDescription = QueryDescriptionFactory.forQueryMetadata(transientQuery, Optional.empty());
 
     // Then:
     assertThat(transientQueryDescription.getFields(), contains(

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/ListAllQueriesFunctionalTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/ListAllQueriesFunctionalTest.java
@@ -62,21 +62,21 @@ public class ListAllQueriesFunctionalTest {
   private static final KsqlHostInfoEntity host1 = new KsqlHostInfoEntity("localhost", 8089);
   private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
   private static final TestKsqlRestApp REST_APP_0 = TestKsqlRestApp
-          .builder(TEST_HARNESS::kafkaBootstrapServers)
-          .withProperty(KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:8088")
-          .withProperty(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG, "http://localhost:8088")
-          .withProperty(KsqlRestConfig.KSQL_HEARTBEAT_ENABLE_CONFIG, true)
-          .withProperty(KsqlConfig.KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG, 1000)
-          .withProperties(ClientTrustStore.trustStoreProps())
-          .build();
+      .builder(TEST_HARNESS::kafkaBootstrapServers)
+      .withProperty(KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:8088")
+      .withProperty(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG, "http://localhost:8088")
+      .withProperty(KsqlRestConfig.KSQL_HEARTBEAT_ENABLE_CONFIG, true)
+      .withProperty(KsqlConfig.KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG, 1000)
+      .withProperties(ClientTrustStore.trustStoreProps())
+      .build();
   private static final TestKsqlRestApp REST_APP_1 = TestKsqlRestApp
-          .builder(TEST_HARNESS::kafkaBootstrapServers)
-          .withProperty(KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:8089")
-          .withProperty(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG, "http://localhost:8089")
-          .withProperty(KsqlRestConfig.KSQL_HEARTBEAT_ENABLE_CONFIG, true)
-          .withProperty(KsqlConfig.KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG, 1000)
-          .withProperties(ClientTrustStore.trustStoreProps())
-          .build();
+      .builder(TEST_HARNESS::kafkaBootstrapServers)
+      .withProperty(KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:8089")
+      .withProperty(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG, "http://localhost:8089")
+      .withProperty(KsqlRestConfig.KSQL_HEARTBEAT_ENABLE_CONFIG, true)
+      .withProperty(KsqlConfig.KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG, 1000)
+      .withProperties(ClientTrustStore.trustStoreProps())
+      .build();
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
@@ -99,33 +99,26 @@ public class ListAllQueriesFunctionalTest {
 
   @Test
   public void shouldShowAllQueries() {
-    // Given:
-    final List<KsqlEntity> entities0 = RestIntegrationTestUtil.makeKsqlRequest(
+    final List<KsqlEntity> allEntities0 = RestIntegrationTestUtil.makeKsqlRequest(
         REST_APP_0,
         "Show Queries;"
     );
-    final List<RunningQuery> runningQueries0 = ((Queries) entities0.get(0)).getQueries();
-    assertThat(runningQueries0.size(), equalTo(1));
-    assertThat(runningQueries0.get(0).getKsqlHostInfo().orElse(null), equalTo(host0));
 
+    final List<RunningQuery> allRunningQueries0 = ((Queries) allEntities0.get(0)).getQueries();
+    assertThat(allRunningQueries0.size(), equalTo(2));
+    assertThat(allRunningQueries0.stream()
+        .map(RunningQuery::getKsqlHostInfo)
+        .map(host -> host.orElse(null))
+        .collect(Collectors.toSet()), containsInAnyOrder(host0, host1));
 
-    final List<KsqlEntity> entities1 = RestIntegrationTestUtil.makeKsqlRequest(
+    final List<KsqlEntity> allEntities1 = RestIntegrationTestUtil.makeKsqlRequest(
         REST_APP_1,
         "Show Queries;"
     );
-    final List<RunningQuery> runningQueries1 = ((Queries) entities1.get(0)).getQueries();
-    assertThat(runningQueries1.size(), equalTo(1));
-    assertThat(runningQueries1.get(0).getKsqlHostInfo().orElse(null), equalTo(host1));
 
-    // Then:
-    final List<KsqlEntity> allEntities = RestIntegrationTestUtil.makeKsqlRequest(
-        REST_APP_0,
-        "Show All Queries;"
-    );
-
-    final List<RunningQuery> allRunningQueries = ((Queries) allEntities.get(0)).getQueries();
-    assertThat(allRunningQueries.size(), equalTo(2));
-    assertThat(allRunningQueries.stream()
+    final List<RunningQuery> allRunningQueries1 = ((Queries) allEntities1.get(0)).getQueries();
+    assertThat(allRunningQueries1.size(), equalTo(2));
+    assertThat(allRunningQueries1.stream()
         .map(RunningQuery::getKsqlHostInfo)
         .map(host -> host.orElse(null))
         .collect(Collectors.toSet()), containsInAnyOrder(host0, host1));
@@ -133,31 +126,24 @@ public class ListAllQueriesFunctionalTest {
 
   @Test
   public void shouldShowAllQueriesExtended() {
-    // Given:
-    final List<KsqlEntity> entities0 = RestIntegrationTestUtil.makeKsqlRequest(
+    final List<KsqlEntity> clusterEntities0 = RestIntegrationTestUtil.makeKsqlRequest(
         REST_APP_0,
-        "Show Queries Extended;"
-    );
-    final List<QueryDescription> queryDescriptions0 = ((QueryDescriptionList) entities0.get(0)).getQueryDescriptions();
-    assertThat(queryDescriptions0.size(), equalTo(1));
-    assertThat(queryDescriptions0.get(0).getKsqlHostInfo().orElse(null), equalTo(host0));
-    
-    final List<KsqlEntity> entities1 = RestIntegrationTestUtil.makeKsqlRequest(
-        REST_APP_1,
-        "Show Queries Extended;"
-    );
-    final List<QueryDescription> queryDescriptions1 = ((QueryDescriptionList) entities1.get(0)).getQueryDescriptions();
-    assertThat(queryDescriptions1.size(), equalTo(1));
-    assertThat(queryDescriptions1.get(0).getKsqlHostInfo().orElse(null), equalTo(host1));
+        "Show Queries Extended;");
 
-    // Then:
-    final List<KsqlEntity> clusterEntities = RestIntegrationTestUtil.makeKsqlRequest(
-        REST_APP_0,
-        "Show All Queries Extended;");
+    final List<QueryDescription> clusterQueryDescriptions0 = ((QueryDescriptionList) clusterEntities0.get(0)).getQueryDescriptions();
+    assertThat(clusterQueryDescriptions0.size(), equalTo(2));
+    assertThat(clusterQueryDescriptions0.stream()
+        .map(QueryDescription::getKsqlHostInfo)
+        .map(host -> host.orElse(null))
+        .collect(Collectors.toSet()), containsInAnyOrder(host0, host1));
 
-    final List<QueryDescription> clusterQueryDescriptions = ((QueryDescriptionList) clusterEntities.get(0)).getQueryDescriptions();
-    assertThat(clusterQueryDescriptions.size(), equalTo(2));
-    assertThat(clusterQueryDescriptions.stream()
+    final List<KsqlEntity> clusterEntities1 = RestIntegrationTestUtil.makeKsqlRequest(
+            REST_APP_0,
+            "Show Queries Extended;");
+
+    final List<QueryDescription> clusterQueryDescriptions1 = ((QueryDescriptionList) clusterEntities1.get(0)).getQueryDescriptions();
+    assertThat(clusterQueryDescriptions1.size(), equalTo(2));
+    assertThat(clusterQueryDescriptions1.stream()
         .map(QueryDescription::getKsqlHostInfo)
         .map(host -> host.orElse(null))
         .collect(Collectors.toSet()), containsInAnyOrder(host0, host1));

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/ListAllQueriesFunctionalTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/ListAllQueriesFunctionalTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.integration;
+
+import static io.confluent.ksql.rest.integration.HighAvailabilityTestUtil.waitForClusterToBeDiscovered;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+
+import io.confluent.common.utils.IntegrationTest;
+import io.confluent.ksql.integration.IntegrationTestHarness;
+import io.confluent.ksql.integration.Retry;
+import io.confluent.ksql.rest.entity.KsqlEntity;
+import io.confluent.ksql.rest.entity.KsqlHostInfoEntity;
+import io.confluent.ksql.rest.entity.Queries;
+import io.confluent.ksql.rest.entity.QueryDescription;
+import io.confluent.ksql.rest.entity.QueryDescriptionList;
+import io.confluent.ksql.rest.entity.RunningQuery;
+import io.confluent.ksql.rest.server.KsqlRestConfig;
+import io.confluent.ksql.rest.server.TestKsqlRestApp;
+import io.confluent.ksql.serde.FormatFactory;
+import io.confluent.ksql.test.util.secure.ClientTrustStore;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.PageViewDataProvider;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import kafka.zookeeper.ZooKeeperClientException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+
+@Category({IntegrationTest.class})
+public class ListAllQueriesFunctionalTest {
+
+  private static final PageViewDataProvider PAGE_VIEWS_PROVIDER = new PageViewDataProvider();
+  private static final String PAGE_VIEW_TOPIC = PAGE_VIEWS_PROVIDER.topicName();
+  private static final String PAGE_VIEW_STREAM = PAGE_VIEWS_PROVIDER.kstreamName();
+  private static final KsqlHostInfoEntity host0 = new KsqlHostInfoEntity("localhost", 8088);
+  private static final KsqlHostInfoEntity host1 = new KsqlHostInfoEntity("localhost", 8089);
+  private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
+  private static final TestKsqlRestApp REST_APP_0 = TestKsqlRestApp
+          .builder(TEST_HARNESS::kafkaBootstrapServers)
+          .withProperty(KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:8088")
+          .withProperty(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG, "http://localhost:8088")
+          .withProperty(KsqlRestConfig.KSQL_HEARTBEAT_ENABLE_CONFIG, true)
+          .withProperty(KsqlConfig.KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG, 1000)
+          .withProperties(ClientTrustStore.trustStoreProps())
+          .build();
+  private static final TestKsqlRestApp REST_APP_1 = TestKsqlRestApp
+          .builder(TEST_HARNESS::kafkaBootstrapServers)
+          .withProperty(KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:8089")
+          .withProperty(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG, "http://localhost:8089")
+          .withProperty(KsqlRestConfig.KSQL_HEARTBEAT_ENABLE_CONFIG, true)
+          .withProperty(KsqlConfig.KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG, 1000)
+          .withProperties(ClientTrustStore.trustStoreProps())
+          .build();
+
+  @ClassRule
+  public static final RuleChain CHAIN = RuleChain
+      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .around(TEST_HARNESS)
+      .around(REST_APP_0)
+      .around(REST_APP_1);
+
+  @BeforeClass
+  public static void setUpClass() throws InterruptedException {
+    TEST_HARNESS.ensureTopics(2, PAGE_VIEW_TOPIC);
+    TEST_HARNESS.produceRows(PAGE_VIEW_TOPIC, PAGE_VIEWS_PROVIDER, FormatFactory.JSON);
+    RestIntegrationTestUtil.createStream(REST_APP_0, PAGE_VIEWS_PROVIDER);
+    RestIntegrationTestUtil.makeKsqlRequest(
+        REST_APP_0,
+        "CREATE STREAM S AS SELECT * FROM " + PAGE_VIEW_STREAM + ";"
+    );
+    waitForClusterToBeDiscovered(REST_APP_0, 2);
+  }
+
+  @Test
+  public void shouldShowAllQueries() {
+    // Given:
+    final List<KsqlEntity> entities0 = RestIntegrationTestUtil.makeKsqlRequest(
+        REST_APP_0,
+        "Show Queries;"
+    );
+    final List<RunningQuery> runningQueries0 = ((Queries) entities0.get(0)).getQueries();
+    assertThat(runningQueries0.size(), equalTo(1));
+    assertThat(runningQueries0.get(0).getKsqlHostInfo().orElse(null), equalTo(host0));
+
+
+    final List<KsqlEntity> entities1 = RestIntegrationTestUtil.makeKsqlRequest(
+        REST_APP_1,
+        "Show Queries;"
+    );
+    final List<RunningQuery> runningQueries1 = ((Queries) entities1.get(0)).getQueries();
+    assertThat(runningQueries1.size(), equalTo(1));
+    assertThat(runningQueries1.get(0).getKsqlHostInfo().orElse(null), equalTo(host1));
+
+    // Then:
+    final List<KsqlEntity> allEntities = RestIntegrationTestUtil.makeKsqlRequest(
+        REST_APP_0,
+        "Show All Queries;"
+    );
+
+    final List<RunningQuery> allRunningQueries = ((Queries) allEntities.get(0)).getQueries();
+    assertThat(allRunningQueries.size(), equalTo(2));
+    assertThat(allRunningQueries.stream()
+        .map(RunningQuery::getKsqlHostInfo)
+        .map(host -> host.orElse(null))
+        .collect(Collectors.toSet()), containsInAnyOrder(host0, host1));
+  }
+
+  @Test
+  public void shouldShowAllQueriesExtended() {
+    // Given:
+    final List<KsqlEntity> entities0 = RestIntegrationTestUtil.makeKsqlRequest(
+        REST_APP_0,
+        "Show Queries Extended;"
+    );
+    final List<QueryDescription> queryDescriptions0 = ((QueryDescriptionList) entities0.get(0)).getQueryDescriptions();
+    assertThat(queryDescriptions0.size(), equalTo(1));
+    assertThat(queryDescriptions0.get(0).getKsqlHostInfo().orElse(null), equalTo(host0));
+    
+    final List<KsqlEntity> entities1 = RestIntegrationTestUtil.makeKsqlRequest(
+        REST_APP_1,
+        "Show Queries Extended;"
+    );
+    final List<QueryDescription> queryDescriptions1 = ((QueryDescriptionList) entities1.get(0)).getQueryDescriptions();
+    assertThat(queryDescriptions1.size(), equalTo(1));
+    assertThat(queryDescriptions1.get(0).getKsqlHostInfo().orElse(null), equalTo(host1));
+
+    // Then:
+    final List<KsqlEntity> clusterEntities = RestIntegrationTestUtil.makeKsqlRequest(
+        REST_APP_0,
+        "Show All Queries Extended;");
+
+    final List<QueryDescription> clusterQueryDescriptions = ((QueryDescriptionList) clusterEntities.get(0)).getQueryDescriptions();
+    assertThat(clusterQueryDescriptions.size(), equalTo(2));
+    assertThat(clusterQueryDescriptions.stream()
+        .map(QueryDescription::getKsqlHostInfo)
+        .map(host -> host.orElse(null))
+        .collect(Collectors.toSet()), containsInAnyOrder(host0, host1));
+  }
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
@@ -133,7 +133,8 @@ public final class RestIntegrationTestUtil {
         sql,
         ImmutableMap.of(),
         Collections.emptyMap(),
-        cmdSeqNum.orElse(null)
+        cmdSeqNum.orElse(null),
+        false
     );
 
     final URI listener = restApp.getHttpListener();

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -228,7 +228,7 @@ public class KsqlRestApplicationTest {
     // Then:
     verify(ksqlResource).handleKsqlStatements(
         securityContextArgumentCaptor.capture(),
-        eq(new KsqlRequest(logCreateStatement, Collections.emptyMap(), Collections.emptyMap(), null))
+        eq(new KsqlRequest(logCreateStatement, Collections.emptyMap(), Collections.emptyMap(), null, true))
     );
     assertThat(securityContextArgumentCaptor.getValue().getUserPrincipal(), is(Optional.empty()));
     assertThat(securityContextArgumentCaptor.getValue().getServiceContext(), is(serviceContext));
@@ -246,7 +246,7 @@ public class KsqlRestApplicationTest {
     // Then:
     verify(ksqlResource, never()).handleKsqlStatements(
         securityContext,
-        new KsqlRequest(logCreateStatement, Collections.emptyMap(), Collections.emptyMap(), null)
+        new KsqlRequest(logCreateStatement, Collections.emptyMap(), Collections.emptyMap(), null, false)
     );
   }
 
@@ -262,7 +262,7 @@ public class KsqlRestApplicationTest {
     inOrder.verify(commandRunner).start();
     inOrder.verify(ksqlResource).handleKsqlStatements(
         securityContextArgumentCaptor.capture(),
-        eq(new KsqlRequest(logCreateStatement, Collections.emptyMap(), Collections.emptyMap(), null))
+        eq(new KsqlRequest(logCreateStatement, Collections.emptyMap(), Collections.emptyMap(), null, true))
     );
     assertThat(securityContextArgumentCaptor.getValue().getUserPrincipal(), is(Optional.empty()));
     assertThat(securityContextArgumentCaptor.getValue().getServiceContext(), is(serviceContext));
@@ -278,7 +278,7 @@ public class KsqlRestApplicationTest {
     inOrder.verify(topicClient).createTopic(eq(LOG_TOPIC_NAME), anyInt(), anyShort());
     inOrder.verify(ksqlResource).handleKsqlStatements(
         securityContextArgumentCaptor.capture(),
-        eq(new KsqlRequest(logCreateStatement, Collections.emptyMap(), Collections.emptyMap(), null))
+        eq(new KsqlRequest(logCreateStatement, Collections.emptyMap(), Collections.emptyMap(), null, true))
     );
     assertThat(securityContextArgumentCaptor.getValue().getUserPrincipal(), is(Optional.empty()));
     assertThat(securityContextArgumentCaptor.getValue().getServiceContext(), is(serviceContext));
@@ -316,7 +316,7 @@ public class KsqlRestApplicationTest {
     final InOrder inOrder = Mockito.inOrder(ksqlResource, serverState);
     verify(ksqlResource).handleKsqlStatements(
         securityContextArgumentCaptor.capture(),
-        eq(new KsqlRequest(logCreateStatement, Collections.emptyMap(), Collections.emptyMap(), null))
+        eq(new KsqlRequest(logCreateStatement, Collections.emptyMap(), Collections.emptyMap(), null, true))
     );
     assertThat(securityContextArgumentCaptor.getValue().getUserPrincipal(), is(Optional.empty()));
     assertThat(securityContextArgumentCaptor.getValue().getServiceContext(), is(serviceContext));

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
@@ -244,7 +244,7 @@ public class RecoveryTest {
     void submitCommands(final String ...statements) {
       for (final String statement : statements) {
         final Response response = ksqlResource.handleKsqlStatements(securityContext,
-            new KsqlRequest(statement, Collections.emptyMap(), Collections.emptyMap(), null));
+            new KsqlRequest(statement, Collections.emptyMap(), Collections.emptyMap(), null, false));
         assertThat(response.getStatus(), equalTo(200));
         executeCommands();
       }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ExplainExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ExplainExecutorTest.java
@@ -71,7 +71,7 @@ public class ExplainExecutorTest {
     ).orElseThrow(IllegalStateException::new);
 
     // Then:
-    assertThat(query.getQueryDescription(), equalTo(QueryDescriptionFactory.forQueryMetadata(metadata)));
+    assertThat(query.getQueryDescription(), equalTo(QueryDescriptionFactory.forQueryMetadata(metadata, Optional.empty())));
   }
 
   @Test

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
@@ -62,6 +62,7 @@ public class ListQueriesExecutorTest {
   @Before
   public void setUp() {
     when(sessionProperties.getKsqlHostInfo()).thenReturn(LOCAL_HOST);
+    when(sessionProperties.getIsInternalRequest()).thenReturn(true);
   }
 
   @Test

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.SessionProperties;
+import io.confluent.ksql.rest.entity.KsqlHostInfoEntity;
 import io.confluent.ksql.rest.entity.Queries;
 import io.confluent.ksql.rest.entity.QueryDescriptionFactory;
 import io.confluent.ksql.rest.entity.QueryDescriptionList;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
@@ -260,7 +260,8 @@ public class ListSourceExecutorTest {
                 ImmutableSet.of(metadata.getSinkName().toString(FormatOptions.noEscape())),
                 ImmutableSet.of(metadata.getResultTopic().getKafkaTopicName()),
                 metadata.getQueryId(),
-                Optional.of(metadata.getState())
+                Optional.of(metadata.getState()),
+                Optional.empty()
             )),
             Optional.empty())));
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PropertyExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PropertyExecutorTest.java
@@ -46,7 +46,7 @@ public class PropertyExecutorTest {
   public void shouldSetProperty() {
     // Given:
     final SessionProperties sessionProperties =
-        new SessionProperties(new HashMap<>(), mock(KsqlHostInfo.class), mock(URL.class));
+        new SessionProperties(new HashMap<>(), mock(KsqlHostInfo.class), mock(URL.class), false);
     final Map<String, Object> properties = sessionProperties.getMutableScopedProperties();
 
     // When:
@@ -69,7 +69,8 @@ public class PropertyExecutorTest {
         new SessionProperties(
             Collections.singletonMap(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "none"),
             mock(KsqlHostInfo.class),
-            mock(URL.class));
+            mock(URL.class),
+            false);
     final Map<String, Object> properties = sessionProperties.getMutableScopedProperties();
 
     // When:

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -255,6 +255,10 @@ public class KsqlResourceTest {
       .valueColumn(ColumnName.of("f1"), SqlTypes.STRING)
       .build();
 
+  private static final KsqlHostInfoEntity LOCAL_HOST = new KsqlHostInfoEntity("some host", 555);
+
+  private static final String APPLICATION_SERVER_CONFIG_STRING = "localhost:555";
+
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -100,6 +100,7 @@ import io.confluent.ksql.rest.entity.FunctionType;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlErrorMessage;
+import io.confluent.ksql.rest.entity.KsqlHostInfoEntity;
 import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.entity.KsqlStatementErrorMessage;
 import io.confluent.ksql.rest.entity.PropertiesList;
@@ -541,8 +542,8 @@ public class KsqlResourceTest {
 
     // Then:
     assertThat(descriptionList.getQueryDescriptions(), containsInAnyOrder(
-        QueryDescriptionFactory.forQueryMetadata(queryMetadata.get(0)),
-        QueryDescriptionFactory.forQueryMetadata(queryMetadata.get(1))));
+        QueryDescriptionFactory.forQueryMetadata(queryMetadata.get(0), Optional.of(LOCAL_HOST)),
+        QueryDescriptionFactory.forQueryMetadata(queryMetadata.get(1), Optional.of(LOCAL_HOST))));
   }
 
   @Test
@@ -1986,7 +1987,8 @@ public class KsqlResourceTest {
             ImmutableSet.of(md.getSinkName().toString(FormatOptions.noEscape())),
             ImmutableSet.of(md.getResultTopic().getKafkaTopicName()),
             md.getQueryId(),
-            Optional.of(md.getState())
+            Optional.of(md.getState()),
+            Optional.empty()
         ))
         .collect(Collectors.toList());
   }
@@ -2212,7 +2214,7 @@ public class KsqlResourceTest {
     configMap.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
     configMap.put("ksql.command.topic.suffix", "commands");
     configMap.put(RestConfig.LISTENERS_CONFIG, "http://localhost:8088");
-    configMap.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "http://localhost:9099");
+    configMap.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "http://" + APPLICATION_SERVER_CONFIG_STRING);
 
     final Properties properties = new Properties();
     properties.putAll(configMap);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -203,7 +203,8 @@ public class KsqlResourceTest {
       "CREATE STREAM S AS SELECT * FROM test_stream;",
       ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"),
       emptyMap(),
-      0L);
+      0L,
+      false);
 
   private static final LogicalSchema SINGLE_FIELD_SCHEMA = LogicalSchema.builder()
       .withRowTime()
@@ -404,7 +405,7 @@ public class KsqlResourceTest {
     // When:
     ksqlResource.handleKsqlStatements(
         securityContext,
-        new KsqlRequest("query", emptyMap(), emptyMap(), null)
+        new KsqlRequest("query", emptyMap(), emptyMap(), null, false)
     );
   }
 
@@ -1435,10 +1436,12 @@ public class KsqlResourceTest {
 
     // When:
     final CommandStatusEntity result = makeSingleRequest(
-        new KsqlRequest("UNSET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "';\n" + csas,
-                        localOverrides,
-                        emptyMap(),
-                        null),
+        new KsqlRequest(
+            "UNSET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "';\n" + csas,
+            localOverrides,
+            emptyMap(),
+            null,
+            false),
         CommandStatusEntity.class);
 
     // Then:
@@ -1536,7 +1539,7 @@ public class KsqlResourceTest {
 
     // When:
     final PropertiesList props = makeSingleRequest(
-        new KsqlRequest("list properties;", overrides, emptyMap(), null),
+        new KsqlRequest("list properties;", overrides, emptyMap(), null, false),
         PropertiesList.class);
 
     // Then:
@@ -2001,7 +2004,7 @@ public class KsqlResourceTest {
       final String ksql,
       final Long seqNum,
       final Code errorCode) {
-    return makeFailingRequest(new KsqlRequest(ksql, emptyMap(), emptyMap(), seqNum), errorCode);
+    return makeFailingRequest(new KsqlRequest(ksql, emptyMap(), emptyMap(), seqNum, false), errorCode);
   }
 
   private KsqlErrorMessage makeFailingRequest(final KsqlRequest ksqlRequest, final Code errorCode) {
@@ -2030,7 +2033,7 @@ public class KsqlResourceTest {
       final Long seqNum,
       final Class<T> expectedEntityType) {
     return makeSingleRequest(
-        new KsqlRequest(sql, emptyMap(), emptyMap(), seqNum), expectedEntityType);
+        new KsqlRequest(sql, emptyMap(), emptyMap(), seqNum, false), expectedEntityType);
   }
 
   private <T extends KsqlEntity> T makeSingleRequest(
@@ -2054,7 +2057,7 @@ public class KsqlResourceTest {
       final Map<String, ?> props,
       final Class<T> expectedEntityType
   ) {
-    final KsqlRequest request = new KsqlRequest(sql, props, emptyMap(), null);
+    final KsqlRequest request = new KsqlRequest(sql, props, emptyMap(), null, false);
     return makeMultipleRequest(request, expectedEntityType);
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -230,7 +230,7 @@ public class StreamedQueryResourceTest {
     // When:
     testResource.streamQuery(
         securityContext,
-        new KsqlRequest("query", Collections.emptyMap(), null, false)
+        new KsqlRequest("query", Collections.emptyMap(), Collections.emptyMap(), null, false)
     );
   }
 
@@ -250,7 +250,7 @@ public class StreamedQueryResourceTest {
     // When:
     testResource.streamQuery(
         securityContext,
-        new KsqlRequest("query", Collections.emptyMap(), null, false)
+        new KsqlRequest("query",  Collections.emptyMap(), Collections.emptyMap(), null, false)
     );
   }
 
@@ -259,7 +259,7 @@ public class StreamedQueryResourceTest {
     // When:
     testResource.streamQuery(
         securityContext,
-        new KsqlRequest(PUSH_QUERY_STRING, Collections.emptyMap(), null, false)
+        new KsqlRequest(PUSH_QUERY_STRING, Collections.emptyMap(), Collections.emptyMap(), null, false)
     );
 
     // Then:
@@ -271,7 +271,7 @@ public class StreamedQueryResourceTest {
     // When:
     testResource.streamQuery(
         securityContext,
-        new KsqlRequest(PUSH_QUERY_STRING, Collections.emptyMap(), 3L, false)
+        new KsqlRequest(PUSH_QUERY_STRING, Collections.emptyMap(), Collections.emptyMap(), 3L, false)
     );
 
     // Then:
@@ -296,7 +296,7 @@ public class StreamedQueryResourceTest {
     // When:
     testResource.streamQuery(
         securityContext,
-        new KsqlRequest(PUSH_QUERY_STRING, Collections.emptyMap(), 3L, false)
+        new KsqlRequest(PUSH_QUERY_STRING, Collections.emptyMap(), Collections.emptyMap(), 3L, false)
     );
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -230,7 +230,7 @@ public class StreamedQueryResourceTest {
     // When:
     testResource.streamQuery(
         securityContext,
-        new KsqlRequest("query", Collections.emptyMap(), Collections.emptyMap(), null)
+        new KsqlRequest("query", Collections.emptyMap(), null, false)
     );
   }
 
@@ -250,7 +250,7 @@ public class StreamedQueryResourceTest {
     // When:
     testResource.streamQuery(
         securityContext,
-        new KsqlRequest("query", Collections.emptyMap(), Collections.emptyMap(), null)
+        new KsqlRequest("query", Collections.emptyMap(), null, false)
     );
   }
 
@@ -259,7 +259,7 @@ public class StreamedQueryResourceTest {
     // When:
     testResource.streamQuery(
         securityContext,
-        new KsqlRequest(PUSH_QUERY_STRING, Collections.emptyMap(), Collections.emptyMap(), null)
+        new KsqlRequest(PUSH_QUERY_STRING, Collections.emptyMap(), null, false)
     );
 
     // Then:
@@ -271,7 +271,7 @@ public class StreamedQueryResourceTest {
     // When:
     testResource.streamQuery(
         securityContext,
-        new KsqlRequest(PUSH_QUERY_STRING, Collections.emptyMap(), Collections.emptyMap(), 3L)
+        new KsqlRequest(PUSH_QUERY_STRING, Collections.emptyMap(), 3L, false)
     );
 
     // Then:
@@ -296,7 +296,7 @@ public class StreamedQueryResourceTest {
     // When:
     testResource.streamQuery(
         securityContext,
-        new KsqlRequest(PUSH_QUERY_STRING, Collections.emptyMap(), Collections.emptyMap(), 3L)
+        new KsqlRequest(PUSH_QUERY_STRING, Collections.emptyMap(), 3L, false)
     );
   }
 
@@ -310,7 +310,7 @@ public class StreamedQueryResourceTest {
     // When:
     testResource.streamQuery(
         securityContext,
-        new KsqlRequest(PULL_QUERY_STRING, Collections.emptyMap(), Collections.emptyMap(), null)
+        new KsqlRequest(PULL_QUERY_STRING, Collections.emptyMap(), Collections.emptyMap(), null, false)
     );
 
     // Then:
@@ -332,7 +332,7 @@ public class StreamedQueryResourceTest {
     // When:
     final Response response = testResource.streamQuery(
         securityContext,
-        new KsqlRequest(PULL_QUERY_STRING, Collections.emptyMap(), Collections.emptyMap(), null)
+        new KsqlRequest(PULL_QUERY_STRING, Collections.emptyMap(), Collections.emptyMap(), null, false)
     );
 
     final KsqlErrorMessage responseEntity = (KsqlErrorMessage) response.getEntity();
@@ -400,7 +400,7 @@ public class StreamedQueryResourceTest {
     final Response response =
         testResource.streamQuery(
             securityContext,
-            new KsqlRequest(queryString, requestStreamsProperties, Collections.emptyMap(), null)
+            new KsqlRequest(queryString, requestStreamsProperties, Collections.emptyMap(), null, false)
         );
     final PipedOutputStream responseOutputStream = new EOFPipedOutputStream();
     final PipedInputStream responseInputStream = new PipedInputStream(responseOutputStream, 1);
@@ -539,7 +539,7 @@ public class StreamedQueryResourceTest {
     /// When:
     testResource.streamQuery(
         securityContext,
-        new KsqlRequest(PUSH_QUERY_STRING, Collections.emptyMap(), Collections.emptyMap(), null)
+        new KsqlRequest(PUSH_QUERY_STRING, Collections.emptyMap(), Collections.emptyMap(), null, false)
     );
 
     // Then:
@@ -558,7 +558,7 @@ public class StreamedQueryResourceTest {
     // When:
     final Response response = testResource.streamQuery(
         securityContext,
-        new KsqlRequest(PUSH_QUERY_STRING, Collections.emptyMap(), Collections.emptyMap(), null)
+        new KsqlRequest(PUSH_QUERY_STRING, Collections.emptyMap(), Collections.emptyMap(), null, false)
     );
 
     final KsqlErrorMessage responseEntity = (KsqlErrorMessage) response.getEntity();
@@ -581,7 +581,7 @@ public class StreamedQueryResourceTest {
     // When:
     final Response response = testResource.streamQuery(
         securityContext,
-        new KsqlRequest(PRINT_TOPIC, Collections.emptyMap(), Collections.emptyMap(), null)
+        new KsqlRequest(PRINT_TOPIC, Collections.emptyMap(), Collections.emptyMap(), null, false)
     );
 
     assertEquals(response.getStatus(), AUTHORIZATION_ERROR_RESPONSE.getStatus());
@@ -627,7 +627,7 @@ public class StreamedQueryResourceTest {
     // When:
     testResource.streamQuery(
         securityContext,
-        new KsqlRequest(PRINT_TOPIC, Collections.emptyMap(), Collections.emptyMap(), null)
+        new KsqlRequest(PRINT_TOPIC, Collections.emptyMap(), Collections.emptyMap(), null, false)
     );
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpointTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpointTest.java
@@ -106,13 +106,15 @@ public class WSQueryEndpointTest {
       "test-sql",
       ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"),
       Collections.emptyMap(),
-      null);
+      null,
+      false);
 
   private static final KsqlRequest ANOTHER_REQUEST = new KsqlRequest(
       "other-sql",
       ImmutableMap.of(),
       Collections.emptyMap(),
-      null);
+      null,
+      false);
 
   private static final long SEQUENCE_NUMBER = 2L;
   private static final KsqlRequest REQUEST_WITHOUT_SEQUENCE_NUMBER = VALID_REQUEST;
@@ -120,7 +122,8 @@ public class WSQueryEndpointTest {
       "test-sql",
       ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"),
       Collections.emptyMap(),
-      SEQUENCE_NUMBER);
+      SEQUENCE_NUMBER,
+      false);
 
   private static final String VALID_VERSION = Versions.KSQL_V1_WS;
   private static final String[] NO_VERSION_PROPERTY = null;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/services/ServerInternalKsqlClientTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/services/ServerInternalKsqlClientTest.java
@@ -40,7 +40,7 @@ public class ServerInternalKsqlClientTest {
 
   private static final String KSQL_STATEMENT = "awesome ksql request;";
   private static final KsqlRequest EXPECTED_REQUEST =
-      new KsqlRequest(KSQL_STATEMENT, Collections.emptyMap(), Collections.emptyMap(), null);
+      new KsqlRequest(KSQL_STATEMENT, Collections.emptyMap(), Collections.emptyMap(), null, true);
 
   @Mock
   private KsqlResource ksqlResource;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/PropertyOverriderTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/PropertyOverriderTest.java
@@ -76,7 +76,7 @@ public class PropertyOverriderTest {
   public void shouldAllowSetKnownProperty() {
     // Given:
     final SessionProperties sessionProperties = 
-        new SessionProperties(new HashedMap<>(), mock(KsqlHostInfo.class), mock(URL.class));
+        new SessionProperties(new HashedMap<>(), mock(KsqlHostInfo.class), mock(URL.class), false);
     final Map<String, Object> properties = sessionProperties.getMutableScopedProperties();
 
     // When:
@@ -102,7 +102,7 @@ public class PropertyOverriderTest {
   public void shouldFailOnInvalidSetPropertyValue() {
     // Given:
     final SessionProperties sessionProperties =
-        new SessionProperties(new HashedMap<>(), mock(KsqlHostInfo.class), mock(URL.class));
+        new SessionProperties(new HashedMap<>(), mock(KsqlHostInfo.class), mock(URL.class), false);
 
     // Expect:
     expectedException.expect(KsqlStatementException.class);
@@ -128,7 +128,7 @@ public class PropertyOverriderTest {
     // Given:
     final Map<String, Object> properties = new HashMap<>();
     final SessionProperties sessionProperties =
-        new SessionProperties(properties, mock(KsqlHostInfo.class), mock(URL.class));
+        new SessionProperties(properties, mock(KsqlHostInfo.class), mock(URL.class), false);
 
     // Expect:
     expectedException.expect(KsqlStatementException.class);
@@ -156,7 +156,7 @@ public class PropertyOverriderTest {
         new SessionProperties(
             Collections.singletonMap(
                 ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"),
-                mock(KsqlHostInfo.class), mock(URL.class));
+                mock(KsqlHostInfo.class), mock(URL.class), false);
     final Map<String, Object> properties = sessionProperties.getMutableScopedProperties();
 
     // When:

--- a/ksql-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
+++ b/ksql-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
@@ -130,6 +130,16 @@ public final class KsqlTarget {
     return get(STATUS_PATH + "/" + commandId, CommandStatus.class);
   }
 
+  public RestResponse<KsqlEntityList> postInternalKsqlRequest(
+      final String ksql
+  ) {
+    return post(
+        KSQL_PATH,
+        createKsqlRequest(ksql, Collections.emptyMap(), Optional.empty(), true),
+        r -> deserialize(r.getBody(), KsqlEntityList.class)
+    );
+  }
+
   public RestResponse<KsqlEntityList> postKsqlRequest(
       final String ksql,
       final Optional<Long> previousCommandSeqNum
@@ -168,17 +178,32 @@ public final class KsqlTarget {
     return executeQueryRequestWithStreamResponse(ksql, previousCommandSeqNum, Object::toString);
   }
 
+
+  private KsqlRequest createKsqlRequest(
+          final String ksql,
+          final Map<String, ?> serverProperties,
+          final Optional<Long> previousCommandSeqNum
+  ) {
+    return createKsqlRequest(
+            ksql,
+            serverProperties,
+            previousCommandSeqNum,
+            false
+    );
+  }
+
   private KsqlRequest createKsqlRequest(
       final String ksql,
       final Map<String, ?> serverProperties,
-      final Optional<Long> previousCommandSeqNum
+      final Optional<Long> previousCommandSeqNum,
+      final Boolean isInternalRequest
   ) {
     return new KsqlRequest(
         ksql,
         localProperties.toMap(),
         serverProperties,
         previousCommandSeqNum.orElse(null),
-        false
+        isInternalRequest
     );
   }
 

--- a/ksql-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
+++ b/ksql-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
@@ -177,7 +177,8 @@ public final class KsqlTarget {
         ksql,
         localProperties.toMap(),
         serverProperties,
-        previousCommandSeqNum.orElse(null)
+        previousCommandSeqNum.orElse(null),
+        false
     );
   }
 

--- a/ksql-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlClientTest.java
+++ b/ksql-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlClientTest.java
@@ -113,7 +113,7 @@ public class KsqlClientTest {
     assertThat(server.getPath(), is("/ksql"));
     assertThat(server.getHeaders().get("Accept"), is("application/json"));
     assertThat(getKsqlRequest(),
-        is(new KsqlRequest(ksql, properties, Collections.emptyMap(), 123L)));
+        is(new KsqlRequest(ksql, properties, Collections.emptyMap(), 123L, false)));
   }
 
   @Test
@@ -309,7 +309,7 @@ public class KsqlClientTest {
 
     assertThat(server.getPath(), is("/query"));
     assertThat(server.getHeaders().get("Accept"), is("application/json"));
-    assertThat(getKsqlRequest(), is(new KsqlRequest(sql, properties, Collections.emptyMap(), 321L)));
+    assertThat(getKsqlRequest(), is(new KsqlRequest(sql, properties, Collections.emptyMap(), 321L, false)));
     assertThat(response.get(), is(expectedResponse));
   }
 
@@ -332,7 +332,7 @@ public class KsqlClientTest {
 
     assertThat(server.getPath(), is("/query"));
     assertThat(server.getHeaders().get("Accept"), is("application/json"));
-    assertThat(getKsqlRequest(), is(new KsqlRequest(sql, properties, Collections.emptyMap(), 321L)));
+    assertThat(getKsqlRequest(), is(new KsqlRequest(sql, properties, Collections.emptyMap(), 321L, false)));
 
     List<StreamedRow> rows = getElementsFromPublisher(numRows, response.getResponse());
     assertThat(rows, is(expectedResponse));
@@ -357,7 +357,7 @@ public class KsqlClientTest {
 
     assertThat(server.getPath(), is("/query"));
     assertThat(server.getHeaders().get("Accept"), is("application/json"));
-    assertThat(getKsqlRequest(), is(new KsqlRequest(sql, properties, Collections.emptyMap(), 321L)));
+    assertThat(getKsqlRequest(), is(new KsqlRequest(sql, properties, Collections.emptyMap(), 321L, false)));
 
     List<StreamedRow> rows = getElementsFromPublisher(numRows + 1, response.getResponse());
     assertThat(rows, is(expectedResponse));
@@ -376,7 +376,7 @@ public class KsqlClientTest {
         .postQueryRequestStreamed(sql, Optional.of(321L));
 
     // Then:
-    assertThat(getKsqlRequest(), is(new KsqlRequest(sql, properties, Collections.emptyMap(), 321L)));
+    assertThat(getKsqlRequest(), is(new KsqlRequest(sql, properties, Collections.emptyMap(), 321L, false)));
 
     // When:
     response.getResponse().close();
@@ -403,7 +403,7 @@ public class KsqlClientTest {
 
     assertThat(server.getPath(), is("/query"));
     assertThat(server.getHeaders().get("Accept"), is("application/json"));
-    assertThat(getKsqlRequest(), is(new KsqlRequest(command, properties, Collections.emptyMap(), 123L)));
+    assertThat(getKsqlRequest(), is(new KsqlRequest(command, properties, Collections.emptyMap(), 123L, false)));
 
     List<String> lines = getElementsFromPublisher(numRows, response.getResponse());
     assertThat(lines, is(expectedResponse));
@@ -422,7 +422,7 @@ public class KsqlClientTest {
         .postPrintTopicRequest(command, Optional.of(123L));
 
     // Then:
-    assertThat(getKsqlRequest(), is(new KsqlRequest(command, properties, Collections.emptyMap(), 123L)));
+    assertThat(getKsqlRequest(), is(new KsqlRequest(command, properties, Collections.emptyMap(), 123L, false)));
 
     // When:
     response.getResponse().close();

--- a/ksql-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlClientUtilTest.java
+++ b/ksql-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlClientUtilTest.java
@@ -171,7 +171,7 @@ public class KsqlClientUtilTest {
     // Given:
     Map<String, Object> props = new HashMap<>();
     props.put("auto.offset.reset", "latest");
-    KsqlRequest request = new KsqlRequest("some ksql", props, Collections.emptyMap(), 21345L);
+    KsqlRequest request = new KsqlRequest("some ksql", props, Collections.emptyMap(), 21345L, null);
 
     // When:
     Buffer buff = KsqlClientUtil.serialize(request);
@@ -179,7 +179,7 @@ public class KsqlClientUtilTest {
     // Then:
     assertThat(buff, is(notNullValue()));
     String expectedJson = "{\"ksql\":\"some ksql\",\"streamsProperties\":{\"auto.offset.reset\":\""
-        + "latest\"},\"requestProperties\":{},\"commandSequenceNumber\":21345}";
+        + "latest\"},\"requestProperties\":{},\"commandSequenceNumber\":21345, \"isInternalRequest\":null}";
     assertThat(new JsonObject(buff), is(new JsonObject(expectedJson)));
 
     // When:

--- a/ksql-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlClientUtilTest.java
+++ b/ksql-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlClientUtilTest.java
@@ -179,7 +179,7 @@ public class KsqlClientUtilTest {
     // Then:
     assertThat(buff, is(notNullValue()));
     String expectedJson = "{\"ksql\":\"some ksql\",\"streamsProperties\":{\"auto.offset.reset\":\""
-        + "latest\"},\"requestProperties\":{},\"commandSequenceNumber\":21345, \"isInternalRequest\":null}";
+        + "latest\"},\"requestProperties\":{},\"commandSequenceNumber\":21345, \"internalRequest\":false}";
     assertThat(new JsonObject(buff), is(new JsonObject(expectedJson)));
 
     // When:

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/SessionProperties.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/SessionProperties.java
@@ -32,20 +32,24 @@ public class SessionProperties {
   private final Map<String, Object> mutableScopedProperties;
   private final KsqlHostInfo ksqlHostInfo;
   private final URL localUrl;
+  private final boolean isInternalRequest;
 
   /**
    * @param mutableScopedProperties   The streamsProperties of the incoming request
    * @param ksqlHostInfo              The ksqlHostInfo of the server that handles the request 
    * @param localUrl                  The url of the server that handles the request
+   * @param isInternalRequest         Flag indicates whether the request is internal or not
    */
   public SessionProperties(
       final Map<String, Object> mutableScopedProperties,
       final KsqlHostInfo ksqlHostInfo,
-      final URL localUrl) {
+      final URL localUrl,
+      final boolean isInternalRequest) {
     this.mutableScopedProperties = 
         new HashMap<>(Objects.requireNonNull(mutableScopedProperties, "mutableScopedProperties"));
     this.ksqlHostInfo = Objects.requireNonNull(ksqlHostInfo, "ksqlHostInfo");
     this.localUrl = Objects.requireNonNull(localUrl, "localUrl");
+    this.isInternalRequest = Objects.requireNonNull(isInternalRequest, "isInternalRequest");
   }
 
   public Map<String, Object> getMutableScopedProperties() {
@@ -58,5 +62,9 @@ public class SessionProperties {
 
   public URL getLocalUrl() {
     return localUrl;
+  }
+
+  public boolean getIsInternalRequest() {
+    return isInternalRequest;
   }
 }

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlHostInfoEntity.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlHostInfoEntity.java
@@ -43,7 +43,7 @@ public class KsqlHostInfoEntity {
     final String [] parts = serializedPair.split(":");
     if (parts.length != 2) {
       throw new KsqlException("Invalid host info. Expected format: <hostname>:<port>, but was "
-                                  + serializedPair);
+              + serializedPair);
     }
 
     this.host = Objects.requireNonNull(parts[0], "host");
@@ -52,8 +52,13 @@ public class KsqlHostInfoEntity {
       this.port = Integer.parseInt(parts[1]);
     } catch (final Exception e) {
       throw new KsqlException("Invalid port. Expected format: <hostname>:<port>, but was "
-                                  + serializedPair, e);
+              + serializedPair, e);
     }
+  }
+
+  public KsqlHostInfoEntity(final KsqlHostInfo ksqlHostInfo) {
+    this.host = ksqlHostInfo.host();
+    this.port = ksqlHostInfo.port();
   }
 
   public String getHost() {

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlRequest.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlRequest.java
@@ -49,7 +49,7 @@ public class KsqlRequest {
       @JsonProperty("requestProperties") final Map<String, ?> requestProperties,
       @JsonProperty("commandSequenceNumber") final Long commandSequenceNumber,
       @JsonProperty("isInternalRequest") final Boolean isInternalRequest
-    ) {
+  ) {
     this.ksql = ksql == null ? "" : ksql;
     this.configOverrides = configOverrides == null
         ? ImmutableMap.of()
@@ -102,7 +102,8 @@ public class KsqlRequest {
 
   @Override
   public int hashCode() {
-    return Objects.hash(ksql, configOverrides, requestProperties, commandSequenceNumber, isInternalRequest);
+    return Objects.hash(
+        ksql, configOverrides, requestProperties, commandSequenceNumber, isInternalRequest);
   }
 
   @Override

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlRequest.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlRequest.java
@@ -40,7 +40,7 @@ public class KsqlRequest {
   private final ImmutableMap<String, Object> configOverrides;
   private final ImmutableMap<String, Object> requestProperties;
   private final Optional<Long> commandSequenceNumber;
-  private final Optional<Boolean> isInternalRequest;
+  private final boolean internalRequest;
 
   @JsonCreator
   public KsqlRequest(
@@ -48,7 +48,7 @@ public class KsqlRequest {
       @JsonProperty("streamsProperties") final Map<String, ?> configOverrides,
       @JsonProperty("requestProperties") final Map<String, ?> requestProperties,
       @JsonProperty("commandSequenceNumber") final Long commandSequenceNumber,
-      @JsonProperty("isInternalRequest") final Boolean isInternalRequest
+      @JsonProperty("internalRequest") final Boolean internalRequest
   ) {
     this.ksql = ksql == null ? "" : ksql;
     this.configOverrides = configOverrides == null
@@ -58,7 +58,7 @@ public class KsqlRequest {
         ? ImmutableMap.of()
         : ImmutableMap.copyOf(serializeClassValues(requestProperties));
     this.commandSequenceNumber = Optional.ofNullable(commandSequenceNumber);
-    this.isInternalRequest = Optional.ofNullable(isInternalRequest);
+    this.internalRequest = internalRequest == null ? false : internalRequest;
   }
 
   public String getKsql() {
@@ -78,8 +78,8 @@ public class KsqlRequest {
     return commandSequenceNumber;
   }
 
-  public Optional<Boolean> getIsInternalRequest() {
-    return isInternalRequest;
+  public boolean getInternalRequest() {
+    return internalRequest;
   }
 
   @Override
@@ -97,13 +97,13 @@ public class KsqlRequest {
         && Objects.equals(configOverrides, that.configOverrides)
         && Objects.equals(requestProperties, that.requestProperties)
         && Objects.equals(commandSequenceNumber, that.commandSequenceNumber)
-        && Objects.equals(isInternalRequest, that.isInternalRequest);
+        && Objects.equals(internalRequest, that.internalRequest);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
-        ksql, configOverrides, requestProperties, commandSequenceNumber, isInternalRequest);
+        ksql, configOverrides, requestProperties, commandSequenceNumber, internalRequest);
   }
 
   @Override
@@ -113,7 +113,7 @@ public class KsqlRequest {
         + ", configOverrides=" + configOverrides
         + ", requestProperties=" + requestProperties
         + ", commandSequenceNumber=" + commandSequenceNumber
-        + ", isInternalRequest=" + isInternalRequest
+        + ", isInternalRequest=" + internalRequest
         + '}';
   }
 

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlRequest.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlRequest.java
@@ -40,14 +40,16 @@ public class KsqlRequest {
   private final ImmutableMap<String, Object> configOverrides;
   private final ImmutableMap<String, Object> requestProperties;
   private final Optional<Long> commandSequenceNumber;
+  private final Optional<Boolean> isInternalRequest;
 
   @JsonCreator
   public KsqlRequest(
       @JsonProperty("ksql") final String ksql,
       @JsonProperty("streamsProperties") final Map<String, ?> configOverrides,
       @JsonProperty("requestProperties") final Map<String, ?> requestProperties,
-      @JsonProperty("commandSequenceNumber") final Long commandSequenceNumber
-  ) {
+      @JsonProperty("commandSequenceNumber") final Long commandSequenceNumber,
+      @JsonProperty("isInternalRequest") final Boolean isInternalRequest
+    ) {
     this.ksql = ksql == null ? "" : ksql;
     this.configOverrides = configOverrides == null
         ? ImmutableMap.of()
@@ -56,6 +58,7 @@ public class KsqlRequest {
         ? ImmutableMap.of()
         : ImmutableMap.copyOf(serializeClassValues(requestProperties));
     this.commandSequenceNumber = Optional.ofNullable(commandSequenceNumber);
+    this.isInternalRequest = Optional.ofNullable(isInternalRequest);
   }
 
   public String getKsql() {
@@ -75,6 +78,10 @@ public class KsqlRequest {
     return commandSequenceNumber;
   }
 
+  public Optional<Boolean> getIsInternalRequest() {
+    return isInternalRequest;
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -89,12 +96,13 @@ public class KsqlRequest {
     return Objects.equals(ksql, that.ksql)
         && Objects.equals(configOverrides, that.configOverrides)
         && Objects.equals(requestProperties, that.requestProperties)
-        && Objects.equals(commandSequenceNumber, that.commandSequenceNumber);
+        && Objects.equals(commandSequenceNumber, that.commandSequenceNumber)
+        && Objects.equals(isInternalRequest, that.isInternalRequest);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(ksql, configOverrides, requestProperties, commandSequenceNumber);
+    return Objects.hash(ksql, configOverrides, requestProperties, commandSequenceNumber, isInternalRequest);
   }
 
   @Override
@@ -104,6 +112,7 @@ public class KsqlRequest {
         + ", configOverrides=" + configOverrides
         + ", requestProperties=" + requestProperties
         + ", commandSequenceNumber=" + commandSequenceNumber
+        + ", isInternalRequest=" + isInternalRequest
         + '}';
   }
 

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryDescription.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryDescription.java
@@ -42,8 +42,10 @@ public class QueryDescription {
   private final String executionPlan;
   private final Map<String, Object> overriddenProperties;
   private final Optional<String> state;
+  private final Optional<KsqlHostInfoEntity> ksqlHostInfo;
 
-  @SuppressWarnings("WeakerAccess") // Invoked via reflection
+  // Invoked via reflection
+  @SuppressWarnings({"WeakerAccess", "checkstyle:ParameterNumber"})
   @JsonCreator
   public QueryDescription(
       @JsonProperty("id") final QueryId id,
@@ -55,7 +57,8 @@ public class QueryDescription {
       @JsonProperty("topology") final String topology,
       @JsonProperty("executionPlan") final String executionPlan,
       @JsonProperty("overriddenProperties") final Map<String, Object> overriddenProperties,
-      @JsonProperty("state") final Optional<String> state
+      @JsonProperty("state") final Optional<String> state,
+      @JsonProperty("ksqlHostInfo") final Optional<KsqlHostInfoEntity> ksqlHostInfo
   ) {
     this.id = Objects.requireNonNull(id, "id");
     this.statementText = Objects.requireNonNull(statementText, "statementText");
@@ -68,6 +71,7 @@ public class QueryDescription {
     this.overriddenProperties = ImmutableMap.copyOf(Objects
         .requireNonNull(overriddenProperties, "overriddenProperties"));
     this.state = Objects.requireNonNull(state, "state");
+    this.ksqlHostInfo = Objects.requireNonNull(ksqlHostInfo, "ksqlHostInfo");
   }
 
   public QueryId getId() {
@@ -108,6 +112,10 @@ public class QueryDescription {
 
   public Optional<String> getState() {
     return state;
+  }
+
+  public Optional<KsqlHostInfoEntity> getKsqlHostInfo() {
+    return ksqlHostInfo;
   }
 
   // CHECKSTYLE_RULES.OFF: CyclomaticComplexity

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/RunningQuery.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/RunningQuery.java
@@ -32,6 +32,7 @@ public class RunningQuery {
   private final Set<String> sinkKafkaTopics;
   private final QueryId id;
   private final Optional<String> state;
+  private final Optional<KsqlHostInfoEntity> ksqlHostInfo;
 
   @JsonCreator
   public RunningQuery(
@@ -39,13 +40,15 @@ public class RunningQuery {
       @JsonProperty("sinks") final Set<String> sinks,
       @JsonProperty("sinkKafkaTopics") final Set<String> sinkKafkaTopics,
       @JsonProperty("id") final QueryId id,
-      @JsonProperty("state") final Optional<String> state
+      @JsonProperty("state") final Optional<String> state,
+      @JsonProperty("ksqlHostInfo") final Optional<KsqlHostInfoEntity> ksqlHostInfo
   ) {
     this.queryString = Objects.requireNonNull(queryString, "queryString");
     this.sinkKafkaTopics = Objects.requireNonNull(sinkKafkaTopics, "sinkKafkaTopics");
     this.sinks = Objects.requireNonNull(sinks, "sinks");
     this.id = Objects.requireNonNull(id, "id");
     this.state = Objects.requireNonNull(state, "state");
+    this.ksqlHostInfo = Objects.requireNonNull(ksqlHostInfo, "ksqlHostInfo");
   }
 
   public String getQueryString() {
@@ -54,7 +57,7 @@ public class RunningQuery {
 
   @JsonIgnore
   public String getQuerySingleLine() {
-    return queryString.replaceAll(System.lineSeparator(), "");
+    return queryString.replaceAll(System.lineSeparator(), " ");
   }
 
   public Set<String> getSinks() {
@@ -73,6 +76,10 @@ public class RunningQuery {
     return state;
   }
 
+  public Optional<KsqlHostInfoEntity> getKsqlHostInfo() {
+    return ksqlHostInfo;
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -86,11 +93,12 @@ public class RunningQuery {
         && Objects.equals(queryString, that.queryString)
         && Objects.equals(sinks, that.sinks)
         && Objects.equals(sinkKafkaTopics, that.sinkKafkaTopics)
-        && Objects.equals(state, that.state);
+        && Objects.equals(state, that.state)
+        && Objects.equals(ksqlHostInfo, that.ksqlHostInfo);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, queryString, sinks, sinkKafkaTopics, state);
+    return Objects.hash(id, queryString, sinks, sinkKafkaTopics, state, ksqlHostInfo);
   }
 }

--- a/ksql-rest-model/src/test/java/io/confluent/ksql/rest/entity/KsqlRequestTest.java
+++ b/ksql-rest-model/src/test/java/io/confluent/ksql/rest/entity/KsqlRequestTest.java
@@ -65,7 +65,7 @@ public class KsqlRequestTest {
       + "\"" + KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_SKIP_FORWARDING + "\":true"
       + "},"
       + "\"commandSequenceNumber\":2,"
-      + "\"isInternalRequest\":null}";
+      + "\"internalRequest\":false}";
   private static final String A_JSON_REQUEST_WITH_NULL_COMMAND_NUMBER = "{"
       + "\"ksql\":\"sql\","
       + "\"streamsProperties\":{"
@@ -77,7 +77,7 @@ public class KsqlRequestTest {
       + "\"" + KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_SKIP_FORWARDING + "\":true"
       + "},"
       + "\"commandSequenceNumber\":null,"
-      + "\"isInternalRequest\":null}";
+      + "\"internalRequest\":false}";
 
   private static final String A_JSON_REQUEST_WITH_NULL_INTERNAL_REQUEST= "{"
       + "\"ksql\":\"sql\","
@@ -89,7 +89,7 @@ public class KsqlRequestTest {
       + "\"requestProperties\":{"
       + "\"" + KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_SKIP_FORWARDING + "\":true"
       + "},"
-      + "\"isInternalRequest\":null}";
+      + "\"internalRequest\":null}";
 
   private static final String A_JSON_REQUEST_WITH_INTERNAL_REQUEST= "{"
       + "\"ksql\":\"sql\","
@@ -98,7 +98,7 @@ public class KsqlRequestTest {
       + "\"" + StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG + "\":\""
       + TimestampExtractor.class.getCanonicalName() + "\""
       + "},"
-      + "\"isInternalRequest\":true}";
+      + "\"internalRequest\":true}";
 
   private static final ImmutableMap<String, Object> SOME_PROPS = ImmutableMap.of(
       ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest",
@@ -140,7 +140,7 @@ public class KsqlRequestTest {
 
   @Test
   public void shoudlHandleNullIsInternalRequest() {
-    assertThat(new KsqlRequest("sql", SOME_PROPS, null, null, null).getIsInternalRequest(), is(Optional.empty()));
+    assertThat(new KsqlRequest("sql", SOME_PROPS, null, null, null).getInternalRequest(), is(false));
   }
 
   @Test

--- a/ksql-rest-model/src/test/java/io/confluent/ksql/rest/entity/KsqlRequestTest.java
+++ b/ksql-rest-model/src/test/java/io/confluent/ksql/rest/entity/KsqlRequestTest.java
@@ -64,7 +64,7 @@ public class KsqlRequestTest {
       + "\"requestProperties\":{"
       + "\"" + KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_SKIP_FORWARDING + "\":true"
       + "},"
-      + "\"commandSequenceNumber\":2}"
+      + "\"commandSequenceNumber\":2,"
       + "\"isInternalRequest\":null}";
   private static final String A_JSON_REQUEST_WITH_NULL_COMMAND_NUMBER = "{"
       + "\"ksql\":\"sql\","
@@ -76,7 +76,7 @@ public class KsqlRequestTest {
       + "\"requestProperties\":{"
       + "\"" + KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_SKIP_FORWARDING + "\":true"
       + "},"
-      + "\"commandSequenceNumber\":null}"
+      + "\"commandSequenceNumber\":null,"
       + "\"isInternalRequest\":null}";
 
   private static final String A_JSON_REQUEST_WITH_NULL_INTERNAL_REQUEST= "{"
@@ -85,6 +85,9 @@ public class KsqlRequestTest {
       + "\"" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "\":\"earliest\","
       + "\"" + StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG + "\":\""
       + TimestampExtractor.class.getCanonicalName() + "\""
+      + "},"
+      + "\"requestProperties\":{"
+      + "\"" + KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_SKIP_FORWARDING + "\":true"
       + "},"
       + "\"isInternalRequest\":null}";
 
@@ -107,11 +110,11 @@ public class KsqlRequestTest {
   private static final long SOME_COMMAND_NUMBER = 2L;
 
   private static final KsqlRequest A_REQUEST = new KsqlRequest(
-      "sql", SOME_PROPS, SOME_REQUEST_PROPS, null, false);
+      "sql", SOME_PROPS, SOME_REQUEST_PROPS, null, null);
   private static final KsqlRequest A_REQUEST_WITH_COMMAND_NUMBER =
-      new KsqlRequest("sql", SOME_PROPS, SOME_REQUEST_PROPS, SOME_COMMAND_NUMBER, false);
+      new KsqlRequest("sql", SOME_PROPS, SOME_REQUEST_PROPS, SOME_COMMAND_NUMBER, null);
   private static final KsqlRequest A_REQUEST_WITH_INTERNAL_REQUEST =
-      new KsqlRequest("sql", SOME_PROPS, SOME_REQUEST_PROPS, null, true);
+      new KsqlRequest("sql", SOME_PROPS, Collections.emptyMap(), null, true);
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
@@ -137,7 +140,7 @@ public class KsqlRequestTest {
 
   @Test
   public void shoudlHandleNullIsInternalRequest() {
-    assertThat(new KsqlRequest("sql", SOME_PROPS, null, null).getIsInternalRequest(), is(Optional.empty()));
+    assertThat(new KsqlRequest("sql", SOME_PROPS, null, null, null).getIsInternalRequest(), is(Optional.empty()));
   }
 
   @Test


### PR DESCRIPTION
### Description 
Unblocks https://github.com/confluentinc/ksql/issues/4308
https://github.com/confluentinc/ksql/issues/4603

`SHOW QUERIES` and `SHOW QUERIES EXTENDED` now returns all queries that are running in the cluster.

The node that receives the request will look up all other nodes in the cluster, and then send `SHOW QUERIES` request to all of them that have a flag set in the request (to prevent the other nodes from also doing a scatter gather), collect the results and return to the user.

Added `isInternalRequest` field to `KsqlRequest` and `SessionProperties` to ensure the scatter gather doesn't get stuck in a loop.


### Testing done 
Wrote an integration test
Also verified locally with two servers up.

```
ksql> show queries;

 Query ID    | Status  | Host Info         | Sink Name | Sink Kafka Topic | Query String                                                                                                  
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 CSAS_FOOB_0 | RUNNING | 10.200.7.150:8088 | FOOB      | FOOB             | CREATE STREAM FOOB WITH (KAFKA_TOPIC='FOOB', PARTITIONS=2, REPLICAS=1) AS SELECT * FROM FOO FOO EMIT CHANGES; 
 CSAS_FOOB_0 | RUNNING | 10.200.7.150:8089 | FOOB      | FOOB             | CREATE STREAM FOOB WITH (KAFKA_TOPIC='FOOB', PARTITIONS=2, REPLICAS=1) AS SELECT * FROM FOO FOO EMIT CHANGES; 
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
For detailed information on a Query run: EXPLAIN <Query ID>;
ksql
```


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

