### PR TITLE
feat: support custom column widths in cli

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/CliConfig.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/CliConfig.java
@@ -27,6 +27,7 @@ import org.apache.kafka.common.config.ConfigException;
 public class CliConfig extends AbstractConfig {
 
   public static final String WRAP_CONFIG = "WRAP";
+  public static final String COLUMN_WIDTH_CONFIG = "COLUMN-WIDTH";
 
   private static final ConfigDef CONFIG_DEF = new ConfigDef()
       .define(
@@ -37,6 +38,15 @@ public class CliConfig extends AbstractConfig {
           Importance.MEDIUM,
           "A value of 'OFF' will clip lines to ensure that query results do not exceed the "
               + "terminal width (i.e. each row will appear on a single line)."
+      )
+      .define(
+          COLUMN_WIDTH_CONFIG,
+          Type.INT,
+          0,
+          ConfigValidators.zeroOrPositive(),
+          Importance.MEDIUM,
+          "The width in characters of each column in tabular output. A value of '0' indicates "
+              + "column width should be based on terminal width and number of columns."
       );
 
   public CliConfig(final Map<?, ?> originals) {

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -378,7 +378,7 @@ public class Console implements Closeable {
       case JSON:
         break;
       case TABULAR:
-        writer().println(TabularRow.createHeader(getWidth(), schema));
+        writer().println(TabularRow.createHeader(getWidth(), schema, config));
         break;
       default:
         throw new RuntimeException(String.format(

--- a/ksql-cli/src/main/java/io/confluent/ksql/util/TabularRow.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/util/TabularRow.java
@@ -34,12 +34,16 @@ public final class TabularRow {
   private static final String CLIPPED = "...";
   private static final int MIN_CELL_WIDTH = 5;
 
-  private final int width;
+  private final int cellWidth;
   private final List<String> columns;
   private final boolean isHeader;
   private final boolean shouldWrap;
 
-  public static TabularRow createHeader(final int width, final LogicalSchema schema) {
+  public static TabularRow createHeader(
+      final int width,
+      final LogicalSchema schema,
+      final CliConfig config
+  ) {
     final List<String> headings = schema.columns().stream()
         .map(Column::name)
         .map(ColumnName::name)
@@ -49,7 +53,7 @@ public final class TabularRow {
         width,
         headings,
         true,
-        true
+        config
     );
   }
 
@@ -62,7 +66,7 @@ public final class TabularRow {
         width,
         value.values().stream().map(Objects::toString).collect(Collectors.toList()),
         false,
-        config.getString(CliConfig.WRAP_CONFIG).equalsIgnoreCase(OnOff.ON.toString())
+        config
     );
   }
 
@@ -70,12 +74,21 @@ public final class TabularRow {
       final int width,
       final List<String> columns,
       final boolean isHeader,
-      final boolean shouldWrap
+      final CliConfig config
   ) {
     this.columns = ImmutableList.copyOf(Objects.requireNonNull(columns, "columns"));
-    this.width = width;
     this.isHeader = isHeader;
-    this.shouldWrap = shouldWrap;
+    this.shouldWrap = isHeader
+        || config.getString(CliConfig.WRAP_CONFIG).equalsIgnoreCase(OnOff.ON.toString());
+
+    final int configCellWidth = config.getInt(CliConfig.COLUMN_WIDTH_CONFIG);
+    if (configCellWidth > 0) {
+      this.cellWidth = configCellWidth;
+    } else if (!columns.isEmpty()) {
+      this.cellWidth = Math.max(width / columns.size() - 2, MIN_CELL_WIDTH);
+    } else {
+      cellWidth = MIN_CELL_WIDTH;
+    }
   }
 
   @Override
@@ -84,7 +97,6 @@ public final class TabularRow {
       return "";
     }
 
-    final int cellWidth = Math.max(width / columns.size() - 2, MIN_CELL_WIDTH);
     final StringBuilder builder = new StringBuilder();
 
     if (isHeader) {

--- a/ksql-cli/src/test/java/io/confluent/ksql/util/TabularRowTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/util/TabularRowTest.java
@@ -48,7 +48,7 @@ public class TabularRowTest {
         .build();
 
     // When:
-    final String formatted = TabularRow.createHeader(20, schema).toString();
+    final String formatted = TabularRow.createHeader(20, schema, config).toString();
 
     // Then:
     assertThat(formatted, is(""
@@ -67,7 +67,7 @@ public class TabularRowTest {
         .build();
 
     // When:
-    final String formatted = TabularRow.createHeader(20, schema).toString();
+    final String formatted = TabularRow.createHeader(20, schema, config).toString();
 
     // Then:
     assertThat(formatted, is(""
@@ -169,7 +169,7 @@ public class TabularRowTest {
         .build();
 
     // When:
-    final String formatted = TabularRow.createHeader(20, schema).toString();
+    final String formatted = TabularRow.createHeader(20, schema, config).toString();
 
     // Then:
     assertThat(formatted, isEmptyString());
@@ -186,7 +186,7 @@ public class TabularRowTest {
         .build();
 
     // When:
-    final String formatted = TabularRow.createHeader(3, schema).toString();
+    final String formatted = TabularRow.createHeader(3, schema, config).toString();
 
     // Then:
     assertThat(formatted,
@@ -196,11 +196,38 @@ public class TabularRowTest {
             + "+-----+-----+-----+"));
   }
 
+  @Test
+  public void shouldFormatCustomColumnWidth() {
+    // Given:
+    givenCustomColumnWidth(10);
+
+    final LogicalSchema schema = LogicalSchema.builder()
+        .noImplicitColumns()
+        .keyColumn(ColumnName.of("foo"), SqlTypes.BIGINT)
+        .valueColumn(ColumnName.of("bar"), SqlTypes.STRING)
+        .valueColumn(ColumnName.of("baz"), SqlTypes.DOUBLE)
+        .build();
+
+    // When:
+    final String formatted = TabularRow.createHeader(999, schema, config).toString();
+
+    // Then:
+    assertThat(formatted,
+        is(""
+            + "+----------+----------+----------+\n"
+            + "|foo       |bar       |baz       |\n"
+            + "+----------+----------+----------+"));
+  }
+
   private void givenWrappingEnabled() {
     when(config.getString(CliConfig.WRAP_CONFIG)).thenReturn(OnOff.ON.toString());
   }
 
   private void givenWrappingDisabled() {
     when(config.getString(CliConfig.WRAP_CONFIG)).thenReturn("Not ON");
+  }
+
+  private void givenCustomColumnWidth(int width) {
+    when(config.getInt(CliConfig.COLUMN_WIDTH_CONFIG)).thenReturn(width);
   }
 }


### PR DESCRIPTION
### Description 
Allow column width to be explicitly specified in tabular cli output. By default, column width is determined based on the terminal width and the number of columns. With these changes, the width of each column may be optionally overridden:
```
ksql> SET CLI COLUMN-WIDTH 10
```
Given a customized value, subsequent renderings of output use the setting:
```
ksql> SELECT * FROM riderLocations
>  WHERE GEO_DISTANCE(latitude, longitude, 37.4133, -122.1162) <= 5 EMIT CHANGES;
+----------+----------+----------+----------+----------+
|ROWTIME   |ROWKEY    |PROFILEID |LATITUDE  |LONGITUDE |
+----------+----------+----------+----------+----------+
```

The default behavior can be re-enabled using:
```
ksql> SET CLI COLUMN-WIDTH 0
```


### Testing done 
Existing and added unit tests
Built Docker image and smoke tested

resolves #4141 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

