### PR TITLE
feat: Provide upper limit on number of push queries

### DIFF
--- a/ksql-api/src/main/java/io/confluent/ksql/api/impl/Utils.java
+++ b/ksql-api/src/main/java/io/confluent/ksql/api/impl/Utils.java
@@ -19,7 +19,6 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import io.vertx.core.impl.VertxThread;
 
 /**
  * General purpose utils (not limited to the server, could be used by client too) for the API
@@ -49,53 +48,19 @@ public final class Utils {
   }
 
   public static void checkIsWorker() {
-    checkThread(true);
-  }
-
-  public static void checkIsNotWorker() {
-    checkThread(false);
-  }
-
-  public static boolean isEventLoopThread() {
-    return isWorkerThread(false);
-  }
-
-  public static boolean isWorkerThread() {
-    return isWorkerThread(true);
-  }
-
-  private static boolean isWorkerThread(final boolean worker) {
-    final Thread thread = Thread.currentThread();
-    if (!(thread instanceof VertxThread)) {
-      throw new IllegalStateException("Not a Vert.x thread " + thread);
-    }
-    final VertxThread vertxThread = (VertxThread) thread;
-    return vertxThread.isWorker() == worker;
-  }
-
-  private static void checkThread(final boolean worker) {
-    if (!isWorkerThread(worker)) {
-      throw new IllegalStateException("Not a " + (worker ? "worker" : "event loop") + " thread");
+    if (!Context.isOnWorkerThread()) {
+      throw new IllegalStateException("Not a worker thread");
     }
   }
 
   public static void checkContext(final Context context) {
-    checkIsNotWorker();
-    if (context != Vertx.currentContext()) {
-      throw new IllegalStateException("On wrong context");
+    if (!isEventLoopAndSameContext(context)) {
+      throw new IllegalStateException("On wrong context or worker");
     }
   }
 
   public static boolean isEventLoopAndSameContext(final Context context) {
-    final Thread thread = Thread.currentThread();
-    if (!(thread instanceof VertxThread)) {
-      return false;
-    }
-    final VertxThread vertxThread = (VertxThread) thread;
-    if (vertxThread.isWorker()) {
-      return false;
-    }
-    return context == Vertx.currentContext();
+    return Context.isOnEventLoopThread() && context == Vertx.currentContext();
   }
 
 }

--- a/ksql-api/src/main/java/io/confluent/ksql/api/plugin/BlockingQueryPublisher.java
+++ b/ksql-api/src/main/java/io/confluent/ksql/api/plugin/BlockingQueryPublisher.java
@@ -120,6 +120,11 @@ public class BlockingQueryPublisher extends BasePublisher<GenericRow>
   }
 
   @Override
+  public boolean isPullQuery() {
+    return false;
+  }
+
+  @Override
   protected void maybeSend() {
     ctx.runOnContext(v -> doSend());
   }

--- a/ksql-api/src/main/java/io/confluent/ksql/api/plugin/KsqlServerEndpoints.java
+++ b/ksql-api/src/main/java/io/confluent/ksql/api/plugin/KsqlServerEndpoints.java
@@ -82,6 +82,7 @@ public class KsqlServerEndpoints implements Endpoints {
     this.reservedInternalTopics = new ReservedInternalTopics(ksqlConfig);
   }
 
+  @Override
   public QueryPublisher createQueryPublisher(
       final String sql, final JsonObject properties,
       final Context context,
@@ -105,6 +106,7 @@ public class KsqlServerEndpoints implements Endpoints {
   private QueryPublisher createPushQueryPublisher(final Context context,
       final ServiceContext serviceContext,
       final ConfiguredStatement<Query> statement, final WorkerExecutor workerExecutor) {
+
     final BlockingQueryPublisher publisher = new BlockingQueryPublisher(context,
         workerExecutor);
     final QueryMetadata queryMetadata = ksqlEngine

--- a/ksql-api/src/main/java/io/confluent/ksql/api/plugin/PullQueryPublisher.java
+++ b/ksql-api/src/main/java/io/confluent/ksql/api/plugin/PullQueryPublisher.java
@@ -54,4 +54,9 @@ public class PullQueryPublisher extends BufferedPublisher<GenericRow> implements
   public List<String> getColumnTypes() {
     return columnTypes;
   }
+
+  @Override
+  public boolean isPullQuery() {
+    return true;
+  }
 }

--- a/ksql-api/src/main/java/io/confluent/ksql/api/server/ApiServerConfig.java
+++ b/ksql-api/src/main/java/io/confluent/ksql/api/server/ApiServerConfig.java
@@ -77,6 +77,11 @@ public class ApiServerConfig extends AbstractConfig {
       "Max number of worker threads for executing blocking code";
   public static final int DEFAULT_WORKER_POOL_SIZE = 100;
 
+  public static final String MAX_PUSH_QUERIES = propertyName("max.push.queries");
+  public static final int DEFAULT_MAX_PUSH_QUERIES = 100;
+  public static final String MAX_PUSH_QUERIES_DOC =
+      "The maximum number of push queries allowed on the server at any one time";
+
   private static String propertyName(final String name) {
     return KsqlConfig.KSQL_CONFIG_PROPERTY_PREFIX + PROPERTY_PREFIX + name;
   }
@@ -141,7 +146,13 @@ public class ApiServerConfig extends AbstractConfig {
           Type.INT,
           DEFAULT_WORKER_POOL_SIZE,
           Importance.MEDIUM,
-          WORKER_POOL_DOC);
+          WORKER_POOL_DOC)
+      .define(
+          MAX_PUSH_QUERIES,
+          Type.INT,
+          DEFAULT_MAX_PUSH_QUERIES,
+          Importance.MEDIUM,
+          MAX_PUSH_QUERIES_DOC);
 
   public ApiServerConfig(final Map<?, ?> map) {
     super(CONFIG_DEF, map);

--- a/ksql-api/src/main/java/io/confluent/ksql/api/server/ApiServerConfig.java
+++ b/ksql-api/src/main/java/io/confluent/ksql/api/server/ApiServerConfig.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.api.server;
 
+import static io.confluent.ksql.configdef.ConfigValidators.oneOrMore;
 import static io.confluent.ksql.configdef.ConfigValidators.zeroOrPositive;
 
 import io.confluent.ksql.util.KsqlConfig;
@@ -23,8 +24,6 @@ import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
-import org.apache.kafka.common.config.ConfigDef.Validator;
-import org.apache.kafka.common.config.ConfigException;
 
 /**
  * Config for the API server
@@ -72,9 +71,9 @@ public class ApiServerConfig extends AbstractConfig {
       "Password for client trust store";
 
   public static final String TLS_CLIENT_AUTH_REQUIRED = propertyName("tls.client.auth.required");
-  public static final boolean DEFAULT_TLS_CLIENT_AUTH_REQUIRED = false;
+  public static final String DEFAULT_TLS_CLIENT_AUTH_REQUIRED = "none";
   public static final String TLS_CLIENT_AUTH_REQUIRED_DOC =
-      "Is client auth required?";
+      "Is client auth required? One of none, request or required";
 
   public static final String WORKER_POOL_SIZE = propertyName("worker.pool.size");
   public static final String WORKER_POOL_DOC =
@@ -143,7 +142,7 @@ public class ApiServerConfig extends AbstractConfig {
           TLS_TRUST_STORE_PASSWORD_DOC)
       .define(
           TLS_CLIENT_AUTH_REQUIRED,
-          Type.BOOLEAN,
+          Type.STRING,
           DEFAULT_TLS_CLIENT_AUTH_REQUIRED,
           Importance.MEDIUM,
           TLS_CLIENT_AUTH_REQUIRED_DOC)
@@ -166,20 +165,5 @@ public class ApiServerConfig extends AbstractConfig {
     super(CONFIG_DEF, map);
   }
 
-  private static Validator oneOrMore() {
-    return (name, val) -> {
-      if (val instanceof Long) {
-        if (((Long) val) < 1) {
-          throw new ConfigException(name, val, "Not >= 1");
-        }
-      } else if (val instanceof Integer) {
-        if (((Integer) val) < 1) {
-          throw new ConfigException(name, val, "Not >= 1");
-        }
-      } else {
-        throw new IllegalArgumentException("validator should only be used with int, long");
-      }
-    };
-  }
 
 }

--- a/ksql-api/src/main/java/io/confluent/ksql/api/server/BasePublisher.java
+++ b/ksql-api/src/main/java/io/confluent/ksql/api/server/BasePublisher.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.api.server;
 
 import io.confluent.ksql.api.impl.Utils;
 import io.vertx.core.Context;
-import io.vertx.core.Vertx;
 import java.util.Objects;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
@@ -51,7 +50,7 @@ public abstract class BasePublisher<T> implements Publisher<T> {
   @Override
   public void subscribe(final Subscriber<? super T> subscriber) {
     Objects.requireNonNull(subscriber);
-    if (Vertx.currentContext() == ctx && !Utils.isWorkerThread()) {
+    if (Utils.isEventLoopAndSameContext(ctx)) {
       doSubscribe(subscriber);
     } else {
       ctx.runOnContext(v -> doSubscribe(subscriber));

--- a/ksql-api/src/main/java/io/confluent/ksql/api/server/ConnectionQueryManager.java
+++ b/ksql-api/src/main/java/io/confluent/ksql/api/server/ConnectionQueryManager.java
@@ -45,6 +45,7 @@ public class ConnectionQueryManager {
     final ConnectionQueries connectionQueries = getConnectionQueries(request);
     final PushQueryHolder query = new PushQueryHolder(server,
         queryPublisher, connectionQueries::removeQuery);
+    server.registerQuery(query);
     connectionQueries.addQuery(query);
     return query;
   }

--- a/ksql-api/src/main/java/io/confluent/ksql/api/server/ErrorCodes.java
+++ b/ksql-api/src/main/java/io/confluent/ksql/api/server/ErrorCodes.java
@@ -30,6 +30,7 @@ public final class ErrorCodes {
   public static final int ERROR_CODE_INVALID_QUERY = 5;
   public static final int ERROR_CODE_MISSING_KEY_FIELD = 6;
   public static final int ERROR_CODE_CANNOT_COERCE_FIELD = 7;
+  public static final int ERROR_MAX_PUSH_QUERIES_EXCEEDED = 8;
 
 
   public static final int ERROR_CODE_INTERNAL_ERROR = 100;

--- a/ksql-api/src/main/java/io/confluent/ksql/api/server/InsertsStreamHandler.java
+++ b/ksql-api/src/main/java/io/confluent/ksql/api/server/InsertsStreamHandler.java
@@ -102,6 +102,7 @@ public class InsertsStreamHandler implements Handler<RoutingContext> {
     }
 
     public void handleBodyBuffer(final Buffer buff) {
+
       if (responseEnded) {
         // Ignore further buffers from request if response has been written (most probably due
         // to error)

--- a/ksql-api/src/main/java/io/confluent/ksql/api/server/PushQueryHolder.java
+++ b/ksql-api/src/main/java/io/confluent/ksql/api/server/PushQueryHolder.java
@@ -41,7 +41,6 @@ public class PushQueryHolder {
     this.queryPublisher = Objects.requireNonNull(queryPublisher);
     this.closeHandler = Objects.requireNonNull(closeHandler);
     this.id = new PushQueryId(UUID.randomUUID().toString());
-    server.registerQuery(this);
   }
 
   public void close() {

--- a/ksql-api/src/main/java/io/confluent/ksql/api/server/Server.java
+++ b/ksql-api/src/main/java/io/confluent/ksql/api/server/Server.java
@@ -141,7 +141,8 @@ public class Server {
 
     final HttpServerOptions options = new HttpServerOptions()
         .setHost(apiServerConfig.getString(ApiServerConfig.LISTEN_HOST))
-        .setPort(apiServerConfig.getInt(ApiServerConfig.LISTEN_PORT));
+        .setPort(apiServerConfig.getInt(ApiServerConfig.LISTEN_PORT))
+        .setReuseAddress(true);
 
     if (apiServerConfig.getBoolean(ApiServerConfig.TLS_ENABLED)) {
       options.setUseAlpn(true)

--- a/ksql-api/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksql-api/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -25,6 +25,7 @@ import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.BodyHandler;
+import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,9 +45,9 @@ public class ServerVerticle extends AbstractVerticle {
 
   public ServerVerticle(final Endpoints endpoints, final HttpServerOptions httpServerOptions,
       final Server server) {
-    this.endpoints = endpoints;
-    this.httpServerOptions = httpServerOptions;
-    this.server = server;
+    this.endpoints = Objects.requireNonNull(endpoints);
+    this.httpServerOptions = Objects.requireNonNull(httpServerOptions);
+    this.server = Objects.requireNonNull(server);
   }
 
   @Override

--- a/ksql-api/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksql-api/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -20,7 +20,6 @@ import io.confluent.ksql.api.spi.Endpoints;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
-import io.vertx.core.WorkerExecutor;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
@@ -40,16 +39,14 @@ public class ServerVerticle extends AbstractVerticle {
   private final Endpoints endpoints;
   private final HttpServerOptions httpServerOptions;
   private final Server server;
-  private final WorkerExecutor workerExecutor;
   private ConnectionQueryManager connectionQueryManager;
   private HttpServer httpServer;
 
   public ServerVerticle(final Endpoints endpoints, final HttpServerOptions httpServerOptions,
-      final Server server, final WorkerExecutor workerExecutor) {
+      final Server server) {
     this.endpoints = endpoints;
     this.httpServerOptions = httpServerOptions;
     this.server = server;
-    this.workerExecutor = workerExecutor;
   }
 
   @Override
@@ -79,11 +76,11 @@ public class ServerVerticle extends AbstractVerticle {
         .produces("application/json")
         .handler(BodyHandler.create())
         .handler(new QueryStreamHandler(endpoints, connectionQueryManager, context,
-            workerExecutor));
+            server));
     router.route(HttpMethod.POST, "/inserts-stream")
         .produces("application/vnd.ksqlapi.delimited.v1")
         .produces("application/json")
-        .handler(new InsertsStreamHandler(context, endpoints, workerExecutor));
+        .handler(new InsertsStreamHandler(context, endpoints, server.getWorkerExecutor()));
     router.route(HttpMethod.POST, "/close-query").handler(BodyHandler.create())
         .handler(new CloseQueryHandler(server));
     return router;

--- a/ksql-api/src/main/java/io/confluent/ksql/api/server/protocol/QueryResponseMetadata.java
+++ b/ksql-api/src/main/java/io/confluent/ksql/api/server/protocol/QueryResponseMetadata.java
@@ -31,7 +31,7 @@ public class QueryResponseMetadata extends SerializableObject {
 
   public QueryResponseMetadata(final String queryId, final List<String> columnNames,
       final List<String> columnTypes) {
-    this.queryId = Objects.requireNonNull(queryId);
+    this.queryId = queryId;
     this.columnNames = Objects.requireNonNull(columnNames);
     this.columnTypes = Objects.requireNonNull(columnTypes);
   }

--- a/ksql-api/src/main/java/io/confluent/ksql/api/server/protocol/QueryResponseMetadata.java
+++ b/ksql-api/src/main/java/io/confluent/ksql/api/server/protocol/QueryResponseMetadata.java
@@ -36,4 +36,10 @@ public class QueryResponseMetadata extends SerializableObject {
     this.columnTypes = Objects.requireNonNull(columnTypes);
   }
 
+  public QueryResponseMetadata(final List<String> columnNames, final List<String> columnTypes) {
+    this.queryId = null;
+    this.columnNames = Objects.requireNonNull(columnNames);
+    this.columnTypes = Objects.requireNonNull(columnTypes);
+  }
+
 }

--- a/ksql-api/src/main/java/io/confluent/ksql/api/spi/QueryPublisher.java
+++ b/ksql-api/src/main/java/io/confluent/ksql/api/spi/QueryPublisher.java
@@ -41,4 +41,9 @@ public interface QueryPublisher extends Publisher<GenericRow> {
    */
   void close();
 
