### PR TITLE
fix: StoreQueryParameters name change

### DIFF
--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsStateStore.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsStateStore.java
@@ -26,7 +26,7 @@ import io.confluent.ksql.util.KsqlConfig;
 import java.util.function.Supplier;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
-import org.apache.kafka.streams.StoreQueryParams;
+import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.state.QueryableStoreType;
 
 /**
@@ -75,12 +75,12 @@ class KsStateStore {
       if (ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PULL_ENABLE_STANDBY_READS)) {
         // True flag allows queries on standby and replica state stores
         return kafkaStreams.store(
-            StoreQueryParams.fromNameAndType(stateStoreName, queryableStoreType)
+            StoreQueryParameters.fromNameAndType(stateStoreName, queryableStoreType)
                 .enableStaleStores());
       } else {
         // False flag allows queries only on active state store
         return kafkaStreams.store(
-            StoreQueryParams.fromNameAndType(stateStoreName, queryableStoreType));
+            StoreQueryParameters.fromNameAndType(stateStoreName, queryableStoreType));
       }
     } catch (final Exception e) {
       final State state = kafkaStreams.state();

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsStateStoreTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsStateStoreTest.java
@@ -37,7 +37,7 @@ import io.confluent.ksql.util.KsqlConfig;
 import java.util.function.Supplier;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
-import org.apache.kafka.streams.StoreQueryParams;
+import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.state.QueryableStoreType;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
@@ -176,7 +176,7 @@ public class KsStateStoreTest {
     store.store(storeType);
 
     // Then:
-    verify(kafkaStreams).store(StoreQueryParams.fromNameAndType(STORE_NAME, storeType));
+    verify(kafkaStreams).store(StoreQueryParameters.fromNameAndType(STORE_NAME, storeType));
   }
 
   @Test


### PR DESCRIPTION
### Description 

StoreQueryParams was renamed to StoreQueryParameters in Kafka Streams which broke the build.

This fixes it.

### Testing done 


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

