### PR TITLE
fix: Tests should use free port for servers

### DIFF
--- a/ksql-api/src/main/java/io/confluent/ksql/api/server/Server.java
+++ b/ksql-api/src/main/java/io/confluent/ksql/api/server/Server.java
@@ -32,6 +32,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.kafka.common.config.ConfigException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,6 +55,7 @@ public class Server {
   private final int maxPushQueryCount;
   private String deploymentID;
   private WorkerExecutor workerExecutor;
+  private AtomicInteger actualPort = new AtomicInteger(-1);
 
   public Server(final Vertx vertx, final ApiServerConfig config, final Endpoints endpoints) {
     this.vertx = Objects.requireNonNull(vertx);
@@ -136,6 +138,14 @@ public class Server {
 
   public int queryConnectionCount() {
     return connections.size();
+  }
+
+  void setActualPort(final int port) {
+    actualPort.set(port);
+  }
+
+  public int getActualPort() {
+    return actualPort.get();
   }
 
   private HttpServerOptions createHttpServerOptions(final ApiServerConfig apiServerConfig) {

--- a/ksql-api/src/test/java/io/confluent/ksql/api/ApiTest.java
+++ b/ksql-api/src/test/java/io/confluent/ksql/api/ApiTest.java
@@ -303,7 +303,7 @@ public class ApiTest extends BaseApiTest {
 
     VertxCompletableFuture<HttpResponse<Void>> responseFuture = new VertxCompletableFuture<>();
     // Make the request to stream a query
-    client.post(8089, "localhost", "/query-stream")
+    client.post("/query-stream")
         .as(BodyCodec.pipe(writeStream))
         .sendJsonObject(DEFAULT_PUSH_QUERY_REQUEST_BODY, responseFuture);
 
@@ -444,7 +444,7 @@ public class ApiTest extends BaseApiTest {
     // When
 
     // Make an HTTP request but keep the request body and response streams open
-    client.post(8089, "localhost", "/inserts-stream")
+    client.post("/inserts-stream")
         .as(BodyCodec.pipe(writeStream))
         .sendStream(readStream, fut);
 
@@ -606,7 +606,7 @@ public class ApiTest extends BaseApiTest {
 
     // When
     client
-        .post(8089, "localhost", "/no-such-endpoint")
+        .post("/no-such-endpoint")
         .sendBuffer(Buffer.buffer(), requestFuture);
     HttpResponse<Buffer> response = requestFuture.get();
 
@@ -620,7 +620,7 @@ public class ApiTest extends BaseApiTest {
     // When
     VertxCompletableFuture<HttpResponse<Buffer>> requestFuture = new VertxCompletableFuture<>();
     client
-        .post(8089, "localhost", "/query-stream")
+        .post("/query-stream")
         .putHeader("accept", "blahblah")
         .sendBuffer(Buffer.buffer(), requestFuture);
     HttpResponse<Buffer> response = requestFuture.get();
@@ -635,7 +635,7 @@ public class ApiTest extends BaseApiTest {
     JsonObject requestBody = new JsonObject().put("sql", DEFAULT_PULL_QUERY);
     VertxCompletableFuture<HttpResponse<Buffer>> requestFuture = new VertxCompletableFuture<>();
     client
-        .post(8089, "localhost", "/query-stream")
+        .post("/query-stream")
         .sendBuffer(requestBody.toBuffer(), requestFuture);
 
     // Then
@@ -652,7 +652,7 @@ public class ApiTest extends BaseApiTest {
     JsonObject requestBody = new JsonObject().put("sql", DEFAULT_PULL_QUERY);
     VertxCompletableFuture<HttpResponse<Buffer>> requestFuture = new VertxCompletableFuture<>();
     client
-        .post(8089, "localhost", "/query-stream")
+        .post("/query-stream")
         .putHeader("accept", "application/vnd.ksqlapi.delimited.v1")
         .sendBuffer(requestBody.toBuffer(), requestFuture);
 
@@ -670,7 +670,7 @@ public class ApiTest extends BaseApiTest {
     JsonObject requestBody = new JsonObject().put("sql", DEFAULT_PULL_QUERY);
     VertxCompletableFuture<HttpResponse<Buffer>> requestFuture = new VertxCompletableFuture<>();
     client
-        .post(8089, "localhost", "/query-stream")
+        .post("/query-stream")
         .putHeader("accept", "application/json")
         .sendBuffer(requestBody.toBuffer(), requestFuture);
 
@@ -698,7 +698,7 @@ public class ApiTest extends BaseApiTest {
     }
     VertxCompletableFuture<HttpResponse<Buffer>> requestFuture = new VertxCompletableFuture<>();
     client
-        .post(8089, "localhost", "/inserts-stream")
+        .post("/inserts-stream")
         .sendBuffer(requestBody, requestFuture);
 
     // Then
@@ -724,7 +724,7 @@ public class ApiTest extends BaseApiTest {
     }
     VertxCompletableFuture<HttpResponse<Buffer>> requestFuture = new VertxCompletableFuture<>();
     client
-        .post(8089, "localhost", "/inserts-stream")
+        .post("/inserts-stream")
         .putHeader("accept", "application/vnd.ksqlapi.delimited.v1")
         .sendBuffer(requestBody, requestFuture);
 
@@ -751,7 +751,7 @@ public class ApiTest extends BaseApiTest {
     }
     VertxCompletableFuture<HttpResponse<Buffer>> requestFuture = new VertxCompletableFuture<>();
     client
-        .post(8089, "localhost", "/inserts-stream")
+        .post("/inserts-stream")
         .putHeader("accept", "application/json")
         .sendBuffer(requestBody, requestFuture);
 
@@ -773,7 +773,7 @@ public class ApiTest extends BaseApiTest {
     // When
     VertxCompletableFuture<HttpResponse<Buffer>> requestFuture = new VertxCompletableFuture<>();
     client
-        .post(8089, "localhost", uri)
+        .post(uri)
         .sendBuffer(requestBody, requestFuture);
     HttpResponse<Buffer> response = requestFuture.get();
 

--- a/ksql-api/src/test/java/io/confluent/ksql/api/BaseApiTest.java
+++ b/ksql-api/src/test/java/io/confluent/ksql/api/BaseApiTest.java
@@ -122,7 +122,8 @@ public class BaseApiTest {
     return new WebClientOptions()
         .setProtocolVersion(HttpVersion.HTTP_2).setHttp2ClearTextUpgrade(false)
         .setDefaultHost("localhost")
-        .setDefaultPort(serverPort);
+        .setDefaultPort(serverPort)
+        .setReusePort(true);
   }
 
   protected WebClient createClient() {

--- a/ksql-api/src/test/java/io/confluent/ksql/api/BaseApiTest.java
+++ b/ksql-api/src/test/java/io/confluent/ksql/api/BaseApiTest.java
@@ -35,7 +35,6 @@ import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.ext.web.codec.BodyCodec;
-import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -66,7 +65,6 @@ public class BaseApiTest {
   protected WebClient client;
   protected Server server;
   protected TestEndpoints testEndpoints;
-  protected int serverPort;
 
   @Before
   public void setUp() throws Exception {
@@ -75,19 +73,11 @@ public class BaseApiTest {
     vertx.exceptionHandler(t -> log.error("Unhandled exception in Vert.x", t));
 
     testEndpoints = new TestEndpoints();
-    serverPort = getFreePort();
     ApiServerConfig serverConfig = createServerConfig();
     server = new Server(vertx, serverConfig, testEndpoints);
     server.start();
     this.client = createClient();
     setDefaultRowGenerator();
-  }
-
-  private int getFreePort() throws Exception {
-    ServerSocket socket = new ServerSocket(0);
-    int port = socket.getLocalPort();
-    socket.close();
-    return port;
   }
 
   @After
@@ -110,8 +100,7 @@ public class BaseApiTest {
   protected ApiServerConfig createServerConfig() {
     final Map<String, Object> config = new HashMap<>();
     config.put("ksql.apiserver.listen.host", "localhost");
-    System.out.println("Server port is " + serverPort);
-    config.put("ksql.apiserver.listen.port", serverPort);
+    config.put("ksql.apiserver.listen.port", 0);
     config.put("ksql.apiserver.tls.enabled", false);
     config.put("ksql.apiserver.verticle.instances", 4);
 
@@ -122,7 +111,7 @@ public class BaseApiTest {
     return new WebClientOptions()
         .setProtocolVersion(HttpVersion.HTTP_2).setHttp2ClearTextUpgrade(false)
         .setDefaultHost("localhost")
-        .setDefaultPort(serverPort)
+        .setDefaultPort(server.getActualPort())
         .setReusePort(true);
   }
 

--- a/ksql-api/src/test/java/io/confluent/ksql/api/BaseApiTest.java
+++ b/ksql-api/src/test/java/io/confluent/ksql/api/BaseApiTest.java
@@ -85,7 +85,9 @@ public class BaseApiTest {
 
   private int getFreePort() throws Exception {
     ServerSocket socket = new ServerSocket(0);
-    return socket.getLocalPort();
+    int port = socket.getLocalPort();
+    socket.close();
+    return port;
   }
 
   @After
@@ -94,7 +96,11 @@ public class BaseApiTest {
       client.close();
     }
     if (server != null) {
-      server.stop();
+      try {
+        server.stop();
+      } catch (Exception e) {
+        log.error("Failed to shutdown server", e);
+      }
     }
     if (vertx != null) {
       vertx.close();
@@ -104,6 +110,7 @@ public class BaseApiTest {
   protected ApiServerConfig createServerConfig() {
     final Map<String, Object> config = new HashMap<>();
     config.put("ksql.apiserver.listen.host", "localhost");
+    System.out.println("Server port is " + serverPort);
     config.put("ksql.apiserver.listen.port", serverPort);
     config.put("ksql.apiserver.tls.enabled", false);
     config.put("ksql.apiserver.verticle.instances", 4);

--- a/ksql-api/src/test/java/io/confluent/ksql/api/TlsTest.java
+++ b/ksql-api/src/test/java/io/confluent/ksql/api/TlsTest.java
@@ -39,7 +39,7 @@ public class TlsTest extends ApiTest {
 
     Map<String, Object> config = new HashMap<>();
     config.put("ksql.apiserver.listen.host", "localhost");
-    config.put("ksql.apiserver.listen.port", serverPort);
+    config.put("ksql.apiserver.listen.port", 0);
     config.put("ksql.apiserver.tls.enabled", true);
     config.put("ksql.apiserver.tls.keystore.path", keyStorePath);
     config.put("ksql.apiserver.tls.keystore.password", keyStorePassword);
@@ -58,7 +58,7 @@ public class TlsTest extends ApiTest {
         setTrustAll(true).
         setVerifyHost(false).
         setDefaultHost("localhost").
-        setDefaultPort(serverPort);
+        setDefaultPort(server.getActualPort());
   }
 
 }

--- a/ksql-api/src/test/java/io/confluent/ksql/api/TlsTest.java
+++ b/ksql-api/src/test/java/io/confluent/ksql/api/TlsTest.java
@@ -39,7 +39,7 @@ public class TlsTest extends ApiTest {
 
     Map<String, Object> config = new HashMap<>();
     config.put("ksql.apiserver.listen.host", "localhost");
-    config.put("ksql.apiserver.listen.port", 8089);
+    config.put("ksql.apiserver.listen.port", serverPort);
     config.put("ksql.apiserver.tls.enabled", true);
     config.put("ksql.apiserver.tls.keystore.path", keyStorePath);
     config.put("ksql.apiserver.tls.keystore.password", keyStorePassword);
@@ -56,7 +56,9 @@ public class TlsTest extends ApiTest {
         setUseAlpn(true).
         setProtocolVersion(HttpVersion.HTTP_2).
         setTrustAll(true).
-        setVerifyHost(false);
+        setVerifyHost(false).
+        setDefaultHost("localhost").
+        setDefaultPort(serverPort);
   }
 
 }


### PR DESCRIPTION
### Description 

To avoid bind exceptions, test servers should use available server port.

### Testing done 


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

