### PR TITLE
chore: bump release version to 0.7.1-SNAPSHOT

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 def config = {
     owner = 'ksql'
     slackChannel = '#ksql-alerts'
-    ksql_db_version = "0.7.0-SNAPSHOT"
+    ksql_db_version = "0.7.1-SNAPSHOT"
     cp_version = "5.5.0-beta200204173843"
     packaging_build_number = "1"
     dockerRegistry = '368821881613.dkr.ecr.us-west-2.amazonaws.com/'


### PR DESCRIPTION
Prepares the CI release build for the next version. This does not actually create the release.
