### PR TITLE
chore: Add perfrunner classes back in that got lost

### DIFF
--- a/ksql-rest-app/src/test/java/io/confluent/ksql/api/perf/BasePerfRunner.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/api/perf/BasePerfRunner.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.perf;
+
+import io.confluent.ksql.api.server.ApiServerConfig;
+import io.confluent.ksql.api.server.Server;
+import io.confluent.ksql.api.spi.Endpoints;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A simple tool for measuring performance of our API.
+ * <p>
+ * Implement the actual test in a subclass by overriding the abstract methods.
+ * <p>
+ * This tool is a simple rough and ready tool that does not pretend to be a fully fledged
+ * performance testing tool. It's really useful for quickly running perf tests in your IDE to get a
+ * rough idea of performance and do a first pass of performance tuning parameters - e.g. reactive
+ * streams buffer sizes.
+ */
+public abstract class BasePerfRunner {
+
+  private Endpoints endpoints;
+  private final AtomicInteger counter = new AtomicInteger();
+  private long totalTime;
+  private int totalCount;
+  private int numWarmupRuns;
+  private int numRuns;
+  private long runMs;
+
+  protected Vertx vertx;
+  protected WebClient client;
+  protected Server server;
+
+  protected volatile Throwable throwable;
+
+  /**
+   * Implement to configure your test
+   */
+  protected abstract void configure();
+
+  /**
+   * Implement this with the clean up logic of your run
+   *
+   * @throws Exception
+   */
+  protected abstract void endRun() throws Exception;
+
+  /**
+   * Implement this with the actual run logic of your test
+   *
+   * @param ms - how long it should run for in ms
+   * @throws Exception
+   */
+  protected abstract void run(long ms) throws Exception;
+
+  protected void count() {
+    counter.incrementAndGet();
+  }
+
+  protected BasePerfRunner setNumWarmupRuns(int runs) {
+    this.numWarmupRuns = runs;
+    return this;
+  }
+
+  protected BasePerfRunner setNumRuns(int runs) {
+    this.numRuns = runs;
+    return this;
+  }
+
+  protected BasePerfRunner setRunMs(long runMs) {
+    this.runMs = runMs;
+    return this;
+  }
+
+  protected BasePerfRunner setEndpoints(Endpoints endpoints) {
+    this.endpoints = endpoints;
+    return this;
+  }
+
+  protected ApiServerConfig createServerConfig() {
+    final Map<String, Object> config = new HashMap<>();
+    config.put("ksql.apiserver.listen.host", "localhost");
+    config.put("ksql.apiserver.listen.port", 8089);
+    config.put("ksql.apiserver.tls.enabled", false);
+
+    return new ApiServerConfig(config);
+  }
+
+  protected void errorOccurred(Throwable throwable) {
+    this.throwable = throwable;
+  }
+
+  protected final void go() {
+    try {
+      configure();
+      setUp();
+      System.out.println("Warming up for " + numWarmupRuns + " iterations");
+      for (int i = 0; i < numWarmupRuns; i++) {
+        System.out.println("Warming up iteration " + (i + 1));
+        doRun();
+      }
+      totalTime = 0;
+      totalCount = 0;
+      System.out.println("Running for " + numRuns + " iterations");
+      for (int i = 0; i < numRuns; i++) {
+        System.out.println("Run iteration " + (i + 1));
+        doRun();
+      }
+      System.out
+          .println(String.format("Mean rate is %.0f counts/sec", calcRate(totalTime, totalCount)));
+      tearDown();
+    } catch (Throwable t) {
+      t.printStackTrace();
+    }
+  }
+
+  private double calcRate(long duration, int count) {
+    return 1000 * (double) count / duration;
+  }
+
+  private void doRun() throws Throwable {
+    counter.set(0);
+
+    long start = System.currentTimeMillis();
+
+    run(runMs);
+
+    long duration = System.currentTimeMillis() - start;
+
+    int sent = counter.get();
+
+    double rate = calcRate(duration, sent);
+
+    if (throwable != null) {
+      throw throwable;
+    }
+
+    System.out.println(String.format("Rate is %.0f counts/sec", rate));
+
+    totalTime += duration;
+    totalCount += sent;
+
+    endRun();
+  }
+
+  private void setUp() {
+    vertx = Vertx.vertx();
+    ApiServerConfig serverConfig = createServerConfig();
+    server = new Server(vertx, serverConfig, endpoints);
+    server.start();
+    client = createClient();
+  }
+
+  private void tearDown() {
+    server.stop();
+    client.close();
+    vertx.close();
+  }
+
+  private WebClientOptions createClientOptions() {
+    return new WebClientOptions()
+        .setProtocolVersion(HttpVersion.HTTP_2).setHttp2ClearTextUpgrade(false);
+  }
+
+  private WebClient createClient() {
+    return WebClient.create(vertx, createClientOptions());
+  }
+
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/api/perf/InsertsStreamRunner.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/api/perf/InsertsStreamRunner.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.perf;
+
+import io.confluent.ksql.api.server.BaseSubscriber;
+import io.confluent.ksql.api.server.BufferedPublisher;
+import io.confluent.ksql.api.server.InsertResult;
+import io.confluent.ksql.api.server.InsertsStreamSubscriber;
+import io.confluent.ksql.api.spi.Endpoints;
+import io.confluent.ksql.api.spi.QueryPublisher;
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.WorkerExecutor;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.parsetools.RecordParser;
+import io.vertx.core.streams.ReadStream;
+import io.vertx.ext.web.codec.BodyCodec;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+public class InsertsStreamRunner extends BasePerfRunner {
+
+  public static void main(String[] args) {
+    new InsertsStreamRunner().go();
+  }
+
+  private SendStream sendStream;
+
+  @Override
+  public void configure() {
+    setNumWarmupRuns(5).setNumRuns(5).setRunMs(10000).setEndpoints(new InsertsStreamEndpoints());
+  }
+
+  @Override
+  public void run(long ms) throws Exception {
+
+    RecordParser parser = RecordParser.newDelimited("\n").handler(row -> {
+      count();
+    });
+
+    sendStream = new SendStream(vertx);
+
+    client.post(8089, "localhost", "/inserts-stream")
+        .as(BodyCodec.pipe(new RunnerUtils.ReceiveStream(parser)))
+        .sendStream(sendStream, ar -> {
+        });
+
+    Thread.sleep(ms);
+
+  }
+
+  @Override
+  protected void endRun() throws Exception {
+    sendStream.pause();
+
+    Thread.sleep(500);
+  }
+
+  // Just send as fast as we can
+  private static class SendStream implements ReadStream<Buffer> {
+
+    private static final int SEND_BATCH_SIZE = 200;
+
+    private static final Buffer REQUEST_ARGS = new JsonObject().put("target", "whatever")
+        .put("properties", new JsonObject()).toBuffer().appendString("\n");
+
+    private static final Buffer ROW = new JsonObject().put("name", "tim").put("age", 105)
+        .put("male", true).toBuffer()
+        .appendString("\n");
+
+    private final Vertx vertx;
+    private Handler<Buffer> handler;
+    private boolean paused;
+    private boolean sentFirst;
+
+    public SendStream(final Vertx vertx) {
+      this.vertx = vertx;
+    }
+
+    private synchronized void checkSend() {
+      Context context = vertx.getOrCreateContext();
+      if (!paused && handler != null) {
+        if (!sentFirst) {
+          handler.handle(REQUEST_ARGS);
+          sentFirst = true;
+        } else {
+          for (int i = 0; i < SEND_BATCH_SIZE; i++) {
+            handler.handle(ROW);
+          }
+        }
+        context.runOnContext(v -> checkSend());
+      }
+    }
+
+    @Override
+    public ReadStream<Buffer> exceptionHandler(final Handler<Throwable> handler) {
+      return this;
+    }
+
+    @Override
+    public synchronized ReadStream<Buffer> handler(@Nullable final Handler<Buffer> handler) {
+      this.handler = handler;
+      checkSend();
+      return this;
+    }
+
+    @Override
+    public synchronized ReadStream<Buffer> pause() {
+      paused = true;
+      return this;
+    }
+
+    @Override
+    public synchronized ReadStream<Buffer> resume() {
+      paused = false;
+      checkSend();
+      return this;
+    }
+
+    @Override
+    public ReadStream<Buffer> fetch(final long amount) {
+      return this;
+    }
+
+    @Override
+    public ReadStream<Buffer> endHandler(@Nullable final Handler<Void> endHandler) {
+      return this;
+    }
+  }
+
+  private class InsertsStreamEndpoints implements Endpoints {
+
+    @Override
+    public QueryPublisher createQueryPublisher(final String sql, final JsonObject properties,
+        final Context context,
+        final WorkerExecutor workerExecutor) {
+      return null;
+    }
+
+    @Override
+    public InsertsStreamSubscriber createInsertsSubscriber(final String target,
+        final JsonObject properties,
+        final Subscriber<InsertResult> acksSubscriber, final Context context,
+        final WorkerExecutor workerExecutor) {
+      return new InsertsSubscriber(context, acksSubscriber);
+    }
+  }
+
+  private class InsertsSubscriber extends BaseSubscriber<JsonObject> implements
+      InsertsStreamSubscriber {
+
+    private static final int REQUEST_BATCH_SIZE = 200;
+    private int tokens;
+    private long seq;
+
+    private BufferedPublisher<InsertResult> publisher;
+
+    public InsertsSubscriber(final Context context, final Subscriber<InsertResult> acksSubscriber) {
+      super(context);
+      publisher = new BufferedPublisher<>(context);
+      publisher.subscribe(acksSubscriber);
+    }
+
+    @Override
+    protected void afterSubscribe(final Subscription subscription) {
+      checkRequestTokens();
+    }
+
+    @Override
+    protected void handleValue(final JsonObject row) {
+      publisher.accept(InsertResult.succeededInsert(seq++));
+      tokens--;
+      checkRequestTokens();
+    }
+
+    @Override
+    protected void handleError(final Throwable t) {
+      errorOccurred(t);
+    }
+
+    private void checkRequestTokens() {
+      if (tokens == 0) {
+        tokens = REQUEST_BATCH_SIZE;
+        makeRequest(REQUEST_BATCH_SIZE);
+      }
+    }
+
+    @Override
+    public void close() {
+    }
+  }
+
+
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/api/perf/PullQueryRunner.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/api/perf/PullQueryRunner.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.perf;
+
+import static io.confluent.ksql.api.perf.RunnerUtils.DEFAULT_COLUMN_NAMES;
+import static io.confluent.ksql.api.perf.RunnerUtils.DEFAULT_COLUMN_TYPES;
+import static io.confluent.ksql.api.perf.RunnerUtils.DEFAULT_ROW;
+
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.api.impl.VertxCompletableFuture;
+import io.confluent.ksql.api.server.BufferedPublisher;
+import io.confluent.ksql.api.server.InsertResult;
+import io.confluent.ksql.api.server.InsertsStreamSubscriber;
+import io.confluent.ksql.api.spi.Endpoints;
+import io.confluent.ksql.api.spi.QueryPublisher;
+import io.vertx.core.Context;
+import io.vertx.core.WorkerExecutor;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpResponse;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Semaphore;
+import org.reactivestreams.Subscriber;
+
+public class PullQueryRunner extends BasePerfRunner {
+
+  public static void main(String[] args) {
+    new PullQueryRunner().go();
+  }
+
+  private static final String DEFAULT_PULL_QUERY = "select * from foo where rowkey=123;";
+  private static final JsonObject DEFAULT_PULL_QUERY_REQUEST_BODY = new JsonObject()
+      .put("sql", DEFAULT_PULL_QUERY)
+      .put("properties", new JsonObject());
+  private static final List<GenericRow> DEFAULT_ROWS = generateResults();
+  private static final int MAX_CONCURRENT_REQUESTS = 100;
+
+  private PullQueryEndpoints pullQueryEndpoints;
+
+  @Override
+  protected void configure() {
+    this.pullQueryEndpoints = new PullQueryEndpoints();
+    setNumWarmupRuns(5).setNumRuns(5).setRunMs(10000).setEndpoints(pullQueryEndpoints);
+  }
+
+  @Override
+  protected void run(long runMs) throws Exception {
+    Semaphore sem = new Semaphore(MAX_CONCURRENT_REQUESTS);
+
+    long start = System.currentTimeMillis();
+
+    do {
+
+      sem.acquire();
+
+      VertxCompletableFuture<HttpResponse<Buffer>> vcf = new VertxCompletableFuture<>();
+
+      client.post(8089, "localhost", "/query-stream")
+          .sendJsonObject(DEFAULT_PULL_QUERY_REQUEST_BODY, vcf);
+
+      vcf.thenAccept(resp -> {
+        count();
+        sem.release();
+      });
+
+    } while (System.currentTimeMillis() - start < runMs);
+  }
+
+  @Override
+  protected void endRun() throws Exception {
+    pullQueryEndpoints.closePublishers();
+
+    Thread.sleep(500);
+  }
+
+  private static List<GenericRow> generateResults() {
+    List<GenericRow> results = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      results.add(DEFAULT_ROW);
+    }
+    return results;
+  }
+
+  private static class PullQueryEndpoints implements Endpoints {
+
+    private final Set<PullQueryPublisher> publishers = new HashSet<>();
+
+    @Override
+    public synchronized QueryPublisher createQueryPublisher(final String sql,
+        final JsonObject properties,
+        final Context context,
+        final WorkerExecutor workerExecutor) {
+      PullQueryPublisher publisher = new PullQueryPublisher(context, DEFAULT_ROWS);
+      publishers.add(publisher);
+      return publisher;
+    }
+
+    @Override
+    public InsertsStreamSubscriber createInsertsSubscriber(final String target,
+        final JsonObject properties,
+        final Subscriber<InsertResult> acksSubscriber, final Context context,
+        final WorkerExecutor workerExecutor) {
+      return null;
+    }
+
+    synchronized void closePublishers() {
+      for (PullQueryPublisher publisher : publishers) {
+        publisher.close();
+      }
+    }
+  }
+
+  private static class PullQueryPublisher extends BufferedPublisher<GenericRow> implements
+      QueryPublisher {
+
+    public PullQueryPublisher(final Context ctx, List<GenericRow> rows) {
+      super(ctx, rows);
+    }
+
+    @Override
+    public List<String> getColumnNames() {
+      return DEFAULT_COLUMN_NAMES;
+    }
+
+    @Override
+    public List<String> getColumnTypes() {
+      return DEFAULT_COLUMN_TYPES;
+    }
+
+    @Override
+    public boolean isPullQuery() {
+      return true;
+    }
+  }
+
+
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/api/perf/QueryStreamRunner.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/api/perf/QueryStreamRunner.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.perf;
+
+import static io.confluent.ksql.api.perf.RunnerUtils.DEFAULT_COLUMN_NAMES;
+import static io.confluent.ksql.api.perf.RunnerUtils.DEFAULT_COLUMN_TYPES;
+import static io.confluent.ksql.api.perf.RunnerUtils.DEFAULT_ROW;
+
+import io.confluent.ksql.api.plugin.BlockingQueryPublisher;
+import io.confluent.ksql.api.server.InsertResult;
+import io.confluent.ksql.api.server.InsertsStreamSubscriber;
+import io.confluent.ksql.api.server.PushQueryHandle;
+import io.confluent.ksql.api.spi.Endpoints;
+import io.confluent.ksql.api.spi.QueryPublisher;
+import io.vertx.core.Context;
+import io.vertx.core.WorkerExecutor;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.parsetools.RecordParser;
+import io.vertx.ext.web.codec.BodyCodec;
+import java.util.HashSet;
+import java.util.List;
+import java.util.OptionalInt;
+import java.util.Set;
+import org.reactivestreams.Subscriber;
+
+public class QueryStreamRunner extends BasePerfRunner {
+
+  private static final String DEFAULT_PUSH_QUERY = "select * from foo emit changes;";
+  private static final JsonObject DEFAULT_PUSH_QUERY_REQUEST_BODY = new JsonObject()
+      .put("sql", DEFAULT_PUSH_QUERY)
+      .put("properties", new JsonObject());
+
+  public static void main(String[] args) {
+    new QueryStreamRunner().go();
+  }
+
+  private QueryStreamEndpoints queryStreamEndpoints;
+
+  @Override
+  protected void configure() {
+    this.queryStreamEndpoints = new QueryStreamEndpoints();
+    setNumWarmupRuns(5).setNumRuns(5).setRunMs(10000).setEndpoints(queryStreamEndpoints);
+  }
+
+  @Override
+  protected void run(long ms) throws Exception {
+
+    RecordParser parser = RecordParser.newDelimited("\n").handler(row -> count());
+
+    client.post(8089, "localhost", "/query-stream")
+        .as(BodyCodec.pipe(new RunnerUtils.ReceiveStream(parser)))
+        .sendJsonObject(DEFAULT_PUSH_QUERY_REQUEST_BODY, ar -> {
+        });
+
+    Thread.sleep(ms);
+  }
+
+  @Override
+  protected void endRun() throws Exception {
+    queryStreamEndpoints.closePublishers();
+
+    Thread.sleep(500);
+  }
+
+  private class QueryStreamEndpoints implements Endpoints {
+
+    private final Set<QueryStreamPublisher> publishers = new HashSet<>();
+
+    @Override
+    public synchronized QueryPublisher createQueryPublisher(final String sql,
+        final JsonObject properties,
+        final Context context,
+        final WorkerExecutor workerExecutor) {
+      QueryStreamPublisher publisher = new QueryStreamPublisher(context,
+          server.getWorkerExecutor());
+      publisher.setQueryHandle(new TestQueryHandle());
+      publishers.add(publisher);
+      publisher.start();
+      return publisher;
+    }
+
+    @Override
+    public InsertsStreamSubscriber createInsertsSubscriber(final String target,
+        final JsonObject properties,
+        final Subscriber<InsertResult> acksSubscriber, final Context context,
+        final WorkerExecutor workerExecutor) {
+      return null;
+    }
+
+    synchronized void closePublishers() {
+      for (QueryStreamPublisher publisher : publishers) {
+        publisher.close();
+      }
+    }
+  }
+
+  private static class TestQueryHandle implements PushQueryHandle {
+
+    @Override
+    public List<String> getColumnNames() {
+      return DEFAULT_COLUMN_NAMES;
+    }
+
+    @Override
+    public List<String> getColumnTypes() {
+      return DEFAULT_COLUMN_TYPES;
+    }
+
+    @Override
+    public OptionalInt getLimit() {
+      return OptionalInt.empty();
+    }
+
+    @Override
+    public void start() {
+    }
+
+    @Override
+    public void stop() {
+    }
+  }
+
+  private static class QueryStreamPublisher extends BlockingQueryPublisher implements Runnable {
+
+    private static final int SEND_BATCH_SIZE = 200;
+    private volatile boolean closed;
+    private Thread thread;
+
+    public QueryStreamPublisher(final Context ctx, final WorkerExecutor workerExecutor) {
+      super(ctx, workerExecutor);
+    }
+
+    public void start() {
+      thread = new Thread(this);
+      thread.start();
+    }
+
+    public void close() {
+      closed = true;
+      try {
+        thread.join();
+      } catch (InterruptedException ignore) {
+        // Ignore
+      }
+    }
+
+    public void run() {
+      while (!closed) {
+        for (int i = 0; i < SEND_BATCH_SIZE; i++) {
+          accept(DEFAULT_ROW);
+        }
+      }
+    }
+  }
+
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/api/perf/RunnerUtils.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/api/perf/RunnerUtils.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.perf;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.GenericRow;
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.parsetools.RecordParser;
+import io.vertx.core.streams.WriteStream;
+import java.util.Arrays;
+import java.util.List;
+
+public class RunnerUtils {
+
+  protected static final List<String> DEFAULT_COLUMN_NAMES = ImmutableList
+      .of("name", "age", "male");
+  protected static final List<String> DEFAULT_COLUMN_TYPES = ImmutableList
+      .of("STRING", "INT", "BOOLEAN");
+  protected static final GenericRow DEFAULT_ROW = GenericRow
+      .fromList(Arrays.asList("tim", 105, true));
+
+  public static class ReceiveStream implements WriteStream<Buffer> {
+
+    private RecordParser recordParser;
+
+    public ReceiveStream(final RecordParser recordParser) {
+      this.recordParser = recordParser;
+    }
+
+    @Override
+    public WriteStream<Buffer> exceptionHandler(final Handler<Throwable> handler) {
+      return this;
+    }
+
+    @Override
+    public WriteStream<Buffer> write(final Buffer data) {
+      return write(data, null);
+    }
+
+    @Override
+    public WriteStream<Buffer> write(final Buffer data, final Handler<AsyncResult<Void>> handler) {
+      recordParser.handle(data);
+      return this;
+    }
+
+    @Override
+    public void end() {
+
+    }
+
+    @Override
+    public void end(final Handler<AsyncResult<Void>> handler) {
+
+    }
+
+    @Override
+    public WriteStream<Buffer> setWriteQueueMaxSize(final int maxSize) {
+      return this;
+    }
+
+    @Override
+    public boolean writeQueueFull() {
+      return false;
+    }
+
+    @Override
+    public WriteStream<Buffer> drainHandler(@Nullable final Handler<Void> handler) {
+      return this;
+    }
+  }
+}


### PR DESCRIPTION
### Description 

I somehow managed to remove all the perfrunner classes in the recent move of the ksql-api package.

This adds them back in. They were already approved in https://github.com/confluentinc/ksql/pull/4590

### Testing done 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