+  /**
+   * @return true if pull query
+   */
+  boolean isPullQuery();
+
 }

--- a/ksql-api/src/test/java/io/confluent/ksql/api/ApiServerConfigTest.java
+++ b/ksql-api/src/test/java/io/confluent/ksql/api/ApiServerConfigTest.java
@@ -38,7 +38,7 @@ public class ApiServerConfigTest {
     map.put(ApiServerConfig.TLS_KEY_STORE_PASSWORD, "ewfwef");
     map.put(ApiServerConfig.TLS_TRUST_STORE_PATH, "wefewf");
     map.put(ApiServerConfig.TLS_TRUST_STORE_PASSWORD, "ergerg");
-    map.put(ApiServerConfig.TLS_CLIENT_AUTH_REQUIRED, true);
+    map.put(ApiServerConfig.TLS_CLIENT_AUTH_REQUIRED, "request");
 
     // When:
     ApiServerConfig config = new ApiServerConfig(map);
@@ -52,7 +52,7 @@ public class ApiServerConfigTest {
     assertThat(config.getString(ApiServerConfig.TLS_KEY_STORE_PASSWORD), is("ewfwef"));
     assertThat(config.getString(ApiServerConfig.TLS_TRUST_STORE_PATH), is("wefewf"));
     assertThat(config.getString(ApiServerConfig.TLS_TRUST_STORE_PASSWORD), is("ergerg"));
-    assertThat(config.getBoolean(ApiServerConfig.TLS_CLIENT_AUTH_REQUIRED), is(true));
+    assertThat(config.getString(ApiServerConfig.TLS_CLIENT_AUTH_REQUIRED), is("request"));
   }
 
   @Test
@@ -74,6 +74,6 @@ public class ApiServerConfigTest {
     assertThat(config.getString(ApiServerConfig.TLS_KEY_STORE_PASSWORD), is(""));
     assertThat(config.getString(ApiServerConfig.TLS_TRUST_STORE_PATH), is(""));
     assertThat(config.getString(ApiServerConfig.TLS_TRUST_STORE_PASSWORD), is(""));
-    assertThat(config.getBoolean(ApiServerConfig.TLS_CLIENT_AUTH_REQUIRED), is(false));
+    assertThat(config.getString(ApiServerConfig.TLS_CLIENT_AUTH_REQUIRED), is("none"));
   }
 }

