### PR TITLE
fix: don't cleanup topics on engine close

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -238,7 +238,7 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
 
   @Override
   public void close() {
-    allLiveQueries.forEach(QueryMetadata::close);
+    allLiveQueries.forEach(QueryMetadata::stop);
     engineMetrics.close();
     aggregateMetricsCollector.shutdown();
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -236,7 +236,12 @@ public final class QueryExecutor {
         overrides,
         queryCloseCallback,
         ksqlConfig.getLong(KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG)
-    );
+    ) {
+      @Override
+      public void stop() {
+        close();
+      }
+    };
   }
 
   private static Optional<MaterializationInfo> getMaterializationInfo(final Object result) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -141,4 +141,9 @@ public class PersistentQueryMetadata extends QueryMetadata {
   ) {
     return materializationProvider.map(builder -> builder.build(queryId, contextStacker));
   }
+
+  @Override
+  public void stop() {
+    doClose(false);
+  }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -36,7 +36,7 @@ import org.apache.kafka.streams.state.StreamsMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class QueryMetadata {
+public abstract class QueryMetadata {
 
   private static final Logger LOG = LoggerFactory.getLogger(QueryMetadata.class);
 
@@ -180,9 +180,7 @@ public class QueryMetadata {
    *
    * @see #close()
    */
-  public void stop() {
-    doClose(false);
-  }
+  public abstract void stop();
 
   /**
    * Closes the {@code QueryMetadata} and cleans up any of
@@ -191,7 +189,7 @@ public class QueryMetadata {
    *
    * @see QueryMetadata#stop()
    */
-  public final void close() {
+  public void close() {
     doClose(true);
     closeCallback.accept(this);
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
@@ -99,13 +99,18 @@ public class TransientQueryMetadata extends QueryMetadata {
   }
 
   @Override
-  public void close() {
+  public void stop() {
+    close();
+  }
+
+  @Override
+  protected void doClose(final boolean cleanUp) {
     // To avoid deadlock, close the queue first to ensure producer side isn't blocked trying to
     // write to the blocking queue, otherwise super.close call can deadlock:
     rowQueue.close();
 
     // Now safe to close:
-    super.close();
+    super.doClose(cleanUp);
     isRunning.set(false);
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -33,6 +33,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
@@ -674,6 +675,63 @@ public class KsqlEngineTest {
 
     // Then:
     verify(topicClient).deleteInternalTopics(query.getQueryApplicationId());
+  }
+
+  @Test
+  public void shouldCleanUpInternalTopicsOnEngineCloseForTransientQueries() {
+    // Given:
+    final QueryMetadata query = KsqlEngineTestUtil.executeQuery(
+        serviceContext,
+        ksqlEngine,
+        "select * from test1 EMIT CHANGES;",
+        KSQL_CONFIG, Collections.emptyMap()
+    );
+
+    query.start();
+
+    // When:
+    ksqlEngine.close();
+
+    // Then:
+    verify(topicClient).deleteInternalTopics(query.getQueryApplicationId());
+  }
+
+  @Test
+  public void shouldNotCleanUpInternalTopicsOnEngineCloseForPersistentQueries() {
+    // Given:
+    final List<QueryMetadata> query = KsqlEngineTestUtil.execute(
+        serviceContext,
+        ksqlEngine,
+        "create stream persistent as select * from test1 EMIT CHANGES;",
+        KSQL_CONFIG, Collections.emptyMap()
+    );
+
+    query.get(0).start();
+
+    // When:
+    ksqlEngine.close();
+
+    // Then (there are no transient queries, so no internal topics should be deleted):
+    verify(topicClient, never()).deleteInternalTopics(any());
+  }
+
+  @Test
+  public void shouldCleanUpInternalTopicsOnQueryCloseForPersistentQueries() {
+    // Given:
+    final List<QueryMetadata> query = KsqlEngineTestUtil.execute(
+        serviceContext,
+        ksqlEngine,
+        "create stream persistent as select * from test1 EMIT CHANGES;",
+        KSQL_CONFIG, Collections.emptyMap()
+    );
+
+    query.get(0).start();
+
+    // When:
+    query.get(0).close();
+
+    // Then (there are no transient queries, so no internal topics should be deleted):
+    verify(topicClient).deleteInternalTopics(query.get(0).getQueryApplicationId());
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
@@ -18,7 +18,10 @@ package io.confluent.ksql.util;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableSet;
@@ -137,6 +140,24 @@ public class QueryMetadataTest {
   }
 
   @Test
+  public void shouldNotCallCloseCallbackOnStop() {
+    // When:
+    query.stop();
+
+    // Then:
+    verifyNoMoreInteractions(closeCallback);
+  }
+
+  @Test
+  public void shouldCallKafkaStreamsCloseOnStop() {
+    // When:
+    query.stop();
+
+    // Then:
+    verify(kafkaStreams).close(Duration.ofMillis(closeTimeout));
+  }
+
+  @Test
   public void shouldCleanUpKStreamsAppAfterCloseOnClose() {
     // When:
     query.close();
@@ -145,6 +166,15 @@ public class QueryMetadataTest {
     final InOrder inOrder = inOrder(kafkaStreams);
     inOrder.verify(kafkaStreams).close(Duration.ofMillis(closeTimeout));
     inOrder.verify(kafkaStreams).cleanUp();
+  }
+
+  @Test
+  public void shouldNotCleanUpKStreamsAppOnStop() {
+    // When:
+    query.stop();
+
+    // Then:
+    verify(kafkaStreams, never()).cleanUp();
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/TransientQueryMetadataTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/TransientQueryMetadataTest.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.util;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
 
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.BlockingRowQueue;
@@ -86,5 +87,18 @@ public class TransientQueryMetadataTest {
     final InOrder inOrder = inOrder(rowQueue, kafkaStreams);
     inOrder.verify(rowQueue).close();
     inOrder.verify(kafkaStreams).close(any());
+  }
+
+  @Test
+  public void shouldCallCloseOnStop() {
+    // When:
+    query.stop();
+
+    // Then:
+    final InOrder inOrder = inOrder(rowQueue, kafkaStreams, closeCallback);
+    inOrder.verify(rowQueue).close();
+    inOrder.verify(kafkaStreams).close(any());
+    inOrder.verify(kafkaStreams).cleanUp();
+    inOrder.verify(closeCallback).accept(query);
   }
 }


### PR DESCRIPTION
Co-authored-by: Rohan <desai.p.rohan@gmail.com>

fixes #4654

### Description 
See the description in the ticket above. This makes it so that we don't cleanup topics for persistent queries on closing the engine (but we do for transient).

### Testing done 
- Unit tests
- Manual testing to ensure we can't reproduce the bug.


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

