### PR TITLE
fix: fix the error message for failing to wait for CommandRunner to catch up in DistributingExecutor

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandStore.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandStore.java
@@ -17,12 +17,10 @@ package io.confluent.ksql.rest.server.computation;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import io.confluent.ksql.rest.Errors;
 import io.confluent.ksql.rest.entity.CommandId;
-import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.server.CommandTopic;
-import io.confluent.ksql.rest.server.resources.KsqlRestException;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.KsqlServerException;
 import java.io.Closeable;
 import java.time.Duration;
 import java.util.Collections;
@@ -256,13 +254,11 @@ public class CommandStore implements CommandQueue, Closeable {
     } catch (final InterruptedException e) {
       final String errorMsg =
           "Interrupted while waiting for command topic consumer to process command topic";
-      throw new KsqlRestException(
-          Errors.serverErrorForStatement(e, errorMsg, new KsqlEntityList()));
+      throw new KsqlServerException(errorMsg);
     } catch (final TimeoutException e) {
       final String errorMsg =
           "Timeout while waiting for command topic consumer to process command topic";
-      throw new KsqlRestException(
-          Errors.serverErrorForStatement(e, errorMsg, new KsqlEntityList()));
+      throw new KsqlServerException(errorMsg);
     }
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/DistributingExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/DistributingExecutor.java
@@ -154,12 +154,12 @@ public class DistributingExecutor {
       // We can't recover from these exceptions, so our only option is close producer and exit.
       // This catch doesn't abortTransaction() since doing that would throw another exception.
       throw new KsqlServerException(String.format(
-          "Could not write the statement '%s' into the command topic: " + e.getMessage(),
+          "Could not write the statement '%s' into the command topic.",
           statement.getStatementText()), e);
     } catch (final Exception e) {
       transactionalProducer.abortTransaction();
       throw new KsqlServerException(String.format(
-          "Could not write the statement '%s' into the command topic: " + e.getMessage(),
+          "Could not write the statement '%s' into the command topic.",
           statement.getStatementText()), e);
     } finally {
       transactionalProducer.close();

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/DistributingExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/DistributingExecutorTest.java
@@ -236,7 +236,7 @@ public class DistributingExecutorTest {
     // Expect:
     expectedException.expect(KsqlServerException.class);
     expectedException.expectMessage(
-        "Could not write the statement 'statement' into the command topic: fail");
+        "Could not write the statement 'statement' into the command topic.");
     expectedException.expectCause(is(cause));
 
     // When:

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -1888,7 +1888,7 @@ public class KsqlResourceTest {
     expectedException.expect(exceptionStatusCode(is(Code.INTERNAL_SERVER_ERROR)));
     expectedException.expect(exceptionErrorMessage(errorMessage(is(
         "Could not write the statement '" + statement
-            + "' into the command topic: blah\nCaused by: blah"))));
+            + "' into the command topic.\nCaused by: blah"))));
 
     // When:
     makeRequest(statement);


### PR DESCRIPTION
### Description 
If you kill the commandRunner thread and then issue a control statement, we'll fail to enqueue the statement because the commandRunner hasn't caught up to the command topic. The error is not great because `CommandStore.waitForCommandConsumer()` is returning a `KsqlRestException` which doesn't have an error message associated with it, which results in this
```
ksql> create stream foo8(age BIGINT) with (Kafka_Topic='foo', VALUE_FORMAT='json');
Could not write the statement 'create stream foo8(age BIGINT) with (Kafka_Topic='foo', VALUE_FORMAT='json');' into the command topic: null
Caused by: io.confluent.ksql.rest.server.resources.KsqlRestException
```
Changing the error thrown to `KsqlServerException` so the error message can get displayed.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._
```
ksql> create stream testssads as select * from KSQL_PROCESSING_LOG;
Could not write the statement 'create stream testssads as select * from KSQL_PROCESSING_LOG;' into the command topic.
Caused by: Timeout while waiting for command topic consumer to process command
        topic

```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

