### PR TITLE
feat: Simple perf tool for new API

### DIFF
--- a/ksql-api/src/main/java/io/confluent/ksql/api/plugin/BlockingQueryPublisher.java
+++ b/ksql-api/src/main/java/io/confluent/ksql/api/plugin/BlockingQueryPublisher.java
@@ -18,7 +18,7 @@ package io.confluent.ksql.api.plugin;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.api.server.BasePublisher;
-import io.confluent.ksql.api.server.PushQueryHandler;
+import io.confluent.ksql.api.server.PushQueryHandle;
 import io.confluent.ksql.api.spi.QueryPublisher;
 import io.vertx.core.Context;
 import io.vertx.core.WorkerExecutor;
@@ -46,13 +46,13 @@ public class BlockingQueryPublisher extends BasePublisher<GenericRow>
 
   private static final Logger log = LoggerFactory.getLogger(BlockingQueryPublisher.class);
 
-  public static final int SEND_MAX_BATCH_SIZE = 10;
-  public static final int BLOCKING_QUEUE_CAPACITY = 1000;
+  public static final int SEND_MAX_BATCH_SIZE = 200;
+  public static final int BLOCKING_QUEUE_CAPACITY = 500;
 
   private final BlockingQueue<GenericRow> queue = new LinkedBlockingQueue<>(
       BLOCKING_QUEUE_CAPACITY);
   private final WorkerExecutor workerExecutor;
-  private PushQueryHandler queryHandle;
+  private PushQueryHandle queryHandle;
   private List<String> columnNames;
   private List<String> columnTypes;
   private OptionalInt limit;
@@ -66,7 +66,7 @@ public class BlockingQueryPublisher extends BasePublisher<GenericRow>
     this.workerExecutor = Objects.requireNonNull(workerExecutor);
   }
 
