### PR TITLE
fix: idempotent terminate that can handle hung streams

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -264,8 +264,10 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
     final String applicationId = query.getQueryApplicationId();
 
     if (!query.getState().equalsIgnoreCase("NOT_RUNNING")) {
-      throw new IllegalStateException("query not stopped."
-          + " id " + applicationId + ", state: " + query.getState());
+      log.warn(
+          "Unregistering query that has not terminated. "
+              + "This may happen when streams threads are hung. State: " + query.getState()
+      );
     }
 
     if (!allLiveQueries.remove(query)) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutor.java
@@ -359,10 +359,8 @@ public class InteractiveStatementExecutor implements KsqlConfigurable {
       return;
     }
 
-    ksqlEngine.getPersistentQuery(queryId.get())
-        .orElseThrow(() ->
-            new KsqlException(String.format("No running query with id %s was found", queryId)))
-        .close();
+    final Optional<PersistentQueryMetadata> query = ksqlEngine.getPersistentQuery(queryId.get());
+    query.ifPresent(PersistentQueryMetadata::close);
   }
 
 }


### PR DESCRIPTION
### Description 
Fixes a couple issues with terminate:
- don't throw if the query doesn't get into NOT_RUNNING state. This can
  happen when streams threads are stuck pending shutdown.
- make terminate idempotent
