### PR TITLE
Use the new topics endpoint in Connect REST API to describe the topics of a connector

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/connect/Connector.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/connect/Connector.java
@@ -31,36 +31,20 @@ import java.util.function.Predicate;
 public class Connector {
 
   private final String name;
-  @EffectivelyImmutable
-  private final Predicate<String> isTopicMatch;
-  @EffectivelyImmutable
-  private final Function<String, String> getSourceName;
   private final DataSourceType sourceType;
   private final Optional<String> keyField;
 
   public Connector(
       final String name,
-      final Predicate<String> isTopicMatch,
-      final Function<String, String> getSourceName,
       final DataSourceType sourceType,
       final String keyField) {
     this.name = Objects.requireNonNull(name, "name");
-    this.isTopicMatch = Objects.requireNonNull(isTopicMatch, "isTopicMatch");
-    this.getSourceName = Objects.requireNonNull(getSourceName, "getSourceName");
     this.sourceType = Objects.requireNonNull(sourceType, "sourceType");
     this.keyField = Optional.ofNullable(keyField);
   }
 
   public String getName() {
     return name;
-  }
-
-  public boolean matches(final String topic) {
-    return isTopicMatch.test(topic);
-  }
-
-  public String mapToSource(final String topic) {
-    return getSourceName.apply(topic);
   }
 
   public DataSourceType getSourceType() {

--- a/ksql-engine/src/main/java/io/confluent/ksql/connect/Connector.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/connect/Connector.java
@@ -17,11 +17,8 @@ package io.confluent.ksql.connect;
 
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
-import io.confluent.ksql.testing.EffectivelyImmutable;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Predicate;
 
 /**
  * A model for a connector, which contains various information that

--- a/ksql-engine/src/main/java/io/confluent/ksql/connect/supported/JdbcSource.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/connect/supported/JdbcSource.java
@@ -44,8 +44,6 @@ public final class JdbcSource implements SupportedConnector {
 
     return Optional.of(new Connector(
         name,
-        topic -> topic.startsWith(prefix),
-        topic -> clean(name + "_" + topic.substring(prefix.length())),
         DataSourceType.KTABLE,
         extractKeyNameFromSmt(properties).orElse(null)
     ));

--- a/ksql-engine/src/main/java/io/confluent/ksql/connect/supported/JdbcSource.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/connect/supported/JdbcSource.java
@@ -40,8 +40,6 @@ public final class JdbcSource implements SupportedConnector {
   @VisibleForTesting
   Optional<Connector> fromConfigs(final Map<String, String> properties) {
     final String name = properties.get("name");
-    final String prefix = properties.get("topic.prefix");
-
     return Optional.of(new Connector(
         name,
         DataSourceType.KTABLE,
@@ -96,10 +94,6 @@ public final class JdbcSource implements SupportedConnector {
     }
 
     return Optional.empty();
-  }
-
-  private static String clean(final String name) {
-    return name.replace('-', '_').replace('.', '_');
   }
 
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/DefaultConnectClient.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/DefaultConnectClient.java
@@ -60,6 +60,7 @@ public class DefaultConnectClient implements ConnectClient {
 
   private static final String CONNECTORS = "/connectors";
   private static final String STATUS = "/status";
+  private static final String TOPICS = "/topics";
   private static final int DEFAULT_TIMEOUT_MS = 5_000;
   private static final int MAX_ATTEMPTS = 3;
 
@@ -230,7 +231,7 @@ public class DefaultConnectClient implements ConnectClient {
           connectUri, connector);
 
       final ConnectResponse<Map<String, Map<String, List<String>>>> connectResponse = withRetries(
-          () -> Request.Get(connectUri.resolve(CONNECTORS + "/" + connector + STATUS))
+          () -> Request.Get(connectUri.resolve(CONNECTORS + "/" + connector + TOPICS))
               .setHeaders(headers())
               .socketTimeout(DEFAULT_TIMEOUT_MS)
               .connectTimeout(DEFAULT_TIMEOUT_MS)

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/DefaultConnectClient.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/DefaultConnectClient.java
@@ -106,7 +106,8 @@ public class DefaultConnectClient implements ConnectClient {
           )
           .execute()
           .handleResponse(
-              createHandler(HttpStatus.SC_CREATED, Function.identity())));
+              createHandler(HttpStatus.SC_CREATED, new TypeReference<ConnectorInfo>() {},
+                  Function.identity())));
 
       connectResponse.error()
           .ifPresent(error -> LOG.warn("Did not CREATE connector {}: {}", connector, error));
@@ -130,7 +131,9 @@ public class DefaultConnectClient implements ConnectClient {
           .connectTimeout(DEFAULT_TIMEOUT_MS)
           .execute()
           .handleResponse(
-              createHandler(HttpStatus.SC_OK, foo -> (List<String>) foo)));
+              createHandler(HttpStatus.SC_OK, new TypeReference<List<String>>() {},
+                  Function.identity())));
+
 
       connectResponse.error()
           .ifPresent(error -> LOG.warn("Could not list connectors: {}.", error));
@@ -155,7 +158,8 @@ public class DefaultConnectClient implements ConnectClient {
           .connectTimeout(DEFAULT_TIMEOUT_MS)
           .execute()
           .handleResponse(
-              createHandler(HttpStatus.SC_OK, Function.identity())));
+              createHandler(HttpStatus.SC_OK, new TypeReference<ConnectorStateInfo>() {},
+                  Function.identity())));
 
       connectResponse.error()
           .ifPresent(error ->
@@ -180,7 +184,9 @@ public class DefaultConnectClient implements ConnectClient {
           .connectTimeout(DEFAULT_TIMEOUT_MS)
           .execute()
           .handleResponse(
-              createHandler(HttpStatus.SC_OK, Function.identity())));
+              createHandler(HttpStatus.SC_OK, new TypeReference<ConnectorInfo>() {},
+                  Function.identity())));
+
 
       connectResponse.error()
           .ifPresent(error -> LOG.warn("Could not list connectors: {}.", error));
@@ -204,7 +210,9 @@ public class DefaultConnectClient implements ConnectClient {
           .connectTimeout(DEFAULT_TIMEOUT_MS)
           .execute()
           .handleResponse(
-              createHandler(HttpStatus.SC_NO_CONTENT, foo -> connector)));
+              createHandler(HttpStatus.SC_NO_CONTENT, new TypeReference<Object>() {},
+                  foo -> connector)));
+
 
       connectResponse.error()
           .ifPresent(error -> LOG.warn("Could not delete connector: {}.", error));
@@ -228,7 +236,9 @@ public class DefaultConnectClient implements ConnectClient {
               .connectTimeout(DEFAULT_TIMEOUT_MS)
               .execute()
               .handleResponse(
-                  createHandler(HttpStatus.SC_OK, Function.identity())));
+                  createHandler(HttpStatus.SC_OK,
+                      new TypeReference<Map<String, Map<String, List<String>>>>() {},
+                      Function.identity())));
 
       connectResponse.error()
           .ifPresent(
@@ -276,6 +286,7 @@ public class DefaultConnectClient implements ConnectClient {
 
   private static <T, C> ResponseHandler<ConnectResponse<T>> createHandler(
       final int expectedStatus,
+      final TypeReference<C> entityTypeRef,
       final Function<C, T> cast
   ) {
     return httpResponse -> {
@@ -289,7 +300,7 @@ public class DefaultConnectClient implements ConnectClient {
       final T data = cast.apply(
           entity == null
               ? null
-              : MAPPER.readValue(entity.getContent(), new TypeReference<T>() {})
+              : MAPPER.readValue(entity.getContent(), entityTypeRef)
       );
 
       return ConnectResponse.success(data, code);

--- a/ksql-engine/src/test/java/io/confluent/ksql/connect/ConnectorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/connect/ConnectorTest.java
@@ -25,15 +25,15 @@ public class ConnectorTest {
   public void shouldImplementHashAndEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            new Connector("foo", foo -> true, foo -> foo, DataSourceType.KTABLE, "key"),
-            new Connector("foo", foo -> false, foo -> foo, DataSourceType.KTABLE, "key"),
-            new Connector("foo", foo -> false, foo -> foo, DataSourceType.KTABLE, "key")
+            new Connector("foo", DataSourceType.KTABLE, "key"),
+            new Connector("foo", DataSourceType.KTABLE, "key"),
+            new Connector("foo", DataSourceType.KTABLE, "key")
         ).addEqualityGroup(
-            new Connector("bar", foo -> true, foo -> foo, DataSourceType.KTABLE, "key")
+            new Connector("bar", DataSourceType.KTABLE, "key")
         ).addEqualityGroup(
-            new Connector("foo", foo -> true, foo -> foo, DataSourceType.KTABLE, "key2")
+            new Connector("foo", DataSourceType.KTABLE, "key2")
         ).addEqualityGroup(
-            new Connector("foo", foo -> true, foo -> foo, DataSourceType.KSTREAM, "key")
+            new Connector("foo", DataSourceType.KSTREAM, "key")
         )
         .testEquals();
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/connect/supported/JdbcSourceTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/connect/supported/JdbcSourceTest.java
@@ -44,47 +44,9 @@ public class JdbcSourceTest {
     // Then:
     final Connector expected = new Connector(
         "foo",
-        foo -> true,
-        foo -> foo,
         DataSourceType.KTABLE,
         null);
     assertThat(maybeConnector, OptionalMatchers.of(is(expected)));
-  }
-
-  @Test
-  public void shouldCreateJdbcConnectorWithValidPrefixTest() {
-    // Given:
-    final Map<String, String> config = ImmutableMap.of(
-        Connectors.CONNECTOR_CLASS, JdbcSource.JDBC_SOURCE_CLASS,
-        "name", "foo",
-        "topic.prefix", "foo-"
-    );
-
-    // When:
-    final Optional<Connector> maybeConnector = jdbcSource.fromConfigs(config);
-
-    // Then:
-    assertThat(
-        "expected match",
-        maybeConnector.map(connector -> connector.matches("foo-bar")).orElse(false));
-  }
-
-  @Test
-  public void shouldCreateJdbcConnectorWithValidMapToSource() {
-    // Given:
-    final Map<String, String> config = ImmutableMap.of(
-        Connectors.CONNECTOR_CLASS, JdbcSource.JDBC_SOURCE_CLASS,
-        "name", "name",
-        "topic.prefix", "foo-"
-    );
-
-    // When:
-    final Optional<Connector> maybeConnector = jdbcSource.fromConfigs(config);
-
-    // Then:
-    assertThat(
-        maybeConnector.map(connector -> connector.mapToSource("foo-bar")).orElse(null),
-        is("name_bar"));
   }
 
   @Test
@@ -104,8 +66,6 @@ public class JdbcSourceTest {
     // Then:
     final Connector expected = new Connector(
         "foo",
-        foo -> true,
-        foo -> foo,
         DataSourceType.KTABLE,
         "key");
     assertThat(maybeConnector, OptionalMatchers.of(is(expected)));

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/DefaultConnectClientTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/DefaultConnectClientTest.java
@@ -212,7 +212,7 @@ public class DefaultConnectClientTest {
   public void testTopics() throws JsonProcessingException {
     // Given:
     WireMock.stubFor(
-        WireMock.get(WireMock.urlEqualTo("/connectors/foo/status"))
+        WireMock.get(WireMock.urlEqualTo("/connectors/foo/topics"))
             .withHeader(HttpHeaders.AUTHORIZATION, new EqualToPattern(AUTH_HEADER))
             .willReturn(WireMock.aResponse()
                 .withStatus(HttpStatus.SC_OK)

--- a/ksql-execution/src/main/java/io/confluent/ksql/services/ConnectClient.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/services/ConnectClient.java
@@ -66,6 +66,14 @@ public interface ConnectClient {
   ConnectResponse<String> delete(String connector);
 
   /**
+   * Get the topics the {@code connector} is using.
+   *
+   * @param connector the connector name
+   * @return the topics
+   */
+  ConnectResponse<Map<String, Map<String, List<String>>>> topics(String connector);
+
+  /**
    * An optionally successful response. Either contains a value of type {@code <T>} or an error,
    * which is the string representation of the response entity.
    */

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutor.java
@@ -94,8 +94,6 @@ public final class DescribeConnectorExecutor {
 
     final ConnectorStateInfo status = statusResponse.datum().get();
     final ConnectorInfo info = infoResponse.datum().get();
-
-
     final Optional<Connector> connector = connectorFactory.apply(info);
     final List<KsqlWarning> warnings;
     final List<String> topics;
@@ -140,7 +138,6 @@ public final class DescribeConnectorExecutor {
     } else {
       sources = ImmutableList.of();
     }
-
 
     final ConnectorDescription description = new ConnectorDescription(
         configuredStatement.getStatementText(),

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutor.java
@@ -46,7 +46,7 @@ public final class DescribeConnectorExecutor {
 
   private static final Logger LOG = LoggerFactory.getLogger(DescribeConnectorExecutor.class);
   @VisibleForTesting
-  protected static final String TOPICS_KEY = "topics";
+  static final String TOPICS_KEY = "topics";
 
   private final Function<ConnectorInfo, Optional<Connector>> connectorFactory;
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/ConnectIntegrationTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/ConnectIntegrationTest.java
@@ -99,7 +99,7 @@ public class ConnectIntegrationTest {
   private Set<String> connectNames;
 
   @Before
-  public void setupRun() throws Exception {
+  public void setupRun() {
     ksqlRestClient = REST_APP.buildKsqlClient(Optional.empty());
     connectNames = new HashSet<>();
   }
@@ -136,7 +136,7 @@ public class ConnectIntegrationTest {
   }
 
   @Test
-  public void shouldDescribeConnector() throws InterruptedException {
+  public void shouldDescribeConnector() {
     // Given:
     create("mock-connector", ImmutableMap.of(
         "connector.class", "org.apache.kafka.connect.tools.MockSourceConnector"

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutorTest.java
@@ -21,11 +21,11 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.connect.Connector;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
@@ -52,20 +52,20 @@ import io.confluent.ksql.services.ConnectClient.ConnectResponse;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Function;
 import org.apache.http.HttpStatus;
-import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.clients.admin.ListTopicsResult;
-import org.apache.kafka.common.KafkaFuture;
-import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo.ConnectorState;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo.TaskState;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorType;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -94,6 +94,16 @@ public class DescribeConnectorExecutorTest {
       ImmutableList.of(),
       ConnectorType.SOURCE);
 
+  private static Map<String, Map<String, List<String>>> EMPTY_ACTIVE_TOPICS = Collections.singletonMap(
+      CONNECTOR_NAME, Collections.singletonMap(
+          DescribeConnectorExecutor.TOPICS_KEY,
+          Collections.emptyList()));
+
+  private static Map<String, Map<String, List<String>>> ACTIVE_TOPICS = Collections.singletonMap(
+      CONNECTOR_NAME, Collections.singletonMap(
+          DescribeConnectorExecutor.TOPICS_KEY,
+          Collections.singletonList(TOPIC)));
+
   @Mock
   private KsqlExecutionContext engine;
   @Mock
@@ -107,11 +117,6 @@ public class DescribeConnectorExecutorTest {
   @Mock
   private Connector connector;
 
-  @Mock
-  private Admin adminClient;
-  @Mock
-  private ListTopicsResult topics;
-
   private Function<ConnectorInfo, Optional<Connector>> connectorFactory;
   private DescribeConnectorExecutor executor;
   private ConfiguredStatement<DescribeConnector> describeStatement;
@@ -120,7 +125,6 @@ public class DescribeConnectorExecutorTest {
   public void setUp() {
     when(engine.getMetaStore()).thenReturn(metaStore);
     when(serviceContext.getConnectClient()).thenReturn(connectClient);
-    when(serviceContext.getAdminClient()).thenReturn(adminClient);
     when(metaStore.getAllDataSources()).thenReturn(ImmutableMap.of(SourceName.of("source"), source));
     when(source.getKafkaTopicName()).thenReturn(TOPIC);
     when(source.getSqlExpression()).thenReturn(STATEMENT);
@@ -144,9 +148,6 @@ public class DescribeConnectorExecutorTest {
     when(connector.matches(any())).thenReturn(false);
     when(connector.matches(TOPIC)).thenReturn(true);
 
-    when(topics.names()).thenReturn(KafkaFuture.completedFuture(ImmutableSet.of(TOPIC, "other-topic")));
-    when(adminClient.listTopics()).thenReturn(topics);
-
     connectorFactory = info -> Optional.of(connector);
     executor = new DescribeConnectorExecutor(connectorFactory);
 
@@ -157,14 +158,29 @@ public class DescribeConnectorExecutorTest {
         new KsqlConfig(ImmutableMap.of()));
   }
 
+  @After
+  public void teardown() {
+    verifyNoMoreInteractions(
+        engine, metaStore, connectClient);
+  }
+
   @SuppressWarnings("OptionalGetWithoutIsPresent")
   @Test
   public void shouldDescribeKnownConnector() {
+    // Given:
+    when(connectClient.topics("connector")).thenReturn(ConnectResponse.success(ACTIVE_TOPICS,
+        HttpStatus.SC_OK));
+
     // When:
     final Optional<KsqlEntity> entity = executor
         .execute(describeStatement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
+    verify(engine).getMetaStore();
+    verify(metaStore).getAllDataSources();
+    verify(connectClient).status("connector");
+    verify(connectClient).describe("connector");
+    verify(connectClient).topics("connector");
     assertThat("Expected a response", entity.isPresent());
     assertThat(entity.get(), instanceOf(ConnectorDescription.class));
 
@@ -181,15 +197,19 @@ public class DescribeConnectorExecutorTest {
   @Test
   public void shouldDescribeKnownConnectorIfTopicListFails() {
     // Given:
-    final KafkaFuture<Set<String>> fut = new KafkaFutureImpl<>();
-    fut.cancel(true);
-    when(topics.names()).thenReturn(fut);
+    when(connectClient.topics("connector")).thenReturn(ConnectResponse.failure(
+        "Topic tracking is disabled.", HttpStatus.SC_FORBIDDEN));
 
     // When:
     final Optional<KsqlEntity> entity = executor
         .execute(describeStatement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
+    verify(engine).getMetaStore();
+    verify(metaStore).getAllDataSources();
+    verify(connectClient).status("connector");
+    verify(connectClient).describe("connector");
+    verify(connectClient).topics("connector");
     assertThat("Expected a response", entity.isPresent());
     assertThat(entity.get(), instanceOf(ConnectorDescription.class));
 
@@ -202,7 +222,7 @@ public class DescribeConnectorExecutorTest {
   @Test
   public void shouldErrorIfConnectClientFailsStatus() {
     // Given:
-    when(connectClient.describe(any())).thenReturn(ConnectResponse.failure("error", HttpStatus.SC_INTERNAL_SERVER_ERROR));
+    when(connectClient.status(any())).thenReturn(ConnectResponse.failure("error", HttpStatus.SC_INTERNAL_SERVER_ERROR));
 
     // When:
     final Optional<KsqlEntity> entity = executor
@@ -237,12 +257,17 @@ public class DescribeConnectorExecutorTest {
     // Given:
     connectorFactory = info -> Optional.empty();
     executor = new DescribeConnectorExecutor(connectorFactory);
+    when(connectClient.topics("connector")).thenReturn(ConnectResponse.success(EMPTY_ACTIVE_TOPICS,
+        HttpStatus.SC_OK));
 
     // When:
     final Optional<KsqlEntity> entity = executor
         .execute(describeStatement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
+    verify(connectClient).status("connector");
+    verify(connectClient).describe("connector");
+    verify(connectClient).topics("connector");
     assertThat("Expected a response", entity.isPresent());
     assertThat(entity.get(), instanceOf(ConnectorDescription.class));
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutorTest.java
@@ -254,8 +254,6 @@ public class DescribeConnectorExecutorTest {
     // Given:
     connectorFactory = info -> Optional.empty();
     executor = new DescribeConnectorExecutor(connectorFactory);
-    when(connectClient.topics("connector")).thenReturn(ConnectResponse.success(EMPTY_ACTIVE_TOPICS,
-        HttpStatus.SC_OK));
 
     // When:
     final Optional<KsqlEntity> entity = executor
@@ -264,7 +262,6 @@ public class DescribeConnectorExecutorTest {
     // Then:
     verify(connectClient).status("connector");
     verify(connectClient).describe("connector");
-    verify(connectClient).topics("connector");
     assertThat("Expected a response", entity.isPresent());
     assertThat(entity.get(), instanceOf(ConnectorDescription.class));
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutorTest.java
@@ -94,11 +94,6 @@ public class DescribeConnectorExecutorTest {
       ImmutableList.of(),
       ConnectorType.SOURCE);
 
-  private static Map<String, Map<String, List<String>>> EMPTY_ACTIVE_TOPICS = Collections.singletonMap(
-      CONNECTOR_NAME, Collections.singletonMap(
-          DescribeConnectorExecutor.TOPICS_KEY,
-          Collections.emptyList()));
-
   private static Map<String, Map<String, List<String>>> ACTIVE_TOPICS = Collections.singletonMap(
       CONNECTOR_NAME, Collections.singletonMap(
           DescribeConnectorExecutor.TOPICS_KEY,

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutorTest.java
@@ -145,9 +145,6 @@ public class DescribeConnectorExecutorTest {
     when(connectClient.status(CONNECTOR_NAME)).thenReturn(ConnectResponse.success(STATUS, HttpStatus.SC_OK));
     when(connectClient.describe("connector")).thenReturn(ConnectResponse.success(INFO, HttpStatus.SC_OK));
 
-    when(connector.matches(any())).thenReturn(false);
-    when(connector.matches(TOPIC)).thenReturn(true);
-
     connectorFactory = info -> Optional.of(connector);
     executor = new DescribeConnectorExecutor(connectorFactory);
 


### PR DESCRIPTION
### Description 
After KIP-558 and starting with Apache Kafka version 2.5, Kafka Connect adds a new 'topics' endpoint per connector to discover the set of topics a connector is using during runtime. Using this new endpoint will allow ksqlDB to get a more accurate view of a connector's active topics. The code is refactor to no longer depend on listing the topics with an adminclient when describing a connector in ksqlDB

Details on active topics tracking here: 
https://cwiki.apache.org/confluence/display/KAFKA/KIP-558%3A+Track+the+set+of+actively+used+topics+by+connectors+in+Kafka+Connect

### Testing done 
Existing unit tests were adjusted to test the new functionality. 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

