### PR TITLE
chore: Remove use of deprecated Jackson API

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonArrayContains.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonArrayContains.java
@@ -29,7 +29,6 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonFactoryBuilder;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
-
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonArrayContains.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonArrayContains.java
@@ -26,8 +26,10 @@ import static com.fasterxml.jackson.core.JsonToken.VALUE_STRING;
 import static com.fasterxml.jackson.core.JsonToken.VALUE_TRUE;
 
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonFactoryBuilder;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
+
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -46,9 +48,9 @@ public class JsonArrayContains {
   static final String DESCRIPTION = "Parses a JSON array and determines whether or not the "
       + "supplied value is contained within the array.";
 
-  private static final JsonFactory PARSER_FACTORY = new JsonFactory()
-      .setCodec(JsonMapper.INSTANCE.mapper)
-      .disable(CANONICALIZE_FIELD_NAMES);
+  private static final JsonFactory PARSER_FACTORY =
+      new JsonFactory(new JsonFactoryBuilder().disable(CANONICALIZE_FIELD_NAMES))
+          .setCodec(JsonMapper.INSTANCE.mapper);
 
   private static final EnumMap<JsonToken, Predicate<Object>> TOKEN_COMPAT;
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonArrayContains.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonArrayContains.java
@@ -47,9 +47,10 @@ public class JsonArrayContains {
   static final String DESCRIPTION = "Parses a JSON array and determines whether or not the "
       + "supplied value is contained within the array.";
 
-  private static final JsonFactory PARSER_FACTORY =
-      new JsonFactory(new JsonFactoryBuilder().disable(CANONICALIZE_FIELD_NAMES))
-          .setCodec(JsonMapper.INSTANCE.mapper);
+  private static final JsonFactory PARSER_FACTORY = new JsonFactoryBuilder()
+      .disable(CANONICALIZE_FIELD_NAMES)
+      .build()
+      .setCodec(JsonMapper.INSTANCE.mapper);
 
   private static final EnumMap<JsonToken, Predicate<Object>> TOKEN_COMPAT;
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/ConfigTopicKeyTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/ConfigTopicKeyTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import com.google.common.testing.EqualsTester;
 import io.confluent.ksql.rest.server.computation.ConfigTopicKey.StringKey;
 import java.nio.charset.StandardCharsets;
@@ -81,7 +82,7 @@ public class ConfigTopicKeyTest {
     @Override
     public boolean matchesSafely(final Exception e) {
       return e instanceof SerializationException
-          && e.getCause() instanceof InvalidDefinitionException
+          && e.getCause() instanceof InvalidDefinitionException || e.getCause() instanceof ValueInstantiationException
           && exceptionClass.isInstance(e.getCause().getCause())
           && e.getCause().getCause().getMessage().contains(msg);
     }


### PR DESCRIPTION
This is to allow an upgrade to Jackson 2.10.x