### PR TITLE
chore: remove legacy AVRO_SCHEMA_ID

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/properties/with/CreateConfigs.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/properties/with/CreateConfigs.java
@@ -32,7 +32,6 @@ public final class CreateConfigs {
   public static final String KEY_NAME_PROPERTY = "KEY";
   public static final String WINDOW_TYPE_PROPERTY = "WINDOW_TYPE";
   public static final String WINDOW_SIZE_PROPERTY = "WINDOW_SIZE";
-  public static final String AVRO_SCHEMA_ID = "AVRO_SCHEMA_ID";
   public static final String SCHEMA_ID = "SCHEMA_ID";
   public static final String SOURCE_CONNECTOR = "SOURCE_CONNECTOR";
 
@@ -69,12 +68,6 @@ public final class CreateConfigs {
           null,
           Importance.LOW,
           "Undocumented feature"
-      ).define(
-          AVRO_SCHEMA_ID,
-          ConfigDef.Type.INT,
-          null,
-          Importance.LOW,
-          "Undocumented feature (deprecated - use SCHEMA_ID instead)"
       ).define(
           SOURCE_CONNECTOR,
           Type.STRING,

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceProperties.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceProperties.java
@@ -130,12 +130,7 @@ public final class CreateSourceProperties {
   }
 
   public Optional<Integer> getSchemaId() {
-    Integer schemaId = props.getInt(CreateConfigs.SCHEMA_ID);
-    if (schemaId == null) {
-      schemaId = props.getInt(CreateConfigs.AVRO_SCHEMA_ID);
-    }
-
-    return Optional.ofNullable(schemaId);
+    return Optional.ofNullable(props.getInt(CreateConfigs.SCHEMA_ID));
   }
 
   public FormatInfo getFormatInfo() {

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourcePropertiesTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourcePropertiesTest.java
@@ -287,19 +287,6 @@ public class CreateSourcePropertiesTest {
   }
 
   @Test
-  public void shouldSetValidLegacySchemaId() {
-    // When:
-    final CreateSourceProperties properties = CreateSourceProperties.from(
-        ImmutableMap.<String, Literal>builder()
-            .putAll(MINIMUM_VALID_PROPS)
-            .put(CreateConfigs.AVRO_SCHEMA_ID, new StringLiteral("1"))
-            .build());
-
-    // Then:
-    assertThat(properties.getSchemaId(), is(Optional.of(1)));
-  }
-
-  @Test
   public void shouldSetValidAvroSchemaName() {
     // When:
     final CreateSourceProperties properties = CreateSourceProperties.from(
@@ -451,6 +438,7 @@ public class CreateSourcePropertiesTest {
     );
   }
 
+  @SuppressWarnings("UnstableApiUsage")
   @Test
   public void shouldProperlyImplementEqualsAndHashCode() {
     new EqualsTester()


### PR DESCRIPTION
### Description 

Our use of query plans means we no longer need this...

`AVRO_SCHEMA_ID` is still likely to be baked into sql statement of query plans held within the command topic of existing cluster, as it is also backed in the historic plans in our QTT tests. 

However, it is never parsed.  The whole point of the plan is that we can change our syntax and not need to maintain backwards compatibility of the syntax!

### Testing done 

`mvn test`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")