--- a/ksql-api/src/test/java/io/confluent/ksql/api/BaseApiTest.java
+++ b/ksql-api/src/test/java/io/confluent/ksql/api/BaseApiTest.java
@@ -88,6 +88,9 @@ public class BaseApiTest {
     if (server != null) {
       server.stop();
     }
+    if (vertx != null) {
+      vertx.close();
+    }
   }
 
   protected ApiServerConfig createServerConfig() {

--- a/ksql-api/src/test/java/io/confluent/ksql/api/BaseApiTest.java
+++ b/ksql-api/src/test/java/io/confluent/ksql/api/BaseApiTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api;
+
+import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.api.impl.VertxCompletableFuture;
+import io.confluent.ksql.api.server.ApiServerConfig;
+import io.confluent.ksql.api.server.Server;
+import io.confluent.ksql.api.utils.ListRowGenerator;
+import io.confluent.ksql.api.utils.QueryResponse;
+import io.confluent.ksql.api.utils.ReceiveStream;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+import io.vertx.ext.web.codec.BodyCodec;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BaseApiTest {
+
+  private static final Logger log = LoggerFactory.getLogger(BaseApiTest.class);
+
+  protected static final JsonArray DEFAULT_COLUMN_NAMES = new JsonArray().add("name").add("age")
+      .add("male");
+  protected static final JsonArray DEFAULT_COLUMN_TYPES = new JsonArray().add("STRING").add("INT")
+      .add("BOOLEAN");
+  protected static final List<JsonArray> DEFAULT_ROWS = generateRows();
+  protected static final JsonObject DEFAULT_PUSH_QUERY_REQUEST_PROPERTIES = new JsonObject()
+      .put("prop1", "val1").put("prop2", 23);
+  protected static final String DEFAULT_PULL_QUERY = "select * from foo where rowkey='1234';";
+  protected static final String DEFAULT_PUSH_QUERY = "select * from foo emit changes;";
+  protected static final JsonObject DEFAULT_PUSH_QUERY_REQUEST_BODY = new JsonObject()
+      .put("sql", DEFAULT_PUSH_QUERY)
+      .put("properties", DEFAULT_PUSH_QUERY_REQUEST_PROPERTIES);
+
+  protected Vertx vertx;
+  protected WebClient client;
+  protected Server server;
+  protected TestEndpoints testEndpoints;
+
+  @Before
+  public void setUp() {
+
+    vertx = Vertx.vertx();
+    vertx.exceptionHandler(t -> log.error("Unhandled exception in Vert.x", t));
+
+    testEndpoints = new TestEndpoints();
+    ApiServerConfig serverConfig = createServerConfig();
+    server = new Server(vertx, serverConfig, testEndpoints);
+    server.start();
+    this.client = createClient();
+    setDefaultRowGenerator();
+  }
+
+  @After
+  public void tearDown() {
+    if (client != null) {
+      client.close();
+    }
+    if (server != null) {
+      server.stop();
+    }
+  }
+
+  protected ApiServerConfig createServerConfig() {
+    final Map<String, Object> config = new HashMap<>();
+    config.put("ksql.apiserver.listen.host", "localhost");
+    config.put("ksql.apiserver.listen.port", 8089);
+    config.put("ksql.apiserver.tls.enabled", false);
+    config.put("ksql.apiserver.verticle.instances", 4);
+
+    return new ApiServerConfig(config);
+  }
+
+  protected WebClientOptions createClientOptions() {
+    return new WebClientOptions()
+        .setProtocolVersion(HttpVersion.HTTP_2).setHttp2ClearTextUpgrade(false);
+  }
+
+  protected WebClient createClient() {
+    return WebClient.create(vertx, createClientOptions());
+  }
+
+  protected QueryResponse executePushQueryAndWaitForRows(final JsonObject requestBody)
+      throws Exception {
+    return executePushQueryAndWaitForRows(client, requestBody);
+  }
+
+  protected QueryResponse executePushQueryAndWaitForRows(final WebClient client,
+      final JsonObject requestBody)
+      throws Exception {
+
+    ReceiveStream writeStream = new ReceiveStream(vertx);
+
+    client.post(8089, "localhost", "/query-stream")
+        .as(BodyCodec.pipe(writeStream))
+        .sendJsonObject(requestBody, ar -> {
+        });
+
+    // Wait for all rows to arrive
+    assertThatEventually(() -> {
+      try {
+        Buffer buff = writeStream.getBody();
+        QueryResponse queryResponse = new QueryResponse(buff.toString());
+        return queryResponse.rows.size();
+      } catch (Throwable t) {
+        return Integer.MAX_VALUE;
+      }
+    }, is(DEFAULT_ROWS.size()));
+
+    // Note, the response hasn't ended at this point
+    assertThat(writeStream.isEnded(), is(false));
+
+    return new QueryResponse(writeStream.getBody().toString());
+  }
+
+
+  protected HttpResponse<Buffer> sendRequest(final String uri, final Buffer requestBody)
+      throws Exception {
+    return sendRequest(client, uri, requestBody);
+  }
+
+  protected HttpResponse<Buffer> sendRequest(final WebClient client, final String uri,
+      final Buffer requestBody)
+      throws Exception {
+    VertxCompletableFuture<HttpResponse<Buffer>> requestFuture = new VertxCompletableFuture<>();
+    client
+        .post(8089, "localhost", uri)
+        .sendBuffer(requestBody, requestFuture);
+    return requestFuture.get();
+  }
+
+  protected static void validateError(final int errorCode, final String message,
+      final JsonObject error) {
+    assertThat(error.size(), is(3));
+    validateErrorCommon(errorCode, message, error);
+  }
+
+  protected static void validateErrorCommon(final int errorCode, final String message,
+      final JsonObject error) {
+    assertThat(error.getString("status"), is("error"));
+    assertThat(error.getInteger("errorCode"), is(errorCode));
+    assertThat(error.getString("message"), is(message));
+  }
+
+  @SuppressWarnings("unchecked")
+  private void setDefaultRowGenerator() {
+    List<GenericRow> rows = new ArrayList<>();
+    for (JsonArray ja : DEFAULT_ROWS) {
+      rows.add(GenericRow.fromList(ja.getList()));
+    }
+    testEndpoints.setRowGeneratorFactory(
+        () -> new ListRowGenerator(
+            DEFAULT_COLUMN_NAMES.getList(),
+            DEFAULT_COLUMN_TYPES.getList(),
+            rows));
+  }
+
+  private static List<JsonArray> generateRows() {
+    List<JsonArray> rows = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      JsonArray row = new JsonArray().add("foo" + i).add(i).add(i % 2 == 0);
+      rows.add(row);
+    }
+    return rows;
+  }
+
+}

