### PR TITLE
test: run latest QTT tests first

### DIFF
--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/QueryTranslationTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/QueryTranslationTest.java
@@ -50,14 +50,14 @@ public class QueryTranslationTest {
 
   private static final Path QUERY_VALIDATION_TEST_DIR = Paths.get("query-validation-tests");
 
+  @SuppressWarnings("UnstableApiUsage")
   @Parameterized.Parameters(name = "{0}")
   public static Collection<Object[]> data() {
     return
         Streams.concat(
-            PlannedTestLoader.of(testFileLoader())
-                .load(),
-            ExpectedTopologiesTestLoader.of(testFileLoader(), "expected_topology/")
-                .load()
+            testFileLoader().load(),
+            PlannedTestLoader.of(testFileLoader()).load(),
+            ExpectedTopologiesTestLoader.of(testFileLoader(), "expected_topology/").load()
         )
         .map(testCase -> new Object[]{testCase.getName(), testCase})
         .collect(Collectors.toCollection(ArrayList::new));

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestLoader.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestLoader.java
@@ -16,11 +16,8 @@
 package io.confluent.ksql.test.planned;
 
 import io.confluent.ksql.test.loader.TestLoader;
-import io.confluent.ksql.test.model.KsqlVersion;
 import io.confluent.ksql.test.tools.TestCase;
-import io.confluent.ksql.test.tools.TopologyAndConfigs;
 import io.confluent.ksql.test.tools.VersionedTest;
-import java.nio.file.Path;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -44,17 +41,13 @@ public class PlannedTestLoader implements TestLoader<VersionedTest> {
 
   @Override
   public Stream<VersionedTest> load() {
-    return innerLoader.load().flatMap(this::buildHistoricalTestCases);
+    return innerLoader.load()
+        .filter(PlannedTestUtils::isPlannedTestCase)
+        .flatMap(PlannedTestLoader::buildHistoricalTestCases);
   }
 
-  private Stream<VersionedTest> buildHistoricalTestCases(final TestCase testCase) {
-    if (PlannedTestUtils.isPlannedTestCase(testCase)) {
-      return TestCasePlanLoader.allForTestCase(testCase).stream()
+  private static Stream<VersionedTest> buildHistoricalTestCases(final TestCase testCase) {
+    return TestCasePlanLoader.allForTestCase(testCase).stream()
           .map(plan -> PlannedTestUtils.buildPlannedTestCase(testCase, plan));
-    } else if (testCase.getVersionBounds().contains(KsqlVersion.current())) {
-      return Stream.of(testCase);
-    } else {
-      return Stream.empty();
-    }
   }
 }


### PR DESCRIPTION
### Description 

Switch QTT around so that it always runs the tests against the latest version first, then looks to test against historic versions.

Why? When running locally to test changes it makes more sense, to me at least!, to test that current functionality works as expected before testing to ensure there is no backwards compatibility issues.  Though I appreciate this could be a person thing.

### Testing done 

test only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

