### PR TITLE
fix: add functional-test dependencies to Docker module

### DIFF
--- a/ksql-docker/pom.xml
+++ b/ksql-docker/pom.xml
@@ -66,6 +66,18 @@
       <scope>compile</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
   </dependencies>
 
 


### PR DESCRIPTION
### Description 
Dependencies required by `ksql-test-runner` are not present in the artifacts copied to Docker images. cf. #4584 

### Testing done 
I built the Docker image locally via
`mvn -Pdocker package -pl ksql-docker -DskipTests -Dspotbugs.skip -Dcheckstyle.skip -Ddockerfile.skip=false -Dskip.docker.build=false -Ddocker.upstream-tag=master-latest -Ddocker.tag=local.build -Ddocker.upstream-registry='368821881613.dkr.ecr.us-west-2.amazonaws.com/'`

Then I ran the repro steps in #4584, using the `placeholder/confluentinc/ksql-docker:local.build` image built above.

The reported exception was not thrown.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

