### PR TITLE
chore: remove soon to be deprecated usage of schemaregistry (MINOR)

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/util/AvroUtil.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/AvroUtil.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.util;
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.ksql.execution.ddl.commands.CreateSourceCommand;
@@ -88,7 +89,7 @@ public final class AvroUtil {
   ) {
     try {
       return schemaRegistryClient.testCompatibility(
-          topicName + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX, avroSchema);
+          topicName + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX, new AvroSchema(avroSchema));
     } catch (final IOException e) {
       throw new KsqlException(String.format(
           "Could not check Schema compatibility: %s", e.getMessage()

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.KsqlConfigTestUtil;
@@ -640,7 +641,7 @@ public class KsqlEngineTest {
         .name("clientHash").type().fixed("MD5").size(16).noDefault()
         .endRecord();
 
-    schemaRegistryClient.register("BAR-value", schema);
+    schemaRegistryClient.register("BAR-value", new AvroSchema(schema));
 
     // When:
     KsqlEngineTestUtil.execute(
@@ -1131,7 +1132,7 @@ public class KsqlEngineTest {
     );
 
     // Then:
-    verify(schemaRegistryClient, never()).register(any(), any(Schema.class));
+    verify(schemaRegistryClient, never()).register(any(), any(AvroSchema.class));
   }
 
   @Test
@@ -1281,7 +1282,8 @@ public class KsqlEngineTest {
   private void givenTopicWithSchema(final String topicName, final Schema schema) {
     try {
       givenTopicsExist(1, topicName);
-      schemaRegistryClient.register(topicName + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX, schema);
+      schemaRegistryClient.register(
+          topicName + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX, new AvroSchema(schema));
     } catch (final Exception e) {
       fail("invalid test:" + e.getMessage());
     }

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
@@ -21,6 +21,7 @@ import static io.confluent.ksql.test.util.MapMatchers.mapHasSize;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.GenericRow;
@@ -636,7 +637,7 @@ public final class IntegrationTestHarness extends ExternalResource {
       final org.apache.avro.Schema avroSchema = AvroSchemas
           .getAvroSchema(schema.valueSchema(), "test_" + topicName, ksqlConfig);
 
-      srClient.register(topicName + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX, avroSchema);
+      srClient.register(topicName + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX, new AvroSchema(avroSchema));
     } catch (final Exception e) {
       throw new AssertionError(e);
     }

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/SandboxedSchemaRegistryClientTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/SandboxedSchemaRegistryClientTest.java
@@ -88,7 +88,7 @@ public final class SandboxedSchemaRegistryClientTest {
     @Mock
     private SchemaRegistryClient delegate;
     @Mock
-    private Schema schema;
+    private AvroSchema schema;
     @Mock
     private SchemaMetadata schemaMetadata;
     private SchemaRegistryClient sandboxedClient;
@@ -140,8 +140,7 @@ public final class SandboxedSchemaRegistryClientTest {
     public void shouldSwallowRegister() throws Exception {
       // When:
       sandboxedClient.register("some subject", schema);
-      sandboxedClient.register("some subject", new AvroSchema(schema));
-      sandboxedClient.register("some subject", new AvroSchema(schema), 1, 1);
+      sandboxedClient.register("some subject", schema, 1, 1);
 
       // Then:
       verifyZeroInteractions(delegate);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/KsqlResourceFunctionalTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/KsqlResourceFunctionalTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
 
 import io.confluent.common.utils.IntegrationTest;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.integration.IntegrationTestHarness;
 import io.confluent.ksql.integration.Retry;
@@ -162,11 +163,11 @@ public class KsqlResourceFunctionalTest {
     TEST_HARNESS.getSchemaRegistryClient()
         .register(
             "books" + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX,
-            AvroSchemas.getAvroSchema(
+            new AvroSchema(AvroSchemas.getAvroSchema(
                 schema.valueSchema(),
                 "books_value",
                 new KsqlConfig(REST_APP.getBaseConfig())
-            )
+            ))
         );
 
     // When:

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -63,6 +63,7 @@ import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.ksql.KsqlConfigTestUtil;
@@ -2219,7 +2220,7 @@ public class KsqlResourceTest {
     final org.apache.avro.Schema.Parser parser = new org.apache.avro.Schema.Parser();
     final org.apache.avro.Schema avroSchema = parser.parse(ordersAvroSchemaStr);
     schemaRegistryClient.register("orders-topic" + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX,
-        avroSchema);
+        new AvroSchema(avroSchema));
   }
 
   private static Matcher<Command> commandWithStatement(final String statement) {
@@ -2257,7 +2258,8 @@ public class KsqlResourceTest {
     final org.apache.avro.Schema schema = org.apache.avro.Schema.create(Type.INT);
 
     try {
-      schemaRegistryClient.register(topicName + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX, schema);
+      schemaRegistryClient.register(
+          topicName + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX, new AvroSchema(schema));
     } catch (final Exception e) {
       fail(e.getMessage());
     }

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/KsqlAvroSerdeFactory.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/KsqlAvroSerdeFactory.java
@@ -19,7 +19,7 @@ import com.google.errorprone.annotations.Immutable;
 import io.confluent.connect.avro.AvroConverter;
 import io.confluent.connect.avro.AvroDataConfig;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.serde.KsqlSerdeFactory;
 import io.confluent.ksql.serde.connect.KsqlConnectDeserializer;
@@ -142,7 +142,7 @@ public class KsqlAvroSerdeFactory implements KsqlSerdeFactory {
     final Map<String, Object> avroConfig = ksqlConfig
         .originalsWithPrefix(KsqlConfig.KSQL_SCHEMA_REGISTRY_PREFIX);
 
-    avroConfig.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+    avroConfig.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
         ksqlConfig.getString(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY));
 
     avroConfig.put(AvroDataConfig.CONNECT_META_DATA_CONFIG, false);

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroDeserializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroDeserializerTest.java
@@ -29,7 +29,7 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.connect.avro.AvroConverter;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
@@ -210,8 +210,8 @@ public class KsqlAvroDeserializerTest {
   @Before
   public void setUp() {
     final ImmutableMap<String, Object> configs = ImmutableMap.of(
-        AbstractKafkaAvroSerDeConfig.AUTO_REGISTER_SCHEMAS, true,
-        AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, ""
+        AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS, true,
+        AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, ""
     );
 
     schemaRegistryClient = new MockSchemaRegistryClient();

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroSerializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroSerializerTest.java
@@ -30,7 +30,7 @@ import io.confluent.connect.avro.AvroData;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.util.DecimalUtil;
@@ -166,8 +166,8 @@ public class KsqlAvroSerializerTest {
   @Before
   public void setup() {
     final ImmutableMap<String, Object> configs = ImmutableMap.of(
-        AbstractKafkaAvroSerDeConfig.AUTO_REGISTER_SCHEMAS, true,
-        AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, ""
+        AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS, true,
+        AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, ""
     );
 
     deserializer = new KafkaAvroDeserializer(schemaRegistryClient, configs);


### PR DESCRIPTION
### Description 

These code bits are about to be deprecated so we're proactively stopping to use them.

### Testing done 

- `mvn clean install`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

