### PR TITLE
test: improve error msg & remove log spam (MINOR)

### DIFF
--- a/ksql-benchmark/src/main/resources/log4j.properties
+++ b/ksql-benchmark/src/main/resources/log4j.properties
@@ -35,6 +35,7 @@ log4j.logger.org.apache.kafka.clients.admin.AdminClientConfig=WARN
 log4j.logger.org.apache.kafka.clients.consumer.ConsumerConfig=WARN
 log4j.logger.org.apache.kafka.clients.producer.ProducerConfig=WARN
 log4j.logger.org.apache.kafka.connect.json.JsonConverterConfig=WARN
+log4j.logger.io.confluent.connect.protobuf.ProtobufDataConfig=WARN
 log4j.logger.org.apache.kafka.streams.StreamsConfig=WARN
 
 # Disable INFO logging from the UDF loader, which logs every UDF ever time it runs:

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
@@ -63,7 +63,6 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.hamcrest.Matcher;
-import org.hamcrest.StringDescription;
 
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
 @SuppressWarnings("deprecation")
@@ -138,10 +137,6 @@ public class TestExecutor implements Closeable {
               ksqlConfig,
               stubKafkaService
           );
-
-      testCase.expectedException().map(ee -> {
-        throw new AssertionError("Expected test to throw" + StringDescription.toString(ee));
-      });
 
       writeInputIntoTopics(testCase.getInputRecords(), stubKafkaService);
       final Set<String> inputTopics = testCase.getInputRecords()

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutorUtil.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutorUtil.java
@@ -68,6 +68,7 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyTestDriver;
+import org.hamcrest.StringDescription;
 
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
 @SuppressWarnings("deprecation")
@@ -218,6 +219,10 @@ public final class TestExecutorUtil {
         Optional.of(serviceContext.getSchemaRegistryClient()),
         stubKafkaService
     );
+
+    testCase.expectedException().map(ee -> {
+      throw new AssertionError("Expected test to throw" + StringDescription.toString(ee));
+    });
 
     assertThat("test did not generate any queries.", queries, is(not(empty())));
     return queries;

--- a/ksql-test-util/src/main/resources/log4j.properties
+++ b/ksql-test-util/src/main/resources/log4j.properties
@@ -35,6 +35,7 @@ log4j.logger.org.apache.kafka.clients.admin.AdminClientConfig=WARN
 log4j.logger.org.apache.kafka.clients.consumer.ConsumerConfig=WARN
 log4j.logger.org.apache.kafka.clients.producer.ProducerConfig=WARN
 log4j.logger.org.apache.kafka.connect.json.JsonConverterConfig=WARN
+log4j.logger.io.confluent.connect.protobuf.ProtobufDataConfig=WARN
 log4j.logger.org.apache.kafka.streams.StreamsConfig=WARN
 
 # Disable INFO logging from the UDF loader, which logs every UDF ever time it runs:


### PR DESCRIPTION
### Description 

This change improves the error message returned by the testing tool & QTT when a test case is expected to throw an exception but doesn't.

Old message was:

```
java.lang.AssertionError: test did not generate any queries.
Expected: is not an empty collection
     but: was <[]>
failed test: key-schemas - KEY key field name
in file: query-validation-tests/key-schemas.json

```

New message is:

```
java.lang.AssertionError: Expected test to throw(an instance of io.confluent.ksql.util.KsqlStatementException and statement text a string containing "CREATE STREAM INPUT (KEY STRING KEY, ID bigint) WITH (kafka_topic='input',value_format='JSON');" and exception with message a string containing "'KEY' is an invalid KEY column name. KSQL currently only supports KEY columns named ROWKEY.")
failed test: key-schemas - KEY key field name
in file: query-validation-tests/key-schemas.json
```

Plus this change suppresses the logging of `ProtobufDataConfig` creation in the tests, which is just noise and fills up the logs on the build servers

### Testing done 
test only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

