### PR TITLE
refactor: do not allow duplicates in schemas by default

### DIFF
--- a/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
@@ -233,7 +233,8 @@ public class LogicalSchemaTest {
   public void shouldPreferKeyOverValueAndMetaColumns() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        // Implicit meta ROWTIME
+        .allowDuplicates()
+        .withRowTime()
         .valueColumn(ROWTIME_NAME, BIGINT)
         .keyColumn(ROWTIME_NAME, BIGINT)
         .build();
@@ -412,6 +413,7 @@ public class LogicalSchemaTest {
     // Then:
     assertThat(result, is(LogicalSchema.builder()
         .withRowTime()
+        .allowDuplicates()
         .keyColumn(K0, INTEGER)
         .keyColumn(K1, STRING)
         .valueColumn(F0, STRING)
@@ -441,6 +443,7 @@ public class LogicalSchemaTest {
     // Then:
     assertThat(result, is(LogicalSchema.builder()
         .withRowTime()
+        .allowDuplicates()
         .keyColumn(K0, INTEGER)
         .keyColumn(K1, STRING)
         .valueColumn(F0, STRING)
@@ -476,6 +479,7 @@ public class LogicalSchemaTest {
     // Given:
     final LogicalSchema ksqlSchema = LogicalSchema.builder()
         .withRowTime()
+        .allowDuplicates()
         .keyColumn(K0, INTEGER)
         .valueColumn(F0, BIGINT)
         .valueColumn(K0, DOUBLE)
@@ -489,6 +493,7 @@ public class LogicalSchemaTest {
     // Then:
     assertThat(result, is(LogicalSchema.builder()
         .withRowTime()
+        .allowDuplicates()
         .keyColumn(K0, INTEGER)
         .valueColumn(F0, BIGINT)
         .valueColumn(F1, BIGINT)
@@ -570,6 +575,7 @@ public class LogicalSchemaTest {
   public void shouldRemoveKeyColumnsWhereEverTheyAre() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
+        .allowDuplicates()
         .keyColumn(K0, STRING)
         .valueColumn(F0, BIGINT)
         .valueColumn(K0, STRING)
@@ -648,7 +654,7 @@ public class LogicalSchemaTest {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
         .keyColumn(F0, DOUBLE)
-        .valueColumn(F0, BIGINT)
+        .valueColumn(F1, BIGINT)
         .build();
 
     // When:
@@ -665,7 +671,7 @@ public class LogicalSchemaTest {
   public void shouldGetValueConnectSchema() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .keyColumn(F0, STRING)
+        .keyColumn(K0, STRING)
         .valueColumn(F0, BIGINT)
         .valueColumn(F1, STRING)
         .build();
@@ -742,6 +748,23 @@ public class LogicalSchemaTest {
 
     // Then:
     assertThat(schema.valueContainsAny(ImmutableSet.of(K0, V0, ROWTIME_NAME)), is(false));
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void shouldThrowOnDuplicateColumnName() {
+    LogicalSchema.builder()
+        .valueColumn(K0, STRING)
+        .keyColumn(K0, BIGINT)
+        .build();
+  }
+
+  @Test
+  public void shouldNotThrowOnDuplicateColumnName() {
+    LogicalSchema.builder()
+        .valueColumn(K0, STRING)
+        .keyColumn(K0, BIGINT)
+        .allowDuplicates()
+        .build();
   }
 
   private static org.apache.kafka.connect.data.Field connectField(

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -387,7 +387,8 @@ public class LogicalPlanner {
     );
 
     final Builder builder = LogicalSchema.builder()
-        .withRowTime();
+        .withRowTime()
+        .allowDuplicates();
 
     final List<Column> keyColumns = schema.key();
 
@@ -444,6 +445,7 @@ public class LogicalPlanner {
     final SqlType keyType = typeManager.getExpressionSqlType(partitionBy);
 
     return LogicalSchema.builder()
+        .allowDuplicates()
         .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, keyType)
         .valueColumns(sourceSchema.value())

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/transform/select/Selection.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/transform/select/Selection.java
@@ -52,6 +52,7 @@ public final class Selection<K> {
       final SelectValueMapper<?> mapper
   ) {
     final LogicalSchema.Builder schemaBuilder = LogicalSchema.builder()
+        .allowDuplicates()
         .withRowTime();
 
     final List<Column> keyCols = sourceSchema.key();

--- a/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/StructuredDataSourceTest.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/StructuredDataSourceTest.java
@@ -76,6 +76,7 @@ public class StructuredDataSourceTest {
   public void shouldThrowIfSchemaContainsRowKey() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
+        .allowDuplicates()
         .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/GroupByParamsFactory.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/GroupByParamsFactory.java
@@ -85,6 +85,7 @@ final class GroupByParamsFactory {
       final SqlType rowKeyType
   ) {
     return LogicalSchema.builder()
+        .allowDuplicates()
         .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, rowKeyType)
         .valueColumns(sourceSchema.value())

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StepSchemaResolver.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StepSchemaResolver.java
@@ -218,6 +218,7 @@ public final class StepSchemaResolver {
         .getExpressionSqlType(step.getKeyExpression());
 
     return LogicalSchema.builder()
+        .allowDuplicates()
         .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, keyType)
         .valueColumns(sourceSchema.value())

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFlatMapBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFlatMapBuilder.java
@@ -99,6 +99,7 @@ public final class StreamFlatMapBuilder {
       final FunctionRegistry functionRegistry
   ) {
     final LogicalSchema.Builder schemaBuilder = LogicalSchema.builder()
+        .allowDuplicates()
         .withRowTime();
 
     final List<Column> cols = inputSchema.value();

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderTest.java
@@ -69,6 +69,7 @@ public class StreamGroupByBuilderTest {
       .withMetaAndKeyColsInValue(false);
 
   private static final LogicalSchema REKEYED_SCHEMA = LogicalSchema.builder()
+      .allowDuplicates()
       .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumns(SCHEMA.value())
@@ -216,6 +217,7 @@ public class StreamGroupByBuilderTest {
 
     // Then:
     assertThat(result.getSchema(), is(LogicalSchema.builder()
+        .allowDuplicates()
         .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumns(SCHEMA.value())

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderTest.java
@@ -74,6 +74,7 @@ public class StreamSelectKeyBuilderTest {
       new UnqualifiedColumnReferenceExp(ColumnName.of("BOI"));
 
   private static final LogicalSchema RESULT_SCHEMA = LogicalSchema.builder()
+      .allowDuplicates()
       .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("BIG"), SqlTypes.BIGINT)

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableGroupByBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableGroupByBuilderTest.java
@@ -66,6 +66,7 @@ public class TableGroupByBuilderTest {
       .withMetaAndKeyColsInValue(false);
 
   private static final LogicalSchema REKEYED_SCHEMA = LogicalSchema.builder()
+      .allowDuplicates()
       .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumns(SCHEMA.value())
@@ -190,6 +191,7 @@ public class TableGroupByBuilderTest {
 
     // Then:
     assertThat(result.getSchema(), is(is(LogicalSchema.builder()
+        .allowDuplicates()
         .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumns(SCHEMA.value())


### PR DESCRIPTION
### Description 

KsqlDB does not support data sources with duplicate column names in the key and value.  (Mainly due to the fact that it copies the key columns into the value while processing with Kafka Streams).

It therefore makes sense, to me at least, that our `LogicalSchema` rejects duplicates by default, but allows them if explicitly told to do so.  Doesn't change anything functionally, but does mean code is more explicit about when it does and does not allow duplicates.

Thoughts? Is this an improvement or just noise?

### Testing done 

Usual.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