--- a/ksql-api/src/test/java/io/confluent/ksql/api/MaxQueriesTest.java
+++ b/ksql-api/src/test/java/io/confluent/ksql/api/MaxQueriesTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api;
+
+import static io.confluent.ksql.api.server.ErrorCodes.ERROR_MAX_PUSH_QUERIES_EXCEEDED;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import io.confluent.ksql.api.server.ApiServerConfig;
+import io.confluent.ksql.api.server.PushQueryId;
+import io.confluent.ksql.api.utils.QueryResponse;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.client.HttpResponse;
+import java.util.Map;
+import org.junit.Test;
+
+public class MaxQueriesTest extends BaseApiTest {
+
+  private static final int MAX_QUERIES = 10;
+
+  @Test
+  public void shouldNotCreateMoreThanMaxQueries() throws Exception {
+
+    for (int i = 0; i < MAX_QUERIES + 4; i++) {
+
+      if (i >= MAX_QUERIES) {
+        HttpResponse<Buffer> response = sendRequest("/query-stream",
+            DEFAULT_PUSH_QUERY_REQUEST_BODY.toBuffer());
+        assertThat(response.statusCode(), is(400));
+        QueryResponse queryResponse = new QueryResponse(response.bodyAsString());
+        validateError(ERROR_MAX_PUSH_QUERIES_EXCEEDED, "Maximum number of push queries exceeded",
+            queryResponse.responseObject);
+      } else {
+        // When:
+        QueryResponse queryResponse = executePushQueryAndWaitForRows(
+            DEFAULT_PUSH_QUERY_REQUEST_BODY);
+        String queryId = queryResponse.responseObject.getString("queryId");
+
+        // Then:
+        assertThat(queryId, is(notNullValue()));
+        assertThat(server.getQueryIDs().contains(new PushQueryId(queryId)), is(true));
+      }
+    }
+
+    assertThat(server.getQueryIDs(), hasSize(MAX_QUERIES));
+  }
+
+  @Override
+  protected ApiServerConfig createServerConfig() {
+    ApiServerConfig config = super.createServerConfig();
+    Map<String, Object> origs = config.originalsWithPrefix("");
+    origs.put(ApiServerConfig.MAX_PUSH_QUERIES, MAX_QUERIES);
+    return new ApiServerConfig(origs);
+  }
+}

