### PR TITLE
test: enable the timestamp format failure test

### DIFF
--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutorUtil.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutorUtil.java
@@ -220,9 +220,11 @@ public final class TestExecutorUtil {
         stubKafkaService
     );
 
-    testCase.expectedException().map(ee -> {
-      throw new AssertionError("Expected test to throw" + StringDescription.toString(ee));
-    });
+    if (testCase.getInputRecords().isEmpty()) {
+      testCase.expectedException().map(ee -> {
+        throw new AssertionError("Expected test to throw" + StringDescription.toString(ee));
+      });
+    }
 
     assertThat("test did not generate any queries.", queries, is(not(empty())));
     return queries;

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/timestamp-extractor.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/timestamp-extractor.json
@@ -38,7 +38,6 @@
     },
     {
       "name": "KSQL throw on invalid timestamp extractor with format",
-      "enabled": false,
       "statements": [
         "CREATE STREAM TEST (ID bigint, TS varchar) WITH (kafka_topic='test_topic', value_format='JSON', timestamp='ts', timestamp_format='yy-MM-dd HH:mm:ssX');",
         "CREATE STREAM TS AS SELECT id FROM test;"


### PR DESCRIPTION
### Description 

Re-enabling this test after allowing tests to continue past building the queries even if an expected exception is present in the case that it has defined input records.

### Testing done 

Ran the test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

