### PR TITLE
chore: if provided, always use revision param in CI release job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,15 +72,15 @@ def job = {
             error("If you are doing a release build you must provide a git sha.")
         }
 
-        config.revision = params.GIT_REVISION
         // For a release build we remove the -SNAPSHOT from the version.
         config.ksql_db_version = config.ksql_db_version.tokenize("-")[0]
         config.docker_tag = config.ksql_db_version
     } else {
         config.docker_tag = config.ksql_db_version.tokenize("-")[0] + '-' + env.BUILD_NUMBER
-        // Use revision param if provided, otherwise default to master
-        config.revision = params.GIT_REVISION ?: 'refs/heads/master'
     }
+    
+    // Use revision param if provided, otherwise default to master
+    config.revision = params.GIT_REVISION ?: 'refs/heads/master'
 
     // Configure the maven repo settings so we can download from the beta artifacts repo
     def settingsFile = "${env.WORKSPACE}/maven-settings.xml"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,8 @@ def job = {
         config.docker_tag = config.ksql_db_version
     } else {
         config.docker_tag = config.ksql_db_version.tokenize("-")[0] + '-' + env.BUILD_NUMBER
-        config.revision = 'refs/heads/master'
+        // Use revision param if provided, otherwise default to master
+        config.revision = params.GIT_REVISION ?: 'refs/heads/master'
     }
 
     // Configure the maven repo settings so we can download from the beta artifacts repo


### PR DESCRIPTION
### Description 
For ksql-db-release job parameters, currently any GIT_REVISION is ignored unless RELEASE_BUILD is true. For pre-release validation, we should be able to run a non-release job at a given sha. The principal thing we want to avoid is creating an unnecessary tag, which happens when RELEASE_BUILD is true.

This PR allows the provided revision to also be used when RELEASE_BUILD is false.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

