### PR TITLE
chore: update CHANGELOG for 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Change Log
 
+## [0.7.1](https://github.com/confluentinc/ksql/releases/tag/v0.7.1-ksqldb) (2020-02-28)
+
+### Features
+
+* feat: support custom column widths in cli (#4616) ([cb66e05](https://github.com/confluentinc/ksql/commit/cb66e05))
+    
+    A new ksqlDB CLI configuration allows you to specify the width of each column in tabular output.
+
+    ```
+    ksql> SET CLI COLUMN-WIDTH 10
+    ```
+    Given a customized value, subsequent renderings of output use the setting:
+    
+    ```
+    ksql> SELECT * FROM riderLocations
+    >  WHERE GEO_DISTANCE(latitude, longitude, 37.4133, -122.1162) <= 5 EMIT CHANGES;
+    +----------+----------+----------+----------+----------+
+    |ROWTIME   |ROWKEY    |PROFILEID |LATITUDE  |LONGITUDE |
+    +----------+----------+----------+----------+----------+
+    ```
+    The default behavior, which determines column width based on terminal width and the number of columns, can be re-enabled using:
+    ```
+    ksql> SET CLI COLUMN-WIDTH 0
+    ```
+
+### Bug Fixes
+
+* fix: add functional-test dependencies to Docker module (#4586) ([04fcf8d](https://github.com/confluentinc/ksql/commit/04fcf8d))
+* fix: don't cleanup topics on engine close (#4658) ([ad66a81](https://github.com/confluentinc/ksql/commit/ad66a81))
+* fix: idempotent terminate that can handle hung streams (#4643) ([d96db14](https://github.com/confluentinc/ksql/commit/d96db14))
+* fix: support partial schemas (#4625) ([7cc19a0](https://github.com/confluentinc/ksql/commit/7cc19a0))
+
+
 ## [0.7.0](https://github.com/confluentinc/ksql/releases/tag/v0.7.0-ksqldb) (2020-02-11)
 
 ### Upgrading


### PR DESCRIPTION
* The referenced tag does not actually exist yet. I will be pushed once we finalize the release and push the Docker images to Docker Hub.
* I targeted master because 5.5.x lacks the commit for the `0.7.0` changelog additions. I figure we can cherry-pick that commit and the squash for this PR into 5.5.x.