### PR TITLE
chore: support PROTOBUF for PRINT TOPIC

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
@@ -76,11 +76,14 @@ import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.connect.data.Struct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
 public class InsertValuesExecutor {
   // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
 
+  private static final Logger LOG = LoggerFactory.getLogger(InsertValuesExecutor.class);
   private static final Duration MAX_SEND_TIMEOUT = Duration.ofSeconds(5);
 
   private final LongSupplier clock;
@@ -453,6 +456,7 @@ public class InsertValuesExecutor {
         }
       }
 
+      LOG.error("Could not serialize row.", e);
       throw new KsqlException("Could not serialize row: " + row, e);
     }
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/RecordFormatterTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/RecordFormatterTest.java
@@ -560,7 +560,7 @@ public class RecordFormatterTest {
     }
 
     @Test
-    public void shouldNotExcludeAvroOnValidProtobuf() {
+    public void shouldNotExcludeProtobufOnValidProtobuf() {
       // Given:
       givenProtoSchemaRegistered();
 
@@ -586,7 +586,7 @@ public class RecordFormatterTest {
     }
 
     @Test
-    public void shouldNotExcludeTimeWindowedProtobufOnValidTimeWindowedAvro() {
+    public void shouldNotExcludeTimeWindowedProtobufOnValidTimeWindowedProtobuf() {
       // Given:
       givenProtoSchemaRegistered();
 
@@ -611,7 +611,7 @@ public class RecordFormatterTest {
     }
 
     @Test
-    public void shouldNotExcludeSessionWindowedProtobufOnValidTimeWindowedAvro() {
+    public void shouldNotExcludeSessionWindowedProtobufOnValidTimeWindowedProtobuf() {
       // Given:
       givenProtoSchemaRegistered();
 


### PR DESCRIPTION
fixes #4516 

### Description 

Adds support for `PRINT TOPIC` for protobuf topics

### Testing done 

Unit testing and manual:

```
ksql> PRINT print_proto FROM BEGINNING;
Key format: UNDEFINED
Value format: PROTOBUF
rowtime: 2/19/20 9:40:02 AM PST, key: <null>, value: COL1: "a" COL2: 2 COL3: "c"
^CTopic printing ceased
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