--- a/ksql-api/src/test/java/io/confluent/ksql/api/MaxQueriesTest.java
+++ b/ksql-api/src/test/java/io/confluent/ksql/api/MaxQueriesTest.java
@@ -63,7 +63,7 @@ public class MaxQueriesTest extends BaseApiTest {
   @Override
   protected ApiServerConfig createServerConfig() {
     ApiServerConfig config = super.createServerConfig();
-    Map<String, Object> origs = config.originalsWithPrefix("");
+    Map<String, Object> origs = config.originals();
     origs.put(ApiServerConfig.MAX_PUSH_QUERIES, MAX_QUERIES);
     return new ApiServerConfig(origs);
   }

--- a/ksql-api/src/test/java/io/confluent/ksql/api/TestQueryPublisher.java
+++ b/ksql-api/src/test/java/io/confluent/ksql/api/TestQueryPublisher.java
@@ -79,4 +79,9 @@ public class TestQueryPublisher extends BasePublisher<GenericRow> implements Que
     return rowGenerator.getColumnTypes();
   }
 
+  @Override
+  public boolean isPullQuery() {
+    return !push;
+  }
+
 }

--- a/ksql-common/src/main/java/io/confluent/ksql/configdef/ConfigValidators.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/configdef/ConfigValidators.java
@@ -138,6 +138,22 @@ public final class ConfigValidators {
     };
   }
 
