### PR TITLE
chore: better error when missing DESCRIBE_CONFIGS acl

### DIFF
--- a/config/ksql-production-server.properties
+++ b/config/ksql-production-server.properties
@@ -31,7 +31,7 @@ listeners=http://0.0.0.0:8088
 ### HTTPS ###
 # To switch KSQL over to communicating using HTTPS comment out the 'listeners' line above
 # uncomment and complete the properties below.
-# See: https://docs.confluent.io/current/ksql/docs/installation/server-config/security.html#configuring-ksql-cli-for-https
+# See: https://docs.ksqldb.io/en/latest/operate-and-deploy/installation/server-config/security/#configure-the-cli-for-https
 #
 # listeners=https://0.0.0.0:8088
 # advertised.listener=?

--- a/config/ksql-server.properties
+++ b/config/ksql-server.properties
@@ -31,7 +31,7 @@ listeners=http://0.0.0.0:8088
 ### HTTPS ###
 # To switch KSQL over to communicating using HTTPS comment out the 'listeners' line above
 # uncomment and complete the properties below.
-# See: https://docs.confluent.io/current/ksql/docs/installation/server-config/security.html#configuring-ksql-cli-for-https
+# See: https://docs.ksqldb.io/en/latest/operate-and-deploy/installation/server-config/security/#configure-the-cli-for-https
 #
 # listeners=https://0.0.0.0:8088
 # advertised.listener=?

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/cmd/Help.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/cmd/Help.java
@@ -56,7 +56,7 @@ final class Help implements CliSpecificCommand {
         "\tThe KSQL CLI provides a terminal-based interactive shell for running queries. "
             + "Each command should be on a separate line. "
             + "For KSQL command syntax, see the documentation at "
-            + "https://docs.confluent.io/current/ksql/docs/developer-guide/syntax-reference.html"
+            + "https://docs.ksqldb.io/en/latest/developer-guide/syntax-reference/"
     );
     terminal.println();
     for (final CliSpecificCommand cliSpecificCommand : cmds.get()) {

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/console/cmd/RemoteServerSpecificCommandTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/console/cmd/RemoteServerSpecificCommandTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.links.DocumentationLinks;
 import io.confluent.ksql.rest.client.KsqlRestClient;
 import io.confluent.ksql.rest.client.KsqlRestClientException;
 import io.confluent.ksql.rest.client.RestResponse;
@@ -169,8 +170,7 @@ public class RemoteServerSpecificCommandTest {
     assertThat(out.toString(), containsString(
         "Remote server at http://192.168.0.1:8080 looks to be configured to use HTTPS /\n"
             + "SSL. Please refer to the KSQL documentation on how to configure the CLI for SSL:\n"
-            + "https://docs.confluent.io/current/ksql/docs/installation/server-config/security.html"
-            + "#configuring-cli-for-https"));
+            + DocumentationLinks.SECURITY_CLI_SSL_DOC_URL));
   }
 
   @Test

--- a/ksql-common/src/main/java/io/confluent/ksql/links/DocumentationLinks.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/links/DocumentationLinks.java
@@ -22,13 +22,16 @@ public final class DocumentationLinks {
   /*
   KSQL
    */
-  private static final String KSQL_DOCS_ROOT_URL = CONFLUENT_DOCS_ROOT_URL + "ksql/docs/";
+  private static final String KSQL_DOCS_ROOT_URL = "https://docs.ksqldb.io/en/latest/";
 
   private static final String SECURITY_DOCS_URL = KSQL_DOCS_ROOT_URL
-      + "installation/server-config/security.html";
+      + "operate-and-deploy/installation/server-config/security/";
 
   public static final String SECURITY_CLI_SSL_DOC_URL = SECURITY_DOCS_URL
-      + "#configuring-cli-for-https";
+      + "#configure-the-cli-for-https";
+
+  public static final String SECURITY_REQUIRED_ACLS_DOC_URL = SECURITY_DOCS_URL
+      + "#required-acls";
 
   /*
   Schema Registry

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaClusterUtil.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaClusterUtil.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.services;
 
 import com.google.common.collect.Iterables;
+import io.confluent.ksql.links.DocumentationLinks;
 import io.confluent.ksql.util.ExecutorUtil;
 import io.confluent.ksql.util.KsqlServerException;
 import java.util.Collection;
@@ -27,7 +28,9 @@ import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.DescribeClusterOptions;
 import org.apache.kafka.clients.admin.DescribeClusterResult;
 import org.apache.kafka.common.Node;
+import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.errors.ClusterAuthorizationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,6 +78,14 @@ public final class KafkaClusterUtil {
       return brokerConfig.get(configResource);
     } catch (final KsqlServerException e) {
       throw e;
+    } catch (final ClusterAuthorizationException e) {
+      throw new KsqlServerException("Could not get Kafka cluster configuration. "
+          + "Please ensure the ksql principal has " + AclOperation.DESCRIBE_CONFIGS + " rights "
+          + "on the Kafka cluster."
+          + System.lineSeparator()
+          + "See " + DocumentationLinks.SECURITY_REQUIRED_ACLS_DOC_URL + " for more info.",
+          e
+      );
     } catch (final Exception e) {
       throw new KsqlServerException("Could not get Kafka cluster configuration!", e);
     }


### PR DESCRIPTION
### Description 

Logged error was:

```
...
Caused by: io.confluent.ksql.util.KsqlServerException: Could not get Kafka cluster configuration!
	at io.confluent.ksql.services.KafkaClusterUtil.getConfig(KafkaClusterUtil.java:77)
	at io.confluent.ksql.services.KafkaTopicClientImpl.getConfig(KafkaTopicClientImpl.java:309)
	at io.confluent.ksql.services.KafkaTopicClientImpl.isTopicDeleteEnabled(KafkaTopicClientImpl.java:298)
	... 21 more
Caused by: org.apache.kafka.common.errors.ClusterAuthorizationException: Cluster authorization failed.
```

and is now:

```
...
Caused by: io.confluent.ksql.util.KsqlServerException: Could not get Kafka cluster configuration. Please ensure the ksql principal has DESCRIBE_CONFIGS rights on the Kafka cluster.
See https://docs.ksqldb.io/en/latest/operate-and-deploy/installation/server-config/security/#required-acls for more info.
at io.confluent.ksql.services.KafkaClusterUtil.getConfig(KafkaClusterUtil.java:77)
	at io.confluent.ksql.services.KafkaTopicClientImpl.getConfig(KafkaTopicClientImpl.java:309)
	at io.confluent.ksql.services.KafkaTopicClientImpl.isTopicDeleteEnabled(KafkaTopicClientImpl.java:298)
	... 21 more
Caused by: org.apache.kafka.common.errors.ClusterAuthorizationException: Cluster authorization failed.
```

I've also switched our doc links over to the new micro site.

cc @MichaelDrogalis 

### Testing done 

Test added + manual.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

