### PR TITLE
fix: Return immutable list of streams metadata

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -146,7 +146,7 @@ public class QueryMetadata {
 
   public Collection<StreamsMetadata> getAllMetadata() {
     try {
-      return kafkaStreams.allMetadata();
+      return ImmutableList.copyOf(kafkaStreams.allMetadata());
     } catch (IllegalStateException e) {
       LOG.error(e.getMessage());
     }


### PR DESCRIPTION
### Description 
Fixes #4639

StreamsMetadata exposes the internal list which can change while iterating over it resulting in a concurrent modification exception. I create an immutable copy of it.

### Testing done 
Unfortunately, I cannot reproduce this bug locally. 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

