### PR TITLE
fix: CommandRunner metric has correct metric displayed when thread dies

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
@@ -70,7 +70,6 @@ public class CommandRunner implements Closeable {
 
   public enum CommandRunnerStatus {
     RUNNING,
-    STUCK,
     ERROR
   }
 
@@ -274,7 +273,7 @@ public class CommandRunner implements Closeable {
     
     return Duration.between(currentCommand.right, clock.instant()).toMillis()
         < commandRunnerHealthTimeout.toMillis()
-        ? CommandRunnerStatus.RUNNING : CommandRunnerStatus.STUCK;
+        ? CommandRunnerStatus.RUNNING : CommandRunnerStatus.ERROR;
   }
 
   private class Runner implements Runnable {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerStatusMetricTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerStatusMetricTest.java
@@ -84,16 +84,7 @@ public class CommandRunnerStatusMetricTest {
   }
 
   @Test
-  public void shouldUpdateToStuckState() {
-    // When:
-    when(commandRunner.checkCommandRunnerStatus()).thenReturn(CommandRunner.CommandRunnerStatus.STUCK);
-
-    // Then:
-    assertThat(currentGaugeValue(), is(CommandRunner.CommandRunnerStatus.STUCK.name()));
-  }
-
-  @Test
-  public void shouldUpdateErrorState() {
+  public void shouldUpdateToErrorState() {
     // When:
     when(commandRunner.checkCommandRunnerStatus()).thenReturn(CommandRunner.CommandRunnerStatus.ERROR);
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerStatusMetricTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerStatusMetricTest.java
@@ -84,7 +84,16 @@ public class CommandRunnerStatusMetricTest {
   }
 
   @Test
-  public void shouldUpdateToErrorState() {
+  public void shouldUpdateToStuckState() {
+    // When:
+    when(commandRunner.checkCommandRunnerStatus()).thenReturn(CommandRunner.CommandRunnerStatus.STUCK);
+
+    // Then:
+    assertThat(currentGaugeValue(), is(CommandRunner.CommandRunnerStatus.STUCK.name()));
+  }
+
+  @Test
+  public void shouldUpdateErrorState() {
     // When:
     when(commandRunner.checkCommandRunnerStatus()).thenReturn(CommandRunner.CommandRunnerStatus.ERROR);
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
@@ -228,7 +228,7 @@ public class CommandRunnerTest {
   }
 
   @Test
-  public void shouldTransitionFromRunningToError() throws InterruptedException {
+  public void shouldTransitionFromRunningToStuck() throws InterruptedException {
     // Given:
     givenQueuedCommands(queuedCommand1);
 
@@ -236,6 +236,7 @@ public class CommandRunnerTest {
     final CountDownLatch handleStatementLatch = new CountDownLatch(1);
     final CountDownLatch commandSetLatch = new CountDownLatch(1);
     when(clock.instant()).thenReturn(current)
+        .thenReturn(current.plusMillis(500))
         .thenReturn(current.plusMillis(500))
         .thenReturn(current.plusMillis(1500))
         .thenReturn(current.plusMillis(2500));
@@ -259,7 +260,7 @@ public class CommandRunnerTest {
     commandRunnerThread.start();
     commandSetLatch.await();
     assertThat(commandRunner.checkCommandRunnerStatus(), is(CommandRunner.CommandRunnerStatus.RUNNING));
-    assertThat(commandRunner.checkCommandRunnerStatus(), is(CommandRunner.CommandRunnerStatus.ERROR));
+    assertThat(commandRunner.checkCommandRunnerStatus(), is(CommandRunner.CommandRunnerStatus.STUCK));
     handleStatementLatch.countDown();
     commandRunnerThread.join();
     assertThat(commandRunner.checkCommandRunnerStatus(), is(CommandRunner.CommandRunnerStatus.RUNNING));


### PR DESCRIPTION
### Description 
Fixes: https://github.com/confluentinc/ksql/issues/4652
Add a new variable to CommandRunner that keeps track of the last time the command topic was polled. If there's too long of a duration between the current time when `CommandRunner.checkCommandRunnerStatus` is called and the last poll, that means the thread is in `ERROR` state.

### Testing done 
Killed the command runner thread and watched the metric. It transitioned to error state after 15 seconds.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

