### PR TITLE
Logical schema no implicits

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -703,6 +703,7 @@ public class CliTest {
 
     final PhysicalSchema resultSchema = PhysicalSchema.from(
         LogicalSchema.builder()
+            .withRowTime()
             .keyColumns(ORDER_DATA_PROVIDER.schema().logicalSchema().key())
             .valueColumn(ColumnName.of("ITEMID"), SqlTypes.STRING)
             .valueColumn(ColumnName.of("COL1"), SqlTypes.DOUBLE)

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -75,6 +75,7 @@ import io.confluent.ksql.schema.ksql.LogicalSchema.Builder;
 import io.confluent.ksql.schema.ksql.SqlBaseType;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.util.SchemaUtil;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -99,7 +100,7 @@ public class ConsoleTest {
   private static final String WHITE_SPACE = " \t ";
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .noImplicitColumns()
+      .withRowTime()
       .keyColumn(ColumnName.of("foo"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("bar"), SqlTypes.STRING)
       .build();
@@ -1469,7 +1470,9 @@ public class ConsoleTest {
   }
 
   private static List<FieldInfo> buildTestSchema(final SqlType... fieldTypes) {
-    final Builder schemaBuilder = LogicalSchema.builder();
+    final Builder schemaBuilder = LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING);
 
     for (int idx = 0; idx < fieldTypes.length; idx++) {
       schemaBuilder.valueColumn(ColumnName.of("f_" + idx), fieldTypes[idx]);

--- a/ksql-cli/src/test/java/io/confluent/ksql/util/TabularRowTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/util/TabularRowTest.java
@@ -42,7 +42,6 @@ public class TabularRowTest {
   public void shouldFormatHeader() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .noImplicitColumns()
         .keyColumn(ColumnName.of("foo"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("bar"), SqlTypes.STRING)
         .build();
@@ -61,7 +60,6 @@ public class TabularRowTest {
   public void shouldMultilineFormatHeader() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .noImplicitColumns()
         .keyColumn(ColumnName.of("foo"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("bar is a long string"), SqlTypes.STRING)
         .build();
@@ -165,7 +163,6 @@ public class TabularRowTest {
   public void shouldFormatNoColumnsHeader() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .noImplicitColumns()
         .build();
 
     // When:
@@ -179,7 +176,6 @@ public class TabularRowTest {
   public void shouldFormatMoreColumnsThanWidth() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .noImplicitColumns()
         .keyColumn(ColumnName.of("foo"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("bar"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("baz"), SqlTypes.DOUBLE)
@@ -202,7 +198,6 @@ public class TabularRowTest {
     givenCustomColumnWidth(10);
 
     final LogicalSchema schema = LogicalSchema.builder()
-        .noImplicitColumns()
         .keyColumn(ColumnName.of("foo"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("bar"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("baz"), SqlTypes.DOUBLE)

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
@@ -306,17 +306,12 @@ public final class LogicalSchema {
 
   public static class Builder {
 
-    private final ImmutableList.Builder<Column> explicitColumns = ImmutableList.builder();
-
+    private final ImmutableList.Builder<Column> columns = ImmutableList.builder();
     private final Set<ColumnName> seenKeys = new HashSet<>();
     private final Set<ColumnName> seenValues = new HashSet<>();
 
-    private boolean addImplicitRowKey = true;
-    private boolean addImplicitRowTime = true;
-
-    public Builder noImplicitColumns() {
-      addImplicitRowKey = false;
-      addImplicitRowTime = false;
+    public Builder withRowTime() {
+      columns.add(IMPLICIT_TIME_COLUMN);
       return this;
     }
 
@@ -349,19 +344,7 @@ public final class LogicalSchema {
     }
 
     public LogicalSchema build() {
-      final ImmutableList.Builder<Column> allColumns = ImmutableList.builder();
-
-      if (addImplicitRowTime) {
-        allColumns.add(IMPLICIT_TIME_COLUMN);
-      }
-
-      if (addImplicitRowKey) {
-        allColumns.add(IMPLICIT_KEY_COLUMN);
-      }
-
-      allColumns.addAll(explicitColumns.build());
-
-      return new LogicalSchema(allColumns.build());
+      return new LogicalSchema(columns.build());
     }
 
     private void addColumn(final Column column) {
@@ -370,7 +353,6 @@ public final class LogicalSchema {
           if (!seenKeys.add(column.name())) {
             throw new KsqlException("Duplicate keys found in schema: " + column);
           }
-          addImplicitRowKey = false;
           break;
 
         case VALUE:
@@ -383,7 +365,7 @@ public final class LogicalSchema {
           break;
       }
 
-      explicitColumns.add(column);
+      columns.add(column);
     }
   }
 }

--- a/ksql-common/src/test/java/io/confluent/ksql/json/LogicalSchemaSerializerTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/json/LogicalSchemaSerializerTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.util.SchemaUtil;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -39,6 +40,8 @@ public class LogicalSchemaSerializerTest {
   public void shouldSerializeSchemaWithImplicitColumns() throws Exception {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("v0"), SqlTypes.INTEGER)
         .build();
 
@@ -53,7 +56,6 @@ public class LogicalSchemaSerializerTest {
   public void shouldSerializeSchemaWithOutImplicitColumns() throws Exception {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .noImplicitColumns()
         .keyColumn(ColumnName.of("key0"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("v0"), SqlTypes.INTEGER)
         .build();

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -379,13 +379,15 @@ public class LogicalPlanner {
 
   private LogicalSchema buildProjectionSchema(
       final LogicalSchema schema,
-      final List<SelectExpression> projection) {
+      final List<SelectExpression> projection
+  ) {
     final ExpressionTypeManager expressionTypeManager = new ExpressionTypeManager(
         schema,
         functionRegistry
     );
 
-    final Builder builder = LogicalSchema.builder();
+    final Builder builder = LogicalSchema.builder()
+        .withRowTime();
 
     final List<Column> keyColumns = schema.key();
 
@@ -424,6 +426,7 @@ public class LogicalPlanner {
     );
 
     return LogicalSchema.builder()
+        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, keyType)
         .valueColumns(sourceSchema.value())
         .build();
@@ -441,6 +444,7 @@ public class LogicalPlanner {
     final SqlType keyType = typeManager.getExpressionSqlType(partitionBy);
 
     return LogicalSchema.builder()
+        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, keyType)
         .valueColumns(sourceSchema.value())
         .build();

--- a/ksql-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -446,9 +446,7 @@ public final class QueryExecutor {
    * only have the value columns.
    */
   private static LogicalSchema buildTransientQuerySchema(final LogicalSchema fullSchema) {
-    final LogicalSchema.Builder builder = LogicalSchema.builder()
-        .noImplicitColumns();
-
+    final LogicalSchema.Builder builder = LogicalSchema.builder();
     builder.valueColumns(fullSchema.value());
     return builder.build();
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalysisTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalysisTest.java
@@ -32,6 +32,7 @@ import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.WindowInfo;
+import io.confluent.ksql.util.SchemaUtil;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -49,6 +50,8 @@ public class AnalysisTest {
   private static final WindowInfo A_WINDOW = WindowInfo.of(WindowType.SESSION, Optional.empty());
 
   private static final LogicalSchema SOURCE_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("bob"), SqlTypes.BIGINT)
       .build();
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerFunctionalTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerFunctionalTest.java
@@ -71,6 +71,7 @@ import io.confluent.ksql.serde.avro.AvroFormat;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlParserTestUtil;
 import io.confluent.ksql.util.MetaStoreFixture;
+import io.confluent.ksql.util.SchemaUtil;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -366,8 +367,10 @@ public class AnalyzerFunctionalTest {
     );
 
     final LogicalSchema schema = LogicalSchema.builder()
-            .valueColumn(ColumnName.of("FIELD1"), SqlTypes.BIGINT)
-            .build();
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
+        .valueColumn(ColumnName.of("FIELD1"), SqlTypes.BIGINT)
+        .build();
 
     final KsqlStream<?> ksqlStream = new KsqlStream<>(
         "create stream s0 with(KAFKA_TOPIC='s0', VALUE_AVRO_SCHEMA_FULL_NAME='org.ac.s1', VALUE_FORMAT='avro');",
@@ -659,6 +662,8 @@ public class AnalyzerFunctionalTest {
 
   private void registerKafkaSource() {
     final LogicalSchema schema = LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(COL0, SqlTypes.BIGINT)
         .build();
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/SourceSchemasTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/SourceSchemasTest.java
@@ -38,11 +38,15 @@ public class SourceSchemasTest {
   private static final ColumnName COMMON_FIELD_NAME = ColumnName.of("F0");
 
   private static final LogicalSchema SCHEMA_1 = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(COMMON_FIELD_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("F1"), SqlTypes.STRING)
       .build();
 
   private static final LogicalSchema SCHEMA_2 = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(COMMON_FIELD_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("F2"), SqlTypes.STRING)
       .build();

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceFactoryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceFactoryTest.java
@@ -74,6 +74,7 @@ import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.SchemaUtil;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
@@ -108,6 +109,7 @@ public class CreateSourceFactoryTest {
       TableElements.of(EXPLICIT_ROWKEY, ELEMENT1, ELEMENT2);
 
   private static final LogicalSchema EXPECTED_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
       .keyColumn(ROWKEY_NAME, SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("bob"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("hojjat"), BIGINT)
@@ -444,6 +446,8 @@ public class CreateSourceFactoryTest {
     givenCommandFactoriesWithMocks();
     final CreateStream statement = new CreateStream(SOME_NAME, ONE_ELEMENTS, true, withProperties);
     final LogicalSchema schema = LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("bob"), SqlTypes.STRING)
         .build();
     when(serdeOptionsSupplier.build(any(), any(), any(), any())).thenReturn(SOME_SERDE_OPTIONS);
@@ -579,7 +583,8 @@ public class CreateSourceFactoryTest {
 
     // Then:
     assertThat(result.getSchema(), is(LogicalSchema.builder()
-        .keyColumn(ColumnName.of("ROWKEY"), SqlTypes.STRING)
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("bob"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("hojjat"), BIGINT)
         .build()

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
@@ -67,6 +67,7 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.SchemaUtil;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.util.Collections;
@@ -99,15 +100,21 @@ public class InsertValuesExecutorTest {
 
   private static final ColumnName COL0 = ColumnName.of("COL0");
   private static final LogicalSchema SINGLE_FIELD_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(COL0, SqlTypes.STRING)
       .build();
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(COL0, SqlTypes.STRING)
       .valueColumn(ColumnName.of("COL1"), SqlTypes.BIGINT)
       .build();
 
   private static final LogicalSchema BIG_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(COL0, SqlTypes.STRING) // named COL0 for auto-ROWKEY
       .valueColumn(ColumnName.of("INT"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("BIGINT"), SqlTypes.BIGINT)

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
@@ -46,6 +46,7 @@ import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.OrderDataProvider;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
+import io.confluent.ksql.util.SchemaUtil;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -119,6 +120,8 @@ public class JsonFormatTest {
     TEST_HARNESS.produceRows(inputTopic, orderDataProvider, JSON);
 
     final LogicalSchema messageSchema = LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("MESSAGE"), SqlTypes.STRING)
         .build();
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
@@ -547,6 +547,8 @@ public class KsMaterializationFunctionalTest {
       final SqlType columnType0
   ) {
     return LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of(columnName0), columnType0)
         .build();
   }
@@ -557,6 +559,8 @@ public class KsMaterializationFunctionalTest {
       final String columnName1, final SqlType columnType1
   ) {
     return LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of(columnName0), columnType0)
         .valueColumn(ColumnName.of(columnName1), columnType1)
         .build();
@@ -569,6 +573,8 @@ public class KsMaterializationFunctionalTest {
       final String columnName2, final SqlType columnType2
   ) {
     return LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of(columnName0), columnType0)
         .valueColumn(ColumnName.of(columnName1), columnType1)
         .valueColumn(ColumnName.of(columnName2), columnType2)

--- a/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -47,6 +47,7 @@ import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
+import io.confluent.ksql.util.SchemaUtil;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import java.util.Arrays;
 import java.util.Collections;
@@ -152,7 +153,6 @@ public class PhysicalPlanBuilderTest {
 
     // Then:
     assertThat(queryMetadata.getLogicalSchema(), is(LogicalSchema.builder()
-        .noImplicitColumns()
         .valueColumn(ColumnName.of("COL0"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("COL2"), SqlTypes.DOUBLE)
         .build()
@@ -167,6 +167,8 @@ public class PhysicalPlanBuilderTest {
 
     // Then:
     assertThat(queryMetadata.getLogicalSchema(), is(LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("COL0"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("COL2"), SqlTypes.DOUBLE)
         .build()

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -43,6 +43,7 @@ import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.serde.avro.AvroFormat;
 import io.confluent.ksql.structured.SchemaKStream;
+import io.confluent.ksql.util.SchemaUtil;
 import java.util.Optional;
 import java.util.OptionalInt;
 import org.junit.Before;
@@ -65,6 +66,8 @@ public class KsqlStructuredDataOutputNodeTest {
   private static final String SINK_KAFKA_TOPIC_NAME = "output_kafka";
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("field1"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("field2"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("field3"), SqlTypes.STRING)
@@ -214,10 +217,6 @@ public class KsqlStructuredDataOutputNodeTest {
 
   private void givenInsertIntoNode() {
     this.createInto = false;
-    buildNode();
-  }
-
-  private void givenNodePartitioningByKey(final String field) {
     buildNode();
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/ProjectNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/ProjectNodeTest.java
@@ -36,6 +36,7 @@ import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.structured.SchemaKStream;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.SchemaUtil;
 import java.util.List;
 import java.util.Optional;
 import org.junit.Before;
@@ -54,6 +55,8 @@ public class ProjectNodeTest {
   private static final SelectExpression SELECT_1 = SelectExpression.of(ColumnName.of("col1"), FALSE_EXPRESSION);
   private static final String KEY_FIELD_NAME = "col0";
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("col0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("col1"), SqlTypes.STRING)
       .build();

--- a/ksql-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
@@ -48,6 +48,7 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
+import io.confluent.ksql.util.SchemaUtil;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import java.util.Collections;
 import java.util.List;
@@ -89,10 +90,14 @@ public class QueryExecutorTest {
   private static final String STORE_NAME = "store";
   private static final String SUMMARY = "summary";
   private static final Map<String, Object> OVERRIDES = Collections.emptyMap();
+
   private static final LogicalSchema SINK_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("col0"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("col1"), SqlTypes.STRING)
       .build();
+
   private static final KeyFormat KEY_FORMAT = KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.JSON.name()));
   private static final PhysicalSchema SINK_PHYSICAL_SCHEMA = PhysicalSchema.from(
       SINK_SCHEMA,

--- a/ksql-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorTest.java
@@ -50,6 +50,7 @@ import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlStatementException;
+import io.confluent.ksql.util.SchemaUtil;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -81,6 +82,8 @@ public class DefaultSchemaInjectorTest {
   private static final String SQL_TEXT = "Some SQL";
 
   private static final List<? extends SimpleColumn> SUPPORTED_SCHEMAS = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("intField"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("bigIntField"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("doubleField"), SqlTypes.DOUBLE)

--- a/ksql-engine/src/test/java/io/confluent/ksql/security/KsqlAuthorizationValidatorImplTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/security/KsqlAuthorizationValidatorImplTest.java
@@ -37,6 +37,7 @@ import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.util.SchemaUtil;
 import java.util.Collections;
 import java.util.Optional;
 import org.apache.kafka.common.acl.AclOperation;
@@ -53,6 +54,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class KsqlAuthorizationValidatorImplTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("F1"), SqlTypes.STRING)
       .build();
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/serde/SerdeOptionsTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/serde/SerdeOptionsTest.java
@@ -26,6 +26,7 @@ import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.SchemaUtil;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -41,10 +42,14 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class SerdeOptionsTest {
 
   private static final LogicalSchema SINGLE_FIELD_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("f0"), SqlTypes.BIGINT)
       .build();
 
   private static final LogicalSchema MULTI_FIELD_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("f0"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("f1"), SqlTypes.DOUBLE)
       .build();

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedStreamTest.java
@@ -44,6 +44,7 @@ import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.serde.WindowInfo;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.SchemaUtil;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -56,21 +57,30 @@ import org.mockito.junit.MockitoJUnitRunner;
 @SuppressWarnings("unchecked")
 @RunWith(MockitoJUnitRunner.class)
 public class SchemaKGroupedStreamTest {
+
   private static final LogicalSchema IN_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("IN0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("IN1"), SqlTypes.INTEGER)
       .build();
+
   private static final LogicalSchema OUT_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("IN0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("KSQL_AGG_VARIABLE_0"), SqlTypes.INTEGER)
       .build();
+
   private static final FunctionCall AGG = new FunctionCall(
       FunctionName.of("SUM"),
       ImmutableList.of(new UnqualifiedColumnReferenceExp(ColumnName.of("IN1")))
   );
+
   private static final KsqlWindowExpression KSQL_WINDOW_EXP = new SessionWindowExpression(
       100, TimeUnit.SECONDS
   );
+
   private static final List<ColumnName> NON_AGGREGATE_COLUMNS = ImmutableList.of(
       ColumnName.of("IN0")
   );

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
@@ -40,6 +40,7 @@ import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.SchemaUtil;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -52,18 +53,26 @@ import org.mockito.junit.MockitoJUnitRunner;
 @SuppressWarnings("unchecked")
 @RunWith(MockitoJUnitRunner.class)
 public class SchemaKGroupedTableTest {
+
   private static final LogicalSchema IN_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("IN0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("IN1"), SqlTypes.INTEGER)
       .build();
+
   private static final LogicalSchema OUT_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("IN0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("KSQL_AGG_VARIABLE_0"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("KSQL_AGG_VARIABLE_1"), SqlTypes.BIGINT)
       .build();
+
   private static final List<ColumnName> NON_AGG_COLUMNS = ImmutableList.of(
       ColumnName.of("IN0")
   );
+
   private static final FunctionCall MIN = udaf("MIN");
   private static final FunctionCall MAX = udaf("MAX");
   private static final FunctionCall SUM = udaf("SUM");

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKSourceFactoryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKSourceFactoryTest.java
@@ -38,7 +38,6 @@ import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.name.ColumnName;
-import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.FormatInfo;
@@ -47,6 +46,7 @@ import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.serde.WindowInfo;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.SchemaUtil;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.Before;
@@ -57,14 +57,19 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SchemaKSourceFactoryTest {
+
   private static final KeyField KEY_FIELD = KeyField.none();
-  private static final SourceName ALIAS = SourceName.of("bob");
+
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("FOO"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("BAR"), SqlTypes.STRING)
       .build();
+
   private static final Set<SerdeOption> SERDE_OPTIONS = ImmutableSet
       .of(SerdeOption.UNWRAP_SINGLE_VALUES);
+
   private static final String TOPIC_NAME = "fred";
   private static final KsqlConfig CONFIG = new KsqlConfig(ImmutableMap.of());
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/SourceTopicsExtractorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/SourceTopicsExtractorTest.java
@@ -41,6 +41,7 @@ import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.SchemaUtil;
 import java.util.Optional;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.junit.After;
@@ -56,6 +57,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class SourceTopicsExtractorTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("F1"), SqlTypes.STRING)
       .build();
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
@@ -52,6 +52,7 @@ import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.SchemaUtil;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -72,6 +73,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class TopicCreateInjectorTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("F1"), SqlTypes.STRING)
       .build();
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/AvroUtilTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/AvroUtilTest.java
@@ -94,6 +94,8 @@ public class AvroUtilTest {
       toKsqlSchema(SINGLE_FIELD_AVRO_SCHEMA_STRING);
 
   private static final LogicalSchema SCHEMA_WITH_MAPS = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("notmap"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("mapcol"), SqlTypes.map(SqlTypes.INTEGER))
       .build();
@@ -304,7 +306,10 @@ public class AvroUtilTest {
     final ConnectToSqlTypeConverter converter = SchemaConverters
         .connectToSqlConverter();
 
-    final Builder builder = LogicalSchema.builder();
+    final Builder builder = LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING);
+
     connectSchema.fields()
         .forEach(f -> builder.valueColumn(ColumnName.of(f.name()), converter.toSqlType(f.schema())));
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/ItemDataProvider.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/ItemDataProvider.java
@@ -29,6 +29,7 @@ import java.util.Map;
 public class ItemDataProvider extends TestDataProvider<String> {
 
   private static final LogicalSchema LOGICAL_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("ID"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("DESCRIPTION"), SqlTypes.STRING)

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/OrderDataProvider.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/OrderDataProvider.java
@@ -30,6 +30,7 @@ import java.util.Map;
 public class OrderDataProvider extends TestDataProvider<Long> {
 
   private static final LogicalSchema LOGICAL_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("ORDERTIME"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("ORDERID"), SqlTypes.STRING)

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/PageViewDataProvider.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/PageViewDataProvider.java
@@ -28,6 +28,7 @@ import java.util.Map;
 public class PageViewDataProvider extends TestDataProvider<Long> {
 
   private static final LogicalSchema LOGICAL_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("VIEWTIME"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("USERID"), SqlTypes.STRING)

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/PlanSummaryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/PlanSummaryTest.java
@@ -42,8 +42,12 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PlanSummaryTest {
+
   private static final QueryId QUERY_ID = new QueryId("QID");
+
   private static final LogicalSchema SOURCE_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("L0"), SqlTypes.INTEGER)
       .build();
 
@@ -74,8 +78,11 @@ public class PlanSummaryTest {
   public void shouldSummarizeWithSource() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("L1"), SqlTypes.STRING)
         .build();
+
     final ExecutionStep<?> step = givenStep(StreamSelect.class, "child", schema, sourceStep);
 
     // When:
@@ -92,11 +99,17 @@ public class PlanSummaryTest {
   public void shouldSummarizePlanWithMultipleSources() {
     // Given:
     final LogicalSchema sourceSchema2 = LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("L0_2"), SqlTypes.STRING)
         .build();
+
     final LogicalSchema schema = LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("L1"), SqlTypes.STRING)
         .build();
+
     final ExecutionStep<?> sourceStep2 = givenStep(StreamSource.class, "src2", sourceSchema2);
     final ExecutionStep<?> step =
         givenStep(StreamStreamJoin.class, "child", schema, sourceStep, sourceStep2);

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
@@ -48,8 +48,11 @@ public class QueryMetadataTest {
 
   private static final String QUERY_APPLICATION_ID = "Query1";
   private static final LogicalSchema SOME_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("f0"), SqlTypes.STRING)
       .build();
+
   private static final Set<SourceName> SOME_SOURCES = ImmutableSet.of(SourceName.of("s1"), SourceName.of("s2"));
   private static final Long closeTimeout = KsqlConfig.KSQL_SHUTDOWN_TIMEOUT_MS_DEFAULT;
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/UserDataProvider.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/UserDataProvider.java
@@ -28,6 +28,8 @@ import java.util.Map;
 public class UserDataProvider extends TestDataProvider<String> {
 
   private static final LogicalSchema LOGICAL_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("REGISTERTIME"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("GENDER"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("REGIONID"), SqlTypes.STRING)

--- a/ksql-examples/src/main/java/io/confluent/ksql/datagen/RowGenerator.java
+++ b/ksql-examples/src/main/java/io/confluent/ksql/datagen/RowGenerator.java
@@ -277,7 +277,9 @@ public class RowGenerator {
       throw new IllegalArgumentException("key field does not exist in schema: " + keyFieldName);
     }
 
-    final Builder schemaBuilder = LogicalSchema.builder();
+    final Builder schemaBuilder = LogicalSchema.builder()
+        .withRowTime();
+
     final ConnectToSqlTypeConverter converter = SchemaConverters.connectToSqlConverter();
 
     schemaBuilder

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/transform/select/Selection.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/transform/select/Selection.java
@@ -51,7 +51,8 @@ public final class Selection<K> {
       final LogicalSchema sourceSchema,
       final SelectValueMapper<?> mapper
   ) {
-    final LogicalSchema.Builder schemaBuilder = LogicalSchema.builder();
+    final LogicalSchema.Builder schemaBuilder = LogicalSchema.builder()
+        .withRowTime();
 
     final List<Column> keyCols = sourceSchema.key();
 

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/builder/KsqlQueryBuilderTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/builder/KsqlQueryBuilderTest.java
@@ -46,6 +46,7 @@ import io.confluent.ksql.serde.WindowInfo;
 import io.confluent.ksql.serde.avro.AvroFormat;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.SchemaUtil;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -65,6 +66,8 @@ public class KsqlQueryBuilderTest {
 
   private static final PhysicalSchema SOME_SCHEMA = PhysicalSchema.from(
       LogicalSchema.builder()
+          .withRowTime()
+          .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
           .valueColumn(ColumnName.of("f0"), SqlTypes.BOOLEAN)
           .build(),
       SerdeOption.none()

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/ddl/commands/CreateSourceCommandTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/ddl/commands/CreateSourceCommandTest.java
@@ -48,8 +48,11 @@ public class CreateSourceCommandTest {
   public void shouldThrowOnMultipleKeyColumns() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .keyColumn(K0, SqlTypes.STRING)
         .keyColumn(K1, SqlTypes.STRING)
+        .valueColumn(ColumnName.of("V0"), SqlTypes.STRING)
         .build();
 
     // When:

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/function/UdafUtilTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/function/UdafUtilTest.java
@@ -32,6 +32,7 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.util.SchemaUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,10 +43,14 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UdafUtilTest {
+
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("FOO"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("BAR"), SqlTypes.BIGINT)
       .build();
+
   private static final FunctionCall FUNCTION_CALL = new FunctionCall(
       FunctionName.of("AGG"),
       ImmutableList.of(new UnqualifiedColumnReferenceExp(ColumnName.of("BAR")))

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/testutil/TestExpressions.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/testutil/TestExpressions.java
@@ -7,6 +7,7 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlStruct;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.util.SchemaUtil;
 
 public final class TestExpressions {
 
@@ -22,6 +23,8 @@ public final class TestExpressions {
       .build();
 
   public final static LogicalSchema SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("COL0"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("COL1"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("COL2"), SqlTypes.STRING)

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/transform/select/SelectionTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/transform/select/SelectionTest.java
@@ -45,6 +45,8 @@ import org.mockito.junit.MockitoRule;
 
 public class SelectionTest {
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(ColumnName.of("K0"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("GIRAFFE"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("MANATEE"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("RACCOON"), SqlTypes.BIGINT)
@@ -113,7 +115,8 @@ public class SelectionTest {
 
     // Then:
     final LogicalSchema expected = new LogicalSchema.Builder()
-        .keyColumn(ColumnName.of("ROWKEY"), SqlTypes.STRING)
+        .withRowTime()
+        .keyColumn(ColumnName.of("K0"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("FOO"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("BAR"), SqlTypes.BIGINT)
         .build();

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/transform/sqlpredicate/SqlPredicateTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/transform/sqlpredicate/SqlPredicateTest.java
@@ -65,7 +65,6 @@ public class SqlPredicateTest {
   private static final KsqlConfig KSQL_CONFIG = new KsqlConfig(Collections.emptyMap());
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .noImplicitColumns()
       .keyColumn(ColumnName.of("ID"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("COL0"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("COL1"), SqlTypes.DOUBLE)

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
@@ -74,6 +74,7 @@ import io.confluent.ksql.schema.ksql.types.SqlStruct;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.SchemaUtil;
 import java.util.Optional;
 import org.junit.Before;
 import org.junit.Rule;
@@ -479,6 +480,8 @@ public class ExpressionTypeManagerTest {
   public void shouldEvaluateTypeForStructExpression() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(COL0, SqlTypes.array(SqlTypes.INTEGER))
         .build();
 
@@ -508,6 +511,8 @@ public class ExpressionTypeManagerTest {
     final SqlStruct inner = SqlTypes.struct().field("IN0", SqlTypes.INTEGER).build();
 
     final LogicalSchema schema = LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(COL0, SqlTypes.array(inner))
         .build();
 
@@ -535,6 +540,8 @@ public class ExpressionTypeManagerTest {
         .build();
 
     final LogicalSchema schema = LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(COL0, inner)
         .build();
 

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/util/StructKeyUtilTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/util/StructKeyUtilTest.java
@@ -32,9 +32,11 @@ import org.junit.Test;
 public class StructKeyUtilTest {
 
   private static final LogicalSchema LOGICAL_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
       .keyColumn(ColumnName.of("BOB"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("DOES_NOT_MATTER"), SqlTypes.STRING)
       .build();
+
   private KeyBuilder builder;
 
   @Before
@@ -48,6 +50,7 @@ public class StructKeyUtilTest {
     StructKeyUtil.keyBuilder(LogicalSchema.builder()
         .keyColumn(ColumnName.of("BOB"), SqlTypes.STRING)
         .keyColumn(ColumnName.of("JOHN"), SqlTypes.STRING)
+        .valueColumn(ColumnName.of("V0"), SqlTypes.STRING)
         .build());
   }
 

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutorTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutorTest.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.test.rest.RestTestExecutor.RqttQueryResponse;
+import io.confluent.ksql.util.SchemaUtil;
 import java.math.BigDecimal;
 import org.junit.Rule;
 import org.junit.Test;
@@ -32,6 +33,8 @@ import org.junit.rules.ExpectedException;
 public class RestTestExecutorTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("col0"), SqlTypes.STRING)
       .build();
 

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorTest.java
@@ -46,6 +46,7 @@ import io.confluent.ksql.test.tools.conditions.PostConditions;
 import io.confluent.ksql.test.tools.stubs.StubKafkaRecord;
 import io.confluent.ksql.test.tools.stubs.StubKafkaService;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.SchemaUtil;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -70,6 +71,8 @@ public class TestExecutorTest {
   private static final String SINK_TOPIC_NAME = "sink_topic";
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("v0"), SqlTypes.INTEGER)
       .build();
 
@@ -313,6 +316,7 @@ public class TestExecutorTest {
     when(testCase.getOutputRecords()).thenReturn(ImmutableList.of(expected_0, expected_1));
 
     final LogicalSchema schema = LogicalSchema.builder()
+        .withRowTime()
         .keyColumn(ColumnName.of("key"), SqlTypes.INTEGER)
         .valueColumn(ColumnName.of("v0"), SqlTypes.STRING)
         .build();

--- a/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/KeyFieldTest.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/KeyFieldTest.java
@@ -34,6 +34,7 @@ import org.junit.rules.ExpectedException;
 public class KeyFieldTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .keyColumn(ColumnName.of("k"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("field0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("field1"), SqlTypes.BIGINT)
       .build();

--- a/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/MetaStoreModelTest.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/MetaStoreModelTest.java
@@ -37,6 +37,7 @@ import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.test.util.ClassFinder;
 import io.confluent.ksql.test.util.ImmutableTester;
+import io.confluent.ksql.util.SchemaUtil;
 import java.lang.reflect.Modifier;
 import java.util.Collection;
 import java.util.Optional;
@@ -67,6 +68,8 @@ public class MetaStoreModelTest {
       .put(Column.class, Column.of(ColumnName.of("someField"), SqlTypes.INTEGER, Namespace.VALUE, 1))
       .put(SqlType.class, SqlTypes.INTEGER)
       .put(LogicalSchema.class, LogicalSchema.builder()
+          .withRowTime()
+          .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
           .valueColumn(ColumnName.of("f0"), SqlTypes.BIGINT)
           .build())
       .put(KeyFormat.class, KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())))

--- a/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/StructuredDataSourceTest.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/StructuredDataSourceTest.java
@@ -35,6 +35,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class StructuredDataSourceTest {
 
   private static final LogicalSchema SOME_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("f0"), SqlTypes.BIGINT)
       .build();
 
@@ -57,6 +59,8 @@ public class StructuredDataSourceTest {
   public void shouldThrowIfSchemaContainsRowTime() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(SchemaUtil.ROWTIME_NAME, SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("f0"), SqlTypes.BIGINT)
         .build();
@@ -72,6 +76,8 @@ public class StructuredDataSourceTest {
   public void shouldThrowIfSchemaContainsRowKey() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("f0"), SqlTypes.BIGINT)
         .build();
@@ -87,6 +93,8 @@ public class StructuredDataSourceTest {
   public void shouldThrowIfSchemaContainsWindowStart() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(SchemaUtil.WINDOWSTART_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("f0"), SqlTypes.BIGINT)
         .build();
@@ -102,6 +110,8 @@ public class StructuredDataSourceTest {
   public void shouldThrowIfSchemaContainsWindowEnd() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(SchemaUtil.WINDOWEND_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("f0"), SqlTypes.BIGINT)
         .build();

--- a/ksql-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
@@ -52,6 +52,7 @@ public final class MetaStoreFixture {
     final KeyFormat keyFormat = KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name()));
 
     final LogicalSchema test1Schema = LogicalSchema.builder()
+        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("COL0"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("COL1"), SqlTypes.STRING)
@@ -101,6 +102,7 @@ public final class MetaStoreFixture {
     metaStore.putSource(ksqlStream1);
 
     final LogicalSchema test2Schema = LogicalSchema.builder()
+        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("COL0"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("COL1"), SqlTypes.STRING)
@@ -148,6 +150,7 @@ public final class MetaStoreFixture {
         .build();
 
     final LogicalSchema ordersSchema = LogicalSchema.builder()
+        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("ORDERTIME"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("ORDERID"), SqlTypes.BIGINT)
@@ -179,6 +182,7 @@ public final class MetaStoreFixture {
     metaStore.putSource(ksqlStreamOrders);
 
     final LogicalSchema testTable3 = LogicalSchema.builder()
+        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("COL0"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("COL1"), SqlTypes.STRING)
@@ -218,6 +222,8 @@ public final class MetaStoreFixture {
         .build();
 
     final LogicalSchema nestedArrayStructMapSchema = LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("ARRAYCOL"), SqlTypes.array(itemInfoSchema))
         .valueColumn(ColumnName.of("MAPCOL"), SqlTypes.map(itemInfoSchema))
         .valueColumn(ColumnName.of("NESTED_ORDER_COL"), nestedOrdersSchema)
@@ -262,9 +268,8 @@ public final class MetaStoreFixture {
 
     metaStore.putSource(ksqlStream4);
 
-
-
     final LogicalSchema sensorReadingsSchema = LogicalSchema.builder()
+        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("ID"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("SENSOR_NAME"), SqlTypes.STRING)

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/InsertInto.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/InsertInto.java
@@ -19,7 +19,6 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.NodeLocation;
 import io.confluent.ksql.parser.properties.with.CreateSourceAsProperties;
@@ -58,10 +57,6 @@ public class InsertInto
   @Override
   public Query getQuery() {
     return query;
-  }
-
-  public Optional<Expression> getPartitionByColumn() {
-    return query.getPartitionBy();
   }
 
   @Override

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
@@ -116,6 +116,8 @@ public class SqlFormatterTest {
       .build();
 
   private static final LogicalSchema TABLE_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(ColumnName.of("K0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("TABLE"), SqlTypes.STRING)
       .build();
 

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/json/LogicalSchemaDeserializerTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/json/LogicalSchemaDeserializerTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.util.SchemaUtil;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -45,7 +46,6 @@ public class LogicalSchemaDeserializerTest {
 
     // Then:
     assertThat(schema, is(LogicalSchema.builder()
-        .noImplicitColumns()
         .keyColumn(ColumnName.of("ROWKEY"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("v0"), SqlTypes.INTEGER)
         .build()));
@@ -61,7 +61,6 @@ public class LogicalSchemaDeserializerTest {
 
     // Then:
     assertThat(schema, is(LogicalSchema.builder()
-        .noImplicitColumns()
         .keyColumn(ColumnName.of("key"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("v0"), SqlTypes.INTEGER)
         .build()));
@@ -77,7 +76,6 @@ public class LogicalSchemaDeserializerTest {
 
     // Then:
     assertThat(schema, is(LogicalSchema.builder()
-        .noImplicitColumns()
         .valueColumn(ColumnName.of("v0"), SqlTypes.INTEGER)
         .keyColumn(ColumnName.of("key0"), SqlTypes.STRING)
         .build()));
@@ -95,6 +93,8 @@ public class LogicalSchemaDeserializerTest {
 
     // Then:
     assertThat(schema, is(LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("v0"), SqlTypes.INTEGER)
         .build()));
   }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/TableElementsTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/TableElementsTest.java
@@ -216,6 +216,7 @@ public class TableElementsTest {
 
     // Then:
     assertThat(schema, is(LogicalSchema.builder()
+        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("v0"), SqlTypes.INTEGER)
         .build()
@@ -234,7 +235,6 @@ public class TableElementsTest {
 
     // Then:
     assertThat(schema, is(LogicalSchema.builder()
-        .noImplicitColumns()
         .valueColumn(ColumnName.of("v0"), SqlTypes.INTEGER)
         .build()
     ));
@@ -255,7 +255,6 @@ public class TableElementsTest {
 
     // Then:
     assertThat(schema, is(LogicalSchema.builder()
-        .noImplicitColumns()
         .valueColumn(ColumnName.of("v0"), SqlTypes.INTEGER)
         .keyColumn(ColumnName.of("k0"), SqlTypes.INTEGER)
         .valueColumn(ColumnName.of("v1"), SqlTypes.STRING)

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/TableRowsEntityFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/TableRowsEntityFactory.java
@@ -47,7 +47,6 @@ public final class TableRowsEntityFactory {
       final boolean windowed
   ) {
     final Builder builder = LogicalSchema.builder()
-        .noImplicitColumns()
         .keyColumns(schema.key());
 
     if (windowed) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PullQueryExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PullQueryExecutor.java
@@ -845,14 +845,13 @@ public final class PullQueryExecutor {
     }
   }
 
-  private LogicalSchema selectOutputSchema(
+  private static LogicalSchema selectOutputSchema(
       final Result input,
       final KsqlExecutionContext executionContext,
       final ImmutableAnalysis analysis,
       final Optional<WindowType> windowType
   ) {
-    final Builder schemaBuilder = LogicalSchema.builder()
-        .noImplicitColumns();
+    final Builder schemaBuilder = LogicalSchema.builder();
 
     // Copy meta & key columns into the value schema as SelectValueMapper expects it:
     final LogicalSchema schema = input.schema

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriter.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriter.java
@@ -115,8 +115,7 @@ class QueryStreamWriter implements StreamingOutput {
     // Push queries only return value columns, but query metadata schema includes key and meta:
     final LogicalSchema storedSchema = queryMetadata.getLogicalSchema();
 
-    final Builder actualSchemaBuilder = LogicalSchema.builder()
-        .noImplicitColumns();
+    final Builder actualSchemaBuilder = LogicalSchema.builder();
 
     storedSchema.value().forEach(actualSchemaBuilder::valueColumn);
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
@@ -61,12 +61,13 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class QueryDescriptionFactoryTest {
 
   private static final LogicalSchema TRANSIENT_SCHEMA = LogicalSchema.builder()
-      .noImplicitColumns()
       .valueColumn(ColumnName.of("field1"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("field2"), SqlTypes.STRING)
       .build();
 
   private static final LogicalSchema PERSISTENT_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("field1"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("field2"), SqlTypes.STRING)
       .build();
@@ -191,7 +192,7 @@ public class QueryDescriptionFactoryTest {
   public void shouldExposeAllFieldsForPersistentQueries() {
     assertThat(persistentQueryDescription.getFields(), contains(
         new FieldInfo("ROWTIME", new SchemaInfo(SqlBaseType.BIGINT, null, null)),
-        new FieldInfo("ROWKEY", new SchemaInfo(SqlBaseType.STRING, null, null)),
+        new FieldInfo("k0", new SchemaInfo(SqlBaseType.STRING, null, null)),
         new FieldInfo("field1", new SchemaInfo(SqlBaseType.INTEGER, null, null)),
         new FieldInfo("field2", new SchemaInfo(SqlBaseType.STRING, null, null))));
   }
@@ -210,7 +211,6 @@ public class QueryDescriptionFactoryTest {
   public void shouldHandleRowTimeInValueSchemaForTransientQuery() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .noImplicitColumns()
         .valueColumn(ColumnName.of("field1"), SqlTypes.INTEGER)
         .valueColumn(ColumnName.of("ROWTIME"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("field2"), SqlTypes.STRING)
@@ -244,7 +244,6 @@ public class QueryDescriptionFactoryTest {
   public void shouldHandleRowKeyInValueSchemaForTransientQuery() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .noImplicitColumns()
         .valueColumn(ColumnName.of("field1"), SqlTypes.INTEGER)
         .valueColumn(ColumnName.of("ROWKEY"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("field2"), SqlTypes.STRING)

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionFactoryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionFactoryTest.java
@@ -36,6 +36,7 @@ import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.ValueFormat;
+import io.confluent.ksql.util.SchemaUtil;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
@@ -71,6 +72,8 @@ public class SourceDescriptionFactoryTest {
       final String kafkaTopicName,
       final Optional<TimestampColumn> timestampColumn) {
     final LogicalSchema schema = LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("field0"), SqlTypes.INTEGER)
         .build();
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/TableRowsEntityFactoryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/TableRowsEntityFactoryTest.java
@@ -44,10 +44,13 @@ public class TableRowsEntityFactoryTest {
   private static final KeyBuilder STRING_KEY_BUILDER = StructKeyUtil.keyBuilder(SqlTypes.STRING);
 
   private static final LogicalSchema SIMPLE_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("v0"), SqlTypes.BOOLEAN)
       .build();
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .withRowTime()
       .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
       .keyColumn(ColumnName.of("k1"), SqlTypes.BOOLEAN)
       .valueColumn(ColumnName.of("v0"), SqlTypes.INTEGER)
@@ -55,6 +58,7 @@ public class TableRowsEntityFactoryTest {
       .build();
 
   private static final LogicalSchema SCHEMA_NULL = LogicalSchema.builder()
+      .withRowTime()
       .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("v0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("v1"), SqlTypes.INTEGER)
@@ -140,7 +144,6 @@ public class TableRowsEntityFactoryTest {
 
     // Then:
     assertThat(result, is(LogicalSchema.builder()
-        .noImplicitColumns()
         .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
         .keyColumn(ColumnName.of("k1"), SqlTypes.BOOLEAN)
         .valueColumn(SchemaUtil.ROWTIME_NAME, SqlTypes.BIGINT)
@@ -157,7 +160,6 @@ public class TableRowsEntityFactoryTest {
 
     // Then:
     assertThat(result, is(LogicalSchema.builder()
-        .noImplicitColumns()
         .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
         .keyColumn(ColumnName.of("k1"), SqlTypes.BOOLEAN)
         .keyColumn(ColumnName.of("WINDOWSTART"), SqlTypes.BIGINT)

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/KsqlResourceFunctionalTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/KsqlResourceFunctionalTest.java
@@ -42,6 +42,7 @@ import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.avro.AvroSchemas;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.PageViewDataProvider;
+import io.confluent.ksql.util.SchemaUtil;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import kafka.zookeeper.ZooKeeperClientException;
@@ -153,6 +154,8 @@ public class KsqlResourceFunctionalTest {
     // Given:
     final PhysicalSchema schema = PhysicalSchema.from(
         LogicalSchema.builder()
+            .withRowTime()
+            .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
             .valueColumn(ColumnName.of("AUTHOR"), SqlTypes.STRING)
             .valueColumn(ColumnName.of("TITLE"), SqlTypes.STRING)
             .build(),

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryFunctionalTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryFunctionalTest.java
@@ -39,6 +39,7 @@ import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.test.util.KsqlIdentifierTestUtil;
 import io.confluent.ksql.test.util.TestBasicJaasConfig;
+import io.confluent.ksql.util.SchemaUtil;
 import io.confluent.ksql.util.UserDataProvider;
 import io.confluent.rest.RestConfig;
 import java.io.IOException;
@@ -102,6 +103,8 @@ public class PullQueryFunctionalTest {
 
   private static final PhysicalSchema AGGREGATE_SCHEMA = PhysicalSchema.from(
       LogicalSchema.builder()
+          .withRowTime()
+          .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
           .valueColumn(ColumnName.of("COUNT"), SqlTypes.BIGINT)
           .build(),
       SerdeOption.none()

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
@@ -54,6 +54,7 @@ import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.test.util.KsqlIdentifierTestUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.Pair;
+import io.confluent.ksql.util.SchemaUtil;
 import io.confluent.ksql.util.UserDataProvider;
 import java.io.IOException;
 import java.util.List;
@@ -124,6 +125,8 @@ public class PullQueryRoutingFunctionalTest {
 
   private static final PhysicalSchema AGGREGATE_SCHEMA = PhysicalSchema.from(
       LogicalSchema.builder()
+          .withRowTime()
+          .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
           .valueColumn(ColumnName.of("COUNT"), SqlTypes.BIGINT)
           .build(),
       SerdeOption.none()

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -415,7 +415,7 @@ public class RestApiTest {
           }
       );
     } catch (final Exception e) {
-      throw new AssertionError("Invalid JSON received: " + response);
+      throw new AssertionError("Invalid JSON received: " + response, e);
     }
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorFunctionalTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorFunctionalTest.java
@@ -35,6 +35,7 @@ import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.OrderDataProvider;
+import io.confluent.ksql.util.SchemaUtil;
 import io.confluent.ksql.version.metrics.VersionCheckerAgent;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -152,6 +153,8 @@ public class StandaloneExecutorFunctionalTest {
 
     final PhysicalSchema dataSchema = PhysicalSchema.from(
         LogicalSchema.builder()
+            .withRowTime()
+            .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
             .valueColumn(ColumnName.of("ORDERTIME"), SqlTypes.BIGINT)
             .build(),
         SerdeOption.none()
@@ -193,6 +196,8 @@ public class StandaloneExecutorFunctionalTest {
 
     final PhysicalSchema dataSchema = PhysicalSchema.from(
         LogicalSchema.builder()
+            .withRowTime()
+            .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
             .valueColumn(ColumnName.of("ORDERTIME"), SqlTypes.BIGINT)
             .build(),
         SerdeOption.none()
@@ -292,6 +297,8 @@ public class StandaloneExecutorFunctionalTest {
 
   private static void givenIncompatibleSchemaExists(final String topicName) {
     final LogicalSchema logical = LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("ORDERID"), SqlTypes.struct()
             .field("fred", SqlTypes.INTEGER)
             .build())

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
@@ -50,6 +50,7 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.TestServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.SchemaUtil;
 import io.confluent.rest.RestConfig;
 import java.util.Collections;
 import java.util.HashMap;
@@ -61,6 +62,8 @@ import org.junit.rules.ExternalResource;
 public class TemporaryEngine extends ExternalResource {
 
   public static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("val"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("val2"), SqlTypes.decimal(2, 1))
       .valueColumn(ColumnName.of("ADDRESS"), SqlTypes.struct()

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutorTest.java
@@ -38,13 +38,14 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.DescribeConnector;
+import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.ConnectorDescription;
 import io.confluent.ksql.rest.entity.ErrorEntity;
 import io.confluent.ksql.rest.entity.KsqlEntity;
-import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SqlBaseType;
 import io.confluent.ksql.schema.ksql.types.SqlPrimitiveType;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
@@ -54,6 +55,7 @@ import io.confluent.ksql.services.ConnectClient.ConnectResponse;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.SchemaUtil;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -135,6 +137,8 @@ public class DescribeConnectorExecutorTest {
     );
     when(source.getSchema()).thenReturn(
         LogicalSchema.builder()
+            .withRowTime()
+            .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
             .valueColumn(ColumnName.of("foo"), SqlPrimitiveType.of( SqlBaseType.STRING))
             .build());
     when(source.getDataSourceType()).thenReturn(DataSourceType.KTABLE);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -151,6 +151,7 @@ import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.Sandbox;
+import io.confluent.ksql.util.SchemaUtil;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import io.confluent.ksql.version.metrics.ActivenessRegistrar;
 import io.confluent.rest.RestConfig;
@@ -202,7 +203,10 @@ public class KsqlResourceTest {
       ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"),
       emptyMap(),
       0L);
+
   private static final LogicalSchema SINGLE_FIELD_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("val"), SqlTypes.STRING)
       .build();
 
@@ -244,6 +248,8 @@ public class KsqlResourceTest {
   );
 
   private static final LogicalSchema SOME_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("f1"), SqlTypes.STRING)
       .build();
 
@@ -461,6 +467,8 @@ public class KsqlResourceTest {
   public void shouldShowStreamsExtended() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("FIELD1"), SqlTypes.BOOLEAN)
         .valueColumn(ColumnName.of("FIELD2"), SqlTypes.STRING)
         .build();
@@ -490,6 +498,8 @@ public class KsqlResourceTest {
   public void shouldShowTablesExtended() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("FIELD1"), SqlTypes.BOOLEAN)
         .valueColumn(ColumnName.of("FIELD2"), SqlTypes.STRING)
         .build();
@@ -2135,6 +2145,8 @@ public class KsqlResourceTest {
 
   private void addTestTopicAndSources() {
     final LogicalSchema schema1 = LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("S1_F1"), SqlTypes.BOOLEAN)
         .build();
 
@@ -2143,6 +2155,8 @@ public class KsqlResourceTest {
         "TEST_TABLE", "KAFKA_TOPIC_1", schema1);
 
     final LogicalSchema schema2 = LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("S2_F1"), SqlTypes.STRING)
         .build();
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisherTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisherTest.java
@@ -50,7 +50,6 @@ import org.mockito.stubbing.Answer;
 public class PullQueryPublisherTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .noImplicitColumns()
       .keyColumn(ColumnName.of("id"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("bob"), SqlTypes.BIGINT)
       .build();

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriterTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriterTest.java
@@ -37,6 +37,7 @@ import io.confluent.ksql.query.LimitHandler;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.SchemaUtil;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
@@ -93,6 +94,8 @@ public class QueryStreamWriterTest {
     limitHandlerCapture = newCapture();
 
     final LogicalSchema schema = LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("col1"), SqlTypes.STRING)
         .build();
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -112,8 +112,8 @@ public class StreamedQueryResourceTest {
 
   private static final Duration DISCONNECT_CHECK_INTERVAL = Duration.ofMillis(1000);
   private static final Duration COMMAND_QUEUE_CATCHUP_TIMOEUT = Duration.ofMillis(1000);
+
   private static final LogicalSchema SOME_SCHEMA = LogicalSchema.builder()
-      .noImplicitColumns()
       .valueColumn(ColumnName.of("f1"), SqlTypes.INTEGER)
       .build();
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriberTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriberTest.java
@@ -27,6 +27,7 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.rest.server.resources.streaming.Flow.Subscription;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.util.SchemaUtil;
 import java.io.IOException;
 import java.util.Map;
 import javax.websocket.CloseReason;
@@ -121,6 +122,8 @@ public class WebSocketSubscriberTest {
     EasyMock.replay(subscription, session, basic);
 
     subscriber.onSchema(LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("currency"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("amount"), SqlTypes.DOUBLE)
         .build());

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/EntityUtilTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/EntityUtilTest.java
@@ -60,7 +60,6 @@ public class EntityUtilTest {
   public void shouldBuildCorrectMapField() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .noImplicitColumns()
         .valueColumn(ColumnName.of("field"), SqlTypes.map(SqlTypes.INTEGER))
         .build();
 
@@ -80,7 +79,6 @@ public class EntityUtilTest {
   public void shouldBuildCorrectArrayField() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .noImplicitColumns()
         .valueColumn(ColumnName.of("field"), SqlTypes.array(SqlTypes.BIGINT))
         .build();
 
@@ -100,7 +98,6 @@ public class EntityUtilTest {
   public void shouldBuildCorrectStructField() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .noImplicitColumns()
         .valueColumn(ColumnName.of("field"), SqlTypes.struct()
             .field("innerField", SqlTypes.STRING)
             .build())
@@ -123,7 +120,6 @@ public class EntityUtilTest {
   public void shouldBuildMiltipleFieldsCorrectly() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .noImplicitColumns()
         .valueColumn(ColumnName.of("field1"), SqlTypes.INTEGER)
         .valueColumn(ColumnName.of("field2"), SqlTypes.BIGINT)
         .build();
@@ -143,7 +139,6 @@ public class EntityUtilTest {
   public void shouldSupportRowTimeAndKeyInValueSchema() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .noImplicitColumns()
         .valueColumn(ColumnName.of("ROWKEY"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("ROWTIME"), SqlTypes.INTEGER)
         .valueColumn(ColumnName.of("field1"), SqlTypes.INTEGER)
@@ -162,13 +157,14 @@ public class EntityUtilTest {
   public void shouldSupportSchemasWithMetaColumns() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
+        .withRowTime()
         .build();
 
     // When:
     final List<FieldInfo> fields = EntityUtil.buildSourceSchemaEntity(schema);
 
     // Then:
-    assertThat(fields, hasSize(2));
+    assertThat(fields, hasSize(1));
     assertThat(fields.get(0).getName(), equalTo("ROWTIME"));
     assertThat(fields.get(0).getSchema().getTypeName(), equalTo("BIGINT"));
   }
@@ -177,7 +173,6 @@ public class EntityUtilTest {
   public void shouldSupportSchemasWithKeyColumns() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .noImplicitColumns()
         .keyColumn(ColumnName.of("field1"), SqlTypes.INTEGER)
         .build();
 
@@ -194,7 +189,6 @@ public class EntityUtilTest {
   public void shouldMaintainColumnOrder() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .noImplicitColumns()
         .valueColumn(ColumnName.of("field0"), SqlTypes.DOUBLE)
         .keyColumn(ColumnName.of("field1"), SqlTypes.INTEGER)
         .build();
@@ -216,7 +210,6 @@ public class EntityUtilTest {
   ) {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .noImplicitColumns()
         .valueColumn(ColumnName.of("field"), primitiveSchema)
         .build();
 

--- a/ksql-rest-client/src/test/java/io/confluent/ksql/rest/entity/TableRowsEntityTest.java
+++ b/ksql-rest-client/src/test/java/io/confluent/ksql/rest/entity/TableRowsEntityTest.java
@@ -24,8 +24,8 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.json.KsqlTypesSerializationModule;
 import io.confluent.ksql.name.ColumnName;
-import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.parser.json.KsqlTypesDeserializationModule;
+import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.util.Arrays;
@@ -38,7 +38,6 @@ public class TableRowsEntityTest {
   private static final String SOME_SQL = "some SQL";
 
   private static final LogicalSchema LOGICAL_SCHEMA = LogicalSchema.builder()
-      .noImplicitColumns()
       .keyColumn(ColumnName.of("ROWKEY"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("v0"), SqlTypes.DOUBLE)
       .valueColumn(ColumnName.of("v1"), SqlTypes.STRING)

--- a/ksql-serde/src/test/java/io/confluent/ksql/schema/ksql/PhysicalSchemaTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/schema/ksql/PhysicalSchemaTest.java
@@ -25,6 +25,7 @@ import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.test.util.ImmutableTester;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.SchemaUtil;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -32,11 +33,15 @@ import org.junit.rules.ExpectedException;
 public class PhysicalSchemaTest {
 
   private static final LogicalSchema SCHEMA_WITH_MULTIPLE_FIELDS = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("f0"), SqlTypes.BOOLEAN)
       .valueColumn(ColumnName.of("f1"), SqlTypes.BOOLEAN)
       .build();
 
   private static final LogicalSchema SCHEMA_WITH_SINGLE_FIELD = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("f0"), SqlTypes.BOOLEAN)
       .build();
 

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/kafka/KafkaSerdeFactoryTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/kafka/KafkaSerdeFactoryTest.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.SchemaUtil;
 import java.util.function.Supplier;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.connect.data.Struct;
@@ -61,6 +62,8 @@ public class KafkaSerdeFactoryTest {
   public void shouldThrowOnValidateIfMultipleFields() {
     // Given:
     final PersistenceSchema schema = getPersistenceSchema(LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("f0"), SqlTypes.INTEGER)
         .valueColumn(ColumnName.of("f1"), SqlTypes.BIGINT)
         .build());
@@ -221,6 +224,8 @@ public class KafkaSerdeFactoryTest {
 
   private static PersistenceSchema schemaWithFieldOfType(final SqlType fieldSchema) {
     final LogicalSchema logical = LogicalSchema.builder()
+        .withRowTime()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("f0"), fieldSchema)
         .build();
 

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/AggregateParamsFactory.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/AggregateParamsFactory.java
@@ -151,7 +151,8 @@ public class AggregateParamsFactory {
       final boolean useAggregate,
       final boolean addWindowBounds
   ) {
-    final LogicalSchema.Builder schemaBuilder = LogicalSchema.builder();
+    final LogicalSchema.Builder schemaBuilder = LogicalSchema.builder()
+        .withRowTime();
 
     schemaBuilder.keyColumns(schema.key());
 

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/GroupByParamsFactory.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/GroupByParamsFactory.java
@@ -85,6 +85,7 @@ final class GroupByParamsFactory {
       final SqlType rowKeyType
   ) {
     return LogicalSchema.builder()
+        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, rowKeyType)
         .valueColumns(sourceSchema.value())
         .build();

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/JoinParamsFactory.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/JoinParamsFactory.java
@@ -40,6 +40,7 @@ public final class JoinParamsFactory {
     throwOnKeyMismatch(leftSchema, rightSchema);
 
     return LogicalSchema.builder()
+        .withRowTime()
         .keyColumns(leftSchema.key())
         .valueColumns(leftSchema.value())
         .valueColumns(rightSchema.value())

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StepSchemaResolver.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StepSchemaResolver.java
@@ -218,6 +218,7 @@ public final class StepSchemaResolver {
         .getExpressionSqlType(step.getKeyExpression());
 
     return LogicalSchema.builder()
+        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, keyType)
         .valueColumns(sourceSchema.value())
         .build();

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFlatMapBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFlatMapBuilder.java
@@ -96,8 +96,11 @@ public final class StreamFlatMapBuilder {
   public static LogicalSchema buildSchema(
       final LogicalSchema inputSchema,
       final List<FunctionCall> tableFunctions,
-      final FunctionRegistry functionRegistry) {
-    final LogicalSchema.Builder schemaBuilder = LogicalSchema.builder();
+      final FunctionRegistry functionRegistry
+  ) {
+    final LogicalSchema.Builder schemaBuilder = LogicalSchema.builder()
+        .withRowTime();
+
     final List<Column> cols = inputSchema.value();
 
     // We copy all the original columns to the output schema

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/AggregateParamsFactoryTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/AggregateParamsFactoryTest.java
@@ -39,6 +39,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class AggregateParamsFactoryTest {
 
   private static final LogicalSchema INPUT_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(ColumnName.of("k0"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("REQUIRED0"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("ARGUMENT0"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("REQUIRED1"), SqlTypes.STRING)
@@ -210,6 +212,7 @@ public class AggregateParamsFactoryTest {
         schema,
         equalTo(
             LogicalSchema.builder()
+                .withRowTime()
                 .keyColumns(INPUT_SCHEMA.key())
                 .valueColumn(ColumnName.of("REQUIRED0"), SqlTypes.BIGINT)
                 .valueColumn(ColumnName.of("REQUIRED1"), SqlTypes.STRING)
@@ -230,6 +233,7 @@ public class AggregateParamsFactoryTest {
         schema,
         equalTo(
             LogicalSchema.builder()
+                .withRowTime()
                 .keyColumns(INPUT_SCHEMA.key())
                 .valueColumn(ColumnName.of("REQUIRED0"), SqlTypes.BIGINT)
                 .valueColumn(ColumnName.of("REQUIRED1"), SqlTypes.STRING)
@@ -259,6 +263,7 @@ public class AggregateParamsFactoryTest {
         schema,
         equalTo(
             LogicalSchema.builder()
+                .withRowTime()
                 .keyColumns(INPUT_SCHEMA.key())
                 .valueColumn(ColumnName.of("REQUIRED0"), SqlTypes.BIGINT)
                 .valueColumn(ColumnName.of("REQUIRED1"), SqlTypes.STRING)

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/JoinParamsFactoryTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/JoinParamsFactoryTest.java
@@ -17,11 +17,13 @@ import org.junit.rules.ExpectedException;
 public class JoinParamsFactoryTest {
 
   private static final LogicalSchema LEFT_SCHEMA = LogicalSchema.builder()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("BLUE"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("GREEN"), SqlTypes.INTEGER)
       .build();
 
   private static final LogicalSchema RIGHT_SCHEMA = LogicalSchema.builder()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("RED"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("ORANGE"), SqlTypes.DOUBLE)
       .build();
@@ -38,6 +40,7 @@ public class JoinParamsFactoryTest {
 
     // Then:
     assertThat(joinParams.getSchema(), is(LogicalSchema.builder()
+        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("BLUE"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("GREEN"), SqlTypes.INTEGER)

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StepSchemaResolverTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StepSchemaResolverTest.java
@@ -84,6 +84,8 @@ public class StepSchemaResolverTest {
   private static final KsqlConfig CONFIG = new KsqlConfig(Collections.emptyMap());
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("ORANGE"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("APPLE"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("BANANA"), SqlTypes.STRING)
@@ -133,6 +135,8 @@ public class StepSchemaResolverTest {
     // Then:
     assertThat(result, is(
         LogicalSchema.builder()
+            .withRowTime()
+            .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
             .valueColumn(ColumnName.of("ORANGE"), SqlTypes.INTEGER)
             .valueColumn(ColumnName.aggregateColumn(0), SqlTypes.BIGINT)
             .build())
@@ -158,6 +162,8 @@ public class StepSchemaResolverTest {
     // Then:
     assertThat(result, is(
         LogicalSchema.builder()
+            .withRowTime()
+            .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
             .valueColumn(ColumnName.of("ORANGE"), SqlTypes.INTEGER)
             .valueColumn(ColumnName.aggregateColumn(0), SqlTypes.BIGINT)
             .valueColumn(SchemaUtil.WINDOWSTART_NAME, SchemaUtil.WINDOWBOUND_TYPE)
@@ -184,6 +190,8 @@ public class StepSchemaResolverTest {
     // Then:
     assertThat(result, is(
         LogicalSchema.builder()
+            .withRowTime()
+            .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
             .valueColumn(ColumnName.of("JUICE"), SqlTypes.BIGINT)
             .valueColumn(ColumnName.of("PLANTAIN"), SqlTypes.STRING)
             .valueColumn(ColumnName.of("CITRUS"), SqlTypes.INTEGER)
@@ -207,6 +215,8 @@ public class StepSchemaResolverTest {
     // Then:
     assertThat(result, is(
         LogicalSchema.builder()
+            .withRowTime()
+            .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
             .valueColumn(ColumnName.of("ORANGE"), SqlTypes.INTEGER)
             .valueColumn(ColumnName.of("APPLE"), SqlTypes.BIGINT)
             .valueColumn(ColumnName.of("BANANA"), SqlTypes.STRING)
@@ -246,6 +256,7 @@ public class StepSchemaResolverTest {
 
     // Then:
     assertThat(result, is(LogicalSchema.builder()
+        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.INTEGER)
         .valueColumns(SCHEMA.value())
         .build()));
@@ -284,6 +295,7 @@ public class StepSchemaResolverTest {
 
     // Then:
     assertThat(result, is(LogicalSchema.builder()
+        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.INTEGER)
         .valueColumns(SCHEMA.value())
         .build()
@@ -343,6 +355,8 @@ public class StepSchemaResolverTest {
     // Then:
     assertThat(result, is(
         LogicalSchema.builder()
+            .withRowTime()
+            .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
             .valueColumn(ColumnName.of("ORANGE"), SqlTypes.INTEGER)
             .valueColumn(ColumnName.aggregateColumn(0), SqlTypes.BIGINT)
             .build())
@@ -364,6 +378,7 @@ public class StepSchemaResolverTest {
 
     // Then:
     assertThat(result, is(LogicalSchema.builder()
+        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.INTEGER)
         .valueColumns(SCHEMA.value())
         .build()));
@@ -387,6 +402,8 @@ public class StepSchemaResolverTest {
     // Then:
     assertThat(result, is(
         LogicalSchema.builder()
+            .withRowTime()
+            .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
             .valueColumn(ColumnName.of("JUICE"), SqlTypes.BIGINT)
             .valueColumn(ColumnName.of("PLANTAIN"), SqlTypes.STRING)
             .valueColumn(ColumnName.of("CITRUS"), SqlTypes.INTEGER)
@@ -460,7 +477,6 @@ public class StepSchemaResolverTest {
     final KsqlAggregateFunction aggregateFunction = mock(KsqlAggregateFunction.class);
     when(functionRegistry.getAggregateFunction(eq(FunctionName.of(name)), any(), any()))
         .thenReturn(aggregateFunction);
-    when(aggregateFunction.name()).thenReturn(FunctionName.of(name));
     when(aggregateFunction.getAggregateType()).thenReturn(SqlTypes.INTEGER);
     when(aggregateFunction.returnType()).thenReturn(returnType);
     when(aggregateFunction.getInitialValueSupplier()).thenReturn(mock(Supplier.class));

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderTest.java
@@ -30,7 +30,6 @@ import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.logging.processing.ProcessingLoggerFactory;
 import io.confluent.ksql.name.ColumnName;
-import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
@@ -61,15 +60,16 @@ public class StreamGroupByBuilderTest {
 
   private static final KeyBuilder STRING_KEY_BUILDER = StructKeyUtil.keyBuilder(SqlTypes.STRING);
 
-  private static final SourceName ALIAS = SourceName.of("SOURCE");
-
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("PAC"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("MAN"), SqlTypes.STRING)
       .build()
       .withMetaAndKeyColsInValue(false);
 
   private static final LogicalSchema REKEYED_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumns(SCHEMA.value())
       .build();
@@ -216,6 +216,7 @@ public class StreamGroupByBuilderTest {
 
     // Then:
     assertThat(result.getSchema(), is(LogicalSchema.builder()
+        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumns(SCHEMA.value())
         .build()));

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectBuilderTest.java
@@ -45,6 +45,7 @@ import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.SchemaUtil;
 import java.util.List;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.kstream.KStream;
@@ -64,6 +65,8 @@ import org.mockito.junit.MockitoRule;
 public class StreamSelectBuilderTest {
 
   private static final LogicalSchema SCHEMA = new LogicalSchema.Builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("foo"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("bar"), SqlTypes.BIGINT)
       .build()
@@ -175,6 +178,8 @@ public class StreamSelectBuilderTest {
     assertThat(
         result.getSchema(),
         is(LogicalSchema.builder()
+            .withRowTime()
+            .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
             .valueColumn(ColumnName.of("expr1"), SqlTypes.STRING)
             .valueColumn(ColumnName.of("expr2"), SqlTypes.INTEGER)
             .build())

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderTest.java
@@ -63,6 +63,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class StreamSelectKeyBuilderTest {
 
   private static final LogicalSchema SOURCE_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("BIG"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("BOI"), SqlTypes.BIGINT)
@@ -73,6 +74,7 @@ public class StreamSelectKeyBuilderTest {
       new UnqualifiedColumnReferenceExp(ColumnName.of("BOI"));
 
   private static final LogicalSchema RESULT_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("BIG"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("BOI"), SqlTypes.BIGINT)

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilderTest.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SerdeOption;
+import io.confluent.ksql.util.SchemaUtil;
 import java.time.Duration;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.connect.data.Struct;
@@ -45,11 +46,15 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class StreamStreamJoinBuilderTest {
 
   private static final LogicalSchema LEFT_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("BLUE"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("GREEN"), SqlTypes.INTEGER)
       .build();
 
   private static final LogicalSchema RIGHT_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("RED"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("ORANGE"), SqlTypes.DOUBLE)
       .build();

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilderTest.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SerdeOption;
+import io.confluent.ksql.util.SchemaUtil;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.kstream.Joined;
@@ -45,11 +46,15 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class StreamTableJoinBuilderTest {
 
   private static final LogicalSchema LEFT_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("BLUE"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("GREEN"), SqlTypes.INTEGER)
       .build();
 
   private static final LogicalSchema RIGHT_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("RED"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("ORANGE"), SqlTypes.DOUBLE)
       .build();

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableGroupByBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableGroupByBuilderTest.java
@@ -56,19 +56,20 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 public class TableGroupByBuilderTest {
+
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("PAC"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("MAN"), SqlTypes.STRING)
       .build()
       .withMetaAndKeyColsInValue(false);
 
   private static final LogicalSchema REKEYED_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumns(SCHEMA.value())
       .build();
-
-  private static final PhysicalSchema PHYSICAL_SCHEMA =
-      PhysicalSchema.from(SCHEMA, SerdeOption.none());
 
   private static final PhysicalSchema REKEYED_PHYSICAL_SCHEMA =
       PhysicalSchema.from(REKEYED_SCHEMA, SerdeOption.none());
@@ -189,6 +190,7 @@ public class TableGroupByBuilderTest {
 
     // Then:
     assertThat(result.getSchema(), is(is(LogicalSchema.builder()
+        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumns(SCHEMA.value())
         .build())));

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableTableJoinBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableTableJoinBuilderTest.java
@@ -23,6 +23,7 @@ import io.confluent.ksql.execution.plan.TableTableJoin;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.util.SchemaUtil;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.kstream.KTable;
 import org.junit.Before;
@@ -35,11 +36,15 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class TableTableJoinBuilderTest {
 
   private static final LogicalSchema LEFT_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("BLUE"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("GREEN"), SqlTypes.INTEGER)
       .build();
 
   private static final LogicalSchema RIGHT_SCHEMA = LogicalSchema.builder()
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("RED"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("ORANGE"), SqlTypes.DOUBLE)
       .build();

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/KsqlMaterializationTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/KsqlMaterializationTest.java
@@ -60,6 +60,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class KsqlMaterializationTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("v0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("v1"), SqlTypes.STRING)

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/RowTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/RowTest.java
@@ -41,6 +41,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class RowTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .withRowTime()
       .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
       .keyColumn(ColumnName.of("k1"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("v0"), SqlTypes.STRING)
@@ -79,6 +80,7 @@ public class RowTest {
   @Test
   public void shouldImplementEquals() {
     final LogicalSchema differentSchema = LogicalSchema.builder()
+        .withRowTime()
         .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
         .keyColumn(ColumnName.of("k1"), SqlTypes.INTEGER)
         .valueColumn(ColumnName.of("diff0"), SqlTypes.STRING)

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/TableRowValidationTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/TableRowValidationTest.java
@@ -29,6 +29,7 @@ import org.junit.rules.ExpectedException;
 public class TableRowValidationTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .withRowTime()
       .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
       .keyColumn(ColumnName.of("k1"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("v0"), SqlTypes.STRING)
@@ -81,7 +82,6 @@ public class TableRowValidationTest {
   public void shouldThrowOnNoMetaColumnsInSchema() {
     // Given:
     final LogicalSchema noMetaColumns = LogicalSchema.builder()
-        .noImplicitColumns()
         .keyColumns(SCHEMA.key())
         .valueColumns(SCHEMA.value())
         .build();

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/WindowedRowTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/WindowedRowTest.java
@@ -44,6 +44,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class WindowedRowTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .withRowTime()
       .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
       .keyColumn(ColumnName.of("k1"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("v0"), SqlTypes.STRING)
@@ -86,6 +87,7 @@ public class WindowedRowTest {
   @Test
   public void shouldImplementEquals() {
     final LogicalSchema differentSchema = LogicalSchema.builder()
+        .withRowTime()
         .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
         .keyColumn(ColumnName.of("k1"), SqlTypes.INTEGER)
         .valueColumn(ColumnName.of("diff0"), SqlTypes.STRING)

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedSessionTableTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedSessionTableTest.java
@@ -58,6 +58,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class KsMaterializedSessionTableTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .withRowTime()
       .keyColumn(ColumnName.of("ROWKEY"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("v0"), SqlTypes.STRING)
       .build();

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedTableTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedTableTest.java
@@ -51,6 +51,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class KsMaterializedTableTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .withRowTime()
       .keyColumn(ColumnName.of("ROWKEY"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("v0"), SqlTypes.STRING)
       .build();

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedWindowTableTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedWindowTableTest.java
@@ -35,6 +35,7 @@ import io.confluent.ksql.execution.util.StructKeyUtil;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.util.SchemaUtil;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -62,7 +63,8 @@ public class KsMaterializedWindowTableTest {
   private static final Duration WINDOW_SIZE = Duration.ofMinutes(1);
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .keyColumn(ColumnName.of("ROWKEY"), SqlTypes.STRING)
+      .withRowTime()
+      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("v0"), SqlTypes.STRING)
       .build();
 

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsStateStoreTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsStateStoreTest.java
@@ -61,7 +61,6 @@ public class KsStateStoreTest {
   private static final String STORE_NAME = "someStore";
   private static final Long TIMEOUT_MS = 10L;
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .noImplicitColumns()
       .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
       .keyColumn(ColumnName.of("v0"), SqlTypes.BIGINT)
       .build();


### PR DESCRIPTION
### Description 

As we move towards allowing key names other than `ROWKEY` and switching `ROWTIME` to a pseudo column, having implicitly added columns in `LogicalSchema` is actually making the code less readable, not more.

This change removes the implicit columns from `LogicalSchema`. Instead key columns are now added _explicitly_ via `keyColumn()` and `ROWTIME` is now added _explicitly_ via `withRowTime()`.  There is little actual change to production code. The main bit being in `TableElements.toLogicalSchema()`.  Some places now need a `withRowTime()` call, but even these will go once `ROWTIME` is a pseudo column.

Most of the changes are in the test code base.

### Reviewing notes:

I've split the commit into two:
1. Production changes: needs reviewing.
1. Test changes: doesn't really need reviewing as its just adding explicit columns in tests.

### Testing done 

Usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