-  public void setQueryHandle(final PushQueryHandler queryHandle) {
+  public void setQueryHandle(final PushQueryHandle queryHandle) {
     this.queryHandle = Objects.requireNonNull(queryHandle);
     this.limit = queryHandle.getLimit();
     this.columnNames = queryHandle.getColumnNames();

--- a/ksql-api/src/main/java/io/confluent/ksql/api/plugin/InsertsSubscriber.java
+++ b/ksql-api/src/main/java/io/confluent/ksql/api/plugin/InsertsSubscriber.java
@@ -52,7 +52,7 @@ public final class InsertsSubscriber extends BaseSubscriber<JsonObject> implemen
     InsertsStreamSubscriber {
 
   private static final Logger log = LoggerFactory.getLogger(InsertsSubscriber.class);
-  private static final int REQUEST_BATCH_SIZE = 1000;
+  private static final int REQUEST_BATCH_SIZE = 200;
   private static final SqlValueCoercer SQL_VALUE_COERCER = DefaultSqlValueCoercer.INSTANCE;
 
   private final Producer<byte[], byte[]> producer;

--- a/ksql-api/src/main/java/io/confluent/ksql/api/plugin/KsqlServerEndpoints.java
+++ b/ksql-api/src/main/java/io/confluent/ksql/api/plugin/KsqlServerEndpoints.java
@@ -19,7 +19,7 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.api.impl.Utils;
 import io.confluent.ksql.api.server.InsertResult;
 import io.confluent.ksql.api.server.InsertsStreamSubscriber;
-import io.confluent.ksql.api.server.PushQueryHandler;
+import io.confluent.ksql.api.server.PushQueryHandle;
 import io.confluent.ksql.api.spi.Endpoints;
 import io.confluent.ksql.api.spi.QueryPublisher;
 import io.confluent.ksql.engine.KsqlEngine;
@@ -243,7 +243,7 @@ public class KsqlServerEndpoints implements Endpoints {
     return colNames;
   }
 
-  private static class KsqlQueryHandle implements PushQueryHandler {
+  private static class KsqlQueryHandle implements PushQueryHandle {
 
     private final QueryMetadata queryMetadata;
     private final OptionalInt limit;

--- a/ksql-api/src/main/java/io/confluent/ksql/api/server/AcksSubscriber.java
+++ b/ksql-api/src/main/java/io/confluent/ksql/api/server/AcksSubscriber.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 public class AcksSubscriber extends BaseSubscriber<InsertResult> {
 
   private static final Logger log = LoggerFactory.getLogger(AcksSubscriber.class);
-  private static final int REQUEST_BATCH_SIZE = 1000;
+  private static final int REQUEST_BATCH_SIZE = 200;
 
   private final HttpServerResponse response;
   private final InsertsStreamResponseWriter insertsStreamResponseWriter;

--- a/ksql-api/src/main/java/io/confluent/ksql/api/server/BufferedPublisher.java
+++ b/ksql-api/src/main/java/io/confluent/ksql/api/server/BufferedPublisher.java
@@ -33,8 +33,8 @@ import org.slf4j.LoggerFactory;
 public class BufferedPublisher<T> extends BasePublisher<T> {
 
   private static final Logger log = LoggerFactory.getLogger(BufferedPublisher.class);
-  public static final int SEND_MAX_BATCH_SIZE = 10;
-  public static final int DEFAULT_BUFFER_MAX_SIZE = 100;
+  public static final int SEND_MAX_BATCH_SIZE = 200;
+  public static final int DEFAULT_BUFFER_MAX_SIZE = 200;
 
   private final Queue<T> buffer = new ArrayDeque<>();
   private final int bufferMaxSize;

--- a/ksql-api/src/main/java/io/confluent/ksql/api/server/PushQueryHandle.java
+++ b/ksql-api/src/main/java/io/confluent/ksql/api/server/PushQueryHandle.java
@@ -21,7 +21,7 @@ import java.util.OptionalInt;
 /**
  * Handle to a push query running in the engine
  */
-public interface PushQueryHandler {
+public interface PushQueryHandle {
 
   List<String> getColumnNames();
 

--- a/ksql-api/src/main/java/io/confluent/ksql/api/server/QuerySubscriber.java
+++ b/ksql-api/src/main/java/io/confluent/ksql/api/server/QuerySubscriber.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 public class QuerySubscriber extends BaseSubscriber<GenericRow> {
 
   private static final Logger log = LoggerFactory.getLogger(QuerySubscriber.class);
-  private static final int REQUEST_BATCH_SIZE = 1000;
+  private static final int REQUEST_BATCH_SIZE = 200;
 
   private final HttpServerResponse response;
   private final QueryStreamResponseWriter queryStreamResponseWriter;

--- a/ksql-api/src/test/java/io/confluent/ksql/api/perf/BasePerfRunner.java
+++ b/ksql-api/src/test/java/io/confluent/ksql/api/perf/BasePerfRunner.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.perf;
+
+import io.confluent.ksql.api.server.ApiServerConfig;
+import io.confluent.ksql.api.server.Server;
+import io.confluent.ksql.api.spi.Endpoints;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A simple tool for measuring performance of our API.
+ * <p>
+ * Implement the actual test in a subclass by overriding the abstract methods.
+ * <p>
+ * This tool is a simple rough and ready tool that does not pretend to be a fully fledged
+ * performance testing tool. It's really useful for quickly running perf tests in your IDE to get a
+ * rough idea of performance and do a first pass of performance tuning parameters - e.g. reactive
+ * streams buffer sizes.
+ */
+public abstract class BasePerfRunner {
+
+  private Endpoints endpoints;
+  private final AtomicInteger counter = new AtomicInteger();
+  private long totalTime;
+  private int totalCount;
+  private int numWarmupRuns;
+  private int numRuns;
+  private long runMs;
+
+  protected Vertx vertx;
+  protected WebClient client;
+  protected Server server;
+
+  protected volatile Throwable throwable;
+
+  /**
+   * Implement to configure your test
+   */
+  protected abstract void configure();
+
+  /**
+   * Implement this with the clean up logic of your run
+   *
+   * @throws Exception
+   */
+  protected abstract void endRun() throws Exception;
+
+  /**
+   * Implement this with the actual run logic of your test
+   *
+   * @param ms - how long it should run for in ms
+   * @throws Exception
+   */
+  protected abstract void run(long ms) throws Exception;
+
+  protected void count() {
+    counter.incrementAndGet();
+  }
+
+  protected BasePerfRunner setNumWarmupRuns(int runs) {
+    this.numWarmupRuns = runs;
+    return this;
+  }
+
+  protected BasePerfRunner setNumRuns(int runs) {
+    this.numRuns = runs;
+    return this;
+  }
+
+  protected BasePerfRunner setRunMs(long runMs) {
+    this.runMs = runMs;
+    return this;
+  }
+
+  protected BasePerfRunner setEndpoints(Endpoints endpoints) {
+    this.endpoints = endpoints;
+    return this;
+  }
+
+  protected ApiServerConfig createServerConfig() {
+    final Map<String, Object> config = new HashMap<>();
+    config.put("ksql.apiserver.listen.host", "localhost");
+    config.put("ksql.apiserver.listen.port", 8089);
+    config.put("ksql.apiserver.tls.enabled", false);
+
+    return new ApiServerConfig(config);
+  }
+
+  protected void errorOccurred(Throwable throwable) {
+    this.throwable = throwable;
+  }
+
+  protected final void go() {
+    try {
+      configure();
+      setUp();
+      System.out.println("Warming up for " + numWarmupRuns + " iterations");
+      for (int i = 0; i < numWarmupRuns; i++) {
+        System.out.println("Warming up iteration " + (i + 1));
+        doRun();
+      }
+      totalTime = 0;
+      totalCount = 0;
+      System.out.println("Running for " + numRuns + " iterations");
+      for (int i = 0; i < numRuns; i++) {
+        System.out.println("Run iteration " + (i + 1));
+        doRun();
+      }
+      System.out
+          .println(String.format("Mean rate is %.0f counts/sec", calcRate(totalTime, totalCount)));
+      tearDown();
+    } catch (Throwable t) {
+      t.printStackTrace();
+    }
+  }
+
+  private double calcRate(long duration, int count) {
+    return 1000 * (double) count / duration;
+  }
+
+  private void doRun() throws Throwable {
+    counter.set(0);
+
+    long start = System.currentTimeMillis();
+
+    run(runMs);
+
+    long duration = System.currentTimeMillis() - start;
+
+    int sent = counter.get();
+
+    double rate = calcRate(duration, sent);
+
+    if (throwable != null) {
+      throw throwable;
+    }
+
+    System.out.println(String.format("Rate is %.0f counts/sec", rate));
+
+    totalTime += duration;
+    totalCount += sent;
+
+    endRun();
+  }
+
+  private void setUp() {
+    vertx = Vertx.vertx();
+    ApiServerConfig serverConfig = createServerConfig();
+    server = new Server(vertx, serverConfig, endpoints);
+    server.start();
+    client = createClient();
+  }
+
+  private void tearDown() {
+    server.stop();
+    client.close();
+    vertx.close();
+  }
+
+  private WebClientOptions createClientOptions() {
+    return new WebClientOptions()
+        .setProtocolVersion(HttpVersion.HTTP_2).setHttp2ClearTextUpgrade(false);
+  }
+
+  private WebClient createClient() {
+    return WebClient.create(vertx, createClientOptions());
+  }
+
+}

--- a/ksql-api/src/test/java/io/confluent/ksql/api/perf/InsertsStreamRunner.java
+++ b/ksql-api/src/test/java/io/confluent/ksql/api/perf/InsertsStreamRunner.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.perf;
+
+import io.confluent.ksql.api.server.BaseSubscriber;
+import io.confluent.ksql.api.server.BufferedPublisher;
+import io.confluent.ksql.api.server.InsertResult;
+import io.confluent.ksql.api.server.InsertsStreamSubscriber;
+import io.confluent.ksql.api.spi.Endpoints;
+import io.confluent.ksql.api.spi.QueryPublisher;
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.WorkerExecutor;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.parsetools.RecordParser;
+import io.vertx.core.streams.ReadStream;
+import io.vertx.ext.web.codec.BodyCodec;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+public class InsertsStreamRunner extends BasePerfRunner {
+
+  public static void main(String[] args) {
+    new InsertsStreamRunner().go();
+  }
+
+  private SendStream sendStream;
+
+  @Override
+  public void configure() {
+    setNumWarmupRuns(5).setNumRuns(5).setRunMs(10000).setEndpoints(new InsertsStreamEndpoints());
+  }
+
+  @Override
+  public void run(long ms) throws Exception {
+
+    RecordParser parser = RecordParser.newDelimited("\n").handler(row -> {
+      count();
+    });
+
+    sendStream = new SendStream(vertx);
+
+    client.post(8089, "localhost", "/inserts-stream")
+        .as(BodyCodec.pipe(new RunnerUtils.ReceiveStream(parser)))
+        .sendStream(sendStream, ar -> {
+        });
+
+    Thread.sleep(ms);
+
+  }
+
+  @Override
+  protected void endRun() throws Exception {
+    sendStream.pause();
+
+    Thread.sleep(500);
+  }
+
+  // Just send as fast as we can
+  private static class SendStream implements ReadStream<Buffer> {
+
+    private static final int SEND_BATCH_SIZE = 200;
+
+    private static final Buffer REQUEST_ARGS = new JsonObject().put("target", "whatever")
+        .put("properties", new JsonObject()).toBuffer().appendString("\n");
+
+    private static final Buffer ROW = new JsonObject().put("name", "tim").put("age", 105)
+        .put("male", true).toBuffer()
+        .appendString("\n");
+
+    private final Vertx vertx;
+    private Handler<Buffer> handler;
+    private boolean paused;
+    private boolean sentFirst;
+
+    public SendStream(final Vertx vertx) {
+      this.vertx = vertx;
+    }
+
+    private synchronized void checkSend() {
+      Context context = vertx.getOrCreateContext();
+      if (!paused && handler != null) {
+        if (!sentFirst) {
+          handler.handle(REQUEST_ARGS);
+          sentFirst = true;
+        } else {
+          for (int i = 0; i < SEND_BATCH_SIZE; i++) {
+            handler.handle(ROW);
+          }
+        }
+        context.runOnContext(v -> checkSend());
+      }
+    }
+
+    @Override
+    public ReadStream<Buffer> exceptionHandler(final Handler<Throwable> handler) {
+      return this;
+    }
+
+    @Override
+    public synchronized ReadStream<Buffer> handler(@Nullable final Handler<Buffer> handler) {
+      this.handler = handler;
+      checkSend();
+      return this;
+    }
+
+    @Override
+    public synchronized ReadStream<Buffer> pause() {
+      paused = true;
+      return this;
+    }
+
+    @Override
+    public synchronized ReadStream<Buffer> resume() {
+      paused = false;
+      checkSend();
+      return this;
+    }
+
+    @Override
+    public ReadStream<Buffer> fetch(final long amount) {
+      return this;
+    }
+
+    @Override
+    public ReadStream<Buffer> endHandler(@Nullable final Handler<Void> endHandler) {
+      return this;
+    }
+  }
+
+  private class InsertsStreamEndpoints implements Endpoints {
+
+    @Override
+    public QueryPublisher createQueryPublisher(final String sql, final JsonObject properties,
+        final Context context,
+        final WorkerExecutor workerExecutor) {
+      return null;
+    }
+
+    @Override
+    public InsertsStreamSubscriber createInsertsSubscriber(final String target,
+        final JsonObject properties,
+        final Subscriber<InsertResult> acksSubscriber, final Context context,
+        final WorkerExecutor workerExecutor) {
+      return new InsertsSubscriber(context, acksSubscriber);
+    }
+  }
+
+  private class InsertsSubscriber extends BaseSubscriber<JsonObject> implements
+      InsertsStreamSubscriber {
+
+    private static final int REQUEST_BATCH_SIZE = 200;
+    private int tokens;
+    private long seq;
+
+    private BufferedPublisher<InsertResult> publisher;
+
+    public InsertsSubscriber(final Context context, final Subscriber<InsertResult> acksSubscriber) {
+      super(context);
+      publisher = new BufferedPublisher<>(context);
+      publisher.subscribe(acksSubscriber);
+    }
+
+    @Override
+    protected void afterSubscribe(final Subscription subscription) {
+      checkRequestTokens();
+    }
+
+    @Override
+    protected void handleValue(final JsonObject row) {
+      publisher.accept(InsertResult.succeededInsert(seq++));
+      tokens--;
+      checkRequestTokens();
+    }
+
+    @Override
+    protected void handleError(final Throwable t) {
+      errorOccurred(t);
+    }
+
+    private void checkRequestTokens() {
+      if (tokens == 0) {
+        tokens = REQUEST_BATCH_SIZE;
+        makeRequest(REQUEST_BATCH_SIZE);
+      }
+    }
+
+    @Override
+    public void close() {
+    }
+  }
+
+
+}

--- a/ksql-api/src/test/java/io/confluent/ksql/api/perf/PullQueryRunner.java
+++ b/ksql-api/src/test/java/io/confluent/ksql/api/perf/PullQueryRunner.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.perf;
+
+import static io.confluent.ksql.api.perf.RunnerUtils.DEFAULT_COLUMN_NAMES;
+import static io.confluent.ksql.api.perf.RunnerUtils.DEFAULT_COLUMN_TYPES;
+import static io.confluent.ksql.api.perf.RunnerUtils.DEFAULT_ROW;
+
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.api.impl.VertxCompletableFuture;
+import io.confluent.ksql.api.server.BufferedPublisher;
+import io.confluent.ksql.api.server.InsertResult;
+import io.confluent.ksql.api.server.InsertsStreamSubscriber;
+import io.confluent.ksql.api.spi.Endpoints;
+import io.confluent.ksql.api.spi.QueryPublisher;
+import io.vertx.core.Context;
+import io.vertx.core.WorkerExecutor;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpResponse;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Semaphore;
+import org.reactivestreams.Subscriber;
+
+public class PullQueryRunner extends BasePerfRunner {
+
+  public static void main(String[] args) {
+    new PullQueryRunner().go();
+  }
+
+  private static final String DEFAULT_PULL_QUERY = "select * from foo where rowkey=123;";
+  private static final JsonObject DEFAULT_PULL_QUERY_REQUEST_BODY = new JsonObject()
+      .put("sql", DEFAULT_PULL_QUERY)
+      .put("properties", new JsonObject());
+  private static final List<GenericRow> DEFAULT_ROWS = generateResults();
+  private static final int MAX_CONCURRENT_REQUESTS = 100;
+
+  private PullQueryEndpoints pullQueryEndpoints;
+
+  @Override
+  protected void configure() {
+    this.pullQueryEndpoints = new PullQueryEndpoints();
+    setNumWarmupRuns(5).setNumRuns(5).setRunMs(10000).setEndpoints(pullQueryEndpoints);
+  }
+
+  @Override
+  protected void run(long runMs) throws Exception {
+    Semaphore sem = new Semaphore(MAX_CONCURRENT_REQUESTS);
+
+    long start = System.currentTimeMillis();
+
+    do {
+
+      sem.acquire();
+
+      VertxCompletableFuture<HttpResponse<Buffer>> vcf = new VertxCompletableFuture<>();
+
+      client.post(8089, "localhost", "/query-stream")
+          .sendJsonObject(DEFAULT_PULL_QUERY_REQUEST_BODY, vcf);
+
+      vcf.thenAccept(resp -> {
+        count();
+        sem.release();
+      });
+
+    } while (System.currentTimeMillis() - start < runMs);
+  }
+
+  @Override
+  protected void endRun() throws Exception {
+    pullQueryEndpoints.closePublishers();
+
+    Thread.sleep(500);
+  }
+
+  private static List<GenericRow> generateResults() {
+    List<GenericRow> results = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      results.add(DEFAULT_ROW);
+    }
+    return results;
+  }
+
+  private static class PullQueryEndpoints implements Endpoints {
+
+    private final Set<PullQueryPublisher> publishers = new HashSet<>();
+
+    @Override
+    public synchronized QueryPublisher createQueryPublisher(final String sql,
+        final JsonObject properties,
+        final Context context,
+        final WorkerExecutor workerExecutor) {
+      PullQueryPublisher publisher = new PullQueryPublisher(context, DEFAULT_ROWS);
+      publishers.add(publisher);
+      return publisher;
+    }
+
+    @Override
+    public InsertsStreamSubscriber createInsertsSubscriber(final String target,
+        final JsonObject properties,
+        final Subscriber<InsertResult> acksSubscriber, final Context context,
+        final WorkerExecutor workerExecutor) {
+      return null;
+    }
+
+    synchronized void closePublishers() {
+      for (PullQueryPublisher publisher : publishers) {
+        publisher.close();
+      }
+    }
+  }
+
+  private static class PullQueryPublisher extends BufferedPublisher<GenericRow> implements
+      QueryPublisher {
+
+    public PullQueryPublisher(final Context ctx, List<GenericRow> rows) {
+      super(ctx, rows);
+    }
+
+    @Override
+    public List<String> getColumnNames() {
+      return DEFAULT_COLUMN_NAMES;
+    }
+
+    @Override
+    public List<String> getColumnTypes() {
+      return DEFAULT_COLUMN_TYPES;
+    }
+
+    @Override
+    public boolean isPullQuery() {
+      return true;
+    }
+  }
+
+
+}

--- a/ksql-api/src/test/java/io/confluent/ksql/api/perf/QueryStreamRunner.java
+++ b/ksql-api/src/test/java/io/confluent/ksql/api/perf/QueryStreamRunner.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.perf;
+
+import static io.confluent.ksql.api.perf.RunnerUtils.DEFAULT_COLUMN_NAMES;
+import static io.confluent.ksql.api.perf.RunnerUtils.DEFAULT_COLUMN_TYPES;
+import static io.confluent.ksql.api.perf.RunnerUtils.DEFAULT_ROW;
+
+import io.confluent.ksql.api.plugin.BlockingQueryPublisher;
+import io.confluent.ksql.api.server.InsertResult;
+import io.confluent.ksql.api.server.InsertsStreamSubscriber;
+import io.confluent.ksql.api.server.PushQueryHandle;
+import io.confluent.ksql.api.spi.Endpoints;
+import io.confluent.ksql.api.spi.QueryPublisher;
+import io.vertx.core.Context;
+import io.vertx.core.WorkerExecutor;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.parsetools.RecordParser;
+import io.vertx.ext.web.codec.BodyCodec;
+import java.util.HashSet;
+import java.util.List;
+import java.util.OptionalInt;
+import java.util.Set;
+import org.reactivestreams.Subscriber;
+
+public class QueryStreamRunner extends BasePerfRunner {
+
+  private static final String DEFAULT_PUSH_QUERY = "select * from foo emit changes;";
+  private static final JsonObject DEFAULT_PUSH_QUERY_REQUEST_BODY = new JsonObject()
+      .put("sql", DEFAULT_PUSH_QUERY)
+      .put("properties", new JsonObject());
+
+  public static void main(String[] args) {
+    new QueryStreamRunner().go();
+  }
+
+  private QueryStreamEndpoints queryStreamEndpoints;
+
+  @Override
+  protected void configure() {
+    this.queryStreamEndpoints = new QueryStreamEndpoints();
+    setNumWarmupRuns(5).setNumRuns(5).setRunMs(10000).setEndpoints(queryStreamEndpoints);
+  }
+
+  @Override
+  protected void run(long ms) throws Exception {
+
+    RecordParser parser = RecordParser.newDelimited("\n").handler(row -> count());
+
+    client.post(8089, "localhost", "/query-stream")
+        .as(BodyCodec.pipe(new RunnerUtils.ReceiveStream(parser)))
+        .sendJsonObject(DEFAULT_PUSH_QUERY_REQUEST_BODY, ar -> {
+        });
+
+    Thread.sleep(ms);
+  }
+
+  @Override
+  protected void endRun() throws Exception {
+    queryStreamEndpoints.closePublishers();
+
+    Thread.sleep(500);
+  }
+
+  private class QueryStreamEndpoints implements Endpoints {
+
+    private final Set<QueryStreamPublisher> publishers = new HashSet<>();
+
+    @Override
+    public synchronized QueryPublisher createQueryPublisher(final String sql,
+        final JsonObject properties,
+        final Context context,
+        final WorkerExecutor workerExecutor) {
+      QueryStreamPublisher publisher = new QueryStreamPublisher(context,
+          server.getWorkerExecutor());
+      publisher.setQueryHandle(new TestQueryHandle());
+      publishers.add(publisher);
+      publisher.start();
+      return publisher;
+    }
+
+    @Override
+    public InsertsStreamSubscriber createInsertsSubscriber(final String target,
+        final JsonObject properties,
+        final Subscriber<InsertResult> acksSubscriber, final Context context,
+        final WorkerExecutor workerExecutor) {
+      return null;
+    }
+
+    synchronized void closePublishers() {
+      for (QueryStreamPublisher publisher : publishers) {
+        publisher.close();
+      }
+    }
+  }
+
+  private static class TestQueryHandle implements PushQueryHandle {
+
+    @Override
+    public List<String> getColumnNames() {
+      return DEFAULT_COLUMN_NAMES;
+    }
+
+    @Override
+    public List<String> getColumnTypes() {
+      return DEFAULT_COLUMN_TYPES;
+    }
+
+    @Override
+    public OptionalInt getLimit() {
+      return OptionalInt.empty();
+    }
+
+    @Override
+    public void start() {
+    }
+
+    @Override
+    public void stop() {
+    }
+  }
+
+  private static class QueryStreamPublisher extends BlockingQueryPublisher implements Runnable {
+
+    private static final int SEND_BATCH_SIZE = 200;
+    private volatile boolean closed;
+    private Thread thread;
+
+    public QueryStreamPublisher(final Context ctx, final WorkerExecutor workerExecutor) {
+      super(ctx, workerExecutor);
+    }
+
+    public void start() {
+      thread = new Thread(this);
+      thread.start();
+    }
+
+    public void close() {
+      closed = true;
+      try {
+        thread.join();
+      } catch (InterruptedException ignore) {
+        // Ignore
+      }
+    }
+
+    public void run() {
+      while (!closed) {
+        for (int i = 0; i < SEND_BATCH_SIZE; i++) {
+          accept(DEFAULT_ROW);
+        }
+      }
+    }
+  }
+
+}

--- a/ksql-api/src/test/java/io/confluent/ksql/api/perf/RunnerUtils.java
+++ b/ksql-api/src/test/java/io/confluent/ksql/api/perf/RunnerUtils.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.perf;
+
+import io.confluent.ksql.GenericRow;
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.parsetools.RecordParser;
+import io.vertx.core.streams.WriteStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class RunnerUtils {
+
+  protected static final List<String> DEFAULT_COLUMN_NAMES = Collections
+      .unmodifiableList(Arrays.asList("name", "age", "male"));
+  protected static final List<String> DEFAULT_COLUMN_TYPES = Collections.unmodifiableList(Arrays
+      .asList("STRING", "INT", "BOOLEAN"));
+  protected static final GenericRow DEFAULT_ROW = GenericRow
+      .fromList(Arrays.asList("tim", 105, true));
+
+  public static class ReceiveStream implements WriteStream<Buffer> {
+
+    private RecordParser recordParser;
+
+    public ReceiveStream(final RecordParser recordParser) {
+      this.recordParser = recordParser;
+    }
+
+    @Override
+    public WriteStream<Buffer> exceptionHandler(final Handler<Throwable> handler) {
+      return this;
+    }
+
+    @Override
+    public WriteStream<Buffer> write(final Buffer data) {
+      return write(data, null);
+    }
+
+    @Override
+    public WriteStream<Buffer> write(final Buffer data, final Handler<AsyncResult<Void>> handler) {
+      recordParser.handle(data);
+      return this;
+    }
+
+    @Override
+    public void end() {
+
+    }
+
+    @Override
+    public void end(final Handler<AsyncResult<Void>> handler) {
+
+    }
+
+    @Override
+    public WriteStream<Buffer> setWriteQueueMaxSize(final int maxSize) {
+      return this;
+    }
+
+    @Override
+    public boolean writeQueueFull() {
+      return false;
+    }
+
+    @Override
+    public WriteStream<Buffer> drainHandler(@Nullable final Handler<Void> handler) {
+      return this;
+    }
+  }
+}

--- a/ksql-api/src/test/java/io/confluent/ksql/api/perf/RunnerUtils.java
+++ b/ksql-api/src/test/java/io/confluent/ksql/api/perf/RunnerUtils.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.api.perf;
 
+import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.GenericRow;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.AsyncResult;
@@ -23,15 +24,14 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.parsetools.RecordParser;
 import io.vertx.core.streams.WriteStream;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 public class RunnerUtils {
 
-  protected static final List<String> DEFAULT_COLUMN_NAMES = Collections
-      .unmodifiableList(Arrays.asList("name", "age", "male"));
-  protected static final List<String> DEFAULT_COLUMN_TYPES = Collections.unmodifiableList(Arrays
-      .asList("STRING", "INT", "BOOLEAN"));
+  protected static final List<String> DEFAULT_COLUMN_NAMES = ImmutableList
+      .of("name", "age", "male");
+  protected static final List<String> DEFAULT_COLUMN_TYPES = ImmutableList
+      .of("STRING", "INT", "BOOLEAN");
   protected static final GenericRow DEFAULT_ROW = GenericRow
       .fromList(Arrays.asList("tim", 105, true));
 

--- a/ksql-api/src/test/java/io/confluent/ksql/api/plugin/BlockingQueryPublisherTest.java
+++ b/ksql-api/src/test/java/io/confluent/ksql/api/plugin/BlockingQueryPublisherTest.java
@@ -24,7 +24,7 @@ import static org.hamcrest.Matchers.nullValue;
 
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.api.PublisherTestBase;
-import io.confluent.ksql.api.server.PushQueryHandler;
+import io.confluent.ksql.api.server.PushQueryHandle;
 import io.confluent.ksql.api.utils.AsyncAssert;
 import io.vertx.core.WorkerExecutor;
 import java.util.ArrayList;
@@ -223,7 +223,7 @@ public class BlockingQueryPublisherTest extends PublisherTestBase<GenericRow> {
     shouldDeliver(num, num);
   }
 
-  private static class TestQueryHandle implements PushQueryHandler {
+  private static class TestQueryHandle implements PushQueryHandle {
 
     private final OptionalInt limit;
     private int stopCalledTimes;

--- a/ksql-api/src/test/java/io/confluent/ksql/api/tck/BlockingQueryPublisherVerificationTest.java
+++ b/ksql-api/src/test/java/io/confluent/ksql/api/tck/BlockingQueryPublisherVerificationTest.java
@@ -17,7 +17,7 @@ package io.confluent.ksql.api.tck;
 
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.api.plugin.BlockingQueryPublisher;
-import io.confluent.ksql.api.server.PushQueryHandler;
+import io.confluent.ksql.api.server.PushQueryHandle;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
 import io.vertx.core.WorkerExecutor;
@@ -67,7 +67,7 @@ public class BlockingQueryPublisherVerificationTest extends PublisherVerificatio
     return GenericRow.fromList(l);
   }
 
-  private static class TestQueryHandle implements PushQueryHandler {
+  private static class TestQueryHandle implements PushQueryHandle {
 
     private final long elements;
 


### PR DESCRIPTION
### Description 

Implements https://github.com/confluentinc/ksql/issues/4279

This is a stacked PR so please just review commits from "perf runner" and later

This PR introduces a simple perf tool for rough perf testing of our new API.

It's a simple tool that does not pretend to be perfect or a general purpose performance tool, but it's really useful for quickly running some tests in your IDE to get a rough idea of the overhead of the new API machinery. This can be used as first pass for tuning the server.

There's a base class called PerfRunner where all the magic happens. Then you subclass this for your particular test.

The PR also contains some changes to various buffer sizes and the like, tuned by running this perf tool.

### Testing done 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