+  public static Validator oneOrMore() {
+    return (name, val) -> {
+      if (val instanceof Long) {
+        if (((Long) val) < 1) {
+          throw new ConfigException(name, val, "Not >= 1");
+        }
+      } else if (val instanceof Integer) {
+        if (((Integer) val) < 1) {
+          throw new ConfigException(name, val, "Not >= 1");
+        }
+      } else {
+        throw new IllegalArgumentException("validator should only be used with int, long");
+      }
+    };
+  }
+
   public static final class ValidCaseInsensitiveString implements Validator {
 
     private final List<String> validStrings;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/ApiIntegrationTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/ApiIntegrationTest.java
@@ -257,7 +257,7 @@ public class ApiIntegrationTest {
     assertThat(response.rows, hasSize(1));
     assertThat(response.responseObject.getJsonArray("columnNames"), is(expectedColumnNames));
     assertThat(response.responseObject.getJsonArray("columnTypes"), is(expectedColumnTypes));
-    assertThat(response.responseObject.getString("queryId"), is(notNullValue()));
+    assertThat(response.responseObject.getString("queryId"), is(nullValue()));
     assertThat(response.rows.get(0).getString(0), is("USER_1"));  // rowkey
     assertThat(response.rows.get(0).getLong(1), is(notNullValue()));  // rowtime - non deterministic
     assertThat(response.rows.get(0).getLong(2), is(1L)); // count


### PR DESCRIPTION
### Description 

Provides an upper limit on the number of push queries that can be running in the server at any one time.

Push queries are expensive as they own their own Kafka streams topology and associated threads. We can't have too many in the server at once.

### Testing done 

Added new test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

