### PR TITLE
chore: pin confluent dependencies to last released version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,9 @@
         <icu.version>65.1</icu.version>
         <skip.docker.build>true</skip.docker.build>
         <skip.docker.test>true</skip.docker.test>
+        <kafka.version>5.5.0-ccs-SNAPSHOT</kafka.version>
+        <ce.kafka.version>5.5.0-ce-SNAPSHOT</ce.kafka.version>
+        <confluent.version>5.5.0-SNAPSHOT</confluent.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
### Description 
Streams is a little unstable at the moment, so this patch pins our kafka and confluent dependencies
to the tip of the current _release_ branch (5.5.x). Kafka is in code-freeze right now, so this branch
should be pretty stable.

### Testing done 
mvn clean install
