### PR TITLE
fix: don't clean up streams internal topics on service exit

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/embedded/KsqlContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/embedded/KsqlContext.java
@@ -177,7 +177,7 @@ public class KsqlContext implements AutoCloseable {
   }
 
   public void terminateQuery(final QueryId queryId) {
-    ksqlEngine.getPersistentQuery(queryId).ifPresent(QueryMetadata::close);
+    ksqlEngine.getPersistentQuery(queryId).ifPresent(q -> q.close(true));
   }
 
   private static ExecuteResult execute(

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
@@ -217,7 +217,7 @@ final class EngineContext {
     }
   }
 
-  private void unregisterQuery(final QueryMetadata query, boolean cleanUp) {
+  private void unregisterQuery(final QueryMetadata query, final boolean cleanUp) {
     if (query instanceof PersistentQueryMetadata) {
       final PersistentQueryMetadata persistentQuery = (PersistentQueryMetadata) query;
       persistentQueries.remove(persistentQuery.getQueryId());

--- a/ksql-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -60,6 +60,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -80,7 +81,7 @@ public final class QueryExecutor {
   private final ServiceContext serviceContext;
   private final FunctionRegistry functionRegistry;
   private final KafkaStreamsBuilder kafkaStreamsBuilder;
-  private final Consumer<QueryMetadata> queryCloseCallback;
+  private final BiConsumer<QueryMetadata, Boolean> queryCloseCallback;
   private final KsMaterializationFactory ksMaterializationFactory;
   private final KsqlMaterializationFactory ksqlMaterializationFactory;
   private final StreamsBuilder streamsBuilder;
@@ -91,7 +92,7 @@ public final class QueryExecutor {
       final ProcessingLogContext processingLogContext,
       final ServiceContext serviceContext,
       final FunctionRegistry functionRegistry,
-      final Consumer<QueryMetadata> queryCloseCallback) {
+      final BiConsumer<QueryMetadata, Boolean> queryCloseCallback) {
     this(
         ksqlConfig,
         overrides,
@@ -113,7 +114,7 @@ public final class QueryExecutor {
       final ProcessingLogContext processingLogContext,
       final ServiceContext serviceContext,
       final FunctionRegistry functionRegistry,
-      final Consumer<QueryMetadata> queryCloseCallback,
+      final BiConsumer<QueryMetadata, Boolean> queryCloseCallback,
       final KafkaStreamsBuilder kafkaStreamsBuilder,
       final StreamsBuilder streamsBuilder,
       final KsqlMaterializationFactory ksqlMaterializationFactory,

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.Topology;
 
@@ -63,7 +63,7 @@ public class PersistentQueryMetadata extends QueryMetadata {
       final QuerySchemas schemas,
       final Map<String, Object> streamsProperties,
       final Map<String, Object> overriddenProperties,
-      final Consumer<QueryMetadata> closeCallback,
+      final BiConsumer<QueryMetadata, Boolean> closeCallback,
       final long closeTimeout) {
     // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     super(
@@ -91,7 +91,7 @@ public class PersistentQueryMetadata extends QueryMetadata {
 
   private PersistentQueryMetadata(
       final PersistentQueryMetadata other,
-      final Consumer<QueryMetadata> closeCallback
+      final BiConsumer<QueryMetadata, Boolean> closeCallback
   ) {
     super(other, closeCallback);
     this.id = other.id;
@@ -103,7 +103,7 @@ public class PersistentQueryMetadata extends QueryMetadata {
     this.dataSourceType = other.dataSourceType;
   }
 
-  public PersistentQueryMetadata copyWith(final Consumer<QueryMetadata> closeCallback) {
+  public PersistentQueryMetadata copyWith(final BiConsumer<QueryMetadata, Boolean> closeCallback) {
     return new PersistentQueryMetadata(this, closeCallback);
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -28,7 +28,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.LagInfo;
 import org.apache.kafka.streams.Topology;
@@ -177,7 +176,7 @@ public class QueryMetadata {
     close(true);
   }
 
-  public void close(boolean cleanUp) {
+  public void close(final boolean cleanUp) {
     kafkaStreams.close(Duration.ofMillis(closeTimeout));
 
     if (cleanUp) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -172,10 +172,6 @@ public class QueryMetadata {
     return everStarted;
   }
 
-  public void close() {
-    close(true);
-  }
-
   public void close(final boolean cleanUp) {
     kafkaStreams.close(Duration.ofMillis(closeTimeout));
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
@@ -104,8 +104,10 @@ public class TransientQueryMetadata extends QueryMetadata {
     // write to the blocking queue, otherwise super.close call can deadlock:
     rowQueue.close();
 
-    // Now safe to close:
-    super.close(cleanUp);
+    // Now safe to close
+    // We always pass cleanUp true, since transient queries should always have
+    // their internal topics cleaned up.
+    super.close(true);
     isRunning.set(false);
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
@@ -99,7 +99,7 @@ public class TransientQueryMetadata extends QueryMetadata {
   }
 
   @Override
-  public void close(boolean cleanUp) {
+  public void close(final boolean cleanUp) {
     // To avoid deadlock, close the queue first to ensure producer side isn't blocked trying to
     // write to the blocking queue, otherwise super.close call can deadlock:
     rowQueue.close();

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
@@ -99,13 +99,13 @@ public class TransientQueryMetadata extends QueryMetadata {
   }
 
   @Override
-  public void close() {
+  public void close(boolean cleanUp) {
     // To avoid deadlock, close the queue first to ensure producer side isn't blocked trying to
     // write to the blocking queue, otherwise super.close call can deadlock:
     rowQueue.close();
 
     // Now safe to close:
-    super.close(true);
+    super.close(cleanUp);
     isRunning.set(false);
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.Topology;
 
@@ -47,7 +47,7 @@ public class TransientQueryMetadata extends QueryMetadata {
       final Topology topology,
       final Map<String, Object> streamsProperties,
       final Map<String, Object> overriddenProperties,
-      final Consumer<QueryMetadata> closeCallback,
+      final BiConsumer<QueryMetadata, Boolean> closeCallback,
       final long closeTimeout) {
     // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     super(
@@ -105,7 +105,7 @@ public class TransientQueryMetadata extends QueryMetadata {
     rowQueue.close();
 
     // Now safe to close:
-    super.close();
+    super.close(true);
     isRunning.set(false);
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -679,12 +679,12 @@ public class KsqlEngineTest {
   @Test
   public void shouldNotCleanUpInternalTopicsOnCloseIfCleanFalse() {
     // Given:
-    final QueryMetadata query = KsqlEngineTestUtil.executeQuery(
+    final QueryMetadata query = KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
-        "select * from test1 EMIT CHANGES;",
+        "create stream foo as select * from test1 EMIT CHANGES;",
         KSQL_CONFIG, Collections.emptyMap()
-    );
+    ).get(0);
     query.start();
 
     // When:
@@ -697,12 +697,12 @@ public class KsqlEngineTest {
   @Test
   public void shouldNotCleanUpInternalTopicsOnEngineClose() {
     // Given:
-    final QueryMetadata query = KsqlEngineTestUtil.executeQuery(
+    final QueryMetadata query = KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
-        "select * from test1 EMIT CHANGES;",
+        "create stream foo as select * from test1 EMIT CHANGES;",
         KSQL_CONFIG, Collections.emptyMap()
-    );
+    ).get(0);
     query.start();
 
     // When:

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
@@ -160,7 +160,7 @@ public class EndToEndIntegrationTest {
 
   @After
   public void after() {
-    toClose.forEach(QueryMetadata::close);
+    toClose.forEach(q -> q.close(true));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
@@ -261,6 +261,6 @@ public class JsonFormatTest {
 
   private void terminateQuery() {
     ksqlEngine.getPersistentQuery(queryId)
-        .ifPresent(QueryMetadata::close);
+        .ifPresent(q -> q.close(true));
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/SecureIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/SecureIntegrationTest.java
@@ -134,7 +134,7 @@ public class SecureIntegrationTest {
   public void after() {
     if (queryId != null) {
       ksqlEngine.getPersistentQuery(queryId)
-          .ifPresent(QueryMetadata::close);
+          .ifPresent(q -> q.close(true));
     }
     if (ksqlEngine != null) {
       ksqlEngine.close();

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
@@ -258,7 +258,7 @@ public class WindowingIntTest {
   ) {
     assertThat("Initial topics", getTopicNames(), hasSize(nTopics));
 
-    ksqlContext.getPersistentQueries().forEach(QueryMetadata::close);
+    ksqlContext.getPersistentQueries().forEach(q -> q.close(true));
 
     assertThatEventually("After cleanup", this::getTopicNames,
         containsInAnyOrder(

--- a/ksql-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
@@ -140,7 +140,7 @@ public class KsMaterializationFunctionalTest {
 
   @After
   public void after() {
-    toClose.forEach(QueryMetadata::close);
+    toClose.forEach(q -> q.close(true));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
@@ -55,7 +55,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerInterceptor;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -125,7 +125,7 @@ public class QueryExecutorTest {
   @Mock
   private ServiceContext serviceContext;
   @Mock
-  private Consumer<QueryMetadata> closeCallback;
+  private BiConsumer<QueryMetadata, Boolean> closeCallback;
   @Mock
   private KafkaStreamsBuilder kafkaStreamsBuilder;
   @Mock

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/TransientQueryMetadataTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/TransientQueryMetadataTest.java
@@ -23,7 +23,7 @@ import io.confluent.ksql.query.BlockingRowQueue;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.Topology;
 import org.junit.Before;
@@ -56,7 +56,7 @@ public class TransientQueryMetadataTest {
   @Mock
   private Map<String, Object> overrides;
   @Mock
-  private Consumer<QueryMetadata> closeCallback;
+  private BiConsumer<QueryMetadata, Boolean> closeCallback;
   private TransientQueryMetadata query;
 
   @Before
@@ -80,7 +80,7 @@ public class TransientQueryMetadataTest {
   @Test
   public void shouldCloseQueueBeforeTopologyToAvoidDeadLock() {
     // When:
-    query.close();
+    query.close(true);
 
     // Then:
     final InOrder inOrder = inOrder(rowQueue, kafkaStreams);

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/TransientQueryMetadataTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/TransientQueryMetadataTest.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.util;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
 
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.BlockingRowQueue;
@@ -86,5 +87,23 @@ public class TransientQueryMetadataTest {
     final InOrder inOrder = inOrder(rowQueue, kafkaStreams);
     inOrder.verify(rowQueue).close();
     inOrder.verify(kafkaStreams).close(any());
+  }
+
+  @Test
+  public void shouldCloseWithCleanUpTrue() {
+    // When:
+    query.close(true);
+
+    // Then:
+    verify(closeCallback).accept(query, true);
+  }
+
+  @Test
+  public void shouldCloseWithCleanUpTrueEvenIfPassedFalse() {
+    // When:
+    query.close(false);
+
+    // Then:
+    verify(closeCallback).accept(query, true);
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/api/plugin/KsqlServerEndpoints.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/api/plugin/KsqlServerEndpoints.java
@@ -275,7 +275,7 @@ public class KsqlServerEndpoints implements Endpoints {
 
     @Override
     public void stop() {
-      queryMetadata.close();
+      queryMetadata.close(true);
     }
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutor.java
@@ -355,12 +355,12 @@ public class InteractiveStatementExecutor implements KsqlConfigurable {
     final Optional<QueryId> queryId = terminateQuery.getStatement().getQueryId();
 
     if (!queryId.isPresent()) {
-      ksqlEngine.getPersistentQueries().forEach(PersistentQueryMetadata::close);
+      ksqlEngine.getPersistentQueries().forEach(q -> q.close(true));
       return;
     }
 
     final Optional<PersistentQueryMetadata> query = ksqlEngine.getPersistentQuery(queryId.get());
-    query.ifPresent(PersistentQueryMetadata::close);
+    query.ifPresent(q -> q.close(true));
   }
 
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactory.java
@@ -81,7 +81,7 @@ public final class ValidatedCommandFactory {
     final Optional<QueryId> queryId = terminateQuery.getQueryId();
 
     if (!queryId.isPresent()) {
-      context.getPersistentQueries().forEach(PersistentQueryMetadata::close);
+      context.getPersistentQueries().forEach(q -> q.close(true));
       return Command.of(statement);
     }
 
@@ -89,7 +89,7 @@ public final class ValidatedCommandFactory {
         .orElseThrow(() -> new KsqlStatementException(
             "Unknown queryId: " + queryId.get(),
             statement.getStatementText()))
-        .close();
+        .close(true);
     return Command.of(statement);
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactory.java
@@ -26,7 +26,6 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlStatementException;
-import io.confluent.ksql.util.PersistentQueryMetadata;
 import java.util.Objects;
 import java.util.Optional;
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PushQueryPublisher.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PushQueryPublisher.java
@@ -102,7 +102,7 @@ class PushQueryPublisher implements Flow.Publisher<Collection<StreamedRow>> {
       if (!closed) {
         closed = true;
         log.info("Terminating query {}", queryMetadata.getQueryApplicationId());
-        queryMetadata.close();
+        queryMetadata.close(true);
       }
     }
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriter.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriter.java
@@ -101,7 +101,7 @@ class QueryStreamWriter implements StreamingOutput {
       log.error("Exception occurred while writing to connection stream: ", exception);
       outputException(out, exception);
     } finally {
-      queryMetadata.close();
+      queryMetadata.close(true);
     }
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ClusterTerminator.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ClusterTerminator.java
@@ -67,7 +67,7 @@ public class ClusterTerminator {
   }
 
   private void terminatePersistentQueries() {
-    ksqlEngine.getPersistentQueries().forEach(QueryMetadata::close);
+    ksqlEngine.getPersistentQueries().forEach(q -> q.close(true));
   }
 
   private void deleteSinkTopics(final List<String> deleteTopicPatterns) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ClusterTerminator.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ClusterTerminator.java
@@ -26,7 +26,6 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.ExecutorUtil;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
-import io.confluent.ksql.util.QueryMetadata;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
@@ -45,7 +45,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
@@ -80,7 +80,7 @@ public class QueryDescriptionFactoryTest {
   private static final Long closeTimeout = KsqlConfig.KSQL_SHUTDOWN_TIMEOUT_MS_DEFAULT;
 
   @Mock
-  private Consumer<QueryMetadata> queryCloseCallback;
+  private BiConsumer<QueryMetadata, Boolean> queryCloseCallback;
   @Mock
   private KafkaStreams queryStreams;
   @Mock

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutorTest.java
@@ -712,8 +712,8 @@ public class InteractiveStatementExecutorTest {
     );
 
     // Then:
-    verify(query0).close();
-    verify(query1).close();
+    verify(query0).close(true);
+    verify(query1).close(true);
   }
 
   @Test

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactoryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactoryTest.java
@@ -132,7 +132,7 @@ public class ValidatedCommandFactoryTest {
 
     // Then:
     verify(executionContext).getPersistentQuery(QUERY_ID);
-    verify(query1).close();
+    verify(query1).close(true);
   }
 
   @Test
@@ -144,8 +144,8 @@ public class ValidatedCommandFactoryTest {
     commandFactory.create(configuredStatement, executionContext);
 
     // Then:
-    verify(query1).close();
-    verify(query2).close();
+    verify(query1).close(true);
+    verify(query2).close(true);
   }
 
   @Test

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -87,7 +87,7 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
 import org.apache.kafka.common.acl.AclOperation;
@@ -152,7 +152,7 @@ public class StreamedQueryResourceTest {
   @Mock
   private ActivenessRegistrar activenessRegistrar;
   @Mock
-  private Consumer<QueryMetadata> queryCloseCallback;
+  private BiConsumer<QueryMetadata, Boolean> queryCloseCallback;
   @Mock
   private KsqlAuthorizationValidator authorizationValidator;
   @Mock

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/ClusterTerminatorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/ClusterTerminatorTest.java
@@ -127,8 +127,8 @@ public class ClusterTerminatorTest {
     clusterTerminator.terminateCluster(Collections.emptyList());
 
     // Then:
-    verify(persistentQuery0).close();
-    verify(persistentQuery1).close();
+    verify(persistentQuery0).close(true);
+    verify(persistentQuery1).close(true);
   }
 
   @Test
@@ -138,7 +138,7 @@ public class ClusterTerminatorTest {
 
     // Then:
     final InOrder inOrder = Mockito.inOrder(persistentQuery0, ksqlEngine);
-    inOrder.verify(persistentQuery0).close();
+    inOrder.verify(persistentQuery0).close(true);
     inOrder.verify(ksqlEngine).close();
   }
 
@@ -153,7 +153,7 @@ public class ClusterTerminatorTest {
 
     // Then:
     final InOrder inOrder = Mockito.inOrder(kafkaTopicClient, persistentQuery0);
-    inOrder.verify(persistentQuery0).close();
+    inOrder.verify(persistentQuery0).close(true);
     inOrder.verify(kafkaTopicClient).deleteTopics(Collections.singletonList("topic1"));
   }
 


### PR DESCRIPTION
### Description 

When KSQL exits, it calls KsqlEngine.close. This patch changes the engine's
close to close all the queries but not clean up internal topics. Internal
topics are only cleaned up when queries are explicitly closed with the
clean up flag set.

part of the fix for https://github.com/confluentinc/ksql/issues/4654

### Testing done 
- added unit tests
- also reproduced the issue manually and verified it did not occur with this patch

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

