### PR TITLE
test: extend RQTT to support properties (MINOR)

### DIFF
--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestCase.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestCase.java
@@ -19,7 +19,6 @@ import static io.confluent.ksql.test.utils.ImmutableCollections.immutableCopyOf;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.ImmutableList;
-import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.rest.client.RestResponse;
 import io.confluent.ksql.test.rest.model.Response;
 import io.confluent.ksql.test.tools.Record;
@@ -33,11 +32,11 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import org.hamcrest.Matcher;
 
-@Immutable
 class RestTestCase implements Test {
 
   private final Path testPath;
   private final String name;
+  private final Map<String, Object> properties;
   private final ImmutableList<Topic> topics;
   private final ImmutableList<Record> inputRecords;
   private final ImmutableList<Record> outputRecords;
@@ -48,6 +47,7 @@ class RestTestCase implements Test {
   RestTestCase(
       final Path testPath,
       final String name,
+      final Map<String, Object> properties,
       final Collection<Topic> topics,
       final Collection<Record> inputRecords,
       final Collection<Record> outputRecords,
@@ -57,6 +57,7 @@ class RestTestCase implements Test {
   ) {
     this.name = requireNonNull(name, "name");
     this.testPath = requireNonNull(testPath, "testPath");
+    this.properties = immutableCopyOf(requireNonNull(properties, "properties"));
     this.topics = immutableCopyOf(requireNonNull(topics, "topics"));
     this.inputRecords = immutableCopyOf(requireNonNull(inputRecords, "inputRecords"));
     this.outputRecords = immutableCopyOf(requireNonNull(outputRecords, "outputRecords"));
@@ -99,5 +100,9 @@ class RestTestCase implements Test {
 
   public Optional<Matcher<RestResponse<?>>> expectedError() {
     return expectedError;
+  }
+
+  public Map<String, Object> getProperties() {
+    return properties;
   }
 }

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestCaseBuilder.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestCaseBuilder.java
@@ -96,6 +96,7 @@ final class RestTestCaseBuilder {
       return new RestTestCase(
           testPath,
           testName,
+          test.properties(),
           topics.values(),
           inputRecords,
           outputRecords,

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestCaseNode.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestCaseNode.java
@@ -26,6 +26,7 @@ import io.confluent.ksql.test.rest.model.Response;
 import io.confluent.ksql.test.tools.exceptions.InvalidFieldException;
 import io.confluent.ksql.test.tools.exceptions.MissingFieldException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -41,6 +42,7 @@ public class RestTestCaseNode {
   private final List<TopicNode> topics;
   private final List<String> statements;
   private final List<Response> responses;
+  private final Map<String, Object> properties;
   private final Optional<ExpectedErrorNode> expectedError;
   private final boolean enabled;
 
@@ -51,6 +53,7 @@ public class RestTestCaseNode {
       @JsonProperty("outputs") final List<RecordNode> outputs,
       @JsonProperty("topics") final List<TopicNode> topics,
       @JsonProperty("statements") final List<String> statements,
+      @JsonProperty("properties") final Map<String, Object> properties,
       @JsonProperty("expectedError") final ExpectedErrorNode expectedError,
       @JsonProperty("responses") final List<Response> responses,
       @JsonProperty("enabled") final Boolean enabled
@@ -61,6 +64,7 @@ public class RestTestCaseNode {
     this.inputs = immutableCopyOf(inputs);
     this.outputs = immutableCopyOf(outputs);
     this.topics = immutableCopyOf(topics);
+    this.properties = immutableCopyOf(properties);
     this.expectedError = Optional.ofNullable(expectedError);
     this.responses = immutableCopyOf(responses);
     this.enabled = !Boolean.FALSE.equals(enabled);
@@ -102,6 +106,10 @@ public class RestTestCaseNode {
 
   public List<Response> getResponses() {
     return responses;
+  }
+
+  public Map<String, Object> properties() {
+    return properties;
   }
 
   private void validate() {


### PR DESCRIPTION
### Description 

RQTT test cases can now have a properties section, just like QTT test cases, e.g.

```json
"properties": {
    "ksql.some.thing": "whateva"
}
```

### Testing done 

test only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

