### PR TITLE
Partial support for arbitrary key column names.

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -85,6 +85,7 @@ import io.confluent.ksql.util.HandlerMaps;
 import io.confluent.ksql.util.HandlerMaps.ClassHandlerMap1;
 import io.confluent.ksql.util.HandlerMaps.Handler1;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.SchemaUtil;
 import io.confluent.ksql.util.TabularRow;
 import java.io.Closeable;
 import java.io.File;
@@ -454,11 +455,11 @@ public class Console implements Closeable {
       final Optional<WindowType> windowType,
       final String keyField
   ) {
-    if (field.getName().equals("ROWTIME")) {
+    if (field.getName().equals(SchemaUtil.ROWTIME_NAME.text())) {
       return String.format("%-16s %s", field.getSchema().toTypeString(), "(system)");
     }
 
-    if (field.getName().equals("ROWKEY")) {
+    if (field.getName().equals(SchemaUtil.ROWKEY_NAME.text())) {
       final String wt = windowType
           .map(v -> " (Window type: " + v + ")")
           .orElse("");

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -262,6 +262,8 @@ public class KsqlConfig extends AbstractConfig {
       + "behavior, and instead throw an exception to ensure that no data is missed, set "
       + "ksql.timestamp.skip.invalid to true.";
 
+  public static final String KSQL_ANY_KEY_NAME_ENABLED = "ksql.any.key.name.enabled";
+
   private enum ConfigGeneration {
     LEGACY,
     CURRENT
@@ -622,6 +624,13 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_TIMESTAMP_THROW_ON_INVALID_DEFAULT,
             Importance.MEDIUM,
             KSQL_TIMESTAMP_THROW_ON_INVALID_DOC
+        )
+        .define(
+            KSQL_ANY_KEY_NAME_ENABLED,
+            Type.BOOLEAN,
+            false,
+            Importance.LOW,
+            "Feature flag for removing restriction on key names - WIP, do not enable."
         )
         .withClientSslSupport();
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
@@ -37,7 +37,6 @@ import io.confluent.ksql.parser.tree.InsertValues;
 import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.DefaultSqlValueCoercer;
-import io.confluent.ksql.schema.ksql.FormatOptions;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
@@ -61,7 +60,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.function.LongSupplier;
@@ -142,6 +140,7 @@ public class InsertValuesExecutor {
     this.valueSerdeFactory = Objects.requireNonNull(valueSerdeFactory, "valueSerdeFactory");
   }
 
+  @SuppressWarnings("unused") // Part of required API.
   public void execute(
       final ConfiguredStatement<InsertValues> statement,
       final SessionProperties sessionProperties,
@@ -175,7 +174,7 @@ public class InsertValuesExecutor {
     }
   }
 
-  private DataSource getDataSource(
+  private static DataSource getDataSource(
       final KsqlConfig ksqlConfig,
       final MetaStore metaStore,
       final InsertValues insertValues
@@ -266,11 +265,23 @@ public class InsertValuesExecutor {
     final Map<ColumnName, Object> values = resolveValues(
         insertValues, columns, schema, functionRegistry, config);
 
-    handleExplicitKeyField(values, dataSource.getKeyField());
+    handleExplicitKeyField(
+        values,
+        dataSource.getKeyField(),
+        Iterables.getOnlyElement(dataSource.getSchema().key())
+    );
 
-    if (dataSource.getDataSourceType() == DataSourceType.KTABLE
-        && values.get(SchemaUtil.ROWKEY_NAME) == null) {
-      throw new KsqlException("Value for ROWKEY is required for tables");
+    if (dataSource.getDataSourceType() == DataSourceType.KTABLE) {
+      final String noValue = dataSource.getSchema().key().stream()
+          .map(Column::name)
+          .filter(colName -> !values.containsKey(colName))
+          .map(ColumnName::text)
+          .collect(Collectors.joining(", "));
+
+      if (!noValue.isEmpty()) {
+        throw new KsqlException("Value for primary key column(s) "
+            + noValue + " is required for tables");
+      }
     }
 
     final long ts = (long) values.getOrDefault(SchemaUtil.ROWTIME_NAME, clock.getAsLong());
@@ -357,26 +368,29 @@ public class InsertValuesExecutor {
 
   private static void handleExplicitKeyField(
       final Map<ColumnName, Object> values,
-      final KeyField keyField
+      final KeyField keyField,
+      final Column keyColumn
   ) {
-    final Optional<ColumnName> keyFieldName = keyField.ref();
-    if (keyFieldName.isPresent()) {
-      final ColumnName key = keyFieldName.get();
-      final Object keyValue = values.get(key);
-      final Object rowKeyValue = values.get(SchemaUtil.ROWKEY_NAME);
+    // key column: the key column in the source's schema.
+    // key field: the column identified in the WITH clause as being an alias to the key column.
 
-      if (keyValue != null ^ rowKeyValue != null) {
-        if (keyValue == null) {
-          values.put(key, rowKeyValue);
+    keyField.ref().ifPresent(keyFieldName -> {
+      final ColumnName keyColumnName = keyColumn.name();
+      final Object keyFieldValue = values.get(keyFieldName);
+      final Object keyColumnValue = values.get(keyColumnName);
+
+      if (keyFieldValue != null ^ keyColumnValue != null) {
+        if (keyFieldValue == null) {
+          values.put(keyFieldName, keyColumnValue);
         } else {
-          values.put(SchemaUtil.ROWKEY_NAME, keyValue);
+          values.put(keyColumnName, keyFieldValue);
         }
-      } else if (keyValue != null && !Objects.equals(keyValue, rowKeyValue)) {
-        throw new KsqlException(String.format(
-            "Expected ROWKEY and %s to match but got %s and %s respectively.",
-            key.toString(FormatOptions.noEscape()), rowKeyValue, keyValue));
+      } else if (keyFieldValue != null && !Objects.equals(keyFieldValue, keyColumnValue)) {
+        throw new KsqlException(
+            "Expected " + keyColumnName.text() + " and " + keyFieldName.text() + " to match "
+                + "but got " + keyColumnValue + " and " + keyFieldValue + " respectively.");
       }
-    }
+    });
   }
 
   private static SqlType columnType(final ColumnName column, final LogicalSchema schema) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/FilterNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/FilterNode.java
@@ -20,9 +20,7 @@ import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext.Stacker;
 import io.confluent.ksql.execution.expression.tree.Expression;
-import io.confluent.ksql.execution.plan.SelectExpression;
 import io.confluent.ksql.metastore.model.KeyField;
-import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.structured.SchemaKStream;
 import java.util.List;
@@ -33,27 +31,20 @@ public class FilterNode extends PlanNode {
 
   private final PlanNode source;
   private final Expression predicate;
-  private final ImmutableList<SelectExpression> selectExpressions;
 
   public FilterNode(
       final PlanNodeId id,
       final PlanNode source,
       final Expression predicate
   ) {
-    super(id, source.getNodeOutputType());
+    super(id, source.getNodeOutputType(), source.getSchema(), source.getSelectExpressions());
 
     this.source = Objects.requireNonNull(source, "source");
     this.predicate = Objects.requireNonNull(predicate, "predicate");
-    this.selectExpressions = ImmutableList.copyOf(source.getSelectExpressions());
   }
 
   public Expression getPredicate() {
     return predicate;
-  }
-
-  @Override
-  public LogicalSchema getSchema() {
-    return source.getSchema();
   }
 
   @Override
@@ -64,11 +55,6 @@ public class FilterNode extends PlanNode {
   @Override
   public List<PlanNode> getSources() {
     return ImmutableList.of(source);
-  }
-
-  @Override
-  public List<SelectExpression> getSelectExpressions() {
-    return selectExpressions;
   }
 
   public PlanNode getSource() {

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/OutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/OutputNode.java
@@ -19,13 +19,11 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.execution.plan.SelectExpression;
 import io.confluent.ksql.execution.timestamp.TimestampColumn;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.query.id.QueryIdGenerator;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.services.KafkaTopicClient;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -36,7 +34,6 @@ public abstract class OutputNode
     extends PlanNode {
 
   private final PlanNode source;
-  private final LogicalSchema schema;
   private final OptionalInt limit;
   private final Optional<TimestampColumn> timestampColumn;
 
@@ -47,18 +44,12 @@ public abstract class OutputNode
       final OptionalInt limit,
       final Optional<TimestampColumn> timestampColumn
   ) {
-    super(id, source.getNodeOutputType());
+    super(id, source.getNodeOutputType(), schema, source.getSelectExpressions());
 
     this.source = requireNonNull(source, "source");
-    this.schema = requireNonNull(schema, "schema");
     this.limit = requireNonNull(limit, "limit");
     this.timestampColumn =
         requireNonNull(timestampColumn, "timestampColumn");
-  }
-
-  @Override
-  public LogicalSchema getSchema() {
-    return schema;
   }
 
   @Override
@@ -77,11 +68,6 @@ public abstract class OutputNode
   @Override
   protected int getPartitions(final KafkaTopicClient kafkaTopicClient) {
     return source.getPartitions(kafkaTopicClient);
-  }
-
-  @Override
-  public List<SelectExpression> getSelectExpressions() {
-    return Collections.emptyList();
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/PlanNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/PlanNode.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.planner.plan;
 
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.plan.SelectExpression;
@@ -32,29 +33,41 @@ public abstract class PlanNode {
 
   private final PlanNodeId id;
   private final DataSourceType nodeOutputType;
+  private final LogicalSchema schema;
+  private final ImmutableList<SelectExpression> selectExpressions;
 
-  protected PlanNode(final PlanNodeId id, final DataSourceType nodeOutputType) {
-    requireNonNull(id, "id is null");
-    requireNonNull(nodeOutputType, "nodeOutputType is null");
-    this.id = id;
-    this.nodeOutputType = nodeOutputType;
+  protected PlanNode(
+      final PlanNodeId id,
+      final DataSourceType nodeOutputType,
+      final LogicalSchema schema,
+      final List<SelectExpression> selectExpressions
+  ) {
+    this.id = requireNonNull(id, "id");
+    this.nodeOutputType = requireNonNull(nodeOutputType, "nodeOutputType");
+    this.schema = requireNonNull(schema, "schema");
+    this.selectExpressions = ImmutableList
+        .copyOf(requireNonNull(selectExpressions, "projectExpressions"));
   }
 
-  public PlanNodeId getId() {
+  public final PlanNodeId getId() {
     return id;
   }
 
-  public DataSourceType getNodeOutputType() {
+  public final DataSourceType getNodeOutputType() {
     return nodeOutputType;
   }
 
-  public abstract LogicalSchema getSchema();
+  public final LogicalSchema getSchema() {
+    return schema;
+  }
+
+  public final List<SelectExpression> getSelectExpressions() {
+    return selectExpressions;
+  }
 
   public abstract KeyField getKeyField();
 
   public abstract List<PlanNode> getSources();
-  
-  public abstract List<SelectExpression> getSelectExpressions();
 
   public <C, R> R accept(final PlanVisitor<C, R> visitor, final C context) {
     return visitor.visitPlan(this, context);

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/RepartitionNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/RepartitionNode.java
@@ -22,7 +22,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.expression.tree.Expression;
-import io.confluent.ksql.execution.plan.SelectExpression;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.services.KafkaTopicClient;
@@ -35,7 +34,6 @@ public class RepartitionNode extends PlanNode {
   private final PlanNode source;
   private final Expression partitionBy;
   private final KeyField keyField;
-  private final LogicalSchema schema;
 
   public RepartitionNode(
       final PlanNodeId id,
@@ -44,16 +42,10 @@ public class RepartitionNode extends PlanNode {
       final Expression partitionBy,
       final KeyField keyField
   ) {
-    super(id, source.getNodeOutputType());
+    super(id, source.getNodeOutputType(), schema, source.getSelectExpressions());
     this.source = requireNonNull(source, "source");
     this.partitionBy = requireNonNull(partitionBy, "partitionBy");
     this.keyField = requireNonNull(keyField, "keyField");
-    this.schema = requireNonNull(schema, "schema");
-  }
-
-  @Override
-  public LogicalSchema getSchema() {
-    return schema;
   }
 
   @Override
@@ -64,11 +56,6 @@ public class RepartitionNode extends PlanNode {
   @Override
   public List<PlanNode> getSources() {
     return ImmutableList.of(source);
-  }
-
-  @Override
-  public List<SelectExpression> getSelectExpressions() {
-    return source.getSelectExpressions();
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -358,7 +358,7 @@ public class SchemaKStream<K> {
     }
 
     final ColumnName columnName = ((UnqualifiedColumnReferenceExp) expression).getColumnName();
-    final KeyField newKeyField = isRowKey(columnName) ? keyField : KeyField.of(columnName);
+    final KeyField newKeyField = isKeyColumn(columnName) ? keyField : KeyField.of(columnName);
     return getSchema().isMetaColumn(columnName) ? KeyField.none() : newKeyField;
   }
 
@@ -381,12 +381,12 @@ public class SchemaKStream<K> {
         .map(kf -> kf.name().equals(proposedKey.name()))
         .orElse(false);
 
-    return namesMatch || isRowKey(columnName);
+    return namesMatch || isKeyColumn(columnName);
   }
 
-  private boolean isRowKey(final ColumnName fieldName) {
-    // until we support structured keys, there will never be any key column other
-    // than "ROWKEY" - furthermore, that key column is always prefixed at this point
+  private boolean isKeyColumn(final ColumnName fieldName) {
+    // until we support structured keys, there will only be a single key column
+    // - furthermore, that key column is always prefixed at this point
     // unless it is a join, in which case every other source field is prefixed
     return fieldName.equals(schema.key().get(0).name());
   }
@@ -404,12 +404,16 @@ public class SchemaKStream<K> {
       return true;
     }
 
+    if (schema.key().size() != 1) {
+      return true;
+    }
+
     final ColumnName groupByField = fieldNameFromExpression(groupByExpressions.get(0));
     if (groupByField == null) {
       return true;
     }
 
-    if (groupByField.equals(SchemaUtil.ROWKEY_NAME)) {
+    if (groupByField.equals(schema.key().get(0).name())) {
       return false;
     }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.structured;
 
+import com.google.common.collect.Iterables;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.context.QueryContext.Stacker;
@@ -140,15 +141,17 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
 
   @SuppressWarnings("unchecked")
   @Override
-  public SchemaKStream<Struct> selectKey(final Expression keyExpression,
-      final Stacker contextStacker) {
+  public SchemaKStream<Struct> selectKey(
+      final Expression keyExpression,
+      final Stacker contextStacker
+  ) {
     if (repartitionNotNeeded(keyExpression)) {
       return (SchemaKStream<Struct>) this;
     }
 
     throw new UnsupportedOperationException("Cannot repartition a TABLE source. "
-        + "If this is a join, make sure that the criteria uses the TABLE key "
-        + this.keyField.ref().map(ColumnName::toString).orElse("ROWKEY") + " instead of "
+        + "If this is a join, make sure that the criteria uses the TABLE's key column "
+        + Iterables.getOnlyElement(schema.key()).name().text() + " instead of "
         + keyExpression);
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/SourceSchemasTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/SourceSchemasTest.java
@@ -35,20 +35,28 @@ public class SourceSchemasTest {
 
   private static final SourceName ALIAS_1 = SourceName.of("S1");
   private static final SourceName ALIAS_2 = SourceName.of("S2");
-  private static final ColumnName COMMON_FIELD_NAME = ColumnName.of("F0");
+
+  private static final ColumnName K0 = ColumnName.of("K0");
+  private static final ColumnName K1 = ColumnName.of("K1");
+
+  private static final ColumnName COMMON_VALUE_FIELD_NAME = ColumnName.of("V0");
+  private static final ColumnName V1 = ColumnName.of("V1");
+  private static final ColumnName V2 = ColumnName.of("V2");
 
   private static final LogicalSchema SCHEMA_1 = LogicalSchema.builder()
       .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
-      .valueColumn(COMMON_FIELD_NAME, SqlTypes.STRING)
-      .valueColumn(ColumnName.of("F1"), SqlTypes.STRING)
+      .keyColumn(K0, SqlTypes.INTEGER)
+      .valueColumn(COMMON_VALUE_FIELD_NAME, SqlTypes.STRING)
+      .valueColumn(V1, SqlTypes.STRING)
       .build();
 
   private static final LogicalSchema SCHEMA_2 = LogicalSchema.builder()
       .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
-      .valueColumn(COMMON_FIELD_NAME, SqlTypes.STRING)
-      .valueColumn(ColumnName.of("F2"), SqlTypes.STRING)
+      .keyColumn(K1, SqlTypes.STRING)
+      .valueColumn(COMMON_VALUE_FIELD_NAME, SqlTypes.STRING)
+      .valueColumn(V2, SqlTypes.STRING)
       .build();
 
   private SourceSchemas sourceSchemas;
@@ -88,28 +96,28 @@ public class SourceSchemasTest {
 
   @Test
   public void shouldFindNoQualifiedField() {
-    assertThat(sourceSchemas.sourcesWithField(Optional.of(ALIAS_1), ColumnName.of("F2")), is(empty()));
+    assertThat(sourceSchemas.sourcesWithField(Optional.of(ALIAS_1), V2), is(empty()));
   }
 
   @Test
   public void shouldFindUnqualifiedUniqueField() {
-    assertThat(sourceSchemas.sourcesWithField(Optional.empty(), ColumnName.of("F1")), contains(ALIAS_1));
+    assertThat(sourceSchemas.sourcesWithField(Optional.empty(), V1), contains(ALIAS_1));
   }
 
   @Test
   public void shouldFindQualifiedUniqueField() {
-    assertThat(sourceSchemas.sourcesWithField(Optional.of(ALIAS_2), ColumnName.of("F2")), contains(ALIAS_2));
+    assertThat(sourceSchemas.sourcesWithField(Optional.of(ALIAS_2), V2), contains(ALIAS_2));
   }
 
   @Test
   public void shouldFindUnqualifiedCommonField() {
-    assertThat(sourceSchemas.sourcesWithField(Optional.empty(), COMMON_FIELD_NAME),
+    assertThat(sourceSchemas.sourcesWithField(Optional.empty(), COMMON_VALUE_FIELD_NAME),
         containsInAnyOrder(ALIAS_1, ALIAS_2));
   }
 
   @Test
   public void shouldFindQualifiedFieldOnlyInThatSource() {
-    assertThat(sourceSchemas.sourcesWithField(Optional.of(ALIAS_1), COMMON_FIELD_NAME),
+    assertThat(sourceSchemas.sourcesWithField(Optional.of(ALIAS_1), COMMON_VALUE_FIELD_NAME),
         contains(ALIAS_1));
   }
 
@@ -125,22 +133,28 @@ public class SourceSchemasTest {
 
   @Test
   public void shouldMatchNonValueFieldNameIfKeyField() {
-    assertThat(sourceSchemas.matchesNonValueField(Optional.empty(), SchemaUtil.ROWKEY_NAME), is(true));
+    assertThat(sourceSchemas.matchesNonValueField(Optional.empty(), K0), is(true));
+    assertThat(sourceSchemas.matchesNonValueField(Optional.empty(), K1), is(true));
+  }
+
+  @Test
+  public void shouldNotMatchNonKeyFieldOnWrongSource() {
+    assertThat(sourceSchemas.matchesNonValueField(Optional.of(ALIAS_2), K0), is(false));
   }
 
   @Test
   public void shouldMatchNonValueFieldNameIfAliasedKeyField() {
-    assertThat(sourceSchemas.matchesNonValueField(Optional.of(ALIAS_2), SchemaUtil.ROWKEY_NAME), is(true));
+    assertThat(sourceSchemas.matchesNonValueField(Optional.of(ALIAS_2), K1), is(true));
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void shouldThrowOnUnknownSourceWhenMatchingNonValueFields() {
-    sourceSchemas.matchesNonValueField(Optional.of(SourceName.of("unknown")), SchemaUtil.ROWKEY_NAME);
+    sourceSchemas.matchesNonValueField(Optional.of(SourceName.of("unknown")), K0);
   }
 
   @Test
   public void shouldNotMatchOtherFields() {
-    assertThat(sourceSchemas.matchesNonValueField(Optional.of(ALIAS_2), ColumnName.of("F2")), is(false));
+    assertThat(sourceSchemas.matchesNonValueField(Optional.of(ALIAS_2), V2), is(false));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
@@ -66,7 +66,6 @@ import io.confluent.ksql.testutils.AnalysisTestUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.MetaStoreFixture;
-import io.confluent.ksql.util.SchemaUtil;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -88,7 +87,7 @@ public class CodeGenRunnerTest {
     private static final String COL_INVALID_JAVA = "col!Invalid:(";
 
     private static final LogicalSchema META_STORE_SCHEMA = LogicalSchema.builder()
-        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.BIGINT)
+        .keyColumn(ColumnName.of("K0"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("COL0"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("COL1"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("COL2"), SqlTypes.STRING)

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/DdlCommandExecTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/DdlCommandExecTest.java
@@ -28,7 +28,6 @@ import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.serde.WindowInfo;
 import io.confluent.ksql.util.MetaStoreFixture;
-import io.confluent.ksql.util.SchemaUtil;
 import java.util.Optional;
 import java.util.Set;
 import org.hamcrest.MatcherAssert;
@@ -46,7 +45,7 @@ public class DdlCommandExecTest {
   private static final SourceName TABLE_NAME = SourceName.of("t1");
   private static final String TOPIC_NAME = "topic";
   private static final LogicalSchema SCHEMA = new LogicalSchema.Builder()
-      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.BIGINT)
+      .keyColumn(ColumnName.of("K0"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("F1"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("F2"), SqlTypes.STRING)
       .build();

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
@@ -98,25 +99,29 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class InsertValuesExecutorTest {
 
+  private static final ColumnName K0 = ColumnName.of("k0");
   private static final ColumnName COL0 = ColumnName.of("COL0");
-  private static final LogicalSchema SINGLE_FIELD_SCHEMA = LogicalSchema.builder()
+  private static final ColumnName COL1 = ColumnName.of("COL1");
+  private static final ColumnName INT_COL = ColumnName.of("INT");
+
+  private static final LogicalSchema SINGLE_VALUE_COLUMN_SCHEMA = LogicalSchema.builder()
       .withRowTime()
-      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
+      .keyColumn(K0, SqlTypes.STRING)
       .valueColumn(COL0, SqlTypes.STRING)
       .build();
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
       .withRowTime()
-      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
+      .keyColumn(K0, SqlTypes.STRING)
       .valueColumn(COL0, SqlTypes.STRING)
-      .valueColumn(ColumnName.of("COL1"), SqlTypes.BIGINT)
+      .valueColumn(COL1, SqlTypes.BIGINT)
       .build();
 
   private static final LogicalSchema BIG_SCHEMA = LogicalSchema.builder()
       .withRowTime()
-      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
+      .keyColumn(K0, SqlTypes.STRING)
       .valueColumn(COL0, SqlTypes.STRING) // named COL0 for auto-ROWKEY
-      .valueColumn(ColumnName.of("INT"), SqlTypes.INTEGER)
+      .valueColumn(INT_COL, SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("BIGINT"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("DOUBLE"), SqlTypes.DOUBLE)
       .valueColumn(ColumnName.of("BOOLEAN"), SqlTypes.BOOLEAN)
@@ -210,10 +215,10 @@ public class InsertValuesExecutorTest {
   @Test
   public void shouldInsertWrappedSingleField() {
     // Given:
-    givenSourceStreamWithSchema(SINGLE_FIELD_SCHEMA, SerdeOption.none(), Optional.of(COL0));
+    givenSourceStreamWithSchema(SINGLE_VALUE_COLUMN_SCHEMA, SerdeOption.none(), Optional.of(COL0));
 
     final ConfiguredStatement<InsertValues> statement = givenInsertValues(
-        valueFieldNames(SINGLE_FIELD_SCHEMA),
+        valueFieldNames(SINGLE_VALUE_COLUMN_SCHEMA),
         ImmutableList.of(new StringLiteral("new"))
     );
 
@@ -230,13 +235,13 @@ public class InsertValuesExecutorTest {
   public void shouldInsertUnwrappedSingleField() {
     // Given:
     givenSourceStreamWithSchema(
-        SINGLE_FIELD_SCHEMA,
+        SINGLE_VALUE_COLUMN_SCHEMA,
         SerdeOption.of(SerdeOption.UNWRAP_SINGLE_VALUES),
         Optional.of(COL0))
     ;
 
     final ConfiguredStatement<InsertValues> statement = givenInsertValues(
-        valueFieldNames(SINGLE_FIELD_SCHEMA),
+        valueFieldNames(SINGLE_VALUE_COLUMN_SCHEMA),
         ImmutableList.of(new StringLiteral("new"))
     );
 
@@ -252,8 +257,8 @@ public class InsertValuesExecutorTest {
   @Test
   public void shouldFillInRowtime() {
     // Given:
-    final ConfiguredStatement<InsertValues> statement = givenInsertValuesStrings(
-        ImmutableList.of("ROWKEY", "COL0", "COL1"),
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of(K0, COL0, COL1),
         ImmutableList.of(
             new StringLiteral("str"),
             new StringLiteral("str"),
@@ -271,10 +276,10 @@ public class InsertValuesExecutorTest {
   }
 
   @Test
-  public void shouldHandleRowTimeWithoutRowKey() {
+  public void shouldHandleRowTimeWithoutKey() {
     // Given:
-    final ConfiguredStatement<InsertValues> statement = givenInsertValuesStrings(
-        ImmutableList.of("ROWTIME", "COL0", "COL1"),
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of(SchemaUtil.ROWTIME_NAME, COL0, COL1),
         ImmutableList.of(
             new LongLiteral(1234L),
             new StringLiteral("str"),
@@ -292,10 +297,10 @@ public class InsertValuesExecutorTest {
   }
 
   @Test
-  public void shouldFillInRowKeyFromSpecifiedKey() {
+  public void shouldFillInKeyColumnFromSpecifiedKeyField() {
     // Given:
-    final ConfiguredStatement<InsertValues> statement = givenInsertValuesStrings(
-        ImmutableList.of("COL0", "COL1"),
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of(COL0, COL1),
         ImmutableList.of(
             new StringLiteral("str"),
             new LongLiteral(2L)
@@ -335,8 +340,8 @@ public class InsertValuesExecutorTest {
   @Test
   public void shouldFillInMissingColumnsWithNulls() {
     // Given:
-    final ConfiguredStatement<InsertValues> statement = givenInsertValuesStrings(
-        ImmutableList.of("ROWKEY", "COL0"),
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of(K0, COL0),
         ImmutableList.of(
             new StringLiteral("str"),
             new StringLiteral("str"))
@@ -354,8 +359,8 @@ public class InsertValuesExecutorTest {
   @Test
   public void shouldFillInKeyFromRowKey() {
     // Given:
-    final ConfiguredStatement<InsertValues> statement = givenInsertValuesStrings(
-        ImmutableList.of("ROWKEY", "COL1"),
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of(K0, COL1),
         ImmutableList.of(
             new StringLiteral("str"),
             new LongLiteral(2L)
@@ -374,8 +379,8 @@ public class InsertValuesExecutorTest {
   @Test
   public void shouldHandleOutOfOrderSchema() {
     // Given:
-    final ConfiguredStatement<InsertValues> statement = givenInsertValuesStrings(
-        ImmutableList.of("COL1", "COL0"),
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of(COL1, COL0),
         ImmutableList.of(
             new LongLiteral(2L),
             new StringLiteral("str")
@@ -394,8 +399,8 @@ public class InsertValuesExecutorTest {
   @Test
   public void shouldHandleAllSortsOfLiterals() {
     // Given:
-    final ConfiguredStatement<InsertValues> statement = givenInsertValuesStrings(
-        ImmutableList.of("COL1", "COL0"),
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of(COL1, COL0),
         ImmutableList.of(
             new LongLiteral(2L),
             new StringLiteral("str"))
@@ -445,10 +450,10 @@ public class InsertValuesExecutorTest {
   @Test
   public void shouldHandleNegativeValueExpression() {
     // Given:
-    givenSourceStreamWithSchema(SCHEMA, SerdeOption.none(), Optional.of(ColumnName.of("COL0")));
+    givenSourceStreamWithSchema(SCHEMA, SerdeOption.none(), Optional.of(COL0));
 
-    final ConfiguredStatement<InsertValues> statement = givenInsertValuesStrings(
-        ImmutableList.of("COL0", "COL1"),
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of(COL0, COL1),
         ImmutableList.of(
             new StringLiteral("str"),
             ArithmeticUnaryExpression.negative(Optional.empty(), new LongLiteral(1))
@@ -467,10 +472,10 @@ public class InsertValuesExecutorTest {
   @Test
   public void shouldHandleUdfs() {
     // Given:
-    givenSourceStreamWithSchema(SINGLE_FIELD_SCHEMA, SerdeOption.none(), Optional.empty());
+    givenSourceStreamWithSchema(SINGLE_VALUE_COLUMN_SCHEMA, SerdeOption.none(), Optional.empty());
 
-    final ConfiguredStatement<InsertValues> statement = givenInsertValuesStrings(
-        ImmutableList.of("COL0"),
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of(COL0),
         ImmutableList.of(
             new FunctionCall(
                 FunctionName.of("SUBSTRING"),
@@ -488,10 +493,10 @@ public class InsertValuesExecutorTest {
   @Test
   public void shouldHandleNestedUdfs() {
     // Given:
-    givenSourceStreamWithSchema(SINGLE_FIELD_SCHEMA, SerdeOption.none(), Optional.empty());
+    givenSourceStreamWithSchema(SINGLE_VALUE_COLUMN_SCHEMA, SerdeOption.none(), Optional.empty());
 
-    final ConfiguredStatement<InsertValues> statement = givenInsertValuesStrings(
-        ImmutableList.of("COL0"),
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of(COL0),
         ImmutableList.of(
             new FunctionCall(
                 FunctionName.of("SUBSTRING"),
@@ -517,8 +522,8 @@ public class InsertValuesExecutorTest {
     // Given:
     givenSourceStreamWithSchema(SCHEMA, SerdeOption.none(), Optional.of(COL0));
 
-    final ConfiguredStatement<InsertValues> statement = givenInsertValuesStrings(
-        ImmutableList.of("COL0", "COL1"),
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of(COL0, COL1),
         ImmutableList.of(
             new StringLiteral("str"),
             new IntegerLiteral(1)
@@ -689,8 +694,8 @@ public class InsertValuesExecutorTest {
   @Test
   public void shouldThrowIfRowKeyAndKeyDoNotMatch() {
     // Given:
-    final ConfiguredStatement<InsertValues> statement = givenInsertValuesStrings(
-        ImmutableList.of("ROWKEY", "COL0"),
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of(K0, COL0),
         ImmutableList.of(
             new StringLiteral("foo"),
             new StringLiteral("bar"))
@@ -698,7 +703,7 @@ public class InsertValuesExecutorTest {
 
     // Expect:
     expectedException.expect(KsqlException.class);
-    expectedException.expectCause(hasMessage(containsString("Expected ROWKEY and COL0 to match")));
+    expectedException.expectCause(hasMessage(containsString("Expected k0 and COL0 to match")));
 
     // When:
     executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
@@ -726,8 +731,8 @@ public class InsertValuesExecutorTest {
     // Given:
     givenSourceStreamWithSchema(BIG_SCHEMA, SerdeOption.none(), Optional.of(COL0));
 
-    final ConfiguredStatement<InsertValues> statement = givenInsertValuesStrings(
-        ImmutableList.of("INT"),
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of(INT_COL),
         ImmutableList.of(
             new DoubleLiteral(1.1)
         )
@@ -746,8 +751,8 @@ public class InsertValuesExecutorTest {
     // Given:
     givenSourceStreamWithSchema(SCHEMA, SerdeOption.none(), Optional.empty());
 
-    final ConfiguredStatement<InsertValues> statement = givenInsertValuesStrings(
-        ImmutableList.of("ROWKEY", "COL0", "COL1"),
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of(K0, COL0, COL1),
         ImmutableList.of(
             new StringLiteral("key"),
             new StringLiteral("str"),
@@ -768,8 +773,8 @@ public class InsertValuesExecutorTest {
     // Given:
     givenSourceTableWithSchema(SerdeOption.none(), Optional.empty());
 
-    final ConfiguredStatement<InsertValues> statement = givenInsertValuesStrings(
-        ImmutableList.of("ROWKEY", "COL0", "COL1"),
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of(K0, COL0, COL1),
         ImmutableList.of(
             new StringLiteral("key"),
             new StringLiteral("str"),
@@ -790,8 +795,8 @@ public class InsertValuesExecutorTest {
     // Given:
     givenSourceStreamWithSchema(SCHEMA, SerdeOption.none(), Optional.empty());
 
-    final ConfiguredStatement<InsertValues> statement = givenInsertValuesStrings(
-        ImmutableList.of("COL0", "COL1"),
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of(COL0, COL1),
         ImmutableList.of(
             new StringLiteral("str"),
             new LongLiteral(2L))
@@ -811,8 +816,8 @@ public class InsertValuesExecutorTest {
     // Given:
     givenSourceTableWithSchema(SerdeOption.none(), Optional.empty());
 
-    final ConfiguredStatement<InsertValues> statement = givenInsertValuesStrings(
-        ImmutableList.of("COL0", "COL1"),
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of(COL0, COL1),
         ImmutableList.of(
             new StringLiteral("str"),
             new LongLiteral(2L))
@@ -821,7 +826,7 @@ public class InsertValuesExecutorTest {
     // Then:
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage(
-        "Failed to insert values into 'TOPIC'. Value for ROWKEY is required for tables");
+        "Failed to insert values into 'TOPIC'. Value for primary key column(s) k0 is required for tables");
 
     // When:
     executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
@@ -832,8 +837,8 @@ public class InsertValuesExecutorTest {
     // Given:
     givenSourceTableWithSchema(SerdeOption.none(), Optional.of(COL0));
 
-    final ConfiguredStatement<InsertValues> statement = givenInsertValuesStrings(
-        ImmutableList.of("COL1"),
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of(COL1),
         ImmutableList.of(
             new LongLiteral(2L))
     );
@@ -841,7 +846,7 @@ public class InsertValuesExecutorTest {
     // Then:
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage(
-        "Failed to insert values into 'TOPIC'. Value for ROWKEY is required for tables");
+        "Failed to insert values into 'TOPIC'. Value for primary key column(s) k0 is required for tables");
 
     // When:
     executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
@@ -879,13 +884,6 @@ public class InsertValuesExecutorTest {
         "",
         NoopProcessingLogContext.INSTANCE
     );
-  }
-
-  private static ConfiguredStatement<InsertValues> givenInsertValuesStrings(
-      final List<String> columns,
-      final List<Expression> values
-  ) {
-    return givenInsertValues(columns.stream().map(ColumnName::of).collect(Collectors.toList()), values);
   }
 
   private static ConfiguredStatement<InsertValues> givenInsertValues(
@@ -930,7 +928,7 @@ public class InsertValuesExecutorTest {
     );
 
     final KeyField valueKeyField = keyField
-        .map(kf -> KeyField.of(kf))
+        .map(KeyField::of)
         .orElse(KeyField.none());
 
     final DataSource dataSource;
@@ -966,7 +964,7 @@ public class InsertValuesExecutorTest {
 
   private static Struct keyStruct(final String rowKey) {
     final Struct key = new Struct(SCHEMA.keyConnectSchema());
-    key.put("ROWKEY", rowKey);
+    key.put(Iterables.getOnlyElement(SCHEMA.key()).name().text(), rowKey);
     return key;
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/SelectValueMapperIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/SelectValueMapperIntegrationTest.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.execution.util.StructKeyUtil;
 import io.confluent.ksql.function.TestFunctionRegistry;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.planner.plan.PlanNode;
 import io.confluent.ksql.planner.plan.ProjectNode;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
@@ -46,7 +47,8 @@ import org.mockito.junit.MockitoRule;
 
 public class SelectValueMapperIntegrationTest {
 
-  private static final Struct NON_WINDOWED_KEY = StructKeyUtil.keyBuilder(SqlTypes.STRING)
+  private static final Struct NON_WINDOWED_KEY = StructKeyUtil
+      .keyBuilder(ColumnName.of("K"), SqlTypes.STRING)
       .build("someKey");
 
   private final MetaStore metaStore = MetaStoreFixture

--- a/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -354,7 +354,7 @@ public class PhysicalPlanBuilderTest {
     // Then:
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage("Cannot repartition a TABLE source. If this is a join, make "
-        + "sure that the criteria uses the TABLE key `ID` instead of COL0");
+        + "sure that the criteria uses the TABLE's key column ROWKEY instead of COL0");
 
     // When:
     execute("CREATE TABLE t1 AS "
@@ -371,7 +371,7 @@ public class PhysicalPlanBuilderTest {
     // Then:
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage("Cannot repartition a TABLE source. If this is a join, make "
-        + "sure that the criteria uses the TABLE key `ID` instead of COL0");
+        + "sure that the criteria uses the TABLE's key column ROWKEY instead of COL0");
 
     // When:
     execute("CREATE TABLE t1 AS "

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
@@ -59,7 +59,6 @@ import io.confluent.ksql.serde.WindowInfo;
 import io.confluent.ksql.structured.SchemaKStream;
 import io.confluent.ksql.structured.SchemaKTable;
 import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.SchemaUtil;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -80,8 +79,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class DataSourceNodeTest {
 
-  private static final ColumnName TIMESTAMP_FIELD
-      = ColumnName.of("timestamp");
+  private static final ColumnName TIMESTAMP_FIELD = ColumnName.of("timestamp");
   private static final PlanNodeId PLAN_NODE_ID = new PlanNodeId("0");
   private static final SourceName SOURCE_NAME = SourceName.of("datasource");
 
@@ -94,7 +92,7 @@ public class DataSourceNodeTest {
   private static final ColumnName FIELD3 = ColumnName.of("field3");
 
   private static final LogicalSchema REAL_SCHEMA = LogicalSchema.builder()
-      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.INTEGER)
+      .keyColumn(ColumnName.of("k0"), SqlTypes.INTEGER)
       .valueColumn(FIELD1, SqlTypes.INTEGER)
       .valueColumn(FIELD2, SqlTypes.STRING)
       .valueColumn(FIELD3, SqlTypes.STRING)

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/FilterNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/FilterNodeTest.java
@@ -25,6 +25,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext.Stacker;
 import io.confluent.ksql.execution.expression.tree.Expression;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.structured.SchemaKStream;
 import org.junit.Before;
 import org.junit.Rule;
@@ -34,7 +35,8 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 public class FilterNodeTest {
-  private final PlanNodeId nodeId = new PlanNodeId("nodeid");
+
+  private static final PlanNodeId NODE_ID = new PlanNodeId("nodeid");
 
   @Mock
   private Expression predicate;
@@ -55,15 +57,16 @@ public class FilterNodeTest {
   @Before
   @SuppressWarnings("unchecked")
   public void setup() {
+    when(sourceNode.getSchema()).thenReturn(LogicalSchema.builder().build());
     when(sourceNode.buildStream(any()))
         .thenReturn(schemaKStream);
     when(sourceNode.getNodeOutputType()).thenReturn(DataSourceType.KSTREAM);
     when(schemaKStream.filter(any(), any()))
         .thenReturn(schemaKStream);
 
-    when(ksqlStreamBuilder.buildNodeContext(nodeId.toString())).thenReturn(stacker);
+    when(ksqlStreamBuilder.buildNodeContext(NODE_ID.toString())).thenReturn(stacker);
 
-    node = new FilterNode(nodeId, sourceNode, predicate);
+    node = new FilterNode(NODE_ID, sourceNode, predicate);
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
@@ -60,7 +60,6 @@ import io.confluent.ksql.testutils.AnalysisTestUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.MetaStoreFixture;
-import io.confluent.ksql.util.SchemaUtil;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -89,14 +88,14 @@ public class JoinNodeTest {
 
   private static final LogicalSchema LEFT_SOURCE_SCHEMA = LogicalSchema.builder()
       .withRowTime()
-      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.BIGINT)
+      .keyColumn(ColumnName.of("leftKey"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("C0"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("L1"), SqlTypes.STRING)
       .build();
 
   private static final LogicalSchema RIGHT_SOURCE_SCHEMA = LogicalSchema.builder()
       .withRowTime()
-      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.BIGINT)
+      .keyColumn(ColumnName.of("rightKey"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("C0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("R1"), SqlTypes.BIGINT)
       .build();
@@ -647,15 +646,15 @@ public class JoinNodeTest {
     // When:
     assertThat(joinNode.getSchema(), is(LogicalSchema.builder()
         .withRowTime()
-        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.BIGINT)
-        .valueColumn(ColumnName.of(LEFT_ALIAS.text() + "_" + "C0"), SqlTypes.BIGINT)
-        .valueColumn(ColumnName.of(LEFT_ALIAS.text() + "_" + "L1"), SqlTypes.STRING)
-        .valueColumn(ColumnName.of(LEFT_ALIAS.text() + "_" + "ROWTIME"), SqlTypes.BIGINT)
-        .valueColumn(ColumnName.of(LEFT_ALIAS.text() + "_" + "ROWKEY"), SqlTypes.BIGINT)
-        .valueColumn(ColumnName.of(RIGHT_ALIAS.text() + "_" + "C0"), SqlTypes.STRING)
-        .valueColumn(ColumnName.of(RIGHT_ALIAS.text() + "_" + "R1"), SqlTypes.BIGINT)
-        .valueColumn(ColumnName.of(RIGHT_ALIAS.text() + "_" + "ROWTIME"), SqlTypes.BIGINT)
-        .valueColumn(ColumnName.of(RIGHT_ALIAS.text() + "_" + "ROWKEY"), SqlTypes.BIGINT)
+        .keyColumn(ColumnName.of("leftKey"), SqlTypes.BIGINT)
+        .valueColumn(ColumnName.of(LEFT_ALIAS.text() + "_C0"), SqlTypes.BIGINT)
+        .valueColumn(ColumnName.of(LEFT_ALIAS.text() + "_L1"), SqlTypes.STRING)
+        .valueColumn(ColumnName.of(LEFT_ALIAS.text() + "_ROWTIME"), SqlTypes.BIGINT)
+        .valueColumn(ColumnName.of(LEFT_ALIAS.text() + "_leftKey"), SqlTypes.BIGINT)
+        .valueColumn(ColumnName.of(RIGHT_ALIAS.text() + "_C0"), SqlTypes.STRING)
+        .valueColumn(ColumnName.of(RIGHT_ALIAS.text() + "_R1"), SqlTypes.BIGINT)
+        .valueColumn(ColumnName.of(RIGHT_ALIAS.text() + "_ROWTIME"), SqlTypes.BIGINT)
+        .valueColumn(ColumnName.of(RIGHT_ALIAS.text() + "_rightKey"), SqlTypes.BIGINT)
         .build()
     ));
   }
@@ -698,7 +697,7 @@ public class JoinNodeTest {
     // Then:
     assertThat(joinNode.getSchema(), is(LogicalSchema.builder()
         .withRowTime()
-        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.BIGINT)
+        .keyColumn(ColumnName.of("leftKey"), SqlTypes.BIGINT)
         .valueColumns(LEFT_NODE_SCHEMA.value())
         .valueColumns(RIGHT_NODE_SCHEMA.value())
         .build()));

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
@@ -91,6 +91,7 @@ import io.confluent.ksql.testutils.AnalysisTestUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.MetaStoreFixture;
 import io.confluent.ksql.util.Pair;
+import io.confluent.ksql.util.SchemaUtil;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -121,7 +122,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class SchemaKTableTest {
 
-  private static final KeyBuilder STRING_KEY_BUILDER = StructKeyUtil.keyBuilder(SqlTypes.STRING);
+  private static final KeyBuilder STRING_KEY_BUILDER = StructKeyUtil
+      .keyBuilder(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING);
 
   private final KsqlConfig ksqlConfig = new KsqlConfig(Collections.emptyMap());
   private final MetaStore metaStore = MetaStoreFixture.getNewMetaStore(new InternalFunctionRegistry());

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateSourceCommand.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateSourceCommand.java
@@ -20,7 +20,6 @@ import io.confluent.ksql.execution.timestamp.TimestampColumn;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.Column;
-import io.confluent.ksql.schema.ksql.FormatOptions;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.serde.WindowInfo;
@@ -108,16 +107,16 @@ public abstract class CreateSourceCommand implements DdlCommand {
 
       if (!keyFieldType.equals(keyType)) {
         throw new KsqlException("The KEY field ("
-            + keyField.get().toString(FormatOptions.noEscape())
+            + keyField.get().text()
             + ") identified in the WITH clause is of a different type to the actual key column."
             + System.lineSeparator()
-            + "Either change the type of the KEY field to match ROWKEY, "
-            + "or explicitly set ROWKEY to the type of the KEY field by adding "
-            + "'ROWKEY " + keyFieldType + " KEY' in the schema."
+            + "Use of the KEY field is deprecated. Remove the KEY field from the WITH clause and "
+            + "specify the name of the key column by adding "
+            + "'" + keyField.get().text() + " " + keyFieldType + " KEY' to the schema."
             + System.lineSeparator()
             + "KEY field type: " + keyFieldType
             + System.lineSeparator()
-            + "ROWKEY type: " + keyType
+            + "key column type: " + keyType
         );
       }
     }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/util/StructKeyUtil.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/util/StructKeyUtil.java
@@ -15,11 +15,12 @@
 
 package io.confluent.ksql.execution.util;
 
+import com.google.common.collect.Iterables;
+import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.schema.ksql.types.SqlType;
-import io.confluent.ksql.util.SchemaUtil;
 import java.util.List;
 import java.util.Objects;
 import org.apache.kafka.connect.data.Schema;
@@ -40,16 +41,16 @@ public final class StructKeyUtil {
       throw new UnsupportedOperationException("Only single keys supported");
     }
 
-    final SqlType sqlType = keyCols.get(0).type();
-    return keyBuilder(sqlType);
+    final Column keyCol = keyCols.get(0);
+    return keyBuilder(keyCol.name(), keyCol.type());
   }
 
-  public static KeyBuilder keyBuilder(final SqlType sqlType) {
-    final Schema connectSchema = SchemaConverters.sqlToConnectConverter().toConnectSchema(sqlType);
+  public static KeyBuilder keyBuilder(final ColumnName name, final SqlType type) {
+    final Schema connectSchema = SchemaConverters.sqlToConnectConverter().toConnectSchema(type);
 
     return new KeyBuilder(SchemaBuilder
         .struct()
-        .field(SchemaUtil.ROWKEY_NAME.text(), connectSchema)
+        .field(name.text(), connectSchema)
         .build()
     );
   }
@@ -61,12 +62,12 @@ public final class StructKeyUtil {
 
     private KeyBuilder(final Schema keySchema) {
       this.keySchema = Objects.requireNonNull(keySchema, "keySchema");
-      this.keyField = keySchema.field(SchemaUtil.ROWKEY_NAME.text());
+      this.keyField = Iterables.getOnlyElement(keySchema.fields());
     }
 
-    public Struct build(final Object rowKey) {
+    public Struct build(final Object keyValue) {
       final Struct keyStruct = new Struct(keySchema);
-      keyStruct.put(keyField, rowKey);
+      keyStruct.put(keyField, keyValue);
       return keyStruct;
     }
   }

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/ddl/commands/CreateSourceCommandTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/ddl/commands/CreateSourceCommandTest.java
@@ -68,7 +68,7 @@ public class CreateSourceCommandTest {
   }
 
   @Test
-  public void shouldThrowIfKeyFieldDoesNotMatchRowKeyType() {
+  public void shouldThrowIfKeyFieldDoesNotMatchKeyType() {
     // Given:
     final ColumnName keyField = ColumnName.of("keyField");
 
@@ -82,10 +82,10 @@ public class CreateSourceCommandTest {
     expectedException.expectMessage("The KEY field (keyField) identified in the "
         + "WITH clause is of a different type to the actual key column.");
     expectedException.expectMessage(
-        "Either change the type of the KEY field to match ROWKEY, or explicitly set ROWKEY "
-            + "to the type of the KEY field by adding 'ROWKEY STRING KEY' in the schema.");
+        "Use of the KEY field is deprecated. Remove the KEY field from the WITH clause and "
+            + "specify the name of the key column by adding 'keyField STRING KEY' to the schema.");
     expectedException.expectMessage("KEY field type: STRING");
-    expectedException.expectMessage("ROWKEY type: INTEGER");
+    expectedException.expectMessage("key column type: INTEGER");
 
     // When:
     new TestCommand(
@@ -100,7 +100,7 @@ public class CreateSourceCommandTest {
   }
 
   @Test
-  public void shouldNotThrowIfKeyFieldMatchesRowKeyType() {
+  public void shouldNotThrowIfKeyFieldMatchesKeyType() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
         .keyColumn(K0, SqlTypes.INTEGER)
@@ -125,7 +125,7 @@ public class CreateSourceCommandTest {
   public void shouldThrowOnWindowStartColumn() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.INTEGER)
+        .keyColumn(ColumnName.of("K0"), SqlTypes.INTEGER)
         .valueColumn(SchemaUtil.WINDOWSTART_NAME, SqlTypes.INTEGER)
         .build();
 
@@ -149,7 +149,7 @@ public class CreateSourceCommandTest {
   public void shouldThrowOnWindowEndColumn() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.INTEGER)
+        .keyColumn(ColumnName.of("k1"), SqlTypes.INTEGER)
         .valueColumn(SchemaUtil.WINDOWEND_NAME, SqlTypes.INTEGER)
         .build();
 

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/transform/select/SelectionTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/transform/select/SelectionTest.java
@@ -44,6 +44,7 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 public class SelectionTest {
+
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
       .withRowTime()
       .keyColumn(ColumnName.of("K0"), SqlTypes.BIGINT)
@@ -114,12 +115,12 @@ public class SelectionTest {
     final LogicalSchema resultSchema = selection.getSchema();
 
     // Then:
-    final LogicalSchema expected = new LogicalSchema.Builder()
+    assertThat(resultSchema, equalTo(LogicalSchema.builder()
         .withRowTime()
         .keyColumn(ColumnName.of("K0"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("FOO"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("BAR"), SqlTypes.BIGINT)
-        .build();
-    assertThat(resultSchema, equalTo(expected));
+        .build()
+    ));
   }
 }

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/util/StructKeyUtilTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/util/StructKeyUtilTest.java
@@ -33,7 +33,7 @@ public class StructKeyUtilTest {
 
   private static final LogicalSchema LOGICAL_SCHEMA = LogicalSchema.builder()
       .withRowTime()
-      .keyColumn(ColumnName.of("BOB"), SqlTypes.INTEGER)
+      .keyColumn(ColumnName.of("Bob"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("DOES_NOT_MATTER"), SqlTypes.STRING)
       .build();
 
@@ -61,7 +61,7 @@ public class StructKeyUtilTest {
 
     // Then:
     assertThat(result.schema(), is(SchemaBuilder.struct()
-        .field("ROWKEY", Schema.OPTIONAL_INT32_SCHEMA)
+        .field("Bob", Schema.OPTIONAL_INT32_SCHEMA)
         .build()));
   }
 
@@ -71,7 +71,7 @@ public class StructKeyUtilTest {
     final Struct result = builder.build(1);
 
     // Then:
-    assertThat(result.getInt32("ROWKEY"), is(1));
+    assertThat(result.getInt32("Bob"), is(1));
   }
 
   @Test
@@ -80,6 +80,6 @@ public class StructKeyUtilTest {
     final Struct result = builder.build(null);
 
     // Then:
-    assertThat(result.getInt32("ROWKEY"), is(nullValue()));
+    assertThat(result.getInt32("Bob"), is(nullValue()));
   }
 }

--- a/ksql-functional-tests/README.md
+++ b/ksql-functional-tests/README.md
@@ -292,8 +292,7 @@ A post condition can define the list of sources that must exist in the metastore
 {
   "name": "S1",
   "type": "table",
-  "keyField": "FOO",
-  "valueSchema": "STRUCT<ROWTIME BIGINT, ROWKEY STRING, FOO INT, KSQL_COL_1 BIGINT>"
+  "schema": "ID BIGINT KEY, FOO STRING, KSQL_COL_1 BIGINT"
 }
 ```
 
@@ -303,8 +302,7 @@ Each source can define the following attributes:
 |-------------|:------------|
 | name        | (Required) The name of the source. |
 | type        | (Required) Specifies if the source is a STREAM or TABLE. |
-| keyField    | (Optional) Specifies the keyField for the source. If present, but set to `null`, the name of the key field is expected to not be set. If not supplied, the name of the key field will not be checked. |
-| valueSchema | (Optional) Specifies the value SQL schema for the source. |
+| schema      | (Optional) Specifies the SQL schema for the source. |
 
 #### Topics
 A post condition can define a check against the set of topics the case creates

--- a/ksql-functional-tests/src/test/resources/historical_plans/elements_-_validate_without_value_elements_OK_-_custom_key_name/6.0.0_1583319039183/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/elements_-_validate_without_value_elements_OK_-_custom_key_name/6.0.0_1583319039183/plan.json
@@ -1,0 +1,147 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID INTEGER KEY, C1 BIGINT) WITH (KAFKA_TOPIC='input', SCHEMA_ID=1, VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` INTEGER KEY, `C1` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` INTEGER KEY, `C1` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`ID` INTEGER KEY, `C1` BIGINT"
+          },
+          "selectExpressions" : [ "C1 AS C1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/elements_-_validate_without_value_elements_OK_-_custom_key_name/6.0.0_1583319039183/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/elements_-_validate_without_value_elements_OK_-_custom_key_name/6.0.0_1583319039183/spec.json
@@ -1,0 +1,22 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319039183,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<C1 BIGINT> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<C1 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "input",
+    "key" : 42,
+    "value" : {
+      "c1" : 4
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 42,
+    "value" : {
+      "C1" : 4
+    }
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/elements_-_validate_without_value_elements_OK_-_custom_key_name/6.0.0_1583319039183/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/elements_-_validate_without_value_elements_OK_-_custom_key_name/6.0.0_1583319039183/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/group-by_-_only_key_column/6.0.0_1583329131267/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/group-by_-_only_key_column/6.0.0_1583329131267/plan.json
@@ -1,0 +1,190 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID INTEGER KEY, IGNORED INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` INTEGER KEY, `IGNORED` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT COUNT(1) COUNT\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` INTEGER KEY, `COUNT` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` INTEGER KEY, `IGNORED` INTEGER"
+                },
+                "selectExpressions" : [ "ID AS KSQL_INTERNAL_COL_0", "1 AS KSQL_INTERNAL_COL_1" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA",
+                  "properties" : { }
+                },
+                "valueFormat" : {
+                  "format" : "JSON",
+                  "properties" : { }
+                },
+                "options" : [ ]
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "nonAggregateColumns" : [ "KSQL_INTERNAL_COL_0" ],
+            "aggregationFunctions" : [ "COUNT(KSQL_INTERNAL_COL_1)" ]
+          },
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS COUNT" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent335545957785424598",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/group-by_-_only_key_column/6.0.0_1583329131267/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/group-by_-_only_key_column/6.0.0_1583329131267/spec.json
@@ -1,0 +1,69 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583329131267,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<IGNORED INT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : "STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_INTERNAL_COL_1 INT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : "STRUCT<KSQL_INTERNAL_COL_0 INT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<COUNT BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 11,
+    "value" : { },
+    "timestamp" : 12345
+  }, {
+    "topic" : "test_topic",
+    "key" : 10,
+    "value" : { },
+    "timestamp" : 12365
+  }, {
+    "topic" : "test_topic",
+    "key" : 11,
+    "value" : { },
+    "timestamp" : 12375
+  } ],
+  "outputs" : [ {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : 11,
+    "value" : {
+      "KSQL_INTERNAL_COL_0" : 11,
+      "KSQL_AGG_VARIABLE_0" : 1
+    },
+    "timestamp" : 12345
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : 10,
+    "value" : {
+      "KSQL_INTERNAL_COL_0" : 10,
+      "KSQL_AGG_VARIABLE_0" : 1
+    },
+    "timestamp" : 12365
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : 11,
+    "value" : {
+      "KSQL_INTERNAL_COL_0" : 11,
+      "KSQL_AGG_VARIABLE_0" : 2
+    },
+    "timestamp" : 12375
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 11,
+    "value" : {
+      "COUNT" : 1
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 10,
+    "value" : {
+      "COUNT" : 1
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 11,
+    "value" : {
+      "COUNT" : 2
+    }
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/group-by_-_only_key_column/6.0.0_1583329131267/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/group-by_-_only_key_column/6.0.0_1583329131267/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/group-by_-_only_key_column_(stream-_table)/6.0.0_1583319041765/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/group-by_-_only_key_column_(stream-_table)/6.0.0_1583319041765/plan.json
@@ -1,0 +1,190 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID INTEGER KEY, IGNORED STRING) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='DELIMITED');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` INTEGER KEY, `IGNORED` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT COUNT(*) KSQL_COL_0\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` INTEGER KEY, `KSQL_COL_0` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "DELIMITED",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` INTEGER KEY, `IGNORED` STRING"
+                },
+                "selectExpressions" : [ "ROWTIME AS KSQL_INTERNAL_COL_0", "ID AS KSQL_INTERNAL_COL_1" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA",
+                  "properties" : { }
+                },
+                "valueFormat" : {
+                  "format" : "DELIMITED",
+                  "properties" : { }
+                },
+                "options" : [ ]
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "DELIMITED",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "nonAggregateColumns" : [ "KSQL_INTERNAL_COL_0", "KSQL_INTERNAL_COL_1" ],
+            "aggregationFunctions" : [ "COUNT(KSQL_INTERNAL_COL_0)" ]
+          },
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS KSQL_COL_0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/group-by_-_only_key_column_(stream-_table)/6.0.0_1583319041765/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/group-by_-_only_key_column_(stream-_table)/6.0.0_1583319041765/spec.json
@@ -1,0 +1,52 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319041765,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<IGNORED VARCHAR> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : "STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : "STRUCT<KSQL_INTERNAL_COL_0 BIGINT, KSQL_INTERNAL_COL_1 INT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<KSQL_COL_0 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 1,
+    "value" : "-"
+  }, {
+    "topic" : "test_topic",
+    "key" : 2,
+    "value" : "-"
+  }, {
+    "topic" : "test_topic",
+    "key" : 1,
+    "value" : "-"
+  }, {
+    "topic" : "test_topic",
+    "key" : 2,
+    "value" : "-"
+  }, {
+    "topic" : "test_topic",
+    "key" : 1,
+    "value" : "-"
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : "1"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 2,
+    "value" : "1"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : "2"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 2,
+    "value" : "2"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : "3"
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/group-by_-_only_key_column_(stream-_table)/6.0.0_1583319041765/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/group-by_-_only_key_column_(stream-_table)/6.0.0_1583319041765/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/group-by_-_should_handled_quoted_key_and_value/6.0.0_1583329131307/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/group-by_-_should_handled_quoted_key_and_value/6.0.0_1583329131307/plan.json
@@ -1,0 +1,190 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (`Key` STRING KEY, IGNORED INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`Key` STRING KEY, `IGNORED` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT COUNT(1) `Value`\nFROM INPUT INPUT\nGROUP BY INPUT.`Key`\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`Key` STRING KEY, `Value` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`Key` STRING KEY, `IGNORED` INTEGER"
+                },
+                "selectExpressions" : [ "`Key` AS KSQL_INTERNAL_COL_0", "1 AS KSQL_INTERNAL_COL_1" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA",
+                  "properties" : { }
+                },
+                "valueFormat" : {
+                  "format" : "JSON",
+                  "properties" : { }
+                },
+                "options" : [ ]
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "nonAggregateColumns" : [ "KSQL_INTERNAL_COL_0" ],
+            "aggregationFunctions" : [ "COUNT(KSQL_INTERNAL_COL_1)" ]
+          },
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS `Value`" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent335545957785424598",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/group-by_-_should_handled_quoted_key_and_value/6.0.0_1583329131307/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/group-by_-_should_handled_quoted_key_and_value/6.0.0_1583329131307/spec.json
@@ -1,0 +1,69 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583329131307,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<IGNORED INT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : "STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_INTERNAL_COL_1 INT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : "STRUCT<KSQL_INTERNAL_COL_0 VARCHAR, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<Value BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : "11",
+    "value" : { },
+    "timestamp" : 12345
+  }, {
+    "topic" : "test_topic",
+    "key" : "10",
+    "value" : { },
+    "timestamp" : 12365
+  }, {
+    "topic" : "test_topic",
+    "key" : "11",
+    "value" : { },
+    "timestamp" : 12375
+  } ],
+  "outputs" : [ {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "11",
+    "value" : {
+      "KSQL_INTERNAL_COL_0" : "11",
+      "KSQL_AGG_VARIABLE_0" : 1
+    },
+    "timestamp" : 12345
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "10",
+    "value" : {
+      "KSQL_INTERNAL_COL_0" : "10",
+      "KSQL_AGG_VARIABLE_0" : 1
+    },
+    "timestamp" : 12365
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "11",
+    "value" : {
+      "KSQL_INTERNAL_COL_0" : "11",
+      "KSQL_AGG_VARIABLE_0" : 2
+    },
+    "timestamp" : 12375
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "11",
+    "value" : {
+      "Value" : 1
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "10",
+    "value" : {
+      "Value" : 1
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "11",
+    "value" : {
+      "Value" : 2
+    }
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/group-by_-_should_handled_quoted_key_and_value/6.0.0_1583329131307/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/group-by_-_should_handled_quoted_key_and_value/6.0.0_1583329131307/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_a_table_join_pipeline_-_JSON/6.0.0_1583319045585/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_a_table_join_pipeline_-_JSON/6.0.0_1583319045585/plan.json
@@ -1,0 +1,351 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE_2 (ID BIGINT KEY, F3 STRING) WITH (KAFKA_TOPIC='right_topic_2', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE_2",
+      "schema" : "`ID` BIGINT KEY, `F3` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic_2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE INNER_JOIN WITH (PARTITIONS=4) AS SELECT\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_TABLE", "TEST" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            }
+          },
+          "selectExpressions" : [ "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "INNER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_INNER_JOIN_0"
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE INNER_JOIN_2 AS SELECT\n  TT.NAME NAME,\n  TT.F1 F1,\n  T.F3 F3\nFROM INNER_JOIN TT\nINNER JOIN TEST_TABLE_2 T ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "INNER_JOIN_2",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `F1` STRING, `F3` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "INNER_JOIN_2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "INNER_JOIN", "TEST_TABLE_2" ],
+      "sink" : "INNER_JOIN_2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN_2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "INNER_JOIN",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS TT_NAME", "VALUE AS TT_VALUE", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic_2",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F3` STRING"
+              },
+              "selectExpressions" : [ "F3 AS T_F3", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            }
+          },
+          "selectExpressions" : [ "TT_NAME AS NAME", "TT_F1 AS F1", "T_F3 AS F3" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "INNER_JOIN_2",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_INNER_JOIN_2_1"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_a_table_join_pipeline_-_JSON/6.0.0_1583319045585/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_a_table_join_pipeline_-_JSON/6.0.0_1583319045585/spec.json
@@ -1,0 +1,63 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319045585,
+  "schemas" : {
+    "CTAS_INNER_JOIN_2_1.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CTAS_INNER_JOIN_2_1.KafkaTopic_Right.Source" : "STRUCT<F3 VARCHAR> NOT NULL",
+    "CTAS_INNER_JOIN_2_1.INNER_JOIN_2" : "STRUCT<NAME VARCHAR, F1 VARCHAR, F3 VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "X",
+      "VALUE" : 0,
+      "F1" : "yo dawg",
+      "F2" : 50
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic_2",
+    "key" : 0,
+    "value" : {
+      "F3" : "I heard you like joins"
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 100,
+    "value" : {
+      "NAME" : "X",
+      "VALUE" : 0,
+      "F1" : "KSQL has table-table joins",
+      "F2" : 50
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic_2",
+    "key" : 100,
+    "value" : {
+      "F3" : "so now you can join your join"
+    },
+    "timestamp" : 20000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN_2",
+    "key" : 0,
+    "value" : {
+      "NAME" : "X",
+      "F1" : "yo dawg",
+      "F3" : "I heard you like joins"
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN_2",
+    "key" : 100,
+    "value" : {
+      "NAME" : "X",
+      "F1" : "KSQL has table-table joins",
+      "F3" : "so now you can join your join"
+    },
+    "timestamp" : 20000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_a_table_join_pipeline_-_JSON/6.0.0_1583319045585/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_a_table_join_pipeline_-_JSON/6.0.0_1583319045585/topology
@@ -1,0 +1,42 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [INNER_JOIN])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic_2])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: INNER_JOIN_2)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_matching_session_windowed/6.0.0_1583319046811/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_matching_session_windowed/6.0.0_1583319046811/plan.json
@@ -1,0 +1,253 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM S1 (ID INTEGER KEY, V BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='JSON', WINDOW_TYPE='SESSION');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "S1",
+      "schema" : "`ID` INTEGER KEY, `V` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : {
+        "type" : "SESSION",
+        "size" : null
+      }
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM S2 (ID INTEGER KEY, V BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='JSON', WINDOW_TYPE='SESSION');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "S2",
+      "schema" : "`ID` INTEGER KEY, `V` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : {
+        "type" : "SESSION",
+        "size" : null
+      }
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  S1.V S1_V,\n  S2.V S2_V\nFROM S1 S1\nINNER JOIN S2 S2 WITHIN 1 MINUTES ON ((S1.ID = S2.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` INTEGER KEY, `S1_V` BIGINT, `S2_V` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : {
+        "type" : "SESSION",
+        "size" : null
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "S1", "S2" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "windowedStreamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "windowInfo" : {
+                  "type" : "SESSION",
+                  "size" : null
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` INTEGER KEY, `V` BIGINT"
+              },
+              "selectExpressions" : [ "V AS S1_V", "ROWTIME AS S1_ROWTIME", "ID AS S1_ID", "WINDOWSTART AS S1_WINDOWSTART", "WINDOWEND AS S1_WINDOWEND" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "windowedStreamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "windowInfo" : {
+                  "type" : "SESSION",
+                  "size" : null
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` INTEGER KEY, `V` BIGINT"
+              },
+              "selectExpressions" : [ "V AS S2_V", "ROWTIME AS S2_ROWTIME", "ID AS S2_ID", "WINDOWSTART AS S2_WINDOWSTART", "WINDOWEND AS S2_WINDOWEND" ]
+            },
+            "beforeMillis" : 60.000000000,
+            "afterMillis" : 60.000000000
+          },
+          "selectExpressions" : [ "S1_V AS S1_V", "S2_V AS S2_V" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_matching_session_windowed/6.0.0_1583319046811/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_matching_session_windowed/6.0.0_1583319046811/spec.json
@@ -1,0 +1,62 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319046811,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<V BIGINT> NOT NULL",
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<V BIGINT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<S1_V BIGINT, S1_ROWTIME BIGINT, S1_ID INT, S1_WINDOWSTART BIGINT, S1_WINDOWEND BIGINT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Right" : "STRUCT<S2_V BIGINT, S2_ROWTIME BIGINT, S2_ID INT, S2_WINDOWSTART BIGINT, S2_WINDOWEND BIGINT> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<S1_V BIGINT, S2_V BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 1,
+    "value" : {
+      "V" : 1
+    },
+    "timestamp" : 765,
+    "window" : {
+      "start" : 234,
+      "end" : 765,
+      "type" : "SESSION"
+    }
+  }, {
+    "topic" : "right_topic",
+    "key" : 1,
+    "value" : {
+      "V" : 2
+    },
+    "timestamp" : 567,
+    "window" : {
+      "start" : 234,
+      "end" : 567,
+      "type" : "SESSION"
+    }
+  }, {
+    "topic" : "right_topic",
+    "key" : 1,
+    "value" : {
+      "V" : 3
+    },
+    "timestamp" : 765,
+    "window" : {
+      "start" : 234,
+      "end" : 765,
+      "type" : "SESSION"
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : {
+      "S1_V" : 1,
+      "S2_V" : 3
+    },
+    "timestamp" : 765,
+    "window" : {
+      "start" : 234,
+      "end" : 765,
+      "type" : "SESSION"
+    }
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_matching_session_windowed/6.0.0_1583319046811/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_matching_session_windowed/6.0.0_1583319046811/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_matching_time_windowed/6.0.0_1583319046881/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_matching_time_windowed/6.0.0_1583319046881/plan.json
@@ -1,0 +1,253 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM S1 (ID INTEGER KEY, V BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='JSON', WINDOW_SIZE='5 SECONDS', WINDOW_TYPE='Hopping');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "S1",
+      "schema" : "`ID` INTEGER KEY, `V` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : {
+        "type" : "HOPPING",
+        "size" : 5.000000000
+      }
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM S2 (ID INTEGER KEY, V BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='JSON', WINDOW_SIZE='2 SECOND', WINDOW_TYPE='Tumbling');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "S2",
+      "schema" : "`ID` INTEGER KEY, `V` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : {
+        "type" : "TUMBLING",
+        "size" : 2.000000000
+      }
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM S1 S1\nINNER JOIN S2 S2 WITHIN 1 MINUTES ON ((S1.ID = S2.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` INTEGER KEY, `S1_ROWTIME` BIGINT, `S1_ID` INTEGER, `S1_WINDOWSTART` BIGINT, `S1_WINDOWEND` BIGINT, `S1_V` BIGINT, `S2_ROWTIME` BIGINT, `S2_ID` INTEGER, `S2_WINDOWSTART` BIGINT, `S2_WINDOWEND` BIGINT, `S2_V` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : {
+        "type" : "HOPPING",
+        "size" : 5.000000000
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "S1", "S2" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "windowedStreamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "windowInfo" : {
+                  "type" : "HOPPING",
+                  "size" : 5.000000000
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` INTEGER KEY, `V` BIGINT"
+              },
+              "selectExpressions" : [ "V AS S1_V", "ROWTIME AS S1_ROWTIME", "ID AS S1_ID", "WINDOWSTART AS S1_WINDOWSTART", "WINDOWEND AS S1_WINDOWEND" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "windowedStreamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "windowInfo" : {
+                  "type" : "TUMBLING",
+                  "size" : 2.000000000
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` INTEGER KEY, `V` BIGINT"
+              },
+              "selectExpressions" : [ "V AS S2_V", "ROWTIME AS S2_ROWTIME", "ID AS S2_ID", "WINDOWSTART AS S2_WINDOWSTART", "WINDOWEND AS S2_WINDOWEND" ]
+            },
+            "beforeMillis" : 60.000000000,
+            "afterMillis" : 60.000000000
+          },
+          "selectExpressions" : [ "S1_ROWTIME AS S1_ROWTIME", "S1_ID AS S1_ID", "S1_WINDOWSTART AS S1_WINDOWSTART", "S1_WINDOWEND AS S1_WINDOWEND", "S1_V AS S1_V", "S2_ROWTIME AS S2_ROWTIME", "S2_ID AS S2_ID", "S2_WINDOWSTART AS S2_WINDOWSTART", "S2_WINDOWEND AS S2_WINDOWEND", "S2_V AS S2_V" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_matching_time_windowed/6.0.0_1583319046881/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_matching_time_windowed/6.0.0_1583319046881/spec.json
@@ -1,0 +1,115 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319046881,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<V BIGINT> NOT NULL",
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<V BIGINT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<S1_V BIGINT, S1_ROWTIME BIGINT, S1_ID INT, S1_WINDOWSTART BIGINT, S1_WINDOWEND BIGINT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Right" : "STRUCT<S2_V BIGINT, S2_ROWTIME BIGINT, S2_ID INT, S2_WINDOWSTART BIGINT, S2_WINDOWEND BIGINT> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<S1_ROWTIME BIGINT, S1_ID INT, S1_WINDOWSTART BIGINT, S1_WINDOWEND BIGINT, S1_V BIGINT, S2_ROWTIME BIGINT, S2_ID INT, S2_WINDOWSTART BIGINT, S2_WINDOWEND BIGINT, S2_V BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 1,
+    "value" : {
+      "V" : 1
+    },
+    "timestamp" : 0,
+    "window" : {
+      "start" : 0,
+      "end" : 5000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "left_topic",
+    "key" : 1,
+    "value" : {
+      "V" : 2
+    },
+    "timestamp" : 1000,
+    "window" : {
+      "start" : 1000,
+      "end" : 6000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "left_topic",
+    "key" : 1,
+    "value" : {
+      "V" : 3
+    },
+    "timestamp" : 2000,
+    "window" : {
+      "start" : 2000,
+      "end" : 7000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "right_topic",
+    "key" : 1,
+    "value" : {
+      "V" : 4
+    },
+    "timestamp" : 0,
+    "window" : {
+      "start" : 0,
+      "end" : 2000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "right_topic",
+    "key" : 1,
+    "value" : {
+      "V" : 5
+    },
+    "timestamp" : 2000,
+    "window" : {
+      "start" : 2000,
+      "end" : 4000,
+      "type" : "TIME"
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : {
+      "S1_ROWTIME" : 0,
+      "S1_WINDOWSTART" : 0,
+      "S1_WINDOWEND" : 5000,
+      "S1_ID" : 1,
+      "S1_V" : 1,
+      "S2_ROWTIME" : 0,
+      "S2_WINDOWSTART" : 0,
+      "S2_WINDOWEND" : 2000,
+      "S2_ID" : 1,
+      "S2_V" : 4
+    },
+    "timestamp" : 0,
+    "window" : {
+      "start" : 0,
+      "end" : 5000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : {
+      "S1_ROWTIME" : 2000,
+      "S1_WINDOWSTART" : 2000,
+      "S1_WINDOWEND" : 7000,
+      "S1_ID" : 1,
+      "S1_V" : 3,
+      "S2_ROWTIME" : 2000,
+      "S2_WINDOWSTART" : 2000,
+      "S2_WINDOWEND" : 4000,
+      "S2_ID" : 1,
+      "S2_V" : 5
+    },
+    "timestamp" : 2000,
+    "window" : {
+      "start" : 2000,
+      "end" : 7000,
+      "type" : "TIME"
+    }
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_matching_time_windowed/6.0.0_1583319046881/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_matching_time_windowed/6.0.0_1583319046881/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_BIGINT_column_-_AVRO/6.0.0_1583319046422/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_BIGINT_column_-_AVRO/6.0.0_1583319046422/plan.json
@@ -1,0 +1,250 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM L (ID STRING KEY, L0 BIGINT, L1 INTEGER) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "L",
+      "schema" : "`ID` STRING KEY, `L0` BIGINT, `L1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM R (ID STRING KEY, R0 BIGINT, R1 INTEGER) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "R",
+      "schema" : "`ID` STRING KEY, `R0` BIGINT, `R1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  L.ID L_ID,\n  L.L1 L1,\n  R.R1 R1\nFROM L L\nINNER JOIN R R WITHIN 11 SECONDS ON ((L.L0 = R.R0))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` BIGINT KEY, `L_ID` STRING, `L1` INTEGER, `R1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "L", "R" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "LeftSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Left/Source"
+                  },
+                  "topicName" : "left_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "AVRO",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` STRING KEY, `L0` BIGINT, `L1` INTEGER"
+                },
+                "keyExpression" : "L0"
+              },
+              "selectExpressions" : [ "L0 AS L_L0", "L1 AS L_L1", "ROWTIME AS L_ROWTIME", "ID AS L_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "RightSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Right/Source"
+                  },
+                  "topicName" : "right_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "AVRO",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` STRING KEY, `R0` BIGINT, `R1` INTEGER"
+                },
+                "keyExpression" : "R0"
+              },
+              "selectExpressions" : [ "R0 AS R_R0", "R1 AS R_R1", "ROWTIME AS R_ROWTIME", "ID AS R_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "L_ID AS L_ID", "L_L1 AS L1", "R_R1 AS R1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_BIGINT_column_-_AVRO/6.0.0_1583319046422/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_BIGINT_column_-_AVRO/6.0.0_1583319046422/spec.json
@@ -1,0 +1,38 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319046422,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<L0 BIGINT, L1 INT> NOT NULL",
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<R0 BIGINT, R1 INT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<L_L0 BIGINT, L_L1 INT, L_ROWTIME BIGINT, L_ID VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Right" : "STRUCT<R_R0 BIGINT, R_R1 INT, R_ROWTIME BIGINT, R_ID VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<L_ID VARCHAR, L1 INT, R1 INT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : "a",
+    "value" : {
+      "L0" : 1000000000,
+      "L1" : 1
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : "b",
+    "value" : {
+      "R0" : 1000000000,
+      "R1" : 2
+    },
+    "timestamp" : 10000
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 1000000000,
+    "value" : {
+      "L_ID" : "a",
+      "L1" : 1,
+      "R1" : 2
+    },
+    "timestamp" : 10000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_BIGINT_column_-_AVRO/6.0.0_1583319046422/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_BIGINT_column_-_AVRO/6.0.0_1583319046422/topology
@@ -1,0 +1,69 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_BIGINT_column_-_JSON/6.0.0_1583319046460/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_BIGINT_column_-_JSON/6.0.0_1583319046460/plan.json
@@ -1,0 +1,250 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM L (ID STRING KEY, L0 BIGINT, L1 INTEGER) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "L",
+      "schema" : "`ID` STRING KEY, `L0` BIGINT, `L1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM R (ID STRING KEY, R0 BIGINT, R1 INTEGER) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "R",
+      "schema" : "`ID` STRING KEY, `R0` BIGINT, `R1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  L.ID L_ID,\n  L.L1 L1,\n  R.R1 R1\nFROM L L\nINNER JOIN R R WITHIN 11 SECONDS ON ((L.L0 = R.R0))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` BIGINT KEY, `L_ID` STRING, `L1` INTEGER, `R1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "L", "R" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "LeftSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Left/Source"
+                  },
+                  "topicName" : "left_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` STRING KEY, `L0` BIGINT, `L1` INTEGER"
+                },
+                "keyExpression" : "L0"
+              },
+              "selectExpressions" : [ "L0 AS L_L0", "L1 AS L_L1", "ROWTIME AS L_ROWTIME", "ID AS L_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "RightSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Right/Source"
+                  },
+                  "topicName" : "right_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` STRING KEY, `R0` BIGINT, `R1` INTEGER"
+                },
+                "keyExpression" : "R0"
+              },
+              "selectExpressions" : [ "R0 AS R_R0", "R1 AS R_R1", "ROWTIME AS R_ROWTIME", "ID AS R_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "L_ID AS L_ID", "L_L1 AS L1", "R_R1 AS R1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_BIGINT_column_-_JSON/6.0.0_1583319046460/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_BIGINT_column_-_JSON/6.0.0_1583319046460/spec.json
@@ -1,0 +1,38 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319046460,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<L0 BIGINT, L1 INT> NOT NULL",
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<R0 BIGINT, R1 INT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<L_L0 BIGINT, L_L1 INT, L_ROWTIME BIGINT, L_ID VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Right" : "STRUCT<R_R0 BIGINT, R_R1 INT, R_ROWTIME BIGINT, R_ID VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<L_ID VARCHAR, L1 INT, R1 INT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : "a",
+    "value" : {
+      "L0" : 1000000000,
+      "L1" : 1
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : "b",
+    "value" : {
+      "R0" : 1000000000,
+      "R1" : 2
+    },
+    "timestamp" : 10000
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 1000000000,
+    "value" : {
+      "L_ID" : "a",
+      "L1" : 1,
+      "R1" : 2
+    },
+    "timestamp" : 10000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_BIGINT_column_-_JSON/6.0.0_1583319046460/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_BIGINT_column_-_JSON/6.0.0_1583319046460/topology
@@ -1,0 +1,69 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_BIGINT_column_-_PROTOBUF/6.0.0_1583319046499/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_BIGINT_column_-_PROTOBUF/6.0.0_1583319046499/plan.json
@@ -1,0 +1,250 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM L (ID STRING KEY, L0 BIGINT, L1 INTEGER) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "L",
+      "schema" : "`ID` STRING KEY, `L0` BIGINT, `L1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM R (ID STRING KEY, R0 BIGINT, R1 INTEGER) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "R",
+      "schema" : "`ID` STRING KEY, `R0` BIGINT, `R1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  L.ID L_ID,\n  L.L1 L1,\n  R.R1 R1\nFROM L L\nINNER JOIN R R WITHIN 11 SECONDS ON ((L.L0 = R.R0))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` BIGINT KEY, `L_ID` STRING, `L1` INTEGER, `R1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "L", "R" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "LeftSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Left/Source"
+                  },
+                  "topicName" : "left_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "PROTOBUF",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` STRING KEY, `L0` BIGINT, `L1` INTEGER"
+                },
+                "keyExpression" : "L0"
+              },
+              "selectExpressions" : [ "L0 AS L_L0", "L1 AS L_L1", "ROWTIME AS L_ROWTIME", "ID AS L_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "RightSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Right/Source"
+                  },
+                  "topicName" : "right_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "PROTOBUF",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` STRING KEY, `R0` BIGINT, `R1` INTEGER"
+                },
+                "keyExpression" : "R0"
+              },
+              "selectExpressions" : [ "R0 AS R_R0", "R1 AS R_R1", "ROWTIME AS R_ROWTIME", "ID AS R_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "L_ID AS L_ID", "L_L1 AS L1", "R_R1 AS R1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_BIGINT_column_-_PROTOBUF/6.0.0_1583319046499/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_BIGINT_column_-_PROTOBUF/6.0.0_1583319046499/spec.json
@@ -1,0 +1,38 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319046499,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<L0 BIGINT, L1 INT> NOT NULL",
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<R0 BIGINT, R1 INT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<L_L0 BIGINT, L_L1 INT, L_ROWTIME BIGINT, L_ID VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Right" : "STRUCT<R_R0 BIGINT, R_R1 INT, R_ROWTIME BIGINT, R_ID VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<L_ID VARCHAR, L1 INT, R1 INT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : "a",
+    "value" : {
+      "L0" : 1000000000,
+      "L1" : 1
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : "b",
+    "value" : {
+      "R0" : 1000000000,
+      "R1" : 2
+    },
+    "timestamp" : 10000
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 1000000000,
+    "value" : {
+      "L_ID" : "a",
+      "L1" : 1,
+      "R1" : 2
+    },
+    "timestamp" : 10000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_BIGINT_column_-_PROTOBUF/6.0.0_1583319046499/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_BIGINT_column_-_PROTOBUF/6.0.0_1583319046499/topology
@@ -1,0 +1,69 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_DOUBLE_column_-_AVRO/6.0.0_1583319046539/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_DOUBLE_column_-_AVRO/6.0.0_1583319046539/plan.json
@@ -1,0 +1,250 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM L (ID STRING KEY, L0 DOUBLE, L1 INTEGER) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "L",
+      "schema" : "`ID` STRING KEY, `L0` DOUBLE, `L1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM R (ID STRING KEY, R0 DOUBLE, R1 INTEGER) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "R",
+      "schema" : "`ID` STRING KEY, `R0` DOUBLE, `R1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  L.ID L_ID,\n  L.L1 L1,\n  R.R1 R1\nFROM L L\nINNER JOIN R R WITHIN 11 SECONDS ON ((L.L0 = R.R0))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` DOUBLE KEY, `L_ID` STRING, `L1` INTEGER, `R1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "L", "R" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "LeftSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Left/Source"
+                  },
+                  "topicName" : "left_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "AVRO",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` STRING KEY, `L0` DOUBLE, `L1` INTEGER"
+                },
+                "keyExpression" : "L0"
+              },
+              "selectExpressions" : [ "L0 AS L_L0", "L1 AS L_L1", "ROWTIME AS L_ROWTIME", "ID AS L_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "RightSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Right/Source"
+                  },
+                  "topicName" : "right_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "AVRO",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` STRING KEY, `R0` DOUBLE, `R1` INTEGER"
+                },
+                "keyExpression" : "R0"
+              },
+              "selectExpressions" : [ "R0 AS R_R0", "R1 AS R_R1", "ROWTIME AS R_ROWTIME", "ID AS R_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "L_ID AS L_ID", "L_L1 AS L1", "R_R1 AS R1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_DOUBLE_column_-_AVRO/6.0.0_1583319046539/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_DOUBLE_column_-_AVRO/6.0.0_1583319046539/spec.json
@@ -1,0 +1,38 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319046539,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<L0 DOUBLE, L1 INT> NOT NULL",
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<R0 DOUBLE, R1 INT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<L_L0 DOUBLE, L_L1 INT, L_ROWTIME BIGINT, L_ID VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Right" : "STRUCT<R_R0 DOUBLE, R_R1 INT, R_ROWTIME BIGINT, R_ID VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<L_ID VARCHAR, L1 INT, R1 INT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : "a",
+    "value" : {
+      "L0" : 1.23,
+      "L1" : 1
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : "b",
+    "value" : {
+      "R0" : 1.23,
+      "R1" : 2
+    },
+    "timestamp" : 10000
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 1.23,
+    "value" : {
+      "L_ID" : "a",
+      "L1" : 1,
+      "R1" : 2
+    },
+    "timestamp" : 10000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_DOUBLE_column_-_AVRO/6.0.0_1583319046539/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_DOUBLE_column_-_AVRO/6.0.0_1583319046539/topology
@@ -1,0 +1,69 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_DOUBLE_column_-_JSON/6.0.0_1583319046589/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_DOUBLE_column_-_JSON/6.0.0_1583319046589/plan.json
@@ -1,0 +1,250 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM L (ID STRING KEY, L0 DOUBLE, L1 INTEGER) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "L",
+      "schema" : "`ID` STRING KEY, `L0` DOUBLE, `L1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM R (ID STRING KEY, R0 DOUBLE, R1 INTEGER) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "R",
+      "schema" : "`ID` STRING KEY, `R0` DOUBLE, `R1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  L.ID L_ID,\n  L.L1 L1,\n  R.R1 R1\nFROM L L\nINNER JOIN R R WITHIN 11 SECONDS ON ((L.L0 = R.R0))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` DOUBLE KEY, `L_ID` STRING, `L1` INTEGER, `R1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "L", "R" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "LeftSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Left/Source"
+                  },
+                  "topicName" : "left_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` STRING KEY, `L0` DOUBLE, `L1` INTEGER"
+                },
+                "keyExpression" : "L0"
+              },
+              "selectExpressions" : [ "L0 AS L_L0", "L1 AS L_L1", "ROWTIME AS L_ROWTIME", "ID AS L_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "RightSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Right/Source"
+                  },
+                  "topicName" : "right_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` STRING KEY, `R0` DOUBLE, `R1` INTEGER"
+                },
+                "keyExpression" : "R0"
+              },
+              "selectExpressions" : [ "R0 AS R_R0", "R1 AS R_R1", "ROWTIME AS R_ROWTIME", "ID AS R_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "L_ID AS L_ID", "L_L1 AS L1", "R_R1 AS R1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_DOUBLE_column_-_JSON/6.0.0_1583319046589/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_DOUBLE_column_-_JSON/6.0.0_1583319046589/spec.json
@@ -1,0 +1,38 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319046589,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<L0 DOUBLE, L1 INT> NOT NULL",
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<R0 DOUBLE, R1 INT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<L_L0 DOUBLE, L_L1 INT, L_ROWTIME BIGINT, L_ID VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Right" : "STRUCT<R_R0 DOUBLE, R_R1 INT, R_ROWTIME BIGINT, R_ID VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<L_ID VARCHAR, L1 INT, R1 INT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : "a",
+    "value" : {
+      "L0" : 1.23,
+      "L1" : 1
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : "b",
+    "value" : {
+      "R0" : 1.23,
+      "R1" : 2
+    },
+    "timestamp" : 10000
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 1.23,
+    "value" : {
+      "L_ID" : "a",
+      "L1" : 1,
+      "R1" : 2
+    },
+    "timestamp" : 10000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_DOUBLE_column_-_JSON/6.0.0_1583319046589/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_DOUBLE_column_-_JSON/6.0.0_1583319046589/topology
@@ -1,0 +1,69 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_DOUBLE_column_-_PROTOBUF/6.0.0_1583319046631/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_DOUBLE_column_-_PROTOBUF/6.0.0_1583319046631/plan.json
@@ -1,0 +1,250 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM L (ID STRING KEY, L0 DOUBLE, L1 INTEGER) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "L",
+      "schema" : "`ID` STRING KEY, `L0` DOUBLE, `L1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM R (ID STRING KEY, R0 DOUBLE, R1 INTEGER) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "R",
+      "schema" : "`ID` STRING KEY, `R0` DOUBLE, `R1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  L.ID L_ID,\n  L.L1 L1,\n  R.R1 R1\nFROM L L\nINNER JOIN R R WITHIN 11 SECONDS ON ((L.L0 = R.R0))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` DOUBLE KEY, `L_ID` STRING, `L1` INTEGER, `R1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "L", "R" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "LeftSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Left/Source"
+                  },
+                  "topicName" : "left_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "PROTOBUF",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` STRING KEY, `L0` DOUBLE, `L1` INTEGER"
+                },
+                "keyExpression" : "L0"
+              },
+              "selectExpressions" : [ "L0 AS L_L0", "L1 AS L_L1", "ROWTIME AS L_ROWTIME", "ID AS L_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "RightSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Right/Source"
+                  },
+                  "topicName" : "right_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "PROTOBUF",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` STRING KEY, `R0` DOUBLE, `R1` INTEGER"
+                },
+                "keyExpression" : "R0"
+              },
+              "selectExpressions" : [ "R0 AS R_R0", "R1 AS R_R1", "ROWTIME AS R_ROWTIME", "ID AS R_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "L_ID AS L_ID", "L_L1 AS L1", "R_R1 AS R1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_DOUBLE_column_-_PROTOBUF/6.0.0_1583319046631/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_DOUBLE_column_-_PROTOBUF/6.0.0_1583319046631/spec.json
@@ -1,0 +1,38 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319046631,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<L0 DOUBLE, L1 INT> NOT NULL",
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<R0 DOUBLE, R1 INT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<L_L0 DOUBLE, L_L1 INT, L_ROWTIME BIGINT, L_ID VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Right" : "STRUCT<R_R0 DOUBLE, R_R1 INT, R_ROWTIME BIGINT, R_ID VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<L_ID VARCHAR, L1 INT, R1 INT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : "a",
+    "value" : {
+      "L0" : 1.23,
+      "L1" : 1
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : "b",
+    "value" : {
+      "R0" : 1.23,
+      "R1" : 2
+    },
+    "timestamp" : 10000
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 1.23,
+    "value" : {
+      "L_ID" : "a",
+      "L1" : 1,
+      "R1" : 2
+    },
+    "timestamp" : 10000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_DOUBLE_column_-_PROTOBUF/6.0.0_1583319046631/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_DOUBLE_column_-_PROTOBUF/6.0.0_1583319046631/topology
@@ -1,0 +1,69 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_INT_column_-_AVRO/6.0.0_1583319046311/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_INT_column_-_AVRO/6.0.0_1583319046311/plan.json
@@ -1,0 +1,250 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM L (ID STRING KEY, L0 INTEGER, L1 INTEGER) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "L",
+      "schema" : "`ID` STRING KEY, `L0` INTEGER, `L1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM R (ID STRING KEY, R0 INTEGER, R1 INTEGER) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "R",
+      "schema" : "`ID` STRING KEY, `R0` INTEGER, `R1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  L.ID L_ID,\n  L.L1 L1,\n  R.R1 R1\nFROM L L\nINNER JOIN R R WITHIN 11 SECONDS ON ((L.L0 = R.R0))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` INTEGER KEY, `L_ID` STRING, `L1` INTEGER, `R1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "L", "R" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "LeftSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Left/Source"
+                  },
+                  "topicName" : "left_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "AVRO",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` STRING KEY, `L0` INTEGER, `L1` INTEGER"
+                },
+                "keyExpression" : "L0"
+              },
+              "selectExpressions" : [ "L0 AS L_L0", "L1 AS L_L1", "ROWTIME AS L_ROWTIME", "ID AS L_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "RightSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Right/Source"
+                  },
+                  "topicName" : "right_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "AVRO",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` STRING KEY, `R0` INTEGER, `R1` INTEGER"
+                },
+                "keyExpression" : "R0"
+              },
+              "selectExpressions" : [ "R0 AS R_R0", "R1 AS R_R1", "ROWTIME AS R_ROWTIME", "ID AS R_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "L_ID AS L_ID", "L_L1 AS L1", "R_R1 AS R1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_INT_column_-_AVRO/6.0.0_1583319046311/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_INT_column_-_AVRO/6.0.0_1583319046311/spec.json
@@ -1,0 +1,38 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319046311,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<L0 INT, L1 INT> NOT NULL",
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<R0 INT, R1 INT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<L_L0 INT, L_L1 INT, L_ROWTIME BIGINT, L_ID VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Right" : "STRUCT<R_R0 INT, R_R1 INT, R_ROWTIME BIGINT, R_ID VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<L_ID VARCHAR, L1 INT, R1 INT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : "a",
+    "value" : {
+      "L0" : 10,
+      "L1" : 1
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : "b",
+    "value" : {
+      "R0" : 10,
+      "R1" : 2
+    },
+    "timestamp" : 10000
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 10,
+    "value" : {
+      "L_ID" : "a",
+      "L1" : 1,
+      "R1" : 2
+    },
+    "timestamp" : 10000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_INT_column_-_AVRO/6.0.0_1583319046311/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_INT_column_-_AVRO/6.0.0_1583319046311/topology
@@ -1,0 +1,69 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_INT_column_-_JSON/6.0.0_1583319046347/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_INT_column_-_JSON/6.0.0_1583319046347/plan.json
@@ -1,0 +1,250 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM L (ID STRING KEY, L0 INTEGER, L1 INTEGER) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "L",
+      "schema" : "`ID` STRING KEY, `L0` INTEGER, `L1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM R (ID STRING KEY, R0 INTEGER, R1 INTEGER) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "R",
+      "schema" : "`ID` STRING KEY, `R0` INTEGER, `R1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  L.ID L_ID,\n  L.L1 L1,\n  R.R1 R1\nFROM L L\nINNER JOIN R R WITHIN 11 SECONDS ON ((L.L0 = R.R0))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` INTEGER KEY, `L_ID` STRING, `L1` INTEGER, `R1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "L", "R" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "LeftSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Left/Source"
+                  },
+                  "topicName" : "left_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` STRING KEY, `L0` INTEGER, `L1` INTEGER"
+                },
+                "keyExpression" : "L0"
+              },
+              "selectExpressions" : [ "L0 AS L_L0", "L1 AS L_L1", "ROWTIME AS L_ROWTIME", "ID AS L_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "RightSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Right/Source"
+                  },
+                  "topicName" : "right_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` STRING KEY, `R0` INTEGER, `R1` INTEGER"
+                },
+                "keyExpression" : "R0"
+              },
+              "selectExpressions" : [ "R0 AS R_R0", "R1 AS R_R1", "ROWTIME AS R_ROWTIME", "ID AS R_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "L_ID AS L_ID", "L_L1 AS L1", "R_R1 AS R1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_INT_column_-_JSON/6.0.0_1583319046347/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_INT_column_-_JSON/6.0.0_1583319046347/spec.json
@@ -1,0 +1,38 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319046347,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<L0 INT, L1 INT> NOT NULL",
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<R0 INT, R1 INT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<L_L0 INT, L_L1 INT, L_ROWTIME BIGINT, L_ID VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Right" : "STRUCT<R_R0 INT, R_R1 INT, R_ROWTIME BIGINT, R_ID VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<L_ID VARCHAR, L1 INT, R1 INT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : "a",
+    "value" : {
+      "L0" : 10,
+      "L1" : 1
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : "b",
+    "value" : {
+      "R0" : 10,
+      "R1" : 2
+    },
+    "timestamp" : 10000
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 10,
+    "value" : {
+      "L_ID" : "a",
+      "L1" : 1,
+      "R1" : 2
+    },
+    "timestamp" : 10000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_INT_column_-_JSON/6.0.0_1583319046347/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_INT_column_-_JSON/6.0.0_1583319046347/topology
@@ -1,0 +1,69 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_INT_column_-_PROTOBUF/6.0.0_1583319046384/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_INT_column_-_PROTOBUF/6.0.0_1583319046384/plan.json
@@ -1,0 +1,250 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM L (ID STRING KEY, L0 INTEGER, L1 INTEGER) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "L",
+      "schema" : "`ID` STRING KEY, `L0` INTEGER, `L1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM R (ID STRING KEY, R0 INTEGER, R1 INTEGER) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "R",
+      "schema" : "`ID` STRING KEY, `R0` INTEGER, `R1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  L.ID L_ID,\n  L.L1 L1,\n  R.R1 R1\nFROM L L\nINNER JOIN R R WITHIN 11 SECONDS ON ((L.L0 = R.R0))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` INTEGER KEY, `L_ID` STRING, `L1` INTEGER, `R1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "L", "R" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "LeftSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Left/Source"
+                  },
+                  "topicName" : "left_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "PROTOBUF",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` STRING KEY, `L0` INTEGER, `L1` INTEGER"
+                },
+                "keyExpression" : "L0"
+              },
+              "selectExpressions" : [ "L0 AS L_L0", "L1 AS L_L1", "ROWTIME AS L_ROWTIME", "ID AS L_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "RightSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Right/Source"
+                  },
+                  "topicName" : "right_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "PROTOBUF",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` STRING KEY, `R0` INTEGER, `R1` INTEGER"
+                },
+                "keyExpression" : "R0"
+              },
+              "selectExpressions" : [ "R0 AS R_R0", "R1 AS R_R1", "ROWTIME AS R_ROWTIME", "ID AS R_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "L_ID AS L_ID", "L_L1 AS L1", "R_R1 AS R1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_INT_column_-_PROTOBUF/6.0.0_1583319046384/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_INT_column_-_PROTOBUF/6.0.0_1583319046384/spec.json
@@ -1,0 +1,38 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319046384,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<L0 INT, L1 INT> NOT NULL",
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<R0 INT, R1 INT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<L_L0 INT, L_L1 INT, L_ROWTIME BIGINT, L_ID VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Right" : "STRUCT<R_R0 INT, R_R1 INT, R_ROWTIME BIGINT, R_ID VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<L_ID VARCHAR, L1 INT, R1 INT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : "a",
+    "value" : {
+      "L0" : 10,
+      "L1" : 1
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : "b",
+    "value" : {
+      "R0" : 10,
+      "R1" : 2
+    },
+    "timestamp" : 10000
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 10,
+    "value" : {
+      "L_ID" : "a",
+      "L1" : 1,
+      "R1" : 2
+    },
+    "timestamp" : 10000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_INT_column_-_PROTOBUF/6.0.0_1583319046384/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_INT_column_-_PROTOBUF/6.0.0_1583319046384/topology
@@ -1,0 +1,69 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_STRING_column_-_AVRO/6.0.0_1583319046673/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_STRING_column_-_AVRO/6.0.0_1583319046673/plan.json
@@ -1,0 +1,250 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM L (ID STRING KEY, L0 STRING, L1 INTEGER) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "L",
+      "schema" : "`ID` STRING KEY, `L0` STRING, `L1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM R (ID STRING KEY, R0 STRING, R1 INTEGER) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "R",
+      "schema" : "`ID` STRING KEY, `R0` STRING, `R1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  L.ID L_ID,\n  L.L1 L1,\n  R.R1 R1\nFROM L L\nINNER JOIN R R WITHIN 11 SECONDS ON ((L.L0 = R.R0))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` STRING KEY, `L_ID` STRING, `L1` INTEGER, `R1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "L", "R" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "LeftSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Left/Source"
+                  },
+                  "topicName" : "left_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "AVRO",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` STRING KEY, `L0` STRING, `L1` INTEGER"
+                },
+                "keyExpression" : "L0"
+              },
+              "selectExpressions" : [ "L0 AS L_L0", "L1 AS L_L1", "ROWTIME AS L_ROWTIME", "ID AS L_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "RightSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Right/Source"
+                  },
+                  "topicName" : "right_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "AVRO",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` STRING KEY, `R0` STRING, `R1` INTEGER"
+                },
+                "keyExpression" : "R0"
+              },
+              "selectExpressions" : [ "R0 AS R_R0", "R1 AS R_R1", "ROWTIME AS R_ROWTIME", "ID AS R_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "L_ID AS L_ID", "L_L1 AS L1", "R_R1 AS R1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_STRING_column_-_AVRO/6.0.0_1583319046673/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_STRING_column_-_AVRO/6.0.0_1583319046673/spec.json
@@ -1,0 +1,38 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319046673,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<L0 VARCHAR, L1 INT> NOT NULL",
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<R0 VARCHAR, R1 INT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<L_L0 VARCHAR, L_L1 INT, L_ROWTIME BIGINT, L_ID VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Right" : "STRUCT<R_R0 VARCHAR, R_R1 INT, R_ROWTIME BIGINT, R_ID VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<L_ID VARCHAR, L1 INT, R1 INT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : "a",
+    "value" : {
+      "L0" : "x",
+      "L1" : 1
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : "b",
+    "value" : {
+      "R0" : "x",
+      "R1" : 2
+    },
+    "timestamp" : 10000
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : "x",
+    "value" : {
+      "L_ID" : "a",
+      "L1" : 1,
+      "R1" : 2
+    },
+    "timestamp" : 10000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_STRING_column_-_AVRO/6.0.0_1583319046673/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_STRING_column_-_AVRO/6.0.0_1583319046673/topology
@@ -1,0 +1,69 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_STRING_column_-_JSON/6.0.0_1583319046719/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_STRING_column_-_JSON/6.0.0_1583319046719/plan.json
@@ -1,0 +1,250 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM L (ID STRING KEY, L0 STRING, L1 INTEGER) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "L",
+      "schema" : "`ID` STRING KEY, `L0` STRING, `L1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM R (ID STRING KEY, R0 STRING, R1 INTEGER) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "R",
+      "schema" : "`ID` STRING KEY, `R0` STRING, `R1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  L.ID L_ID,\n  L.L1 L1,\n  R.R1 R1\nFROM L L\nINNER JOIN R R WITHIN 11 SECONDS ON ((L.L0 = R.R0))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` STRING KEY, `L_ID` STRING, `L1` INTEGER, `R1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "L", "R" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "LeftSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Left/Source"
+                  },
+                  "topicName" : "left_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` STRING KEY, `L0` STRING, `L1` INTEGER"
+                },
+                "keyExpression" : "L0"
+              },
+              "selectExpressions" : [ "L0 AS L_L0", "L1 AS L_L1", "ROWTIME AS L_ROWTIME", "ID AS L_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "RightSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Right/Source"
+                  },
+                  "topicName" : "right_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` STRING KEY, `R0` STRING, `R1` INTEGER"
+                },
+                "keyExpression" : "R0"
+              },
+              "selectExpressions" : [ "R0 AS R_R0", "R1 AS R_R1", "ROWTIME AS R_ROWTIME", "ID AS R_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "L_ID AS L_ID", "L_L1 AS L1", "R_R1 AS R1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_STRING_column_-_JSON/6.0.0_1583319046719/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_STRING_column_-_JSON/6.0.0_1583319046719/spec.json
@@ -1,0 +1,38 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319046719,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<L0 VARCHAR, L1 INT> NOT NULL",
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<R0 VARCHAR, R1 INT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<L_L0 VARCHAR, L_L1 INT, L_ROWTIME BIGINT, L_ID VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Right" : "STRUCT<R_R0 VARCHAR, R_R1 INT, R_ROWTIME BIGINT, R_ID VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<L_ID VARCHAR, L1 INT, R1 INT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : "a",
+    "value" : {
+      "L0" : "x",
+      "L1" : 1
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : "b",
+    "value" : {
+      "R0" : "x",
+      "R1" : 2
+    },
+    "timestamp" : 10000
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : "x",
+    "value" : {
+      "L_ID" : "a",
+      "L1" : 1,
+      "R1" : 2
+    },
+    "timestamp" : 10000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_STRING_column_-_JSON/6.0.0_1583319046719/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_STRING_column_-_JSON/6.0.0_1583319046719/topology
@@ -1,0 +1,69 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_STRING_column_-_PROTOBUF/6.0.0_1583319046763/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_STRING_column_-_PROTOBUF/6.0.0_1583319046763/plan.json
@@ -1,0 +1,250 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM L (ID STRING KEY, L0 STRING, L1 INTEGER) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "L",
+      "schema" : "`ID` STRING KEY, `L0` STRING, `L1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM R (ID STRING KEY, R0 STRING, R1 INTEGER) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "R",
+      "schema" : "`ID` STRING KEY, `R0` STRING, `R1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  L.ID L_ID,\n  L.L1 L1,\n  R.R1 R1\nFROM L L\nINNER JOIN R R WITHIN 11 SECONDS ON ((L.L0 = R.R0))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` STRING KEY, `L_ID` STRING, `L1` INTEGER, `R1` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "L", "R" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "LeftSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Left/Source"
+                  },
+                  "topicName" : "left_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "PROTOBUF",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` STRING KEY, `L0` STRING, `L1` INTEGER"
+                },
+                "keyExpression" : "L0"
+              },
+              "selectExpressions" : [ "L0 AS L_L0", "L1 AS L_L1", "ROWTIME AS L_ROWTIME", "ID AS L_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "RightSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Right/Source"
+                  },
+                  "topicName" : "right_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "PROTOBUF",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` STRING KEY, `R0` STRING, `R1` INTEGER"
+                },
+                "keyExpression" : "R0"
+              },
+              "selectExpressions" : [ "R0 AS R_R0", "R1 AS R_R1", "ROWTIME AS R_ROWTIME", "ID AS R_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "L_ID AS L_ID", "L_L1 AS L1", "R_R1 AS R1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_STRING_column_-_PROTOBUF/6.0.0_1583319046763/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_STRING_column_-_PROTOBUF/6.0.0_1583319046763/spec.json
@@ -1,0 +1,38 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319046763,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<L0 VARCHAR, L1 INT> NOT NULL",
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<R0 VARCHAR, R1 INT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<L_L0 VARCHAR, L_L1 INT, L_ROWTIME BIGINT, L_ID VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Right" : "STRUCT<R_R0 VARCHAR, R_R1 INT, R_ROWTIME BIGINT, R_ID VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<L_ID VARCHAR, L1 INT, R1 INT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : "a",
+    "value" : {
+      "L0" : "x",
+      "L1" : 1
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : "b",
+    "value" : {
+      "R0" : "x",
+      "R1" : 2
+    },
+    "timestamp" : 10000
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : "x",
+    "value" : {
+      "L_ID" : "a",
+      "L1" : 1,
+      "R1" : 2
+    },
+    "timestamp" : 10000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_STRING_column_-_PROTOBUF/6.0.0_1583319046763/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_KAFKA_STRING_column_-_PROTOBUF/6.0.0_1583319046763/topology
@@ -1,0 +1,69 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_non_STRING_value_column/6.0.0_1583319046266/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_non_STRING_value_column/6.0.0_1583319046266/plan.json
@@ -1,0 +1,230 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT_STREAM (K STRING KEY, SF BIGINT) WITH (KAFKA_TOPIC='stream_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT_STREAM",
+      "schema" : "`K` STRING KEY, `SF` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "stream_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE INPUT_TABLE (ID BIGINT KEY, TF INTEGER) WITH (KAFKA_TOPIC='table_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "INPUT_TABLE",
+      "schema" : "`ID` BIGINT KEY, `TF` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "table_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM INPUT_STREAM S\nINNER JOIN INPUT_TABLE T ON ((S.SF = T.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` BIGINT KEY, `S_ROWTIME` BIGINT, `S_K` STRING, `S_SF` BIGINT, `T_ROWTIME` BIGINT, `T_ID` BIGINT, `T_TF` INTEGER",
+      "keyField" : "S_SF",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT_STREAM", "INPUT_TABLE" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "LeftSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Left/Source"
+                  },
+                  "topicName" : "stream_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`K` STRING KEY, `SF` BIGINT"
+                },
+                "keyExpression" : "SF"
+              },
+              "selectExpressions" : [ "SF AS S_SF", "ROWTIME AS S_ROWTIME", "K AS S_K" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "table_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `TF` INTEGER"
+              },
+              "selectExpressions" : [ "TF AS T_TF", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            }
+          },
+          "selectExpressions" : [ "S_ROWTIME AS S_ROWTIME", "S_K AS S_K", "S_SF AS S_SF", "T_ROWTIME AS T_ROWTIME", "T_ID AS T_ID", "T_TF AS T_TF" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_non_STRING_value_column/6.0.0_1583319046266/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_non_STRING_value_column/6.0.0_1583319046266/spec.json
@@ -1,0 +1,52 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319046266,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<TF INT> NOT NULL",
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<SF BIGINT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<S_SF BIGINT, S_ROWTIME BIGINT, S_K VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<S_ROWTIME BIGINT, S_K VARCHAR, S_SF BIGINT, T_ROWTIME BIGINT, T_ID BIGINT, T_TF INT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "table_topic",
+    "key" : 26589,
+    "value" : {
+      "TF" : 1
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "stream_topic",
+    "key" : "a",
+    "value" : {
+      "SF" : 12589
+    },
+    "timestamp" : 100
+  }, {
+    "topic" : "table_topic",
+    "key" : 12589,
+    "value" : {
+      "TF" : 12
+    },
+    "timestamp" : 200
+  }, {
+    "topic" : "stream_topic",
+    "key" : "b",
+    "value" : {
+      "SF" : 12589
+    },
+    "timestamp" : 300
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 12589,
+    "value" : {
+      "S_K" : "b",
+      "S_ROWTIME" : 300,
+      "S_SF" : 12589,
+      "T_ROWTIME" : 300,
+      "T_ID" : 12589,
+      "T_TF" : 12
+    },
+    "timestamp" : 300
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_non_STRING_value_column/6.0.0_1583319046266/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_non_STRING_value_column/6.0.0_1583319046266/topology
@@ -1,0 +1,45 @@
+Topologies:
+   Sub-topology: 0
+    Source: Join-repartition-source (topics: [Join-repartition])
+      --> Join
+    Source: KSTREAM-SOURCE-0000000000 (topics: [table_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- Join-repartition-source
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000014
+      <-- Join
+    Sink: KSTREAM-SINK-0000000014 (topic: OUTPUT)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000004 (topics: [stream_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> KSTREAM-FILTER-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KSTREAM-FILTER-0000000006 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000007
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-KEY-SELECT-0000000007 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000006
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000007
+    Processor: Join-repartition-filter (stores: [])
+      --> Join-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-repartition-sink (topic: Join-repartition)
+      <-- Join-repartition-filter
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_unqualified_join_criteria/6.0.0_1583319046239/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_unqualified_join_criteria/6.0.0_1583319046239/plan.json
@@ -1,0 +1,236 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (LEFT_ID BIGINT KEY, NAME STRING) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`LEFT_ID` BIGINT KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (RIGHT_ID BIGINT KEY, F1 STRING) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`RIGHT_ID` BIGINT KEY, `F1` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM LEFT_OUTER_JOIN AS SELECT\n  T.NAME NAME,\n  TT.F1 F1\nFROM TEST T\nLEFT OUTER JOIN TEST_STREAM TT WITHIN 11 SECONDS ON ((T.LEFT_ID = TT.RIGHT_ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "LEFT_OUTER_JOIN",
+      "schema" : "`LEFT_ID` BIGINT KEY, `NAME` STRING, `F1` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "LEFT_OUTER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "LEFT_OUTER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "LEFT_OUTER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "LEFT",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`LEFT_ID` BIGINT KEY, `NAME` STRING"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "ROWTIME AS T_ROWTIME", "LEFT_ID AS T_LEFT_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`RIGHT_ID` BIGINT KEY, `F1` STRING"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "ROWTIME AS TT_ROWTIME", "RIGHT_ID AS TT_RIGHT_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "T_NAME AS NAME", "TT_F1 AS F1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "LEFT_OUTER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_LEFT_OUTER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_unqualified_join_criteria/6.0.0_1583319046239/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_unqualified_join_criteria/6.0.0_1583319046239/spec.json
@@ -1,0 +1,125 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319046239,
+  "schemas" : {
+    "CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.Join.Left" : "STRUCT<T_NAME VARCHAR, T_ROWTIME BIGINT, T_LEFT_ID BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.Join.Right" : "STRUCT<TT_F1 VARCHAR, TT_ROWTIME BIGINT, TT_RIGHT_ID BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN" : "STRUCT<NAME VARCHAR, F1 VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero"
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah"
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100"
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo"
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a"
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 100,
+    "value" : {
+      "F1" : "newblah"
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety"
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar"
+    },
+    "timestamp" : 30000
+  } ],
+  "outputs" : [ {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "F1" : null
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "F1" : "blah"
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "F1" : null
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "F1" : "blah"
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "F1" : "a"
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "F1" : null
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "F1" : null
+    },
+    "timestamp" : 30000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_unqualified_join_criteria/6.0.0_1583319046239/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_on_unqualified_join_criteria/6.0.0_1583319046239/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000009-store])
+      --> Join-outer-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-outer-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-OUTEROTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-outer-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: LEFT_OUTER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_-_AVRO/6.0.0_1583319043960/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_-_AVRO/6.0.0_1583319043960/plan.json
@@ -1,0 +1,236 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_STREAM TT WITHIN 11 SECONDS ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "INNER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_-_AVRO/6.0.0_1583319043960/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_-_AVRO/6.0.0_1583319043960/spec.json
@@ -1,0 +1,107 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319043960,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Right" : "STRUCT<TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 100,
+    "value" : {
+      "F1" : "newblah",
+      "F2" : 150
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 30000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_-_AVRO/6.0.0_1583319043960/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_-_AVRO/6.0.0_1583319043960/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: INNER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_-_JSON/6.0.0_1583319044009/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_-_JSON/6.0.0_1583319044009/plan.json
@@ -1,0 +1,236 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_STREAM TT WITHIN 11 SECONDS ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "INNER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_-_JSON/6.0.0_1583319044009/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_-_JSON/6.0.0_1583319044009/spec.json
@@ -1,0 +1,107 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319044009,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Right" : "STRUCT<TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 100,
+    "value" : {
+      "F1" : "newblah",
+      "F2" : 150
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 30000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_-_JSON/6.0.0_1583319044009/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_-_JSON/6.0.0_1583319044009/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: INNER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_-_PROTOBUF/6.0.0_1583319044058/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_-_PROTOBUF/6.0.0_1583319044058/plan.json
@@ -1,0 +1,236 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_STREAM TT WITHIN 11 SECONDS ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "INNER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_-_PROTOBUF/6.0.0_1583319044058/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_-_PROTOBUF/6.0.0_1583319044058/spec.json
@@ -1,0 +1,107 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319044058,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Right" : "STRUCT<TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 100,
+    "value" : {
+      "F1" : "newblah",
+      "F2" : 150
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 30000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_-_PROTOBUF/6.0.0_1583319044058/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_-_PROTOBUF/6.0.0_1583319044058/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: INNER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_fields_-_AVRO/6.0.0_1583319044370/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_fields_-_AVRO/6.0.0_1583319044370/plan.json
@@ -1,0 +1,236 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 STRING) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT *\nFROM TEST TT\nINNER JOIN TEST_STREAM T WITHIN 11 SECONDS ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `TT_ROWTIME` BIGINT, `TT_ID` BIGINT, `TT_NAME` STRING, `T_ROWTIME` BIGINT, `T_ID` BIGINT, `T_F1` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING"
+              },
+              "selectExpressions" : [ "NAME AS TT_NAME", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING"
+              },
+              "selectExpressions" : [ "F1 AS T_F1", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "TT_ROWTIME AS TT_ROWTIME", "TT_ID AS TT_ID", "TT_NAME AS TT_NAME", "T_ROWTIME AS T_ROWTIME", "T_ID AS T_ID", "T_F1 AS T_F1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "INNER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_fields_-_AVRO/6.0.0_1583319044370/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_fields_-_AVRO/6.0.0_1583319044370/spec.json
@@ -1,0 +1,217 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319044370,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<TT_NAME VARCHAR, TT_ROWTIME BIGINT, TT_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Right" : "STRUCT<T_F1 VARCHAR, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<TT_ROWTIME BIGINT, TT_ID BIGINT, TT_NAME VARCHAR, T_ROWTIME BIGINT, T_ID BIGINT, T_F1 VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero"
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah"
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100"
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo"
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a"
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 100,
+    "value" : {
+      "F1" : "newblah"
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety"
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar"
+    },
+    "timestamp" : 30000
+  } ],
+  "outputs" : [ {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog",
+    "key" : 0,
+    "value" : {
+      "TT_ROWTIME" : 0,
+      "TT_ID" : 0,
+      "TT_NAME" : "zero"
+    },
+    "timestamp" : 0,
+    "window" : {
+      "start" : 0,
+      "end" : 11000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINOTHER-0000000009-store-changelog",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 10000,
+      "T_ID" : 0,
+      "T_F1" : "blah"
+    },
+    "timestamp" : 10000,
+    "window" : {
+      "start" : 10000,
+      "end" : 21000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog",
+    "key" : 10,
+    "value" : {
+      "TT_ROWTIME" : 11000,
+      "TT_ID" : 10,
+      "TT_NAME" : "100"
+    },
+    "timestamp" : 11000,
+    "window" : {
+      "start" : 11000,
+      "end" : 22000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog",
+    "key" : 0,
+    "value" : {
+      "TT_ROWTIME" : 13000,
+      "TT_ID" : 0,
+      "TT_NAME" : "foo"
+    },
+    "timestamp" : 13000,
+    "window" : {
+      "start" : 13000,
+      "end" : 24000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINOTHER-0000000009-store-changelog",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 15000,
+      "T_ID" : 0,
+      "T_F1" : "a"
+    },
+    "timestamp" : 15000,
+    "window" : {
+      "start" : 15000,
+      "end" : 26000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINOTHER-0000000009-store-changelog",
+    "key" : 100,
+    "value" : {
+      "T_ROWTIME" : 16000,
+      "T_ID" : 100,
+      "T_F1" : "newblah"
+    },
+    "timestamp" : 16000,
+    "window" : {
+      "start" : 16000,
+      "end" : 27000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog",
+    "key" : 90,
+    "value" : {
+      "TT_ROWTIME" : 17000,
+      "TT_ID" : 90,
+      "TT_NAME" : "ninety"
+    },
+    "timestamp" : 17000,
+    "window" : {
+      "start" : 17000,
+      "end" : 28000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog",
+    "key" : 0,
+    "value" : {
+      "TT_ROWTIME" : 30000,
+      "TT_ID" : 0,
+      "TT_NAME" : "bar"
+    },
+    "timestamp" : 30000,
+    "window" : {
+      "start" : 30000,
+      "end" : 41000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_F1" : "blah",
+      "T_ROWTIME" : 10000,
+      "TT_ID" : 0,
+      "TT_NAME" : "zero",
+      "TT_ROWTIME" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_F1" : "blah",
+      "T_ROWTIME" : 10000,
+      "TT_ID" : 0,
+      "TT_NAME" : "foo",
+      "TT_ROWTIME" : 13000
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_F1" : "a",
+      "T_ROWTIME" : 15000,
+      "TT_ID" : 0,
+      "TT_NAME" : "foo",
+      "TT_ROWTIME" : 13000
+    },
+    "timestamp" : 15000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_fields_-_AVRO/6.0.0_1583319044370/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_fields_-_AVRO/6.0.0_1583319044370/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: INNER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_fields_-_JSON/6.0.0_1583319044415/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_fields_-_JSON/6.0.0_1583319044415/plan.json
@@ -1,0 +1,236 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 STRING) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT *\nFROM TEST TT\nINNER JOIN TEST_STREAM T WITHIN 11 SECONDS ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `TT_ROWTIME` BIGINT, `TT_ID` BIGINT, `TT_NAME` STRING, `T_ROWTIME` BIGINT, `T_ID` BIGINT, `T_F1` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING"
+              },
+              "selectExpressions" : [ "NAME AS TT_NAME", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING"
+              },
+              "selectExpressions" : [ "F1 AS T_F1", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "TT_ROWTIME AS TT_ROWTIME", "TT_ID AS TT_ID", "TT_NAME AS TT_NAME", "T_ROWTIME AS T_ROWTIME", "T_ID AS T_ID", "T_F1 AS T_F1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "INNER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_fields_-_JSON/6.0.0_1583319044415/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_fields_-_JSON/6.0.0_1583319044415/spec.json
@@ -1,0 +1,217 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319044415,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<TT_NAME VARCHAR, TT_ROWTIME BIGINT, TT_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Right" : "STRUCT<T_F1 VARCHAR, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<TT_ROWTIME BIGINT, TT_ID BIGINT, TT_NAME VARCHAR, T_ROWTIME BIGINT, T_ID BIGINT, T_F1 VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero"
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah"
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100"
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo"
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a"
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 100,
+    "value" : {
+      "F1" : "newblah"
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety"
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar"
+    },
+    "timestamp" : 30000
+  } ],
+  "outputs" : [ {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog",
+    "key" : 0,
+    "value" : {
+      "TT_ROWTIME" : 0,
+      "TT_ID" : 0,
+      "TT_NAME" : "zero"
+    },
+    "timestamp" : 0,
+    "window" : {
+      "start" : 0,
+      "end" : 11000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINOTHER-0000000009-store-changelog",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 10000,
+      "T_ID" : 0,
+      "T_F1" : "blah"
+    },
+    "timestamp" : 10000,
+    "window" : {
+      "start" : 10000,
+      "end" : 21000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog",
+    "key" : 10,
+    "value" : {
+      "TT_ROWTIME" : 11000,
+      "TT_ID" : 10,
+      "TT_NAME" : "100"
+    },
+    "timestamp" : 11000,
+    "window" : {
+      "start" : 11000,
+      "end" : 22000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog",
+    "key" : 0,
+    "value" : {
+      "TT_ROWTIME" : 13000,
+      "TT_ID" : 0,
+      "TT_NAME" : "foo"
+    },
+    "timestamp" : 13000,
+    "window" : {
+      "start" : 13000,
+      "end" : 24000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINOTHER-0000000009-store-changelog",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 15000,
+      "T_ID" : 0,
+      "T_F1" : "a"
+    },
+    "timestamp" : 15000,
+    "window" : {
+      "start" : 15000,
+      "end" : 26000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINOTHER-0000000009-store-changelog",
+    "key" : 100,
+    "value" : {
+      "T_ROWTIME" : 16000,
+      "T_ID" : 100,
+      "T_F1" : "newblah"
+    },
+    "timestamp" : 16000,
+    "window" : {
+      "start" : 16000,
+      "end" : 27000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog",
+    "key" : 90,
+    "value" : {
+      "TT_ROWTIME" : 17000,
+      "TT_ID" : 90,
+      "TT_NAME" : "ninety"
+    },
+    "timestamp" : 17000,
+    "window" : {
+      "start" : 17000,
+      "end" : 28000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog",
+    "key" : 0,
+    "value" : {
+      "TT_ROWTIME" : 30000,
+      "TT_ID" : 0,
+      "TT_NAME" : "bar"
+    },
+    "timestamp" : 30000,
+    "window" : {
+      "start" : 30000,
+      "end" : 41000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_F1" : "blah",
+      "T_ROWTIME" : 10000,
+      "TT_ID" : 0,
+      "TT_NAME" : "zero",
+      "TT_ROWTIME" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_F1" : "blah",
+      "T_ROWTIME" : 10000,
+      "TT_ID" : 0,
+      "TT_NAME" : "foo",
+      "TT_ROWTIME" : 13000
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_F1" : "a",
+      "T_ROWTIME" : 15000,
+      "TT_ID" : 0,
+      "TT_NAME" : "foo",
+      "TT_ROWTIME" : 13000
+    },
+    "timestamp" : 15000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_fields_-_JSON/6.0.0_1583319044415/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_fields_-_JSON/6.0.0_1583319044415/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: INNER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_fields_-_PROTOBUF/6.0.0_1583319044454/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_fields_-_PROTOBUF/6.0.0_1583319044454/plan.json
@@ -1,0 +1,236 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 STRING) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT *\nFROM TEST TT\nINNER JOIN TEST_STREAM T WITHIN 11 SECONDS ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `TT_ROWTIME` BIGINT, `TT_ID` BIGINT, `TT_NAME` STRING, `T_ROWTIME` BIGINT, `T_ID` BIGINT, `T_F1` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING"
+              },
+              "selectExpressions" : [ "NAME AS TT_NAME", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING"
+              },
+              "selectExpressions" : [ "F1 AS T_F1", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "TT_ROWTIME AS TT_ROWTIME", "TT_ID AS TT_ID", "TT_NAME AS TT_NAME", "T_ROWTIME AS T_ROWTIME", "T_ID AS T_ID", "T_F1 AS T_F1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "INNER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_fields_-_PROTOBUF/6.0.0_1583319044454/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_fields_-_PROTOBUF/6.0.0_1583319044454/spec.json
@@ -1,0 +1,217 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319044454,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<TT_NAME VARCHAR, TT_ROWTIME BIGINT, TT_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Right" : "STRUCT<T_F1 VARCHAR, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<TT_ROWTIME BIGINT, TT_ID BIGINT, TT_NAME VARCHAR, T_ROWTIME BIGINT, T_ID BIGINT, T_F1 VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero"
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah"
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100"
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo"
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a"
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 100,
+    "value" : {
+      "F1" : "newblah"
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety"
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar"
+    },
+    "timestamp" : 30000
+  } ],
+  "outputs" : [ {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog",
+    "key" : 0,
+    "value" : {
+      "TT_ROWTIME" : 0,
+      "TT_ID" : 0,
+      "TT_NAME" : "zero"
+    },
+    "timestamp" : 0,
+    "window" : {
+      "start" : 0,
+      "end" : 11000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINOTHER-0000000009-store-changelog",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 10000,
+      "T_ID" : 0,
+      "T_F1" : "blah"
+    },
+    "timestamp" : 10000,
+    "window" : {
+      "start" : 10000,
+      "end" : 21000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog",
+    "key" : 10,
+    "value" : {
+      "TT_ROWTIME" : 11000,
+      "TT_ID" : 10,
+      "TT_NAME" : "100"
+    },
+    "timestamp" : 11000,
+    "window" : {
+      "start" : 11000,
+      "end" : 22000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog",
+    "key" : 0,
+    "value" : {
+      "TT_ROWTIME" : 13000,
+      "TT_ID" : 0,
+      "TT_NAME" : "foo"
+    },
+    "timestamp" : 13000,
+    "window" : {
+      "start" : 13000,
+      "end" : 24000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINOTHER-0000000009-store-changelog",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 15000,
+      "T_ID" : 0,
+      "T_F1" : "a"
+    },
+    "timestamp" : 15000,
+    "window" : {
+      "start" : 15000,
+      "end" : 26000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINOTHER-0000000009-store-changelog",
+    "key" : 100,
+    "value" : {
+      "T_ROWTIME" : 16000,
+      "T_ID" : 100,
+      "T_F1" : "newblah"
+    },
+    "timestamp" : 16000,
+    "window" : {
+      "start" : 16000,
+      "end" : 27000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog",
+    "key" : 90,
+    "value" : {
+      "TT_ROWTIME" : 17000,
+      "TT_ID" : 90,
+      "TT_NAME" : "ninety"
+    },
+    "timestamp" : 17000,
+    "window" : {
+      "start" : 17000,
+      "end" : 28000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog",
+    "key" : 0,
+    "value" : {
+      "TT_ROWTIME" : 30000,
+      "TT_ID" : 0,
+      "TT_NAME" : "bar"
+    },
+    "timestamp" : 30000,
+    "window" : {
+      "start" : 30000,
+      "end" : 41000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_F1" : "blah",
+      "T_ROWTIME" : 10000,
+      "TT_ID" : 0,
+      "TT_NAME" : "zero",
+      "TT_ROWTIME" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_F1" : "blah",
+      "T_ROWTIME" : 10000,
+      "TT_ID" : 0,
+      "TT_NAME" : "foo",
+      "TT_ROWTIME" : 13000
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_F1" : "a",
+      "T_ROWTIME" : 15000,
+      "TT_ID" : 0,
+      "TT_NAME" : "foo",
+      "TT_ROWTIME" : 13000
+    },
+    "timestamp" : 15000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_fields_-_PROTOBUF/6.0.0_1583319044454/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_fields_-_PROTOBUF/6.0.0_1583319044454/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: INNER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_left_fields_some_right_-_AVRO/6.0.0_1583319044111/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_left_fields_some_right_-_AVRO/6.0.0_1583319044111/plan.json
@@ -1,0 +1,236 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  T.*,\n  TT.F1 F1\nFROM TEST T\nINNER JOIN TEST_STREAM TT WITHIN 11 SECONDS ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `T_ROWTIME` BIGINT, `T_ID` BIGINT, `T_NAME` STRING, `T_VALUE` BIGINT, `F1` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "T_ROWTIME AS T_ROWTIME", "T_ID AS T_ID", "T_NAME AS T_NAME", "T_VALUE AS T_VALUE", "TT_F1 AS F1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "INNER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_left_fields_some_right_-_AVRO/6.0.0_1583319044111/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_left_fields_some_right_-_AVRO/6.0.0_1583319044111/spec.json
@@ -1,0 +1,110 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319044111,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Right" : "STRUCT<TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<T_ROWTIME BIGINT, T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, F1 VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 100,
+    "value" : {
+      "F1" : "newblah",
+      "F2" : 150
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 30000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_NAME" : "zero",
+      "T_VALUE" : 0,
+      "F1" : "blah",
+      "T_ROWTIME" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_NAME" : "foo",
+      "T_VALUE" : 100,
+      "F1" : "blah",
+      "T_ROWTIME" : 13000
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_NAME" : "foo",
+      "T_VALUE" : 100,
+      "F1" : "a",
+      "T_ROWTIME" : 13000
+    },
+    "timestamp" : 15000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_left_fields_some_right_-_AVRO/6.0.0_1583319044111/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_left_fields_some_right_-_AVRO/6.0.0_1583319044111/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: INNER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_left_fields_some_right_-_JSON/6.0.0_1583319044151/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_left_fields_some_right_-_JSON/6.0.0_1583319044151/plan.json
@@ -1,0 +1,236 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  T.*,\n  TT.F1 F1\nFROM TEST T\nINNER JOIN TEST_STREAM TT WITHIN 11 SECONDS ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `T_ROWTIME` BIGINT, `T_ID` BIGINT, `T_NAME` STRING, `T_VALUE` BIGINT, `F1` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "T_ROWTIME AS T_ROWTIME", "T_ID AS T_ID", "T_NAME AS T_NAME", "T_VALUE AS T_VALUE", "TT_F1 AS F1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "INNER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_left_fields_some_right_-_JSON/6.0.0_1583319044151/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_left_fields_some_right_-_JSON/6.0.0_1583319044151/spec.json
@@ -1,0 +1,110 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319044151,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Right" : "STRUCT<TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<T_ROWTIME BIGINT, T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, F1 VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 100,
+    "value" : {
+      "F1" : "newblah",
+      "F2" : 150
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 30000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_NAME" : "zero",
+      "T_VALUE" : 0,
+      "F1" : "blah",
+      "T_ROWTIME" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_NAME" : "foo",
+      "T_VALUE" : 100,
+      "F1" : "blah",
+      "T_ROWTIME" : 13000
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_NAME" : "foo",
+      "T_VALUE" : 100,
+      "F1" : "a",
+      "T_ROWTIME" : 13000
+    },
+    "timestamp" : 15000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_left_fields_some_right_-_JSON/6.0.0_1583319044151/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_left_fields_some_right_-_JSON/6.0.0_1583319044151/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: INNER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_left_fields_some_right_-_PROTOBUF/6.0.0_1583319044195/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_left_fields_some_right_-_PROTOBUF/6.0.0_1583319044195/plan.json
@@ -1,0 +1,236 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  T.*,\n  TT.F1 F1\nFROM TEST T\nINNER JOIN TEST_STREAM TT WITHIN 11 SECONDS ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `T_ROWTIME` BIGINT, `T_ID` BIGINT, `T_NAME` STRING, `T_VALUE` BIGINT, `F1` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "T_ROWTIME AS T_ROWTIME", "T_ID AS T_ID", "T_NAME AS T_NAME", "T_VALUE AS T_VALUE", "TT_F1 AS F1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "INNER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_left_fields_some_right_-_PROTOBUF/6.0.0_1583319044195/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_left_fields_some_right_-_PROTOBUF/6.0.0_1583319044195/spec.json
@@ -1,0 +1,110 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319044195,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Right" : "STRUCT<TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<T_ROWTIME BIGINT, T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, F1 VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 100,
+    "value" : {
+      "F1" : "newblah",
+      "F2" : 150
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 30000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_NAME" : "zero",
+      "T_VALUE" : 0,
+      "F1" : "blah",
+      "T_ROWTIME" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_NAME" : "foo",
+      "T_VALUE" : 100,
+      "F1" : "blah",
+      "T_ROWTIME" : 13000
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_NAME" : "foo",
+      "T_VALUE" : 100,
+      "F1" : "a",
+      "T_ROWTIME" : 13000
+    },
+    "timestamp" : 15000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_left_fields_some_right_-_PROTOBUF/6.0.0_1583319044195/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_left_fields_some_right_-_PROTOBUF/6.0.0_1583319044195/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: INNER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_right_fields_some_left_-_AVRO/6.0.0_1583319044242/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_right_fields_some_left_-_AVRO/6.0.0_1583319044242/plan.json
@@ -1,0 +1,236 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  T.*,\n  TT.NAME NAME\nFROM TEST TT\nINNER JOIN TEST_STREAM T WITHIN 11 SECONDS ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `T_ROWTIME` BIGINT, `T_ID` BIGINT, `T_F1` STRING, `T_F2` BIGINT, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS TT_NAME", "VALUE AS TT_VALUE", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS T_F1", "F2 AS T_F2", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "T_ROWTIME AS T_ROWTIME", "T_ID AS T_ID", "T_F1 AS T_F1", "T_F2 AS T_F2", "TT_NAME AS NAME" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "INNER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_right_fields_some_left_-_AVRO/6.0.0_1583319044242/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_right_fields_some_left_-_AVRO/6.0.0_1583319044242/spec.json
@@ -1,0 +1,110 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319044242,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<TT_NAME VARCHAR, TT_VALUE BIGINT, TT_ROWTIME BIGINT, TT_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Right" : "STRUCT<T_F1 VARCHAR, T_F2 BIGINT, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<T_ROWTIME BIGINT, T_ID BIGINT, T_F1 VARCHAR, T_F2 BIGINT, NAME VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 100,
+    "value" : {
+      "F1" : "newblah",
+      "F2" : 150
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 30000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_F1" : "blah",
+      "T_F2" : 50,
+      "T_ROWTIME" : 10000,
+      "NAME" : "zero"
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_F1" : "blah",
+      "T_F2" : 50,
+      "T_ROWTIME" : 10000,
+      "NAME" : "foo"
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_F1" : "a",
+      "T_F2" : 10,
+      "T_ROWTIME" : 15000,
+      "NAME" : "foo"
+    },
+    "timestamp" : 15000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_right_fields_some_left_-_AVRO/6.0.0_1583319044242/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_right_fields_some_left_-_AVRO/6.0.0_1583319044242/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: INNER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_right_fields_some_left_-_JSON/6.0.0_1583319044289/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_right_fields_some_left_-_JSON/6.0.0_1583319044289/plan.json
@@ -1,0 +1,236 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  T.*,\n  TT.NAME NAME\nFROM TEST TT\nINNER JOIN TEST_STREAM T WITHIN 11 SECONDS ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `T_ROWTIME` BIGINT, `T_ID` BIGINT, `T_F1` STRING, `T_F2` BIGINT, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS TT_NAME", "VALUE AS TT_VALUE", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS T_F1", "F2 AS T_F2", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "T_ROWTIME AS T_ROWTIME", "T_ID AS T_ID", "T_F1 AS T_F1", "T_F2 AS T_F2", "TT_NAME AS NAME" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "INNER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_right_fields_some_left_-_JSON/6.0.0_1583319044289/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_right_fields_some_left_-_JSON/6.0.0_1583319044289/spec.json
@@ -1,0 +1,110 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319044289,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<TT_NAME VARCHAR, TT_VALUE BIGINT, TT_ROWTIME BIGINT, TT_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Right" : "STRUCT<T_F1 VARCHAR, T_F2 BIGINT, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<T_ROWTIME BIGINT, T_ID BIGINT, T_F1 VARCHAR, T_F2 BIGINT, NAME VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 100,
+    "value" : {
+      "F1" : "newblah",
+      "F2" : 150
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 30000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_F1" : "blah",
+      "T_F2" : 50,
+      "T_ROWTIME" : 10000,
+      "NAME" : "zero"
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_F1" : "blah",
+      "T_F2" : 50,
+      "T_ROWTIME" : 10000,
+      "NAME" : "foo"
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_F1" : "a",
+      "T_F2" : 10,
+      "T_ROWTIME" : 15000,
+      "NAME" : "foo"
+    },
+    "timestamp" : 15000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_right_fields_some_left_-_JSON/6.0.0_1583319044289/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_right_fields_some_left_-_JSON/6.0.0_1583319044289/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: INNER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_right_fields_some_left_-_PROTOBUF/6.0.0_1583319044330/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_right_fields_some_left_-_PROTOBUF/6.0.0_1583319044330/plan.json
@@ -1,0 +1,236 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  T.*,\n  TT.NAME NAME\nFROM TEST TT\nINNER JOIN TEST_STREAM T WITHIN 11 SECONDS ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `T_ROWTIME` BIGINT, `T_ID` BIGINT, `T_F1` STRING, `T_F2` BIGINT, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS TT_NAME", "VALUE AS TT_VALUE", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS T_F1", "F2 AS T_F2", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "T_ROWTIME AS T_ROWTIME", "T_ID AS T_ID", "T_F1 AS T_F1", "T_F2 AS T_F2", "TT_NAME AS NAME" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "INNER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_right_fields_some_left_-_PROTOBUF/6.0.0_1583319044330/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_right_fields_some_left_-_PROTOBUF/6.0.0_1583319044330/spec.json
@@ -1,0 +1,110 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319044330,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<TT_NAME VARCHAR, TT_VALUE BIGINT, TT_ROWTIME BIGINT, TT_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Right" : "STRUCT<T_F1 VARCHAR, T_F2 BIGINT, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<T_ROWTIME BIGINT, T_ID BIGINT, T_F1 VARCHAR, T_F2 BIGINT, NAME VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 100,
+    "value" : {
+      "F1" : "newblah",
+      "F2" : 150
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 30000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_F1" : "blah",
+      "T_F2" : 50,
+      "T_ROWTIME" : 10000,
+      "NAME" : "zero"
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_F1" : "blah",
+      "T_F2" : 50,
+      "T_ROWTIME" : 10000,
+      "NAME" : "foo"
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_F1" : "a",
+      "T_F2" : 10,
+      "T_ROWTIME" : 15000,
+      "NAME" : "foo"
+    },
+    "timestamp" : 15000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_right_fields_some_left_-_PROTOBUF/6.0.0_1583319044330/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_all_right_fields_some_left_-_PROTOBUF/6.0.0_1583319044330/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: INNER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_different_before_and_after_windows_-_AVRO/6.0.0_1583319044492/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_different_before_and_after_windows_-_AVRO/6.0.0_1583319044492/plan.json
@@ -1,0 +1,236 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_STREAM TT WITHIN (11 SECONDS, 10 SECONDS) ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 10.000000000
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "INNER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_different_before_and_after_windows_-_AVRO/6.0.0_1583319044492/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_different_before_and_after_windows_-_AVRO/6.0.0_1583319044492/spec.json
@@ -1,0 +1,99 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319044492,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Right" : "STRUCT<TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 12000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 100,
+    "value" : {
+      "F1" : "newblah",
+      "F2" : 150
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 30000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_different_before_and_after_windows_-_AVRO/6.0.0_1583319044492/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_different_before_and_after_windows_-_AVRO/6.0.0_1583319044492/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: INNER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_different_before_and_after_windows_-_JSON/6.0.0_1583319044534/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_different_before_and_after_windows_-_JSON/6.0.0_1583319044534/plan.json
@@ -1,0 +1,236 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_STREAM TT WITHIN (11 SECONDS, 10 SECONDS) ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 10.000000000
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "INNER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_different_before_and_after_windows_-_JSON/6.0.0_1583319044534/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_different_before_and_after_windows_-_JSON/6.0.0_1583319044534/spec.json
@@ -1,0 +1,99 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319044534,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Right" : "STRUCT<TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 12000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 100,
+    "value" : {
+      "F1" : "newblah",
+      "F2" : 150
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 30000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_different_before_and_after_windows_-_JSON/6.0.0_1583319044534/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_different_before_and_after_windows_-_JSON/6.0.0_1583319044534/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: INNER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_different_before_and_after_windows_-_PROTOBUF/6.0.0_1583319044577/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_different_before_and_after_windows_-_PROTOBUF/6.0.0_1583319044577/plan.json
@@ -1,0 +1,236 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_STREAM TT WITHIN (11 SECONDS, 10 SECONDS) ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 10.000000000
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "INNER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_different_before_and_after_windows_-_PROTOBUF/6.0.0_1583319044577/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_different_before_and_after_windows_-_PROTOBUF/6.0.0_1583319044577/spec.json
@@ -1,0 +1,99 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319044577,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Right" : "STRUCT<TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 12000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 100,
+    "value" : {
+      "F1" : "newblah",
+      "F2" : 150
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 30000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_different_before_and_after_windows_-_PROTOBUF/6.0.0_1583319044577/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_different_before_and_after_windows_-_PROTOBUF/6.0.0_1583319044577/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: INNER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_out_of_order_messages_-_AVRO/6.0.0_1583319044623/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_out_of_order_messages_-_AVRO/6.0.0_1583319044623/plan.json
@@ -1,0 +1,236 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_STREAM TT WITHIN 10 SECONDS ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            },
+            "beforeMillis" : 10.000000000,
+            "afterMillis" : 10.000000000
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "INNER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_out_of_order_messages_-_AVRO/6.0.0_1583319044623/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_out_of_order_messages_-_AVRO/6.0.0_1583319044623/spec.json
@@ -1,0 +1,140 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319044623,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Right" : "STRUCT<TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 9999
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 100,
+    "value" : {
+      "F1" : "newblah",
+      "F2" : 150
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 30000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "late-message",
+      "VALUE" : 10000
+    },
+    "timestamp" : 6000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 9999
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "late-message",
+      "VALUE" : 10000,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 9999
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "late-message",
+      "VALUE" : 10000,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_out_of_order_messages_-_AVRO/6.0.0_1583319044623/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_out_of_order_messages_-_AVRO/6.0.0_1583319044623/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: INNER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_out_of_order_messages_-_JSON/6.0.0_1583319044669/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_out_of_order_messages_-_JSON/6.0.0_1583319044669/plan.json
@@ -1,0 +1,236 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_STREAM TT WITHIN 10 SECONDS ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            },
+            "beforeMillis" : 10.000000000,
+            "afterMillis" : 10.000000000
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "INNER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_out_of_order_messages_-_JSON/6.0.0_1583319044669/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_out_of_order_messages_-_JSON/6.0.0_1583319044669/spec.json
@@ -1,0 +1,140 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319044669,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Right" : "STRUCT<TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 9999
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 100,
+    "value" : {
+      "F1" : "newblah",
+      "F2" : 150
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 30000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "late-message",
+      "VALUE" : 10000
+    },
+    "timestamp" : 6000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 9999
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "late-message",
+      "VALUE" : 10000,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 9999
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "late-message",
+      "VALUE" : 10000,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_out_of_order_messages_-_JSON/6.0.0_1583319044669/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_out_of_order_messages_-_JSON/6.0.0_1583319044669/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: INNER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_out_of_order_messages_-_PROTOBUF/6.0.0_1583319044712/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_out_of_order_messages_-_PROTOBUF/6.0.0_1583319044712/plan.json
@@ -1,0 +1,236 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_STREAM TT WITHIN 10 SECONDS ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            },
+            "beforeMillis" : 10.000000000,
+            "afterMillis" : 10.000000000
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "INNER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_out_of_order_messages_-_PROTOBUF/6.0.0_1583319044712/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_out_of_order_messages_-_PROTOBUF/6.0.0_1583319044712/spec.json
@@ -1,0 +1,140 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319044712,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Right" : "STRUCT<TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 9999
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 100,
+    "value" : {
+      "F1" : "newblah",
+      "F2" : 150
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 30000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "late-message",
+      "VALUE" : 10000
+    },
+    "timestamp" : 6000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 9999
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "late-message",
+      "VALUE" : 10000,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 9999
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "late-message",
+      "VALUE" : 10000,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_out_of_order_messages_-_PROTOBUF/6.0.0_1583319044712/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_inner_join_with_out_of_order_messages_-_PROTOBUF/6.0.0_1583319044712/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: INNER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_CASE_expression/6.0.0_1583319046181/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_CASE_expression/6.0.0_1583319046181/plan.json
@@ -1,0 +1,243 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST1 (ID INTEGER KEY, IGNORED STRING) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST1",
+      "schema" : "`ID` INTEGER KEY, `IGNORED` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST2 (ID INTEGER KEY, IGNORED STRING) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST2",
+      "schema" : "`ID` INTEGER KEY, `IGNORED` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT T.ID T_ID\nFROM TEST1 T\nINNER JOIN TEST2 TT WITHIN 30 SECONDS ON ((T.ID = (CASE WHEN (TT.ID = 2) THEN 1 ELSE 3 END)))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` INTEGER KEY, `T_ID` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST1", "TEST2" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` INTEGER KEY, `IGNORED` STRING"
+              },
+              "selectExpressions" : [ "IGNORED AS T_IGNORED", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "RightSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Right/Source"
+                  },
+                  "topicName" : "right_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` INTEGER KEY, `IGNORED` STRING"
+                },
+                "keyExpression" : "(CASE WHEN (ID = 2) THEN 1 ELSE 3 END)"
+              },
+              "selectExpressions" : [ "IGNORED AS TT_IGNORED", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            },
+            "beforeMillis" : 30.000000000,
+            "afterMillis" : 30.000000000
+          },
+          "selectExpressions" : [ "T_ID AS T_ID" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_CASE_expression/6.0.0_1583319046181/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_CASE_expression/6.0.0_1583319046181/spec.json
@@ -1,0 +1,35 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319046181,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<IGNORED VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<IGNORED VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<T_IGNORED VARCHAR, T_ROWTIME BIGINT, T_ID INT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Right" : "STRUCT<TT_IGNORED VARCHAR, TT_ROWTIME BIGINT, TT_ID INT> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<T_ID INT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 1,
+    "value" : { },
+    "timestamp" : 0
+  }, {
+    "topic" : "left_topic",
+    "key" : 3,
+    "value" : { },
+    "timestamp" : 5
+  }, {
+    "topic" : "right_topic",
+    "key" : 2,
+    "value" : { },
+    "timestamp" : 10
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : {
+      "T_ID" : 1
+    },
+    "timestamp" : 10
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_CASE_expression/6.0.0_1583319046181/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_CASE_expression/6.0.0_1583319046181/topology
@@ -1,0 +1,54 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000014-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000013-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000013-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000014-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000017
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000017 (topic: OUTPUT)
+      <-- Project
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> KSTREAM-FILTER-0000000005
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: KSTREAM-FILTER-0000000005 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000006
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-KEY-SELECT-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000005
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000006
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_CAST/6.0.0_1583319046030/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_CAST/6.0.0_1583319046030/plan.json
@@ -1,0 +1,243 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST1 (ID BIGINT KEY, X BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST1",
+      "schema" : "`ID` BIGINT KEY, `X` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST2 (ID INTEGER KEY, X INTEGER) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST2",
+      "schema" : "`ID` INTEGER KEY, `X` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT T.X T_X\nFROM TEST1 T\nINNER JOIN TEST2 TT WITHIN 30 SECONDS ON ((T.ID = CAST(TT.ID AS BIGINT)))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `T_X` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST1", "TEST2" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `X` BIGINT"
+              },
+              "selectExpressions" : [ "X AS T_X", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "RightSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Right/Source"
+                  },
+                  "topicName" : "right_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` INTEGER KEY, `X` INTEGER"
+                },
+                "keyExpression" : "CAST(ID AS BIGINT)"
+              },
+              "selectExpressions" : [ "X AS TT_X", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            },
+            "beforeMillis" : 30.000000000,
+            "afterMillis" : 30.000000000
+          },
+          "selectExpressions" : [ "T_X AS T_X" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_CAST/6.0.0_1583319046030/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_CAST/6.0.0_1583319046030/spec.json
@@ -1,0 +1,43 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319046030,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<X BIGINT> NOT NULL",
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<X INT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<T_X BIGINT, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Right" : "STRUCT<TT_X INT, TT_ROWTIME BIGINT, TT_ID INT> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<T_X BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 1,
+    "value" : {
+      "x" : 2
+    },
+    "timestamp" : 10
+  }, {
+    "topic" : "right_topic",
+    "key" : 1,
+    "value" : {
+      "x" : 3
+    },
+    "timestamp" : 10
+  } ],
+  "outputs" : [ {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-right-repartition",
+    "key" : 1,
+    "value" : {
+      "TT_X" : 3,
+      "TT_ROWTIME" : 10,
+      "TT_ID" : 1
+    },
+    "timestamp" : 10
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : {
+      "T_X" : 2
+    },
+    "timestamp" : 10
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_CAST/6.0.0_1583319046030/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_CAST/6.0.0_1583319046030/topology
@@ -1,0 +1,54 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000014-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000013-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000013-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000014-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000017
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000017 (topic: OUTPUT)
+      <-- Project
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> KSTREAM-FILTER-0000000005
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: KSTREAM-FILTER-0000000005 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000006
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-KEY-SELECT-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000005
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000006
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_CAST_double_to_int/6.0.0_1583319046064/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_CAST_double_to_int/6.0.0_1583319046064/plan.json
@@ -1,0 +1,243 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM L (ID INTEGER KEY, X BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "L",
+      "schema" : "`ID` INTEGER KEY, `X` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM R (ID DOUBLE KEY, X BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "R",
+      "schema" : "`ID` DOUBLE KEY, `X` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT L.X L_X\nFROM L L\nINNER JOIN R R WITHIN 30 SECONDS ON ((L.ID = CAST(R.ID AS INTEGER)))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` INTEGER KEY, `L_X` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "L", "R" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` INTEGER KEY, `X` BIGINT"
+              },
+              "selectExpressions" : [ "X AS L_X", "ROWTIME AS L_ROWTIME", "ID AS L_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "RightSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Right/Source"
+                  },
+                  "topicName" : "right_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` DOUBLE KEY, `X` BIGINT"
+                },
+                "keyExpression" : "CAST(ID AS INTEGER)"
+              },
+              "selectExpressions" : [ "X AS R_X", "ROWTIME AS R_ROWTIME", "ID AS R_ID" ]
+            },
+            "beforeMillis" : 30.000000000,
+            "afterMillis" : 30.000000000
+          },
+          "selectExpressions" : [ "L_X AS L_X" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_CAST_double_to_int/6.0.0_1583319046064/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_CAST_double_to_int/6.0.0_1583319046064/spec.json
@@ -1,0 +1,34 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319046064,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<X BIGINT> NOT NULL",
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<X BIGINT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<L_X BIGINT, L_ROWTIME BIGINT, L_ID INT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Right" : "STRUCT<R_X BIGINT, R_ROWTIME BIGINT, R_ID DOUBLE> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<L_X BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 1,
+    "value" : {
+      "x" : 2
+    },
+    "timestamp" : 10
+  }, {
+    "topic" : "right_topic",
+    "key" : 1.0,
+    "value" : {
+      "x" : 3
+    },
+    "timestamp" : 11
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : {
+      "L_X" : 2
+    },
+    "timestamp" : 11
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_CAST_double_to_int/6.0.0_1583319046064/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_CAST_double_to_int/6.0.0_1583319046064/topology
@@ -1,0 +1,54 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000014-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000013-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000013-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000014-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000017
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000017 (topic: OUTPUT)
+      <-- Project
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> KSTREAM-FILTER-0000000005
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: KSTREAM-FILTER-0000000005 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000006
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-KEY-SELECT-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000005
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000006
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_arithmetic_binary_expression/6.0.0_1583319046120/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_arithmetic_binary_expression/6.0.0_1583319046120/plan.json
@@ -1,0 +1,243 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST1 (ID INTEGER KEY, NAME STRING) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST1",
+      "schema" : "`ID` INTEGER KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST2 (ID INTEGER KEY, NAME STRING) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST2",
+      "schema" : "`ID` INTEGER KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  T.ID T_ID,\n  TT.ID TT_ID\nFROM TEST1 T\nINNER JOIN TEST2 TT WITHIN 30 SECONDS ON ((T.ID = (TT.ID + 1)))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` INTEGER KEY, `T_ID` INTEGER, `TT_ID` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST1", "TEST2" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` INTEGER KEY, `NAME` STRING"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "RightSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Right/Source"
+                  },
+                  "topicName" : "right_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` INTEGER KEY, `NAME` STRING"
+                },
+                "keyExpression" : "(ID + 1)"
+              },
+              "selectExpressions" : [ "NAME AS TT_NAME", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            },
+            "beforeMillis" : 30.000000000,
+            "afterMillis" : 30.000000000
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "TT_ID AS TT_ID" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_arithmetic_binary_expression/6.0.0_1583319046120/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_arithmetic_binary_expression/6.0.0_1583319046120/spec.json
@@ -1,0 +1,35 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319046120,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<NAME VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<T_NAME VARCHAR, T_ROWTIME BIGINT, T_ID INT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Right" : "STRUCT<TT_NAME VARCHAR, TT_ROWTIME BIGINT, TT_ID INT> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<T_ID INT, TT_ID INT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 1,
+    "value" : {
+      "name" : "-"
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "name" : "-"
+    },
+    "timestamp" : 10
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : {
+      "T_ID" : 1,
+      "TT_ID" : 0
+    },
+    "timestamp" : 10
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_arithmetic_binary_expression/6.0.0_1583319046120/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_arithmetic_binary_expression/6.0.0_1583319046120/topology
@@ -1,0 +1,54 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000014-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000013-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000013-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000014-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000017
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000017 (topic: OUTPUT)
+      <-- Project
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> KSTREAM-FILTER-0000000005
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: KSTREAM-FILTER-0000000005 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000006
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-KEY-SELECT-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000005
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000006
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_arithmetic_unary_expression/6.0.0_1583319046150/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_arithmetic_unary_expression/6.0.0_1583319046150/plan.json
@@ -1,0 +1,243 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST1 (ID INTEGER KEY, NAME STRING) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST1",
+      "schema" : "`ID` INTEGER KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST2 (ID INTEGER KEY, NAME STRING) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST2",
+      "schema" : "`ID` INTEGER KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  T.NAME T_NAME,\n  TT.NAME TT_NAME\nFROM TEST1 T\nINNER JOIN TEST2 TT WITHIN 30 SECONDS ON ((T.ID = -TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` INTEGER KEY, `T_NAME` STRING, `TT_NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST1", "TEST2" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` INTEGER KEY, `NAME` STRING"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "RightSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Right/Source"
+                  },
+                  "topicName" : "right_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` INTEGER KEY, `NAME` STRING"
+                },
+                "keyExpression" : "-ID"
+              },
+              "selectExpressions" : [ "NAME AS TT_NAME", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            },
+            "beforeMillis" : 30.000000000,
+            "afterMillis" : 30.000000000
+          },
+          "selectExpressions" : [ "T_NAME AS T_NAME", "TT_NAME AS TT_NAME" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_arithmetic_unary_expression/6.0.0_1583319046150/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_arithmetic_unary_expression/6.0.0_1583319046150/spec.json
@@ -1,0 +1,35 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319046150,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<NAME VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<T_NAME VARCHAR, T_ROWTIME BIGINT, T_ID INT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Right" : "STRUCT<TT_NAME VARCHAR, TT_ROWTIME BIGINT, TT_ID INT> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<T_NAME VARCHAR, TT_NAME VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 1,
+    "value" : {
+      "name" : "a"
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : -1,
+    "value" : {
+      "name" : "b"
+    },
+    "timestamp" : 10
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : {
+      "T_NAME" : "a",
+      "TT_NAME" : "b"
+    },
+    "timestamp" : 10
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_arithmetic_unary_expression/6.0.0_1583319046150/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_arithmetic_unary_expression/6.0.0_1583319046150/topology
@@ -1,0 +1,54 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000014-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000013-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000013-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000014-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000017
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000017 (topic: OUTPUT)
+      <-- Project
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> KSTREAM-FILTER-0000000005
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: KSTREAM-FILTER-0000000005 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000006
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-KEY-SELECT-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000005
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000006
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_arithmetic_unary_expression_flipped_sides/6.0.0_1583319046211/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_arithmetic_unary_expression_flipped_sides/6.0.0_1583319046211/plan.json
@@ -1,0 +1,243 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST1 (ID INTEGER KEY, IGNORED STRING) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST1",
+      "schema" : "`ID` INTEGER KEY, `IGNORED` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST2 (ID INTEGER KEY, IGNORED STRING) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST2",
+      "schema" : "`ID` INTEGER KEY, `IGNORED` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT T.ID T_ID\nFROM TEST1 T\nINNER JOIN TEST2 TT WITHIN 30 SECONDS ON ((-TT.ID = T.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` INTEGER KEY, `T_ID` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST1", "TEST2" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` INTEGER KEY, `IGNORED` STRING"
+              },
+              "selectExpressions" : [ "IGNORED AS T_IGNORED", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "RightSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Right/Source"
+                  },
+                  "topicName" : "right_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` INTEGER KEY, `IGNORED` STRING"
+                },
+                "keyExpression" : "-ID"
+              },
+              "selectExpressions" : [ "IGNORED AS TT_IGNORED", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            },
+            "beforeMillis" : 30.000000000,
+            "afterMillis" : 30.000000000
+          },
+          "selectExpressions" : [ "T_ID AS T_ID" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_arithmetic_unary_expression_flipped_sides/6.0.0_1583319046211/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_arithmetic_unary_expression_flipped_sides/6.0.0_1583319046211/spec.json
@@ -1,0 +1,30 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319046211,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<IGNORED VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<IGNORED VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<T_IGNORED VARCHAR, T_ROWTIME BIGINT, T_ID INT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Right" : "STRUCT<TT_IGNORED VARCHAR, TT_ROWTIME BIGINT, TT_ID INT> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<T_ID INT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 1,
+    "value" : { },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : -1,
+    "value" : { },
+    "timestamp" : 10
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : {
+      "T_ID" : 1
+    },
+    "timestamp" : 10
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_arithmetic_unary_expression_flipped_sides/6.0.0_1583319046211/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_arithmetic_unary_expression_flipped_sides/6.0.0_1583319046211/topology
@@ -1,0 +1,54 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000014-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000013-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000013-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000014-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000017
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000017 (topic: OUTPUT)
+      <-- Project
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> KSTREAM-FILTER-0000000005
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: KSTREAM-FILTER-0000000005 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000006
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-KEY-SELECT-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000005
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000006
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_function/6.0.0_1583319046001/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_function/6.0.0_1583319046001/plan.json
@@ -1,0 +1,250 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST1 (ID STRING) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST1",
+      "schema" : "`ROWKEY` STRING KEY, `ID` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST2 (ID STRING) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST2",
+      "schema" : "`ROWKEY` STRING KEY, `ID` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT T.ID T_ID\nFROM TEST1 T\nINNER JOIN TEST2 TT WITHIN 30 SECONDS ON ((T.ID = SUBSTRING(TT.ID, 2)))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` STRING KEY, `T_ID` STRING",
+      "keyField" : "T_ID",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST1", "TEST2" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "LeftSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Left/Source"
+                  },
+                  "topicName" : "left_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ROWKEY` STRING KEY, `ID` STRING"
+                },
+                "keyExpression" : "ID"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "RightSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Right/Source"
+                  },
+                  "topicName" : "right_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ROWKEY` STRING KEY, `ID` STRING"
+                },
+                "keyExpression" : "SUBSTRING(ID, 2)"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            },
+            "beforeMillis" : 30.000000000,
+            "afterMillis" : 30.000000000
+          },
+          "selectExpressions" : [ "T_ID AS T_ID" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_function/6.0.0_1583319046001/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_function/6.0.0_1583319046001/spec.json
@@ -1,0 +1,34 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319046001,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<ID VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<ID VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<T_ID VARCHAR, T_ROWTIME BIGINT, T_ROWKEY VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Right" : "STRUCT<TT_ID VARCHAR, TT_ROWTIME BIGINT, TT_ROWKEY VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<T_ID VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : "foo",
+    "value" : {
+      "id" : "foo"
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : "!foo",
+    "value" : {
+      "id" : "!foo"
+    },
+    "timestamp" : 10
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : "foo",
+    "value" : {
+      "T_ID" : "foo"
+    },
+    "timestamp" : 10
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_function/6.0.0_1583319046001/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_function/6.0.0_1583319046001/topology
@@ -1,0 +1,69 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_subscript/6.0.0_1583319046093/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_subscript/6.0.0_1583319046093/plan.json
@@ -1,0 +1,243 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST1 (ID INTEGER KEY, NAME STRING) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST1",
+      "schema" : "`ID` INTEGER KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST2 (K STRING KEY, ID ARRAY<INTEGER>) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST2",
+      "schema" : "`K` STRING KEY, `ID` ARRAY<INTEGER>",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT T.ID T_ID\nFROM TEST1 T\nINNER JOIN TEST2 TT WITHIN 30 SECONDS ON ((T.ID = TT.ID[1]))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` INTEGER KEY, `T_ID` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST1", "TEST2" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` INTEGER KEY, `NAME` STRING"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "RightSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Right/Source"
+                  },
+                  "topicName" : "right_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`K` STRING KEY, `ID` ARRAY<INTEGER>"
+                },
+                "keyExpression" : "ID[1]"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "ROWTIME AS TT_ROWTIME", "K AS TT_K" ]
+            },
+            "beforeMillis" : 30.000000000,
+            "afterMillis" : 30.000000000
+          },
+          "selectExpressions" : [ "T_ID AS T_ID" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_subscript/6.0.0_1583319046093/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_subscript/6.0.0_1583319046093/spec.json
@@ -1,0 +1,41 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319046093,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<ID ARRAY<INT>> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<T_NAME VARCHAR, T_ROWTIME BIGINT, T_ID INT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Right" : "STRUCT<TT_ID ARRAY<INT>, TT_ROWTIME BIGINT, TT_K VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<T_ID INT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 1,
+    "value" : {
+      "name" : "-"
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "left_topic",
+    "key" : 2,
+    "value" : {
+      "name" : "-"
+    },
+    "timestamp" : 5
+  }, {
+    "topic" : "right_topic",
+    "key" : "k",
+    "value" : {
+      "id" : [ 1, 2, 3 ]
+    },
+    "timestamp" : 10
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : {
+      "T_ID" : 1
+    },
+    "timestamp" : 10
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_subscript/6.0.0_1583319046093/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_join_-_contains_subscript/6.0.0_1583319046093/topology
@@ -1,0 +1,54 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000014-store])
+      --> Join-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000013-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000013-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000014-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000017
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000017 (topic: OUTPUT)
+      <-- Project
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> KSTREAM-FILTER-0000000005
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: KSTREAM-FILTER-0000000005 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000006
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-KEY-SELECT-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000005
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000006
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_AVRO/6.0.0_1583319043519/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_AVRO/6.0.0_1583319043519/plan.json
@@ -1,0 +1,236 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM LEFT_OUTER_JOIN AS SELECT\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nLEFT OUTER JOIN TEST_STREAM TT WITHIN 11 SECONDS ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "LEFT_OUTER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "LEFT_OUTER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "LEFT_OUTER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "LEFT_OUTER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "LEFT",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "LEFT_OUTER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_LEFT_OUTER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_AVRO/6.0.0_1583319043519/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_AVRO/6.0.0_1583319043519/spec.json
@@ -1,0 +1,267 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319043519,
+  "schemas" : {
+    "CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.Join.Left" : "STRUCT<T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.Join.Right" : "STRUCT<TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_ID BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN" : "STRUCT<NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 100,
+    "value" : {
+      "F1" : "newblah",
+      "F2" : 150
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 30000
+  } ],
+  "outputs" : [ {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 0,
+      "T_ID" : 0,
+      "T_NAME" : "zero",
+      "T_VALUE" : 0
+    },
+    "timestamp" : 0,
+    "window" : {
+      "start" : 0,
+      "end" : 11000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000009-store-changelog",
+    "key" : 0,
+    "value" : {
+      "TT_ROWTIME" : 10000,
+      "TT_ID" : 0,
+      "TT_F1" : "blah",
+      "TT_F2" : 50
+    },
+    "timestamp" : 10000,
+    "window" : {
+      "start" : 10000,
+      "end" : 21000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog",
+    "key" : 10,
+    "value" : {
+      "T_ROWTIME" : 11000,
+      "T_ID" : 10,
+      "T_NAME" : "100",
+      "T_VALUE" : 5
+    },
+    "timestamp" : 11000,
+    "window" : {
+      "start" : 11000,
+      "end" : 22000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 13000,
+      "T_ID" : 0,
+      "T_NAME" : "foo",
+      "T_VALUE" : 100
+    },
+    "timestamp" : 13000,
+    "window" : {
+      "start" : 13000,
+      "end" : 24000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000009-store-changelog",
+    "key" : 0,
+    "value" : {
+      "TT_ROWTIME" : 15000,
+      "TT_ID" : 0,
+      "TT_F1" : "a",
+      "TT_F2" : 10
+    },
+    "timestamp" : 15000,
+    "window" : {
+      "start" : 15000,
+      "end" : 26000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000009-store-changelog",
+    "key" : 100,
+    "value" : {
+      "TT_ROWTIME" : 16000,
+      "TT_ID" : 100,
+      "TT_F1" : "newblah",
+      "TT_F2" : 150
+    },
+    "timestamp" : 16000,
+    "window" : {
+      "start" : 16000,
+      "end" : 27000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog",
+    "key" : 90,
+    "value" : {
+      "T_ROWTIME" : 17000,
+      "T_ID" : 90,
+      "T_NAME" : "ninety",
+      "T_VALUE" : 90
+    },
+    "timestamp" : 17000,
+    "window" : {
+      "start" : 17000,
+      "end" : 28000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 30000,
+      "T_ID" : 0,
+      "T_NAME" : "bar",
+      "T_VALUE" : 99
+    },
+    "timestamp" : 30000,
+    "window" : {
+      "start" : 30000,
+      "end" : 41000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 30000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_AVRO/6.0.0_1583319043519/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_AVRO/6.0.0_1583319043519/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000009-store])
+      --> Join-outer-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-outer-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-OUTEROTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-outer-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: LEFT_OUTER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_JSON/6.0.0_1583319043567/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_JSON/6.0.0_1583319043567/plan.json
@@ -1,0 +1,236 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM LEFT_OUTER_JOIN AS SELECT\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nLEFT OUTER JOIN TEST_STREAM TT WITHIN 11 SECONDS ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "LEFT_OUTER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "LEFT_OUTER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "LEFT_OUTER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "LEFT_OUTER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "LEFT",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "LEFT_OUTER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_LEFT_OUTER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_JSON/6.0.0_1583319043567/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_JSON/6.0.0_1583319043567/spec.json
@@ -1,0 +1,267 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319043567,
+  "schemas" : {
+    "CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.Join.Left" : "STRUCT<T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.Join.Right" : "STRUCT<TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_ID BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN" : "STRUCT<NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 100,
+    "value" : {
+      "F1" : "newblah",
+      "F2" : 150
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 30000
+  } ],
+  "outputs" : [ {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 0,
+      "T_ID" : 0,
+      "T_NAME" : "zero",
+      "T_VALUE" : 0
+    },
+    "timestamp" : 0,
+    "window" : {
+      "start" : 0,
+      "end" : 11000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000009-store-changelog",
+    "key" : 0,
+    "value" : {
+      "TT_ROWTIME" : 10000,
+      "TT_ID" : 0,
+      "TT_F1" : "blah",
+      "TT_F2" : 50
+    },
+    "timestamp" : 10000,
+    "window" : {
+      "start" : 10000,
+      "end" : 21000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog",
+    "key" : 10,
+    "value" : {
+      "T_ROWTIME" : 11000,
+      "T_ID" : 10,
+      "T_NAME" : "100",
+      "T_VALUE" : 5
+    },
+    "timestamp" : 11000,
+    "window" : {
+      "start" : 11000,
+      "end" : 22000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 13000,
+      "T_ID" : 0,
+      "T_NAME" : "foo",
+      "T_VALUE" : 100
+    },
+    "timestamp" : 13000,
+    "window" : {
+      "start" : 13000,
+      "end" : 24000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000009-store-changelog",
+    "key" : 0,
+    "value" : {
+      "TT_ROWTIME" : 15000,
+      "TT_ID" : 0,
+      "TT_F1" : "a",
+      "TT_F2" : 10
+    },
+    "timestamp" : 15000,
+    "window" : {
+      "start" : 15000,
+      "end" : 26000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000009-store-changelog",
+    "key" : 100,
+    "value" : {
+      "TT_ROWTIME" : 16000,
+      "TT_ID" : 100,
+      "TT_F1" : "newblah",
+      "TT_F2" : 150
+    },
+    "timestamp" : 16000,
+    "window" : {
+      "start" : 16000,
+      "end" : 27000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog",
+    "key" : 90,
+    "value" : {
+      "T_ROWTIME" : 17000,
+      "T_ID" : 90,
+      "T_NAME" : "ninety",
+      "T_VALUE" : 90
+    },
+    "timestamp" : 17000,
+    "window" : {
+      "start" : 17000,
+      "end" : 28000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 30000,
+      "T_ID" : 0,
+      "T_NAME" : "bar",
+      "T_VALUE" : 99
+    },
+    "timestamp" : 30000,
+    "window" : {
+      "start" : 30000,
+      "end" : 41000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 30000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_JSON/6.0.0_1583319043567/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_JSON/6.0.0_1583319043567/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000009-store])
+      --> Join-outer-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-outer-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-OUTEROTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-outer-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: LEFT_OUTER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_PROTOBUF/6.0.0_1583319043603/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_PROTOBUF/6.0.0_1583319043603/plan.json
@@ -1,0 +1,236 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM LEFT_OUTER_JOIN AS SELECT\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nLEFT OUTER JOIN TEST_STREAM TT WITHIN 11 SECONDS ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "LEFT_OUTER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "LEFT_OUTER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "LEFT_OUTER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "LEFT_OUTER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "LEFT",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "LEFT_OUTER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_LEFT_OUTER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_PROTOBUF/6.0.0_1583319043603/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_PROTOBUF/6.0.0_1583319043603/spec.json
@@ -1,0 +1,267 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319043603,
+  "schemas" : {
+    "CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.Join.Left" : "STRUCT<T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.Join.Right" : "STRUCT<TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_ID BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN" : "STRUCT<NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 100,
+    "value" : {
+      "F1" : "newblah",
+      "F2" : 150
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 30000
+  } ],
+  "outputs" : [ {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 0,
+      "T_ID" : 0,
+      "T_NAME" : "zero",
+      "T_VALUE" : 0
+    },
+    "timestamp" : 0,
+    "window" : {
+      "start" : 0,
+      "end" : 11000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000009-store-changelog",
+    "key" : 0,
+    "value" : {
+      "TT_ROWTIME" : 10000,
+      "TT_ID" : 0,
+      "TT_F1" : "blah",
+      "TT_F2" : 50
+    },
+    "timestamp" : 10000,
+    "window" : {
+      "start" : 10000,
+      "end" : 21000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog",
+    "key" : 10,
+    "value" : {
+      "T_ROWTIME" : 11000,
+      "T_ID" : 10,
+      "T_NAME" : "100",
+      "T_VALUE" : 5
+    },
+    "timestamp" : 11000,
+    "window" : {
+      "start" : 11000,
+      "end" : 22000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 13000,
+      "T_ID" : 0,
+      "T_NAME" : "foo",
+      "T_VALUE" : 100
+    },
+    "timestamp" : 13000,
+    "window" : {
+      "start" : 13000,
+      "end" : 24000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000009-store-changelog",
+    "key" : 0,
+    "value" : {
+      "TT_ROWTIME" : 15000,
+      "TT_ID" : 0,
+      "TT_F1" : "a",
+      "TT_F2" : 10
+    },
+    "timestamp" : 15000,
+    "window" : {
+      "start" : 15000,
+      "end" : 26000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000009-store-changelog",
+    "key" : 100,
+    "value" : {
+      "TT_ROWTIME" : 16000,
+      "TT_ID" : 100,
+      "TT_F1" : "newblah",
+      "TT_F2" : 150
+    },
+    "timestamp" : 16000,
+    "window" : {
+      "start" : 16000,
+      "end" : 27000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog",
+    "key" : 90,
+    "value" : {
+      "T_ROWTIME" : 17000,
+      "T_ID" : 90,
+      "T_NAME" : "ninety",
+      "T_VALUE" : 90
+    },
+    "timestamp" : 17000,
+    "window" : {
+      "start" : 17000,
+      "end" : 28000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 30000,
+      "T_ID" : 0,
+      "T_NAME" : "bar",
+      "T_VALUE" : 99
+    },
+    "timestamp" : 30000,
+    "window" : {
+      "start" : 30000,
+      "end" : 41000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5,
+      "F1" : "",
+      "F2" : 0
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90,
+      "F1" : "",
+      "F2" : 0
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "",
+      "F2" : 0
+    },
+    "timestamp" : 30000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_PROTOBUF/6.0.0_1583319043603/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_PROTOBUF/6.0.0_1583319043603/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000009-store])
+      --> Join-outer-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-outer-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-OUTEROTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-outer-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: LEFT_OUTER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_rekey_-_AVRO/6.0.0_1583319043796/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_rekey_-_AVRO/6.0.0_1583319043796/plan.json
@@ -1,0 +1,250 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (K STRING KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`K` STRING KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (K STRING KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`K` STRING KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM LEFT_OUTER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nLEFT OUTER JOIN TEST_STREAM TT WITHIN 11 SECONDS ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "LEFT_OUTER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "T_ID",
+      "timestampColumn" : null,
+      "topicName" : "LEFT_OUTER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "LEFT_OUTER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "LEFT_OUTER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "LEFT",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "LeftSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Left/Source"
+                  },
+                  "topicName" : "left_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "AVRO",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`K` STRING KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+                },
+                "keyExpression" : "ID"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "K AS T_K" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "RightSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Right/Source"
+                  },
+                  "topicName" : "right_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "AVRO",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`K` STRING KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+                },
+                "keyExpression" : "ID"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "K AS TT_K" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "LEFT_OUTER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_LEFT_OUTER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_rekey_-_AVRO/6.0.0_1583319043796/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_rekey_-_AVRO/6.0.0_1583319043796/spec.json
@@ -1,0 +1,378 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319043796,
+  "schemas" : {
+    "CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.Join.Left" : "STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_K VARCHAR> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.Join.Right" : "STRUCT<TT_ID BIGINT, TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_K VARCHAR> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : "",
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : "",
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : "",
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : "",
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : "",
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : "",
+    "value" : {
+      "ID" : 100,
+      "F1" : "newblah",
+      "F2" : 150
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : "",
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "left_topic",
+    "key" : "",
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 30000
+  } ],
+  "outputs" : [ {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 0,
+      "T_K" : "",
+      "T_ID" : 0,
+      "T_NAME" : "zero",
+      "T_VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-right-repartition",
+    "key" : 0,
+    "value" : {
+      "TT_ROWTIME" : 10000,
+      "TT_K" : "",
+      "TT_ID" : 0,
+      "TT_F1" : "blah",
+      "TT_F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition",
+    "key" : 10,
+    "value" : {
+      "T_ROWTIME" : 11000,
+      "T_K" : "",
+      "T_ID" : 10,
+      "T_NAME" : "100",
+      "T_VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 13000,
+      "T_K" : "",
+      "T_ID" : 0,
+      "T_NAME" : "foo",
+      "T_VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-right-repartition",
+    "key" : 0,
+    "value" : {
+      "TT_ROWTIME" : 15000,
+      "TT_K" : "",
+      "TT_ID" : 0,
+      "TT_F1" : "a",
+      "TT_F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-right-repartition",
+    "key" : 100,
+    "value" : {
+      "TT_ROWTIME" : 16000,
+      "TT_K" : "",
+      "TT_ID" : 100,
+      "TT_F1" : "newblah",
+      "TT_F2" : 150
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition",
+    "key" : 90,
+    "value" : {
+      "T_ROWTIME" : 17000,
+      "T_K" : "",
+      "T_ID" : 90,
+      "T_NAME" : "ninety",
+      "T_VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 30000,
+      "T_K" : "",
+      "T_ID" : 0,
+      "T_NAME" : "bar",
+      "T_VALUE" : 99
+    },
+    "timestamp" : 30000
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000018-store-changelog",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 0,
+      "T_K" : "",
+      "T_ID" : 0,
+      "T_NAME" : "zero",
+      "T_VALUE" : 0
+    },
+    "timestamp" : 0,
+    "window" : {
+      "start" : 0,
+      "end" : 11000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000019-store-changelog",
+    "key" : 0,
+    "value" : {
+      "TT_ROWTIME" : 10000,
+      "TT_K" : "",
+      "TT_ID" : 0,
+      "TT_F1" : "blah",
+      "TT_F2" : 50
+    },
+    "timestamp" : 10000,
+    "window" : {
+      "start" : 10000,
+      "end" : 21000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000018-store-changelog",
+    "key" : 10,
+    "value" : {
+      "T_ROWTIME" : 11000,
+      "T_K" : "",
+      "T_ID" : 10,
+      "T_NAME" : "100",
+      "T_VALUE" : 5
+    },
+    "timestamp" : 11000,
+    "window" : {
+      "start" : 11000,
+      "end" : 22000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000018-store-changelog",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 13000,
+      "T_K" : "",
+      "T_ID" : 0,
+      "T_NAME" : "foo",
+      "T_VALUE" : 100
+    },
+    "timestamp" : 13000,
+    "window" : {
+      "start" : 13000,
+      "end" : 24000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000019-store-changelog",
+    "key" : 0,
+    "value" : {
+      "TT_ROWTIME" : 15000,
+      "TT_K" : "",
+      "TT_ID" : 0,
+      "TT_F1" : "a",
+      "TT_F2" : 10
+    },
+    "timestamp" : 15000,
+    "window" : {
+      "start" : 15000,
+      "end" : 26000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000019-store-changelog",
+    "key" : 100,
+    "value" : {
+      "TT_ROWTIME" : 16000,
+      "TT_K" : "",
+      "TT_ID" : 100,
+      "TT_F1" : "newblah",
+      "TT_F2" : 150
+    },
+    "timestamp" : 16000,
+    "window" : {
+      "start" : 16000,
+      "end" : 27000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000018-store-changelog",
+    "key" : 90,
+    "value" : {
+      "T_ROWTIME" : 17000,
+      "T_K" : "",
+      "T_ID" : 90,
+      "T_NAME" : "ninety",
+      "T_VALUE" : 90
+    },
+    "timestamp" : 17000,
+    "window" : {
+      "start" : 17000,
+      "end" : 28000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000018-store-changelog",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 30000,
+      "T_K" : "",
+      "T_ID" : 0,
+      "T_NAME" : "bar",
+      "T_VALUE" : 99
+    },
+    "timestamp" : 30000,
+    "window" : {
+      "start" : 30000,
+      "end" : 41000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 10,
+    "value" : {
+      "T_ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 90,
+    "value" : {
+      "T_ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 30000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_rekey_-_AVRO/6.0.0_1583319043796/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_rekey_-_AVRO/6.0.0_1583319043796/topology
@@ -1,0 +1,69 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000019-store])
+      --> Join-outer-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-outer-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-OUTEROTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-outer-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: LEFT_OUTER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_rekey_-_JSON/6.0.0_1583319043850/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_rekey_-_JSON/6.0.0_1583319043850/plan.json
@@ -1,0 +1,250 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (K STRING KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`K` STRING KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (K STRING KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`K` STRING KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM LEFT_OUTER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nLEFT OUTER JOIN TEST_STREAM TT WITHIN 11 SECONDS ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "LEFT_OUTER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "T_ID",
+      "timestampColumn" : null,
+      "topicName" : "LEFT_OUTER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "LEFT_OUTER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "LEFT_OUTER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "LEFT",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "LeftSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Left/Source"
+                  },
+                  "topicName" : "left_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`K` STRING KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+                },
+                "keyExpression" : "ID"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "K AS T_K" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "RightSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Right/Source"
+                  },
+                  "topicName" : "right_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`K` STRING KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+                },
+                "keyExpression" : "ID"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "K AS TT_K" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "LEFT_OUTER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_LEFT_OUTER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_rekey_-_JSON/6.0.0_1583319043850/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_rekey_-_JSON/6.0.0_1583319043850/spec.json
@@ -1,0 +1,378 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319043850,
+  "schemas" : {
+    "CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.Join.Left" : "STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_K VARCHAR> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.Join.Right" : "STRUCT<TT_ID BIGINT, TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_K VARCHAR> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : "",
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : "",
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : "",
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : "",
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : "",
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : "",
+    "value" : {
+      "ID" : 100,
+      "F1" : "newblah",
+      "F2" : 150
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : "",
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "left_topic",
+    "key" : "",
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 30000
+  } ],
+  "outputs" : [ {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 0,
+      "T_K" : "",
+      "T_ID" : 0,
+      "T_NAME" : "zero",
+      "T_VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-right-repartition",
+    "key" : 0,
+    "value" : {
+      "TT_ROWTIME" : 10000,
+      "TT_K" : "",
+      "TT_ID" : 0,
+      "TT_F1" : "blah",
+      "TT_F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition",
+    "key" : 10,
+    "value" : {
+      "T_ROWTIME" : 11000,
+      "T_K" : "",
+      "T_ID" : 10,
+      "T_NAME" : "100",
+      "T_VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 13000,
+      "T_K" : "",
+      "T_ID" : 0,
+      "T_NAME" : "foo",
+      "T_VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-right-repartition",
+    "key" : 0,
+    "value" : {
+      "TT_ROWTIME" : 15000,
+      "TT_K" : "",
+      "TT_ID" : 0,
+      "TT_F1" : "a",
+      "TT_F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-right-repartition",
+    "key" : 100,
+    "value" : {
+      "TT_ROWTIME" : 16000,
+      "TT_K" : "",
+      "TT_ID" : 100,
+      "TT_F1" : "newblah",
+      "TT_F2" : 150
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition",
+    "key" : 90,
+    "value" : {
+      "T_ROWTIME" : 17000,
+      "T_K" : "",
+      "T_ID" : 90,
+      "T_NAME" : "ninety",
+      "T_VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 30000,
+      "T_K" : "",
+      "T_ID" : 0,
+      "T_NAME" : "bar",
+      "T_VALUE" : 99
+    },
+    "timestamp" : 30000
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000018-store-changelog",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 0,
+      "T_K" : "",
+      "T_ID" : 0,
+      "T_NAME" : "zero",
+      "T_VALUE" : 0
+    },
+    "timestamp" : 0,
+    "window" : {
+      "start" : 0,
+      "end" : 11000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000019-store-changelog",
+    "key" : 0,
+    "value" : {
+      "TT_ROWTIME" : 10000,
+      "TT_K" : "",
+      "TT_ID" : 0,
+      "TT_F1" : "blah",
+      "TT_F2" : 50
+    },
+    "timestamp" : 10000,
+    "window" : {
+      "start" : 10000,
+      "end" : 21000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000018-store-changelog",
+    "key" : 10,
+    "value" : {
+      "T_ROWTIME" : 11000,
+      "T_K" : "",
+      "T_ID" : 10,
+      "T_NAME" : "100",
+      "T_VALUE" : 5
+    },
+    "timestamp" : 11000,
+    "window" : {
+      "start" : 11000,
+      "end" : 22000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000018-store-changelog",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 13000,
+      "T_K" : "",
+      "T_ID" : 0,
+      "T_NAME" : "foo",
+      "T_VALUE" : 100
+    },
+    "timestamp" : 13000,
+    "window" : {
+      "start" : 13000,
+      "end" : 24000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000019-store-changelog",
+    "key" : 0,
+    "value" : {
+      "TT_ROWTIME" : 15000,
+      "TT_K" : "",
+      "TT_ID" : 0,
+      "TT_F1" : "a",
+      "TT_F2" : 10
+    },
+    "timestamp" : 15000,
+    "window" : {
+      "start" : 15000,
+      "end" : 26000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000019-store-changelog",
+    "key" : 100,
+    "value" : {
+      "TT_ROWTIME" : 16000,
+      "TT_K" : "",
+      "TT_ID" : 100,
+      "TT_F1" : "newblah",
+      "TT_F2" : 150
+    },
+    "timestamp" : 16000,
+    "window" : {
+      "start" : 16000,
+      "end" : 27000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000018-store-changelog",
+    "key" : 90,
+    "value" : {
+      "T_ROWTIME" : 17000,
+      "T_K" : "",
+      "T_ID" : 90,
+      "T_NAME" : "ninety",
+      "T_VALUE" : 90
+    },
+    "timestamp" : 17000,
+    "window" : {
+      "start" : 17000,
+      "end" : 28000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000018-store-changelog",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 30000,
+      "T_K" : "",
+      "T_ID" : 0,
+      "T_NAME" : "bar",
+      "T_VALUE" : 99
+    },
+    "timestamp" : 30000,
+    "window" : {
+      "start" : 30000,
+      "end" : 41000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 10,
+    "value" : {
+      "T_ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 90,
+    "value" : {
+      "T_ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 30000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_rekey_-_JSON/6.0.0_1583319043850/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_rekey_-_JSON/6.0.0_1583319043850/topology
@@ -1,0 +1,69 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000019-store])
+      --> Join-outer-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-outer-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-OUTEROTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-outer-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: LEFT_OUTER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_rekey_-_PROTOBUF/6.0.0_1583319043903/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_rekey_-_PROTOBUF/6.0.0_1583319043903/plan.json
@@ -1,0 +1,250 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (K STRING KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`K` STRING KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (K STRING KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`K` STRING KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM LEFT_OUTER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nLEFT OUTER JOIN TEST_STREAM TT WITHIN 11 SECONDS ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "LEFT_OUTER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "T_ID",
+      "timestampColumn" : null,
+      "topicName" : "LEFT_OUTER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "LEFT_OUTER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "LEFT_OUTER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "LEFT",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "LeftSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Left/Source"
+                  },
+                  "topicName" : "left_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "PROTOBUF",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`K` STRING KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+                },
+                "keyExpression" : "ID"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "K AS T_K" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "RightSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Right/Source"
+                  },
+                  "topicName" : "right_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "PROTOBUF",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`K` STRING KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+                },
+                "keyExpression" : "ID"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "K AS TT_K" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "LEFT_OUTER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_LEFT_OUTER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_rekey_-_PROTOBUF/6.0.0_1583319043903/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_rekey_-_PROTOBUF/6.0.0_1583319043903/spec.json
@@ -1,0 +1,378 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319043903,
+  "schemas" : {
+    "CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.Join.Left" : "STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_K VARCHAR> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.Join.Right" : "STRUCT<TT_ID BIGINT, TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_K VARCHAR> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : "",
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : "",
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : "",
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : "",
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : "",
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : "",
+    "value" : {
+      "ID" : 100,
+      "F1" : "newblah",
+      "F2" : 150
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : "",
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "left_topic",
+    "key" : "",
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 30000
+  } ],
+  "outputs" : [ {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 0,
+      "T_K" : "",
+      "T_ID" : 0,
+      "T_NAME" : "zero",
+      "T_VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-right-repartition",
+    "key" : 0,
+    "value" : {
+      "TT_ROWTIME" : 10000,
+      "TT_K" : "",
+      "TT_ID" : 0,
+      "TT_F1" : "blah",
+      "TT_F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition",
+    "key" : 10,
+    "value" : {
+      "T_ROWTIME" : 11000,
+      "T_K" : "",
+      "T_ID" : 10,
+      "T_NAME" : "100",
+      "T_VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 13000,
+      "T_K" : "",
+      "T_ID" : 0,
+      "T_NAME" : "foo",
+      "T_VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-right-repartition",
+    "key" : 0,
+    "value" : {
+      "TT_ROWTIME" : 15000,
+      "TT_K" : "",
+      "TT_ID" : 0,
+      "TT_F1" : "a",
+      "TT_F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-right-repartition",
+    "key" : 100,
+    "value" : {
+      "TT_ROWTIME" : 16000,
+      "TT_K" : "",
+      "TT_ID" : 100,
+      "TT_F1" : "newblah",
+      "TT_F2" : 150
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition",
+    "key" : 90,
+    "value" : {
+      "T_ROWTIME" : 17000,
+      "T_K" : "",
+      "T_ID" : 90,
+      "T_NAME" : "ninety",
+      "T_VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 30000,
+      "T_K" : "",
+      "T_ID" : 0,
+      "T_NAME" : "bar",
+      "T_VALUE" : 99
+    },
+    "timestamp" : 30000
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000018-store-changelog",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 0,
+      "T_K" : "",
+      "T_ID" : 0,
+      "T_NAME" : "zero",
+      "T_VALUE" : 0
+    },
+    "timestamp" : 0,
+    "window" : {
+      "start" : 0,
+      "end" : 11000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000019-store-changelog",
+    "key" : 0,
+    "value" : {
+      "TT_ROWTIME" : 10000,
+      "TT_K" : "",
+      "TT_ID" : 0,
+      "TT_F1" : "blah",
+      "TT_F2" : 50
+    },
+    "timestamp" : 10000,
+    "window" : {
+      "start" : 10000,
+      "end" : 21000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000018-store-changelog",
+    "key" : 10,
+    "value" : {
+      "T_ROWTIME" : 11000,
+      "T_K" : "",
+      "T_ID" : 10,
+      "T_NAME" : "100",
+      "T_VALUE" : 5
+    },
+    "timestamp" : 11000,
+    "window" : {
+      "start" : 11000,
+      "end" : 22000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000018-store-changelog",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 13000,
+      "T_K" : "",
+      "T_ID" : 0,
+      "T_NAME" : "foo",
+      "T_VALUE" : 100
+    },
+    "timestamp" : 13000,
+    "window" : {
+      "start" : 13000,
+      "end" : 24000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000019-store-changelog",
+    "key" : 0,
+    "value" : {
+      "TT_ROWTIME" : 15000,
+      "TT_K" : "",
+      "TT_ID" : 0,
+      "TT_F1" : "a",
+      "TT_F2" : 10
+    },
+    "timestamp" : 15000,
+    "window" : {
+      "start" : 15000,
+      "end" : 26000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000019-store-changelog",
+    "key" : 100,
+    "value" : {
+      "TT_ROWTIME" : 16000,
+      "TT_K" : "",
+      "TT_ID" : 100,
+      "TT_F1" : "newblah",
+      "TT_F2" : 150
+    },
+    "timestamp" : 16000,
+    "window" : {
+      "start" : 16000,
+      "end" : 27000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000018-store-changelog",
+    "key" : 90,
+    "value" : {
+      "T_ROWTIME" : 17000,
+      "T_K" : "",
+      "T_ID" : 90,
+      "T_NAME" : "ninety",
+      "T_VALUE" : 90
+    },
+    "timestamp" : 17000,
+    "window" : {
+      "start" : 17000,
+      "end" : 28000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000018-store-changelog",
+    "key" : 0,
+    "value" : {
+      "T_ROWTIME" : 30000,
+      "T_K" : "",
+      "T_ID" : 0,
+      "T_NAME" : "bar",
+      "T_VALUE" : 99
+    },
+    "timestamp" : 30000,
+    "window" : {
+      "start" : 30000,
+      "end" : 41000,
+      "type" : "TIME"
+    }
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 10,
+    "value" : {
+      "T_ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5,
+      "F1" : "",
+      "F2" : 0
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 90,
+    "value" : {
+      "T_ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90,
+      "F1" : "",
+      "F2" : 0
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "",
+      "F2" : 0
+    },
+    "timestamp" : 30000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_rekey_-_PROTOBUF/6.0.0_1583319043903/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_-_rekey_-_PROTOBUF/6.0.0_1583319043903/topology
@@ -1,0 +1,69 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000019-store])
+      --> Join-outer-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-outer-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-OUTEROTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-outer-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: LEFT_OUTER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_with_rowkey_-_rekey_-_AVRO/6.0.0_1583319043641/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_with_rowkey_-_rekey_-_AVRO/6.0.0_1583319043641/plan.json
@@ -1,0 +1,250 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (K STRING KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`K` STRING KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (K STRING KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`K` STRING KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM LEFT_OUTER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nLEFT OUTER JOIN TEST_STREAM TT WITHIN 11 SECONDS ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "LEFT_OUTER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "T_ID",
+      "timestampColumn" : null,
+      "topicName" : "LEFT_OUTER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "LEFT_OUTER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "LEFT_OUTER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "LEFT",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "LeftSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Left/Source"
+                  },
+                  "topicName" : "left_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "AVRO",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`K` STRING KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+                },
+                "keyExpression" : "ID"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "K AS T_K" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "RightSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Right/Source"
+                  },
+                  "topicName" : "right_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "AVRO",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`K` STRING KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+                },
+                "keyExpression" : "ID"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "K AS TT_K" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "LEFT_OUTER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_LEFT_OUTER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_with_rowkey_-_rekey_-_AVRO/6.0.0_1583319043641/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_with_rowkey_-_rekey_-_AVRO/6.0.0_1583319043641/spec.json
@@ -1,0 +1,162 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319043641,
+  "schemas" : {
+    "CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.Join.Left" : "STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_K VARCHAR> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.Join.Right" : "STRUCT<TT_ID BIGINT, TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_K VARCHAR> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : "foo",
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : "foo",
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : "foo",
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : "foo",
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : "foo",
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : "foo",
+    "value" : {
+      "ID" : 100,
+      "F1" : "newblah",
+      "F2" : 150
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : "foo",
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "left_topic",
+    "key" : "foo",
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 30000
+  } ],
+  "outputs" : [ {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 10,
+    "value" : {
+      "T_ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 90,
+    "value" : {
+      "T_ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 30000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_with_rowkey_-_rekey_-_AVRO/6.0.0_1583319043641/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_with_rowkey_-_rekey_-_AVRO/6.0.0_1583319043641/topology
@@ -1,0 +1,69 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000019-store])
+      --> Join-outer-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-outer-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-OUTEROTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-outer-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: LEFT_OUTER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_with_rowkey_-_rekey_-_JSON/6.0.0_1583319043696/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_with_rowkey_-_rekey_-_JSON/6.0.0_1583319043696/plan.json
@@ -1,0 +1,250 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (K STRING KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`K` STRING KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (K STRING KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`K` STRING KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM LEFT_OUTER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nLEFT OUTER JOIN TEST_STREAM TT WITHIN 11 SECONDS ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "LEFT_OUTER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "T_ID",
+      "timestampColumn" : null,
+      "topicName" : "LEFT_OUTER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "LEFT_OUTER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "LEFT_OUTER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "LEFT",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "LeftSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Left/Source"
+                  },
+                  "topicName" : "left_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`K` STRING KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+                },
+                "keyExpression" : "ID"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "K AS T_K" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "RightSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Right/Source"
+                  },
+                  "topicName" : "right_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`K` STRING KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+                },
+                "keyExpression" : "ID"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "K AS TT_K" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "LEFT_OUTER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_LEFT_OUTER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_with_rowkey_-_rekey_-_JSON/6.0.0_1583319043696/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_with_rowkey_-_rekey_-_JSON/6.0.0_1583319043696/spec.json
@@ -1,0 +1,162 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319043696,
+  "schemas" : {
+    "CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.Join.Left" : "STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_K VARCHAR> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.Join.Right" : "STRUCT<TT_ID BIGINT, TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_K VARCHAR> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : "foo",
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : "foo",
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : "foo",
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : "foo",
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : "foo",
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : "foo",
+    "value" : {
+      "ID" : 100,
+      "F1" : "newblah",
+      "F2" : 150
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : "foo",
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "left_topic",
+    "key" : "foo",
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 30000
+  } ],
+  "outputs" : [ {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 10,
+    "value" : {
+      "T_ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 90,
+    "value" : {
+      "T_ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 30000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_with_rowkey_-_rekey_-_JSON/6.0.0_1583319043696/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_with_rowkey_-_rekey_-_JSON/6.0.0_1583319043696/topology
@@ -1,0 +1,69 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000019-store])
+      --> Join-outer-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-outer-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-OUTEROTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-outer-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: LEFT_OUTER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_with_rowkey_-_rekey_-_PROTOBUF/6.0.0_1583319043742/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_with_rowkey_-_rekey_-_PROTOBUF/6.0.0_1583319043742/plan.json
@@ -1,0 +1,250 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (K STRING KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`K` STRING KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (K STRING KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`K` STRING KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM LEFT_OUTER_JOIN AS SELECT\n  T.ID T_ID,\n  T.K T_K,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nLEFT OUTER JOIN TEST_STREAM TT WITHIN 11 SECONDS ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "LEFT_OUTER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `T_ID` BIGINT, `T_K` STRING, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "T_ID",
+      "timestampColumn" : null,
+      "topicName" : "LEFT_OUTER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "LEFT_OUTER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "LEFT_OUTER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "LEFT",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "LeftSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Left/Source"
+                  },
+                  "topicName" : "left_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "PROTOBUF",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`K` STRING KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+                },
+                "keyExpression" : "ID"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "K AS T_K" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "RightSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Right/Source"
+                  },
+                  "topicName" : "right_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "PROTOBUF",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`K` STRING KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+                },
+                "keyExpression" : "ID"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "K AS TT_K" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_K AS T_K", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "LEFT_OUTER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_LEFT_OUTER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_with_rowkey_-_rekey_-_PROTOBUF/6.0.0_1583319043742/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_with_rowkey_-_rekey_-_PROTOBUF/6.0.0_1583319043742/spec.json
@@ -1,0 +1,169 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319043742,
+  "schemas" : {
+    "CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.Join.Left" : "STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_K VARCHAR> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.Join.Right" : "STRUCT<TT_ID BIGINT, TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_K VARCHAR> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN" : "STRUCT<T_ID BIGINT, T_K VARCHAR, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : "foo",
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : "foo",
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : "foo",
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : "foo",
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : "foo",
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : "foo",
+    "value" : {
+      "ID" : 100,
+      "F1" : "newblah",
+      "F2" : 150
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : "foo",
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "left_topic",
+    "key" : "foo",
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 30000
+  } ],
+  "outputs" : [ {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_K" : "foo",
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_K" : "foo",
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 10,
+    "value" : {
+      "T_ID" : 10,
+      "T_K" : "foo",
+      "NAME" : "100",
+      "VALUE" : 5,
+      "F1" : "",
+      "F2" : 0
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_K" : "foo",
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_K" : "foo",
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 90,
+    "value" : {
+      "T_ID" : 90,
+      "T_K" : "foo",
+      "NAME" : "ninety",
+      "VALUE" : 90,
+      "F1" : "",
+      "F2" : 0
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "T_K" : "foo",
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "",
+      "F2" : 0
+    },
+    "timestamp" : 30000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_with_rowkey_-_rekey_-_PROTOBUF/6.0.0_1583319043742/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_left_join_with_rowkey_-_rekey_-_PROTOBUF/6.0.0_1583319043742/topology
@@ -1,0 +1,69 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> KSTREAM-FILTER-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-FILTER-0000000002 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-KEY-SELECT-0000000003 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000002
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-left-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000003
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-TRANSFORMVALUES-0000000006 (stores: [])
+      --> KSTREAM-FILTER-0000000007
+      <-- KSTREAM-SOURCE-0000000005
+    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000006
+    Processor: KSTREAM-KEY-SELECT-0000000008 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-FILTER-0000000007
+    Processor: PrependAliasRight (stores: [])
+      --> Join-right-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000008
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
+      <-- PrependAliasRight
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
+
+  Sub-topology: 2
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
+      --> Join-this-windowed
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
+      --> Join-other-windowed
+    Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000019-store])
+      --> Join-outer-other-join
+      <-- Join-right-repartition-source
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-this-join
+      <-- Join-left-repartition-source
+    Processor: Join-outer-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-OUTEROTHER-0000000019-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-outer-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000022 (topic: LEFT_OUTER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_outer_join_-_AVRO/6.0.0_1583319044758/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_outer_join_-_AVRO/6.0.0_1583319044758/plan.json
@@ -1,0 +1,236 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM LEFT_OUTER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nFULL OUTER JOIN TEST_STREAM TT WITHIN 11 SECONDS ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "LEFT_OUTER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "LEFT_OUTER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "LEFT_OUTER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "LEFT_OUTER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "OUTER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "LEFT_OUTER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_LEFT_OUTER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_outer_join_-_AVRO/6.0.0_1583319044758/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_outer_join_-_AVRO/6.0.0_1583319044758/spec.json
@@ -1,0 +1,165 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319044758,
+  "schemas" : {
+    "CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.Join.Left" : "STRUCT<T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.Join.Right" : "STRUCT<TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_ID BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 30000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "right_topic",
+    "key" : 100,
+    "value" : {
+      "F1" : "newblah",
+      "F2" : 150
+    },
+    "timestamp" : 20000
+  } ],
+  "outputs" : [ {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 10,
+    "value" : {
+      "T_ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 30000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 90,
+    "value" : {
+      "T_ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 100,
+    "value" : {
+      "T_ID" : null,
+      "NAME" : null,
+      "VALUE" : null,
+      "F1" : "newblah",
+      "F2" : 150
+    },
+    "timestamp" : 20000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_outer_join_-_AVRO/6.0.0_1583319044758/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_outer_join_-_AVRO/6.0.0_1583319044758/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000009-store])
+      --> Join-outer-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-OUTERTHIS-0000000008-store])
+      --> Join-outer-this-join
+      <-- PrependAliasLeft
+    Processor: Join-outer-other-join (stores: [KSTREAM-OUTERTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-outer-this-join (stores: [KSTREAM-OUTEROTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-outer-this-join, Join-outer-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: LEFT_OUTER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_outer_join_-_JSON/6.0.0_1583319044802/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_outer_join_-_JSON/6.0.0_1583319044802/plan.json
@@ -1,0 +1,236 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM LEFT_OUTER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nFULL OUTER JOIN TEST_STREAM TT WITHIN 11 SECONDS ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "LEFT_OUTER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "LEFT_OUTER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "LEFT_OUTER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "LEFT_OUTER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "OUTER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "LEFT_OUTER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_LEFT_OUTER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_outer_join_-_JSON/6.0.0_1583319044802/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_outer_join_-_JSON/6.0.0_1583319044802/spec.json
@@ -1,0 +1,165 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319044802,
+  "schemas" : {
+    "CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.Join.Left" : "STRUCT<T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.Join.Right" : "STRUCT<TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_ID BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 30000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "right_topic",
+    "key" : 100,
+    "value" : {
+      "F1" : "newblah",
+      "F2" : 150
+    },
+    "timestamp" : 20000
+  } ],
+  "outputs" : [ {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 10,
+    "value" : {
+      "T_ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 30000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 90,
+    "value" : {
+      "T_ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 100,
+    "value" : {
+      "T_ID" : null,
+      "NAME" : null,
+      "VALUE" : null,
+      "F1" : "newblah",
+      "F2" : 150
+    },
+    "timestamp" : 20000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_outer_join_-_JSON/6.0.0_1583319044802/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_outer_join_-_JSON/6.0.0_1583319044802/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000009-store])
+      --> Join-outer-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-OUTERTHIS-0000000008-store])
+      --> Join-outer-this-join
+      <-- PrependAliasLeft
+    Processor: Join-outer-other-join (stores: [KSTREAM-OUTERTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-outer-this-join (stores: [KSTREAM-OUTEROTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-outer-this-join, Join-outer-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: LEFT_OUTER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_outer_join_-_PROTOBUF/6.0.0_1583319044848/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_outer_join_-_PROTOBUF/6.0.0_1583319044848/plan.json
@@ -1,0 +1,236 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST_STREAM",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM LEFT_OUTER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nFULL OUTER JOIN TEST_STREAM TT WITHIN 11 SECONDS ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "LEFT_OUTER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "LEFT_OUTER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_STREAM", "TEST" ],
+      "sink" : "LEFT_OUTER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "LEFT_OUTER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "OUTER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            },
+            "beforeMillis" : 11.000000000,
+            "afterMillis" : 11.000000000
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "LEFT_OUTER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_LEFT_OUTER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_outer_join_-_PROTOBUF/6.0.0_1583319044848/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_outer_join_-_PROTOBUF/6.0.0_1583319044848/spec.json
@@ -1,0 +1,165 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319044848,
+  "schemas" : {
+    "CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.Join.Left" : "STRUCT<T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.Join.Right" : "STRUCT<TT_F1 VARCHAR, TT_F2 BIGINT, TT_ROWTIME BIGINT, TT_ID BIGINT> NOT NULL",
+    "CSAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 30000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "right_topic",
+    "key" : 100,
+    "value" : {
+      "F1" : "newblah",
+      "F2" : 150
+    },
+    "timestamp" : 20000
+  } ],
+  "outputs" : [ {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 10,
+    "value" : {
+      "T_ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5,
+      "F1" : "",
+      "F2" : 0
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "",
+      "F2" : 0
+    },
+    "timestamp" : 30000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 90,
+    "value" : {
+      "T_ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90,
+      "F1" : "",
+      "F2" : 0
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 100,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "",
+      "VALUE" : 0,
+      "F1" : "newblah",
+      "F2" : 150
+    },
+    "timestamp" : 20000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_outer_join_-_PROTOBUF/6.0.0_1583319044848/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_outer_join_-_PROTOBUF/6.0.0_1583319044848/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000009-store])
+      --> Join-outer-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-OUTERTHIS-0000000008-store])
+      --> Join-outer-this-join
+      <-- PrependAliasLeft
+    Processor: Join-outer-other-join (stores: [KSTREAM-OUTERTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-outer-this-join (stores: [KSTREAM-OUTEROTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-outer-this-join, Join-outer-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: LEFT_OUTER_JOIN)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_unwrapped_single_field_value_schema_on_inputs/6.0.0_1583319045735/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_unwrapped_single_field_value_schema_on_inputs/6.0.0_1583319045735/plan.json
@@ -1,0 +1,236 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM S1 (ID BIGINT KEY, NAME STRING) WITH (KAFKA_TOPIC='S1', VALUE_FORMAT='JSON', WRAP_SINGLE_VALUE=false);",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "S1",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "S1",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ "UNWRAP_SINGLE_VALUES" ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM S2 (ID BIGINT KEY, NAME STRING) WITH (KAFKA_TOPIC='S2', VALUE_FORMAT='JSON', WRAP_SINGLE_VALUE=false);",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "S2",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ "UNWRAP_SINGLE_VALUES" ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  S1.NAME NAME1,\n  S2.NAME NAME2\nFROM S1 S1\nINNER JOIN S2 S2 WITHIN 1 SECONDS ON ((S1.ID = S2.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `NAME1` STRING, `NAME2` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "S1", "S2" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "S1",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ "UNWRAP_SINGLE_VALUES" ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING"
+              },
+              "selectExpressions" : [ "NAME AS S1_NAME", "ROWTIME AS S1_ROWTIME", "ID AS S1_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "S2",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ "UNWRAP_SINGLE_VALUES" ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING"
+              },
+              "selectExpressions" : [ "NAME AS S2_NAME", "ROWTIME AS S2_ROWTIME", "ID AS S2_ID" ]
+            },
+            "beforeMillis" : 1.000000000,
+            "afterMillis" : 1.000000000
+          },
+          "selectExpressions" : [ "S1_NAME AS NAME1", "S2_NAME AS NAME2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_unwrapped_single_field_value_schema_on_inputs/6.0.0_1583319045735/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_unwrapped_single_field_value_schema_on_inputs/6.0.0_1583319045735/spec.json
@@ -1,0 +1,41 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319045735,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "VARCHAR",
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "VARCHAR",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<S1_NAME VARCHAR, S1_ROWTIME BIGINT, S1_ID BIGINT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Right" : "STRUCT<S2_NAME VARCHAR, S2_ROWTIME BIGINT, S2_ID BIGINT> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<NAME1 VARCHAR, NAME2 VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "S1",
+    "key" : 0,
+    "value" : "a",
+    "timestamp" : 0
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : "b",
+    "timestamp" : 10
+  }, {
+    "topic" : "S1",
+    "key" : 0,
+    "value" : null,
+    "timestamp" : 20
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : null,
+    "timestamp" : 30
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "NAME1" : "a",
+      "NAME2" : "b"
+    },
+    "timestamp" : 10
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_unwrapped_single_field_value_schema_on_inputs/6.0.0_1583319045735/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_unwrapped_single_field_value_schema_on_inputs/6.0.0_1583319045735/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [S1])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [S2])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_unwrapped_single_field_value_schema_on_inputs_and_output/6.0.0_1583319045768/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_unwrapped_single_field_value_schema_on_inputs_and_output/6.0.0_1583319045768/plan.json
@@ -1,0 +1,236 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM S1 (ID BIGINT KEY, NAME STRING) WITH (KAFKA_TOPIC='S1', VALUE_FORMAT='JSON', WRAP_SINGLE_VALUE=false);",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "S1",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "S1",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ "UNWRAP_SINGLE_VALUES" ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM S2 (ID BIGINT KEY, NAME STRING) WITH (KAFKA_TOPIC='S2', VALUE_FORMAT='JSON', WRAP_SINGLE_VALUE=false);",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "S2",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ "UNWRAP_SINGLE_VALUES" ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT WITH (WRAP_SINGLE_VALUE=false) AS SELECT S1.NAME NAME\nFROM S1 S1\nINNER JOIN S2 S2 WITHIN 1 SECONDS ON ((S1.ID = S2.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ "UNWRAP_SINGLE_VALUES" ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "S1", "S2" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "S1",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ "UNWRAP_SINGLE_VALUES" ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING"
+              },
+              "selectExpressions" : [ "NAME AS S1_NAME", "ROWTIME AS S1_ROWTIME", "ID AS S1_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "S2",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ "UNWRAP_SINGLE_VALUES" ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING"
+              },
+              "selectExpressions" : [ "NAME AS S2_NAME", "ROWTIME AS S2_ROWTIME", "ID AS S2_ID" ]
+            },
+            "beforeMillis" : 1.000000000,
+            "afterMillis" : 1.000000000
+          },
+          "selectExpressions" : [ "S1_NAME AS NAME" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ "UNWRAP_SINGLE_VALUES" ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_unwrapped_single_field_value_schema_on_inputs_and_output/6.0.0_1583319045768/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_unwrapped_single_field_value_schema_on_inputs_and_output/6.0.0_1583319045768/spec.json
@@ -1,0 +1,38 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319045768,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "VARCHAR",
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "VARCHAR",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<S1_NAME VARCHAR, S1_ROWTIME BIGINT, S1_ID BIGINT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Right" : "STRUCT<S2_NAME VARCHAR, S2_ROWTIME BIGINT, S2_ID BIGINT> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "VARCHAR"
+  },
+  "inputs" : [ {
+    "topic" : "S1",
+    "key" : 0,
+    "value" : "a",
+    "timestamp" : 0
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : "b",
+    "timestamp" : 10
+  }, {
+    "topic" : "S1",
+    "key" : 0,
+    "value" : null,
+    "timestamp" : 20
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : null,
+    "timestamp" : 30
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : "a",
+    "timestamp" : 10
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_unwrapped_single_field_value_schema_on_inputs_and_output/6.0.0_1583319045768/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_unwrapped_single_field_value_schema_on_inputs_and_output/6.0.0_1583319045768/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [S1])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [S2])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_wrapped_single_field_value_schema_on_inputs/6.0.0_1583319045708/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_wrapped_single_field_value_schema_on_inputs/6.0.0_1583319045708/plan.json
@@ -1,0 +1,236 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM S1 (ID BIGINT KEY, NAME STRING) WITH (KAFKA_TOPIC='S1', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "S1",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "S1",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM S2 (ID BIGINT KEY, NAME STRING) WITH (KAFKA_TOPIC='S2', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "S2",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  S1.NAME NAME1,\n  S2.NAME NAME2\nFROM S1 S1\nINNER JOIN S2 S2 WITHIN 1 SECONDS ON ((S1.ID = S2.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `NAME1` STRING, `NAME2` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "S1", "S2" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "S1",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING"
+              },
+              "selectExpressions" : [ "NAME AS S1_NAME", "ROWTIME AS S1_ROWTIME", "ID AS S1_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "S2",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING"
+              },
+              "selectExpressions" : [ "NAME AS S2_NAME", "ROWTIME AS S2_ROWTIME", "ID AS S2_ID" ]
+            },
+            "beforeMillis" : 1.000000000,
+            "afterMillis" : 1.000000000
+          },
+          "selectExpressions" : [ "S1_NAME AS NAME1", "S2_NAME AS NAME2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_wrapped_single_field_value_schema_on_inputs/6.0.0_1583319045708/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_wrapped_single_field_value_schema_on_inputs/6.0.0_1583319045708/spec.json
@@ -1,0 +1,73 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319045708,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<NAME VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<S1_NAME VARCHAR, S1_ROWTIME BIGINT, S1_ID BIGINT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Right" : "STRUCT<S2_NAME VARCHAR, S2_ROWTIME BIGINT, S2_ID BIGINT> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<NAME1 VARCHAR, NAME2 VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "S1",
+    "key" : 0,
+    "value" : {
+      "NAME" : "a"
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "NAME" : "b"
+    },
+    "timestamp" : 10
+  }, {
+    "topic" : "S1",
+    "key" : 0,
+    "value" : {
+      "ID" : null
+    },
+    "timestamp" : 20
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : null
+    },
+    "timestamp" : 30
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "NAME1" : "a",
+      "NAME2" : "b"
+    },
+    "timestamp" : 10
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "NAME1" : null,
+      "NAME2" : "b"
+    },
+    "timestamp" : 20
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "NAME1" : "a",
+      "NAME2" : null
+    },
+    "timestamp" : 30
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "NAME1" : null,
+      "NAME2" : null
+    },
+    "timestamp" : 30
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_wrapped_single_field_value_schema_on_inputs/6.0.0_1583319045708/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-stream_wrapped_single_field_value_schema_on_inputs/6.0.0_1583319045708/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [S1])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [S2])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_inner_join_-_AVRO/6.0.0_1583319045441/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_inner_join_-_AVRO/6.0.0_1583319045441/plan.json
@@ -1,0 +1,223 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='test_table', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "test_table",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_TABLE", "TEST" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "test_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "test_table",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "INNER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_inner_join_-_AVRO/6.0.0_1583319045441/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_inner_join_-_AVRO/6.0.0_1583319045441/spec.json
@@ -1,0 +1,101 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319045441,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "test_table",
+    "key" : 10,
+    "value" : {
+      "F1" : "100",
+      "F2" : 5
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "blah",
+      "VALUE" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 15000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_inner_join_-_AVRO/6.0.0_1583319045441/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_inner_join_-_AVRO/6.0.0_1583319045441/topology
@@ -1,0 +1,30 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: INNER_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_inner_join_-_JSON/6.0.0_1583319045487/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_inner_join_-_JSON/6.0.0_1583319045487/plan.json
@@ -1,0 +1,223 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='test_table', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "test_table",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_TABLE", "TEST" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "test_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "test_table",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "INNER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_inner_join_-_JSON/6.0.0_1583319045487/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_inner_join_-_JSON/6.0.0_1583319045487/spec.json
@@ -1,0 +1,101 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319045487,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "test_table",
+    "key" : 10,
+    "value" : {
+      "F1" : "100",
+      "F2" : 5
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "blah",
+      "VALUE" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 15000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_inner_join_-_JSON/6.0.0_1583319045487/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_inner_join_-_JSON/6.0.0_1583319045487/topology
@@ -1,0 +1,30 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: INNER_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_inner_join_-_PROTOBUF/6.0.0_1583319045537/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_inner_join_-_PROTOBUF/6.0.0_1583319045537/plan.json
@@ -1,0 +1,223 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='test_table', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "test_table",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_TABLE", "TEST" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "test_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "test_table",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "INNER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_inner_join_-_PROTOBUF/6.0.0_1583319045537/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_inner_join_-_PROTOBUF/6.0.0_1583319045537/spec.json
@@ -1,0 +1,101 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319045537,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "test_table",
+    "key" : 10,
+    "value" : {
+      "F1" : "100",
+      "F2" : 5
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "blah",
+      "VALUE" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 15000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_inner_join_-_PROTOBUF/6.0.0_1583319045537/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_inner_join_-_PROTOBUF/6.0.0_1583319045537/topology
@@ -1,0 +1,30 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: INNER_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_left_join_-_AVRO/6.0.0_1583319045300/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_left_join_-_AVRO/6.0.0_1583319045300/plan.json
@@ -1,0 +1,223 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='test_table', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "test_table",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM LEFT_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nLEFT OUTER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "LEFT_JOIN",
+      "schema" : "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "LEFT_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_TABLE", "TEST" ],
+      "sink" : "LEFT_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "LEFT_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "LEFT",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "test_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "test_table",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "LEFT_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_LEFT_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_left_join_-_AVRO/6.0.0_1583319045300/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_left_join_-_AVRO/6.0.0_1583319045300/spec.json
@@ -1,0 +1,112 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319045300,
+  "schemas" : {
+    "CSAS_LEFT_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_LEFT_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_LEFT_JOIN_0.Join.Left" : "STRUCT<T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_LEFT_JOIN_0.LEFT_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "test_table",
+    "key" : 10,
+    "value" : {
+      "F1" : "100",
+      "F2" : 5
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "blah",
+      "VALUE" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 15000
+  } ],
+  "outputs" : [ {
+    "topic" : "LEFT_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "LEFT_JOIN",
+    "key" : 90,
+    "value" : {
+      "T_ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 15000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_left_join_-_AVRO/6.0.0_1583319045300/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_left_join_-_AVRO/6.0.0_1583319045300/topology
@@ -1,0 +1,30 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: LEFT_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_left_join_-_JSON/6.0.0_1583319045348/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_left_join_-_JSON/6.0.0_1583319045348/plan.json
@@ -1,0 +1,223 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='test_table', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "test_table",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM LEFT_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nLEFT OUTER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "LEFT_JOIN",
+      "schema" : "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "LEFT_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_TABLE", "TEST" ],
+      "sink" : "LEFT_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "LEFT_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "LEFT",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "test_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "test_table",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "LEFT_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_LEFT_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_left_join_-_JSON/6.0.0_1583319045348/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_left_join_-_JSON/6.0.0_1583319045348/spec.json
@@ -1,0 +1,112 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319045348,
+  "schemas" : {
+    "CSAS_LEFT_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_LEFT_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_LEFT_JOIN_0.Join.Left" : "STRUCT<T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_LEFT_JOIN_0.LEFT_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "test_table",
+    "key" : 10,
+    "value" : {
+      "F1" : "100",
+      "F2" : 5
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "blah",
+      "VALUE" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 15000
+  } ],
+  "outputs" : [ {
+    "topic" : "LEFT_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "LEFT_JOIN",
+    "key" : 90,
+    "value" : {
+      "T_ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 15000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_left_join_-_JSON/6.0.0_1583319045348/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_left_join_-_JSON/6.0.0_1583319045348/topology
@@ -1,0 +1,30 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: LEFT_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_left_join_-_PROTOBUF/6.0.0_1583319045397/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_left_join_-_PROTOBUF/6.0.0_1583319045397/plan.json
@@ -1,0 +1,223 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='test_table', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "test_table",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM LEFT_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nLEFT OUTER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "LEFT_JOIN",
+      "schema" : "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "LEFT_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_TABLE", "TEST" ],
+      "sink" : "LEFT_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "LEFT_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "LEFT",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "test_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "test_table",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "LEFT_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_LEFT_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_left_join_-_PROTOBUF/6.0.0_1583319045397/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_left_join_-_PROTOBUF/6.0.0_1583319045397/spec.json
@@ -1,0 +1,112 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319045397,
+  "schemas" : {
+    "CSAS_LEFT_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_LEFT_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_LEFT_JOIN_0.Join.Left" : "STRUCT<T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ID BIGINT> NOT NULL",
+    "CSAS_LEFT_JOIN_0.LEFT_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "test_table",
+    "key" : 10,
+    "value" : {
+      "F1" : "100",
+      "F2" : 5
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "blah",
+      "VALUE" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 15000
+  } ],
+  "outputs" : [ {
+    "topic" : "LEFT_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "LEFT_JOIN",
+    "key" : 90,
+    "value" : {
+      "T_ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90,
+      "F1" : "",
+      "F2" : 0
+    },
+    "timestamp" : 15000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_left_join_-_PROTOBUF/6.0.0_1583319045397/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_left_join_-_PROTOBUF/6.0.0_1583319045397/topology
@@ -1,0 +1,30 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: LEFT_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_unwrapped_single_field_value_schema_on_inputs/6.0.0_1583319045835/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_unwrapped_single_field_value_schema_on_inputs/6.0.0_1583319045835/plan.json
@@ -1,0 +1,223 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM S (ID BIGINT KEY, NAME STRING) WITH (KAFKA_TOPIC='S', VALUE_FORMAT='JSON', WRAP_SINGLE_VALUE=false);",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "S",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "S",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ "UNWRAP_SINGLE_VALUES" ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE T (ID BIGINT KEY, NAME STRING) WITH (KAFKA_TOPIC='T', VALUE_FORMAT='JSON', WRAP_SINGLE_VALUE=false);",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "T",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "T",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ "UNWRAP_SINGLE_VALUES" ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  S.NAME NAME1,\n  T.NAME NAME2\nFROM S S\nINNER JOIN T T ON ((S.ID = T.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `NAME1` STRING, `NAME2` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "S", "T" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "S",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ "UNWRAP_SINGLE_VALUES" ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING"
+              },
+              "selectExpressions" : [ "NAME AS S_NAME", "ROWTIME AS S_ROWTIME", "ID AS S_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "T",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ "UNWRAP_SINGLE_VALUES" ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            }
+          },
+          "selectExpressions" : [ "S_NAME AS NAME1", "T_NAME AS NAME2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_unwrapped_single_field_value_schema_on_inputs/6.0.0_1583319045835/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_unwrapped_single_field_value_schema_on_inputs/6.0.0_1583319045835/spec.json
@@ -1,0 +1,45 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319045835,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "VARCHAR",
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "VARCHAR",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<S_NAME VARCHAR, S_ROWTIME BIGINT, S_ID BIGINT> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<NAME1 VARCHAR, NAME2 VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "T",
+    "key" : 0,
+    "value" : "b",
+    "timestamp" : 0
+  }, {
+    "topic" : "S",
+    "key" : 0,
+    "value" : "a",
+    "timestamp" : 10
+  }, {
+    "topic" : "S",
+    "key" : 0,
+    "value" : null,
+    "timestamp" : 20
+  }, {
+    "topic" : "T",
+    "key" : 0,
+    "value" : null,
+    "timestamp" : 30
+  }, {
+    "topic" : "S",
+    "key" : 0,
+    "value" : null,
+    "timestamp" : 40
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "NAME1" : "a",
+      "NAME2" : "b"
+    },
+    "timestamp" : 10
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_unwrapped_single_field_value_schema_on_inputs/6.0.0_1583319045835/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_unwrapped_single_field_value_schema_on_inputs/6.0.0_1583319045835/topology
@@ -1,0 +1,30 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [S])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [T])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: OUTPUT)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_unwrapped_single_field_value_schema_on_inputs_and_output/6.0.0_1583319045871/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_unwrapped_single_field_value_schema_on_inputs_and_output/6.0.0_1583319045871/plan.json
@@ -1,0 +1,223 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM S (ID BIGINT KEY, NAME STRING) WITH (KAFKA_TOPIC='S', VALUE_FORMAT='JSON', WRAP_SINGLE_VALUE=false);",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "S",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "S",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ "UNWRAP_SINGLE_VALUES" ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE T (ID BIGINT KEY, NAME STRING) WITH (KAFKA_TOPIC='T', VALUE_FORMAT='JSON', WRAP_SINGLE_VALUE=false);",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "T",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "T",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ "UNWRAP_SINGLE_VALUES" ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT WITH (WRAP_SINGLE_VALUE=false) AS SELECT S.NAME NAME\nFROM S S\nINNER JOIN T T ON ((S.ID = T.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ "UNWRAP_SINGLE_VALUES" ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "S", "T" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "S",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ "UNWRAP_SINGLE_VALUES" ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING"
+              },
+              "selectExpressions" : [ "NAME AS S_NAME", "ROWTIME AS S_ROWTIME", "ID AS S_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "T",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ "UNWRAP_SINGLE_VALUES" ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            }
+          },
+          "selectExpressions" : [ "S_NAME AS NAME" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ "UNWRAP_SINGLE_VALUES" ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_unwrapped_single_field_value_schema_on_inputs_and_output/6.0.0_1583319045871/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_unwrapped_single_field_value_schema_on_inputs_and_output/6.0.0_1583319045871/spec.json
@@ -1,0 +1,42 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319045871,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "VARCHAR",
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "VARCHAR",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<S_NAME VARCHAR, S_ROWTIME BIGINT, S_ID BIGINT> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "VARCHAR"
+  },
+  "inputs" : [ {
+    "topic" : "T",
+    "key" : 0,
+    "value" : "b",
+    "timestamp" : 0
+  }, {
+    "topic" : "S",
+    "key" : 0,
+    "value" : "a",
+    "timestamp" : 10
+  }, {
+    "topic" : "S",
+    "key" : 0,
+    "value" : null,
+    "timestamp" : 20
+  }, {
+    "topic" : "T",
+    "key" : 0,
+    "value" : null,
+    "timestamp" : 30
+  }, {
+    "topic" : "S",
+    "key" : 0,
+    "value" : null,
+    "timestamp" : 40
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : "a",
+    "timestamp" : 10
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_unwrapped_single_field_value_schema_on_inputs_and_output/6.0.0_1583319045871/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_unwrapped_single_field_value_schema_on_inputs_and_output/6.0.0_1583319045871/topology
@@ -1,0 +1,30 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [S])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [T])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: OUTPUT)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_wrapped_single_field_value_schema_on_inputs/6.0.0_1583319045798/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_wrapped_single_field_value_schema_on_inputs/6.0.0_1583319045798/plan.json
@@ -1,0 +1,223 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM S (ID BIGINT KEY, NAME STRING) WITH (KAFKA_TOPIC='S', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "S",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "S",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE T (ID BIGINT KEY, NAME STRING) WITH (KAFKA_TOPIC='T', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "T",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "T",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  S.NAME NAME1,\n  T.NAME NAME2\nFROM S S\nINNER JOIN T T ON ((S.ID = T.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `NAME1` STRING, `NAME2` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "S", "T" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "S",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING"
+              },
+              "selectExpressions" : [ "NAME AS S_NAME", "ROWTIME AS S_ROWTIME", "ID AS S_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "T",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            }
+          },
+          "selectExpressions" : [ "S_NAME AS NAME1", "T_NAME AS NAME2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_wrapped_single_field_value_schema_on_inputs/6.0.0_1583319045798/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_wrapped_single_field_value_schema_on_inputs/6.0.0_1583319045798/spec.json
@@ -1,0 +1,83 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319045798,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<NAME VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<S_NAME VARCHAR, S_ROWTIME BIGINT, S_ID BIGINT> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<NAME1 VARCHAR, NAME2 VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "T",
+    "key" : 0,
+    "value" : {
+      "NAME" : "b"
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "S",
+    "key" : 0,
+    "value" : {
+      "NAME" : "a"
+    },
+    "timestamp" : 10
+  }, {
+    "topic" : "S",
+    "key" : 0,
+    "value" : {
+      "NAME" : null
+    },
+    "timestamp" : 20
+  }, {
+    "topic" : "T",
+    "key" : 0,
+    "value" : {
+      "NAME" : null
+    },
+    "timestamp" : 30
+  }, {
+    "topic" : "S",
+    "key" : 0,
+    "value" : {
+      "NAME" : null
+    },
+    "timestamp" : 40
+  }, {
+    "topic" : "T",
+    "key" : 0,
+    "value" : null,
+    "timestamp" : 50
+  }, {
+    "topic" : "S",
+    "key" : 0,
+    "value" : {
+      "NAME" : "a"
+    },
+    "timestamp" : 60
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "NAME1" : "a",
+      "NAME2" : "b"
+    },
+    "timestamp" : 10
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "NAME1" : null,
+      "NAME2" : "b"
+    },
+    "timestamp" : 20
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "NAME1" : null,
+      "NAME2" : null
+    },
+    "timestamp" : 40
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_wrapped_single_field_value_schema_on_inputs/6.0.0_1583319045798/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_stream-table_wrapped_single_field_value_schema_on_inputs/6.0.0_1583319045798/topology
@@ -1,0 +1,30 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [S])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [T])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: OUTPUT)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_inner_join_-_AVRO/6.0.0_1583319045047/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_inner_join_-_AVRO/6.0.0_1583319045047/plan.json
@@ -1,0 +1,212 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE INNER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_TABLE", "TEST" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "INNER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_inner_join_-_AVRO/6.0.0_1583319045047/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_inner_join_-_AVRO/6.0.0_1583319045047/spec.json
@@ -1,0 +1,119 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319045047,
+  "schemas" : {
+    "CTAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CTAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CTAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 15,
+    "value" : {
+      "F1" : "c",
+      "F2" : 20
+    },
+    "timestamp" : 15500
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 16000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_inner_join_-_AVRO/6.0.0_1583319045047/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_inner_join_-_AVRO/6.0.0_1583319045047/topology
@@ -1,0 +1,42 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: INNER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_inner_join_-_JSON/6.0.0_1583319045090/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_inner_join_-_JSON/6.0.0_1583319045090/plan.json
@@ -1,0 +1,212 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE INNER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_TABLE", "TEST" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "INNER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_inner_join_-_JSON/6.0.0_1583319045090/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_inner_join_-_JSON/6.0.0_1583319045090/spec.json
@@ -1,0 +1,119 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319045090,
+  "schemas" : {
+    "CTAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CTAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CTAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 15,
+    "value" : {
+      "F1" : "c",
+      "F2" : 20
+    },
+    "timestamp" : 15500
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 16000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_inner_join_-_JSON/6.0.0_1583319045090/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_inner_join_-_JSON/6.0.0_1583319045090/topology
@@ -1,0 +1,42 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: INNER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_inner_join_-_PROTOBUF/6.0.0_1583319045132/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_inner_join_-_PROTOBUF/6.0.0_1583319045132/plan.json
@@ -1,0 +1,212 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE INNER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_TABLE", "TEST" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "INNER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_inner_join_-_PROTOBUF/6.0.0_1583319045132/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_inner_join_-_PROTOBUF/6.0.0_1583319045132/spec.json
@@ -1,0 +1,119 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319045132,
+  "schemas" : {
+    "CTAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CTAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CTAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 15,
+    "value" : {
+      "F1" : "c",
+      "F2" : 20
+    },
+    "timestamp" : 15500
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 16000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_inner_join_-_PROTOBUF/6.0.0_1583319045132/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_inner_join_-_PROTOBUF/6.0.0_1583319045132/topology
@@ -1,0 +1,42 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: INNER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_join_with_where_clause/6.0.0_1583319045667/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_join_with_where_clause/6.0.0_1583319045667/plan.json
@@ -1,0 +1,219 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nWHERE ((T.VALUE > 10) AND (TT.F2 > 5))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_TABLE", "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableFilterV1",
+            "properties" : {
+              "queryContext" : "WhereFilter"
+            },
+            "source" : {
+              "@type" : "tableTableJoinV1",
+              "properties" : {
+                "queryContext" : "Join"
+              },
+              "joinType" : "INNER",
+              "leftSource" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "PrependAliasLeft"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Left/Source"
+                  },
+                  "topicName" : "left_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+                },
+                "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+              },
+              "rightSource" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "PrependAliasRight"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Right/Source"
+                  },
+                  "topicName" : "right_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    },
+                    "options" : [ ]
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+                },
+                "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+              }
+            },
+            "filterExpression" : "((T_VALUE > 10) AND (TT_F2 > 5))"
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_join_with_where_clause/6.0.0_1583319045667/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_join_with_where_clause/6.0.0_1583319045667/spec.json
@@ -1,0 +1,117 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319045667,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<T_ID BIGINT, NAME VARCHAR, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 4
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "right_topic",
+    "key" : 90,
+    "value" : {
+      "F1" : "b",
+      "F2" : 10
+    },
+    "timestamp" : 18000
+  }, {
+    "topic" : "right_topic",
+    "key" : 90,
+    "value" : null,
+    "timestamp" : 19000
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : null,
+    "timestamp" : 10000
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : null,
+    "timestamp" : 13000
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 90,
+    "value" : {
+      "T_ID" : 90,
+      "NAME" : "ninety",
+      "F1" : "b",
+      "F2" : 10
+    },
+    "timestamp" : 18000
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 90,
+    "value" : null,
+    "timestamp" : 19000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_join_with_where_clause/6.0.0_1583319045667/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_join_with_where_clause/6.0.0_1583319045667/topology
@@ -1,0 +1,51 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> WhereFilter-ApplyPredicate
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: WhereFilter-ApplyPredicate (stores: [])
+      --> WhereFilter-Filter
+      <-- KTABLE-MERGE-0000000008
+    Processor: WhereFilter-Filter (stores: [])
+      --> WhereFilter-PostProcess
+      <-- WhereFilter-ApplyPredicate
+    Processor: WhereFilter-PostProcess (stores: [])
+      --> Project
+      <-- WhereFilter-Filter
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000015
+      <-- WhereFilter-PostProcess
+    Processor: KTABLE-TOSTREAM-0000000015 (stores: [])
+      --> KSTREAM-SINK-0000000016
+      <-- Project
+    Sink: KSTREAM-SINK-0000000016 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000015
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_left_join_-_AVRO/6.0.0_1583319044900/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_left_join_-_AVRO/6.0.0_1583319044900/plan.json
@@ -1,0 +1,212 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE LEFT_OUTER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nLEFT OUTER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "LEFT_OUTER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "LEFT_OUTER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_TABLE", "TEST" ],
+      "sink" : "LEFT_OUTER_JOIN",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "LEFT_OUTER_JOIN"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "LEFT",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "LEFT_OUTER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_LEFT_OUTER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_left_join_-_AVRO/6.0.0_1583319044900/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_left_join_-_AVRO/6.0.0_1583319044900/spec.json
@@ -1,0 +1,144 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319044900,
+  "schemas" : {
+    "CTAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CTAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CTAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  } ],
+  "outputs" : [ {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 10,
+    "value" : {
+      "T_ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 90,
+    "value" : {
+      "T_ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 17000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_left_join_-_AVRO/6.0.0_1583319044900/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_left_join_-_AVRO/6.0.0_1583319044900/topology
@@ -1,0 +1,42 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: LEFT_OUTER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_left_join_-_JSON/6.0.0_1583319044961/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_left_join_-_JSON/6.0.0_1583319044961/plan.json
@@ -1,0 +1,212 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE LEFT_OUTER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nLEFT OUTER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "LEFT_OUTER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "LEFT_OUTER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_TABLE", "TEST" ],
+      "sink" : "LEFT_OUTER_JOIN",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "LEFT_OUTER_JOIN"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "LEFT",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "LEFT_OUTER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_LEFT_OUTER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_left_join_-_JSON/6.0.0_1583319044961/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_left_join_-_JSON/6.0.0_1583319044961/spec.json
@@ -1,0 +1,144 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319044961,
+  "schemas" : {
+    "CTAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CTAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CTAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  } ],
+  "outputs" : [ {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 10,
+    "value" : {
+      "T_ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 90,
+    "value" : {
+      "T_ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 17000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_left_join_-_JSON/6.0.0_1583319044961/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_left_join_-_JSON/6.0.0_1583319044961/topology
@@ -1,0 +1,42 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: LEFT_OUTER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_left_join_-_PROTOBUF/6.0.0_1583319045007/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_left_join_-_PROTOBUF/6.0.0_1583319045007/plan.json
@@ -1,0 +1,212 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE LEFT_OUTER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nLEFT OUTER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "LEFT_OUTER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "LEFT_OUTER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_TABLE", "TEST" ],
+      "sink" : "LEFT_OUTER_JOIN",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "LEFT_OUTER_JOIN"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "LEFT",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "LEFT_OUTER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_LEFT_OUTER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_left_join_-_PROTOBUF/6.0.0_1583319045007/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_left_join_-_PROTOBUF/6.0.0_1583319045007/spec.json
@@ -1,0 +1,144 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319045007,
+  "schemas" : {
+    "CTAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CTAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CTAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  } ],
+  "outputs" : [ {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 10,
+    "value" : {
+      "T_ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5,
+      "F1" : "",
+      "F2" : 0
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 90,
+    "value" : {
+      "T_ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90,
+      "F1" : "",
+      "F2" : 0
+    },
+    "timestamp" : 17000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_left_join_-_PROTOBUF/6.0.0_1583319045007/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_left_join_-_PROTOBUF/6.0.0_1583319045007/topology
@@ -1,0 +1,42 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: LEFT_OUTER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_outer_join_-_AVRO/6.0.0_1583319045174/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_outer_join_-_AVRO/6.0.0_1583319045174/plan.json
@@ -1,0 +1,212 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nFULL OUTER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_TABLE", "TEST" ],
+      "sink" : "OUTER_JOIN",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTER_JOIN"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "OUTER",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_OUTER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_outer_join_-_AVRO/6.0.0_1583319045174/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_outer_join_-_AVRO/6.0.0_1583319045174/spec.json
@@ -1,0 +1,144 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319045174,
+  "schemas" : {
+    "CTAS_OUTER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CTAS_OUTER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CTAS_OUTER_JOIN_0.OUTER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 15,
+    "value" : {
+      "F1" : "c",
+      "F2" : 20
+    },
+    "timestamp" : 15500
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 16000
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 10,
+    "value" : {
+      "T_ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 15,
+    "value" : {
+      "T_ID" : null,
+      "NAME" : null,
+      "VALUE" : null,
+      "F1" : "c",
+      "F2" : 20
+    },
+    "timestamp" : 15500
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 16000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_outer_join_-_AVRO/6.0.0_1583319045174/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_outer_join_-_AVRO/6.0.0_1583319045174/topology
@@ -1,0 +1,42 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: OUTER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_outer_join_-_JSON/6.0.0_1583319045215/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_outer_join_-_JSON/6.0.0_1583319045215/plan.json
@@ -1,0 +1,212 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nFULL OUTER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_TABLE", "TEST" ],
+      "sink" : "OUTER_JOIN",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTER_JOIN"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "OUTER",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_OUTER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_outer_join_-_JSON/6.0.0_1583319045215/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_outer_join_-_JSON/6.0.0_1583319045215/spec.json
@@ -1,0 +1,144 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319045215,
+  "schemas" : {
+    "CTAS_OUTER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CTAS_OUTER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CTAS_OUTER_JOIN_0.OUTER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 15,
+    "value" : {
+      "F1" : "c",
+      "F2" : 20
+    },
+    "timestamp" : 15500
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 16000
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 10,
+    "value" : {
+      "T_ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 15,
+    "value" : {
+      "T_ID" : null,
+      "NAME" : null,
+      "VALUE" : null,
+      "F1" : "c",
+      "F2" : 20
+    },
+    "timestamp" : 15500
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 16000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_outer_join_-_JSON/6.0.0_1583319045215/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_outer_join_-_JSON/6.0.0_1583319045215/topology
@@ -1,0 +1,42 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: OUTER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_outer_join_-_PROTOBUF/6.0.0_1583319045259/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_outer_join_-_PROTOBUF/6.0.0_1583319045259/plan.json
@@ -1,0 +1,212 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ID BIGINT KEY, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nFULL OUTER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTER_JOIN",
+      "schema" : "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST_TABLE", "TEST" ],
+      "sink" : "OUTER_JOIN",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTER_JOIN"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "OUTER",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ID AS T_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ID AS TT_ID" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTER_JOIN",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_OUTER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_outer_join_-_PROTOBUF/6.0.0_1583319045259/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_outer_join_-_PROTOBUF/6.0.0_1583319045259/spec.json
@@ -1,0 +1,144 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319045259,
+  "schemas" : {
+    "CTAS_OUTER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CTAS_OUTER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CTAS_OUTER_JOIN_0.OUTER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 15,
+    "value" : {
+      "F1" : "c",
+      "F2" : 20
+    },
+    "timestamp" : 15500
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 16000
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 10,
+    "value" : {
+      "T_ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5,
+      "F1" : "",
+      "F2" : 0
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 15,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "",
+      "VALUE" : 0,
+      "F1" : "c",
+      "F2" : 20
+    },
+    "timestamp" : 15500
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 16000
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_outer_join_-_PROTOBUF/6.0.0_1583319045259/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_outer_join_-_PROTOBUF/6.0.0_1583319045259/topology
@@ -1,0 +1,42 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: OUTER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_unwrapped_single_field_value_schema_on_inputs/6.0.0_1583319045946/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_unwrapped_single_field_value_schema_on_inputs/6.0.0_1583319045946/plan.json
@@ -1,0 +1,212 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE T1 (ID BIGINT KEY, NAME STRING) WITH (KAFKA_TOPIC='T1', VALUE_FORMAT='JSON', WRAP_SINGLE_VALUE=false);",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "T1",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "T1",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ "UNWRAP_SINGLE_VALUES" ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE T2 (ID BIGINT KEY, NAME STRING) WITH (KAFKA_TOPIC='T2', VALUE_FORMAT='JSON', WRAP_SINGLE_VALUE=false);",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "T2",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "T2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ "UNWRAP_SINGLE_VALUES" ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  T1.NAME NAME1,\n  T2.NAME NAME2\nFROM T1 T1\nINNER JOIN T2 T2 ON ((T1.ID = T2.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `NAME1` STRING, `NAME2` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "T1", "T2" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "T1",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ "UNWRAP_SINGLE_VALUES" ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING"
+              },
+              "selectExpressions" : [ "NAME AS T1_NAME", "ROWTIME AS T1_ROWTIME", "ID AS T1_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "T2",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ "UNWRAP_SINGLE_VALUES" ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING"
+              },
+              "selectExpressions" : [ "NAME AS T2_NAME", "ROWTIME AS T2_ROWTIME", "ID AS T2_ID" ]
+            }
+          },
+          "selectExpressions" : [ "T1_NAME AS NAME1", "T2_NAME AS NAME2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_unwrapped_single_field_value_schema_on_inputs/6.0.0_1583319045946/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_unwrapped_single_field_value_schema_on_inputs/6.0.0_1583319045946/spec.json
@@ -1,0 +1,49 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319045946,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KafkaTopic_Left.Source" : "VARCHAR",
+    "CTAS_OUTPUT_0.KafkaTopic_Right.Source" : "VARCHAR",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<NAME1 VARCHAR, NAME2 VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "T1",
+    "key" : 0,
+    "value" : "a",
+    "timestamp" : 0
+  }, {
+    "topic" : "T2",
+    "key" : 0,
+    "value" : "b",
+    "timestamp" : 10
+  }, {
+    "topic" : "T1",
+    "key" : 0,
+    "value" : null,
+    "timestamp" : 20
+  }, {
+    "topic" : "T2",
+    "key" : 0,
+    "value" : null,
+    "timestamp" : 30
+  }, {
+    "topic" : "T1",
+    "key" : 0,
+    "value" : null,
+    "timestamp" : 40
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "NAME1" : "a",
+      "NAME2" : "b"
+    },
+    "timestamp" : 10
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : null,
+    "timestamp" : 20
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_unwrapped_single_field_value_schema_on_inputs/6.0.0_1583319045946/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_unwrapped_single_field_value_schema_on_inputs/6.0.0_1583319045946/topology
@@ -1,0 +1,42 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [T1])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [T2])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_unwrapped_single_field_value_schema_on_inputs_and_output/6.0.0_1583319045976/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_unwrapped_single_field_value_schema_on_inputs_and_output/6.0.0_1583319045976/plan.json
@@ -1,0 +1,212 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE T1 (ID BIGINT KEY, NAME STRING) WITH (KAFKA_TOPIC='T1', VALUE_FORMAT='JSON', WRAP_SINGLE_VALUE=false);",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "T1",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "T1",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ "UNWRAP_SINGLE_VALUES" ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE T2 (ID BIGINT KEY, NAME STRING) WITH (KAFKA_TOPIC='T2', VALUE_FORMAT='JSON', WRAP_SINGLE_VALUE=false);",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "T2",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "T2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ "UNWRAP_SINGLE_VALUES" ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT WITH (WRAP_SINGLE_VALUE=false) AS SELECT T1.NAME NAME\nFROM T1 T1\nINNER JOIN T2 T2 ON ((T1.ID = T2.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ "UNWRAP_SINGLE_VALUES" ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "T1", "T2" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "T1",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ "UNWRAP_SINGLE_VALUES" ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING"
+              },
+              "selectExpressions" : [ "NAME AS T1_NAME", "ROWTIME AS T1_ROWTIME", "ID AS T1_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "T2",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ "UNWRAP_SINGLE_VALUES" ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING"
+              },
+              "selectExpressions" : [ "NAME AS T2_NAME", "ROWTIME AS T2_ROWTIME", "ID AS T2_ID" ]
+            }
+          },
+          "selectExpressions" : [ "T1_NAME AS NAME" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ "UNWRAP_SINGLE_VALUES" ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_unwrapped_single_field_value_schema_on_inputs_and_output/6.0.0_1583319045976/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_unwrapped_single_field_value_schema_on_inputs_and_output/6.0.0_1583319045976/spec.json
@@ -1,0 +1,46 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319045976,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KafkaTopic_Left.Source" : "VARCHAR",
+    "CTAS_OUTPUT_0.KafkaTopic_Right.Source" : "VARCHAR",
+    "CTAS_OUTPUT_0.OUTPUT" : "VARCHAR"
+  },
+  "inputs" : [ {
+    "topic" : "T1",
+    "key" : 0,
+    "value" : "a",
+    "timestamp" : 0
+  }, {
+    "topic" : "T2",
+    "key" : 0,
+    "value" : "b",
+    "timestamp" : 10
+  }, {
+    "topic" : "T1",
+    "key" : 0,
+    "value" : null,
+    "timestamp" : 20
+  }, {
+    "topic" : "T2",
+    "key" : 0,
+    "value" : null,
+    "timestamp" : 30
+  }, {
+    "topic" : "T1",
+    "key" : 0,
+    "value" : null,
+    "timestamp" : 40
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : "a",
+    "timestamp" : 10
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : null,
+    "timestamp" : 20
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_unwrapped_single_field_value_schema_on_inputs_and_output/6.0.0_1583319045976/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_unwrapped_single_field_value_schema_on_inputs_and_output/6.0.0_1583319045976/topology
@@ -1,0 +1,42 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [T1])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [T2])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_wrapped_single_field_value_schema_on_inputs/6.0.0_1583319045918/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_wrapped_single_field_value_schema_on_inputs/6.0.0_1583319045918/plan.json
@@ -1,0 +1,212 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE T1 (ID BIGINT KEY, NAME STRING) WITH (KAFKA_TOPIC='T1', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "T1",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "T1",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE T2 (ID BIGINT KEY, NAME STRING) WITH (KAFKA_TOPIC='T2', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "T2",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "T2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  T1.NAME NAME1,\n  T2.NAME NAME2\nFROM T1 T1\nINNER JOIN T2 T2 ON ((T1.ID = T2.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `NAME1` STRING, `NAME2` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "T1", "T2" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "T1",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING"
+              },
+              "selectExpressions" : [ "NAME AS T1_NAME", "ROWTIME AS T1_ROWTIME", "ID AS T1_ID" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "T2",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING"
+              },
+              "selectExpressions" : [ "NAME AS T2_NAME", "ROWTIME AS T2_ROWTIME", "ID AS T2_ID" ]
+            }
+          },
+          "selectExpressions" : [ "T1_NAME AS NAME1", "T2_NAME AS NAME2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_wrapped_single_field_value_schema_on_inputs/6.0.0_1583319045918/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_wrapped_single_field_value_schema_on_inputs/6.0.0_1583319045918/spec.json
@@ -1,0 +1,93 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319045918,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<NAME VARCHAR> NOT NULL",
+    "CTAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<NAME VARCHAR> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<NAME1 VARCHAR, NAME2 VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "T1",
+    "key" : 0,
+    "value" : {
+      "NAME" : "a"
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "T2",
+    "key" : 0,
+    "value" : {
+      "NAME" : "b"
+    },
+    "timestamp" : 10
+  }, {
+    "topic" : "T1",
+    "key" : 0,
+    "value" : {
+      "NAME" : null
+    },
+    "timestamp" : 20
+  }, {
+    "topic" : "T2",
+    "key" : 0,
+    "value" : {
+      "NAME" : null
+    },
+    "timestamp" : 30
+  }, {
+    "topic" : "T1",
+    "key" : 0,
+    "value" : {
+      "NAME" : null
+    },
+    "timestamp" : 40
+  }, {
+    "topic" : "T1",
+    "key" : 0,
+    "value" : null,
+    "timestamp" : 50
+  }, {
+    "topic" : "T2",
+    "key" : 0,
+    "value" : null,
+    "timestamp" : 60
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "NAME1" : "a",
+      "NAME2" : "b"
+    },
+    "timestamp" : 10
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "NAME1" : null,
+      "NAME2" : "b"
+    },
+    "timestamp" : 20
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "NAME1" : null,
+      "NAME2" : null
+    },
+    "timestamp" : 30
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "NAME1" : null,
+      "NAME2" : null
+    },
+    "timestamp" : 40
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : null,
+    "timestamp" : 50
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_wrapped_single_field_value_schema_on_inputs/6.0.0_1583319045918/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/joins_-_table-table_wrapped_single_field_value_schema_on_inputs/6.0.0_1583319045918/topology
@@ -1,0 +1,42 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [T1])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [T2])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/key-schemas_-_KEY_key_field_name/6.0.0_1583166643536/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/key-schemas_-_KEY_key_field_name/6.0.0_1583166643536/plan.json
@@ -1,0 +1,145 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (KEY STRING KEY, ID BIGINT) WITH (KAFKA_TOPIC='input', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`KEY` STRING KEY, `ID` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.ID ID,\n  INPUT.KEY KEY2\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`KEY` STRING KEY, `ID` BIGINT, `KEY2` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`KEY` STRING KEY, `ID` BIGINT"
+          },
+          "selectExpressions" : [ "ID AS ID", "KEY AS KEY2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent6357789129346422021",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/key-schemas_-_KEY_key_field_name/6.0.0_1583166643536/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/key-schemas_-_KEY_key_field_name/6.0.0_1583166643536/spec.json
@@ -1,0 +1,23 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583166643536,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<ID BIGINT> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<ID BIGINT, KEY2 VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "input",
+    "key" : "a",
+    "value" : {
+      "id" : 1
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : "a",
+    "value" : {
+      "ID" : 1,
+      "KEY2" : "a"
+    }
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/key-schemas_-_KEY_key_field_name/6.0.0_1583166643536/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/key-schemas_-_KEY_key_field_name/6.0.0_1583166643536/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/key-schemas_-_explicit_key_field_named_other_than_ROWKEY/6.0.0_1583166643478/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/key-schemas_-_explicit_key_field_named_other_than_ROWKEY/6.0.0_1583166643478/plan.json
@@ -1,0 +1,145 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (OTHER DOUBLE KEY, ID BIGINT) WITH (KAFKA_TOPIC='input', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`OTHER` DOUBLE KEY, `ID` BIGINT",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.ID ID,\n  INPUT.OTHER KEY\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`OTHER` DOUBLE KEY, `ID` BIGINT, `KEY` DOUBLE",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`OTHER` DOUBLE KEY, `ID` BIGINT"
+          },
+          "selectExpressions" : [ "ID AS ID", "OTHER AS KEY" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent6357789129346422021",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/key-schemas_-_explicit_key_field_named_other_than_ROWKEY/6.0.0_1583166643478/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/key-schemas_-_explicit_key_field_named_other_than_ROWKEY/6.0.0_1583166643478/spec.json
@@ -1,0 +1,23 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583166643478,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<ID BIGINT> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<ID BIGINT, KEY DOUBLE> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "input",
+    "key" : 3.0,
+    "value" : {
+      "id" : 1
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 3.0,
+    "value" : {
+      "ID" : 1,
+      "KEY" : 3.0
+    }
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/key-schemas_-_explicit_key_field_named_other_than_ROWKEY/6.0.0_1583166643478/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/key-schemas_-_explicit_key_field_named_other_than_ROWKEY/6.0.0_1583166643478/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/partition-by_-_only_key_column/6.0.0_1583329143853/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/partition-by_-_only_key_column/6.0.0_1583329143853/plan.json
@@ -1,0 +1,147 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID INTEGER KEY, NAME STRING) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` INTEGER KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM INPUT INPUT\nPARTITION BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` INTEGER KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`ID` INTEGER KEY, `NAME` STRING"
+          },
+          "selectExpressions" : [ "NAME AS NAME" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent335545957785424598",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/partition-by_-_only_key_column/6.0.0_1583329143853/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/partition-by_-_only_key_column/6.0.0_1583329143853/spec.json
@@ -1,0 +1,49 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583329143853,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<NAME VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<NAME VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 11,
+    "value" : {
+      "name" : "a"
+    },
+    "timestamp" : 12345
+  }, {
+    "topic" : "test_topic",
+    "key" : 10,
+    "value" : {
+      "name" : "b"
+    },
+    "timestamp" : 12365
+  }, {
+    "topic" : "test_topic",
+    "key" : 11,
+    "value" : {
+      "name" : "c"
+    },
+    "timestamp" : 12375
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 11,
+    "value" : {
+      "NAME" : "a"
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 10,
+    "value" : {
+      "NAME" : "b"
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 11,
+    "value" : {
+      "NAME" : "c"
+    }
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/partition-by_-_only_key_column/6.0.0_1583329143853/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/partition-by_-_only_key_column/6.0.0_1583329143853/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/partition-by_-_partition_by_only_key_column/6.0.0_1583319053891/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/partition-by_-_partition_by_only_key_column/6.0.0_1583319053891/plan.json
@@ -1,0 +1,147 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID INTEGER KEY, NAME STRING) WITH (KAFKA_TOPIC='input', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` INTEGER KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM INPUT INPUT\nPARTITION BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` INTEGER KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`ID` INTEGER KEY, `NAME` STRING"
+          },
+          "selectExpressions" : [ "NAME AS NAME" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/partition-by_-_partition_by_only_key_column/6.0.0_1583319053891/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/partition-by_-_partition_by_only_key_column/6.0.0_1583319053891/spec.json
@@ -1,0 +1,22 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319053891,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<NAME VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<NAME VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "input",
+    "key" : 10,
+    "value" : {
+      "NAME" : "bob"
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 10,
+    "value" : {
+      "NAME" : "bob"
+    }
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/partition-by_-_partition_by_only_key_column/6.0.0_1583319053891/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/partition-by_-_partition_by_only_key_column/6.0.0_1583319053891/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/partition-by_-_should_handled_quoted_key_and_value/6.0.0_1583329143863/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/partition-by_-_should_handled_quoted_key_and_value/6.0.0_1583329143863/plan.json
@@ -1,0 +1,147 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (`Key` STRING KEY, `Name` STRING) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`Key` STRING KEY, `Name` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  *,\n  INPUT.`Name` `Name2`\nFROM INPUT INPUT\nPARTITION BY INPUT.`Key`\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`Key` STRING KEY, `Name` STRING, `Name2` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`Key` STRING KEY, `Name` STRING"
+          },
+          "selectExpressions" : [ "`Name` AS `Name`", "`Name` AS `Name2`" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent335545957785424598",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/partition-by_-_should_handled_quoted_key_and_value/6.0.0_1583329143863/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/partition-by_-_should_handled_quoted_key_and_value/6.0.0_1583329143863/spec.json
@@ -1,0 +1,52 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583329143863,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<Name VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<Name VARCHAR, Name2 VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : "x",
+    "value" : {
+      "Name" : "a"
+    },
+    "timestamp" : 12345
+  }, {
+    "topic" : "test_topic",
+    "key" : "y",
+    "value" : {
+      "Name" : "b"
+    },
+    "timestamp" : 12365
+  }, {
+    "topic" : "test_topic",
+    "key" : "x",
+    "value" : {
+      "Name" : "c"
+    },
+    "timestamp" : 12375
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : "x",
+    "value" : {
+      "Name" : "a",
+      "Name2" : "a"
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "y",
+    "value" : {
+      "Name" : "b",
+      "Name2" : "b"
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "x",
+    "value" : {
+      "Name" : "c",
+      "Name2" : "c"
+    }
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/partition-by_-_should_handled_quoted_key_and_value/6.0.0_1583329143863/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/partition-by_-_should_handled_quoted_key_and_value/6.0.0_1583329143863/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/select_-_all_columns_-_explicit/6.0.0_1583319054694/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/select_-_all_columns_-_explicit/6.0.0_1583319054694/plan.json
@@ -1,0 +1,147 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID INTEGER KEY, NAME STRING) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` INTEGER KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.ID ID_COPY,\n  INPUT.ROWTIME ROWTIME_COPY,\n  INPUT.NAME NAME\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` INTEGER KEY, `ID_COPY` INTEGER, `ROWTIME_COPY` BIGINT, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`ID` INTEGER KEY, `NAME` STRING"
+          },
+          "selectExpressions" : [ "ID AS ID_COPY", "ROWTIME AS ROWTIME_COPY", "NAME AS NAME" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/select_-_all_columns_-_explicit/6.0.0_1583319054694/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/select_-_all_columns_-_explicit/6.0.0_1583319054694/spec.json
@@ -1,0 +1,26 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319054694,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<NAME VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<ID_COPY INT, ROWTIME_COPY BIGINT, NAME VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 8,
+    "value" : {
+      "name" : "a"
+    },
+    "timestamp" : 1234
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 8,
+    "value" : {
+      "ID_COPY" : 8,
+      "ROWTIME_COPY" : 1234,
+      "NAME" : "a"
+    },
+    "timestamp" : 1234
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/select_-_all_columns_-_explicit/6.0.0_1583319054694/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/select_-_all_columns_-_explicit/6.0.0_1583319054694/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/select_-_all_columns_-_star/6.0.0_1583319054687/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/select_-_all_columns_-_star/6.0.0_1583319054687/plan.json
@@ -1,0 +1,147 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID INTEGER KEY, NAME STRING) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` INTEGER KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` INTEGER KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`ID` INTEGER KEY, `NAME` STRING"
+          },
+          "selectExpressions" : [ "NAME AS NAME" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/select_-_all_columns_-_star/6.0.0_1583319054687/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/select_-_all_columns_-_star/6.0.0_1583319054687/spec.json
@@ -1,0 +1,22 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319054687,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<NAME VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<NAME VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 8,
+    "value" : {
+      "name" : "a"
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 8,
+    "value" : {
+      "NAME" : "a"
+    }
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/select_-_all_columns_-_star/6.0.0_1583319054687/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/select_-_all_columns_-_star/6.0.0_1583319054687/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/select_-_key_column/6.0.0_1583319054671/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/select_-_key_column/6.0.0_1583319054671/plan.json
@@ -1,0 +1,147 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID INTEGER KEY, NAME STRING) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` INTEGER KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT INPUT.ID ID_COPY\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` INTEGER KEY, `ID_COPY` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`ID` INTEGER KEY, `NAME` STRING"
+          },
+          "selectExpressions" : [ "ID AS ID_COPY" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/select_-_key_column/6.0.0_1583319054671/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/select_-_key_column/6.0.0_1583319054671/spec.json
@@ -1,0 +1,22 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319054671,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<NAME VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<ID_COPY INT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 8,
+    "value" : {
+      "name" : "a"
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 8,
+    "value" : {
+      "ID_COPY" : 8
+    }
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/select_-_key_column/6.0.0_1583319054671/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/select_-_key_column/6.0.0_1583319054671/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/select_-_value_column/6.0.0_1583319054680/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/select_-_value_column/6.0.0_1583319054680/plan.json
@@ -1,0 +1,147 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID INTEGER KEY, NAME STRING) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` INTEGER KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT INPUT.NAME NAME\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` INTEGER KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`ID` INTEGER KEY, `NAME` STRING"
+          },
+          "selectExpressions" : [ "NAME AS NAME" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/select_-_value_column/6.0.0_1583319054680/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/select_-_value_column/6.0.0_1583319054680/spec.json
@@ -1,0 +1,22 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319054680,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<NAME VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<NAME VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 8,
+    "value" : {
+      "name" : "a"
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 8,
+    "value" : {
+      "NAME" : "a"
+    }
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/select_-_value_column/6.0.0_1583319054680/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/select_-_value_column/6.0.0_1583319054680/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/table-functions_-_test_udtf_-_key_column/6.0.0_1583319056601/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/table-functions_-_test_udtf_-_key_column/6.0.0_1583319056601/plan.json
@@ -1,0 +1,154 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID INTEGER KEY, NAME STRING) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` INTEGER KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT TEST_UDTF(TEST.ID) KSQL_COL_0\nFROM TEST TEST\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` INTEGER KEY, `KSQL_COL_0` INTEGER",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamFlatMapV1",
+            "properties" : {
+              "queryContext" : "FlatMap"
+            },
+            "source" : {
+              "@type" : "streamSourceV1",
+              "properties" : {
+                "queryContext" : "KsqlTopic/Source"
+              },
+              "topicName" : "test_topic",
+              "formats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA",
+                  "properties" : { }
+                },
+                "valueFormat" : {
+                  "format" : "JSON",
+                  "properties" : { }
+                },
+                "options" : [ ]
+              },
+              "timestampColumn" : null,
+              "sourceSchema" : "`ID` INTEGER KEY, `NAME` STRING"
+            },
+            "tableFunctions" : [ "TEST_UDTF(ID)" ]
+          },
+          "selectExpressions" : [ "KSQL_SYNTH_0 AS KSQL_COL_0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/table-functions_-_test_udtf_-_key_column/6.0.0_1583319056601/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/table-functions_-_test_udtf_-_key_column/6.0.0_1583319056601/spec.json
@@ -1,0 +1,22 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319056601,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<NAME VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<KSQL_COL_0 INT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 10,
+    "value" : {
+      "NAME" : "bob"
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 10,
+    "value" : {
+      "KSQL_COL_0" : 10
+    }
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/table-functions_-_test_udtf_-_key_column/6.0.0_1583319056601/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/table-functions_-_test_udtf_-_key_column/6.0.0_1583319056601/topology
@@ -1,0 +1,16 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> FlatMap
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: FlatMap (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- FlatMap
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/where_-_on_key_column/6.0.0_1583319057678/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/where_-_on_key_column/6.0.0_1583319057678/plan.json
@@ -1,0 +1,154 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID INTEGER KEY, NAME STRING) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` INTEGER KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM INPUT INPUT\nWHERE (INPUT.ID < 10)\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` INTEGER KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamFilterV1",
+            "properties" : {
+              "queryContext" : "WhereFilter"
+            },
+            "source" : {
+              "@type" : "streamSourceV1",
+              "properties" : {
+                "queryContext" : "KsqlTopic/Source"
+              },
+              "topicName" : "test_topic",
+              "formats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA",
+                  "properties" : { }
+                },
+                "valueFormat" : {
+                  "format" : "JSON",
+                  "properties" : { }
+                },
+                "options" : [ ]
+              },
+              "timestampColumn" : null,
+              "sourceSchema" : "`ID` INTEGER KEY, `NAME` STRING"
+            },
+            "filterExpression" : "(ID < 10)"
+          },
+          "selectExpressions" : [ "NAME AS NAME" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/where_-_on_key_column/6.0.0_1583319057678/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/where_-_on_key_column/6.0.0_1583319057678/spec.json
@@ -1,0 +1,46 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319057678,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<NAME VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<NAME VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 8,
+    "value" : {
+      "name" : "a"
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 9,
+    "value" : {
+      "name" : "a"
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 10,
+    "value" : {
+      "name" : "b"
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 11,
+    "value" : {
+      "name" : "c"
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 8,
+    "value" : {
+      "NAME" : "a"
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 9,
+    "value" : {
+      "NAME" : "a"
+    }
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/where_-_on_key_column/6.0.0_1583319057678/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/where_-_on_key_column/6.0.0_1583319057678/topology
@@ -1,0 +1,16 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/historical_plans/where_-_on_value_column/6.0.0_1583319057687/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/where_-_on_value_column/6.0.0_1583319057687/plan.json
@@ -1,0 +1,154 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID INTEGER KEY, NAME STRING) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` INTEGER KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM INPUT INPUT\nWHERE (NOT (INPUT.NAME LIKE '%not%'))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` INTEGER KEY, `NAME` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamFilterV1",
+            "properties" : {
+              "queryContext" : "WhereFilter"
+            },
+            "source" : {
+              "@type" : "streamSourceV1",
+              "properties" : {
+                "queryContext" : "KsqlTopic/Source"
+              },
+              "topicName" : "test_topic",
+              "formats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA",
+                  "properties" : { }
+                },
+                "valueFormat" : {
+                  "format" : "JSON",
+                  "properties" : { }
+                },
+                "options" : [ ]
+              },
+              "timestampColumn" : null,
+              "sourceSchema" : "`ID` INTEGER KEY, `NAME` STRING"
+            },
+            "filterExpression" : "(NOT (NAME LIKE '%not%'))"
+          },
+          "selectExpressions" : [ "NAME AS NAME" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.new.api.enabled" : "false",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3333823077133685458",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/where_-_on_value_column/6.0.0_1583319057687/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/where_-_on_value_column/6.0.0_1583319057687/spec.json
@@ -1,0 +1,46 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583319057687,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<NAME VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<NAME VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 8,
+    "value" : {
+      "name" : "this one"
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 9,
+    "value" : {
+      "name" : "not this one"
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 10,
+    "value" : {
+      "name" : "and this one"
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 11,
+    "value" : {
+      "name" : "but not this one"
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 8,
+    "value" : {
+      "NAME" : "this one"
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 10,
+    "value" : {
+      "NAME" : "and this one"
+    }
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/where_-_on_value_column/6.0.0_1583319057687/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/where_-_on_value_column/6.0.0_1583319057687/topology
@@ -1,0 +1,16 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/elements.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/elements.json
@@ -210,6 +210,34 @@
       }
     },
     {
+      "name": "validate without value elements OK - custom key name",
+      "statements": [
+        "CREATE STREAM INPUT (id int key) WITH (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM input;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "topics": [
+        {
+          "name": "input",
+          "schema": {"type": "object","properties": {"c1": {"type": "integer"}}},
+          "format": "JSON"
+        },
+        {
+          "name": "OUTPUT",
+          "format": "JSON"
+        }
+      ],
+      "inputs": [{"topic": "input", "key": 42, "value": {"c1": 4}}],
+      "outputs": [{"topic": "OUTPUT", "key": 42, "value": {"C1": 4}}],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, C1 BIGINT"}
+        ]
+      }
+    },
+    {
       "name": "validate with elements OK",
       "format": ["JSON", "PROTOBUF"],
       "statements": [
@@ -574,8 +602,28 @@
         "CREATE STREAM OUTPUT AS SELECT ROWKEY FROM INPUT;"
       ],
       "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlException",
+        "type": "io.confluent.ksql.util.KsqlStatementException",
         "message": "Reserved column name in select: `ROWKEY`. Please remove or alias the column."
+      }
+    },
+    {
+      "name": "non-join should reject KEY column name in projection",
+      "comments": [
+        "changes to the ksql query semantics are required to allow this.",
+        "At the moment, the key schema passes through the select un-changed.",
+        "which means the key column in the projection is added to the value schema",
+        "but the name of the column clashes with the key column, resulting in an error"
+      ],
+      "statements": [
+        "CREATE STREAM INPUT (K INT KEY, F0 INT) WITH (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT K FROM INPUT;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Value column name(s) `K` clashes with key column name(s)."
       }
     },
     {
@@ -629,8 +677,29 @@
         "CREATE STREAM OUTPUT as SELECT l.ROWKEY AS ROWKEY, f0, f1 FROM left_stream l join right_stream r WITHIN 1 seconds ON l.rowkey = r.rowkey;"
       ],
       "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlException",
+        "type": "io.confluent.ksql.util.KsqlStatementException",
         "message": "Reserved column name in select: `ROWKEY`. Please remove or alias the column."
+      }
+    },
+    {
+      "name": "join should reject KEY column name in projection",
+      "comments": [
+        "changes to the ksql query semantics are required to allow this.",
+        "At the moment, the key schema passes through the select un-changed.",
+        "which means the key column in the projection is added to the value schema",
+        "but the name of the column clashes with the key column, resulting in an error"
+      ],
+      "statements": [
+        "CREATE STREAM LEFT_STREAM (K DOUBLE KEY, F0 INT) WITH (kafka_topic='left', value_format='JSON');",
+        "CREATE STREAM RIGHT_STREAM (K DOUBLE KEY, F1 INT) WITH (kafka_topic='right', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT l.K AS K, f0, f1 FROM left_stream l join right_stream r WITHIN 1 seconds ON l.k = r.k;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Value column name(s) `K` clashes with key column name(s)."
       }
     },
     {

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/group-by.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/group-by.json
@@ -709,35 +709,43 @@
         {"topic": "OUTPUT", "key": "1", "value": "2"},
         {"topic": "OUTPUT", "key": "2", "value": "2"},
         {"topic": "OUTPUT", "key": "1", "value": "3"}
-      ]
-    },
-    {
-      "name": "ROWKEY (stream->table) - without repartition",
-      "comment": [
-        "Clone of test 'ROWKEY (stream->table)' but checking no repartition topic is created post v5.4"
-      ],
-      "statements": [
-        "CREATE STREAM TEST (ignored VARCHAR) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
-        "CREATE TABLE OUTPUT AS SELECT COUNT(*) FROM TEST GROUP BY ROWKEY;"
-      ],
-      "inputs": [
-        {"topic": "test_topic", "key": "1", "value": "-"},
-        {"topic": "test_topic", "key": "2", "value": "-"},
-        {"topic": "test_topic", "key": "1", "value": "-"},
-        {"topic": "test_topic", "key": "2", "value": "-"},
-        {"topic": "test_topic", "key": "1", "value": "-"}
-      ],
-      "outputs": [
-        {"topic": "OUTPUT", "key": "1", "value": "1"},
-        {"topic": "OUTPUT", "key": "2", "value": "1"},
-        {"topic": "OUTPUT", "key": "1", "value": "2"},
-        {"topic": "OUTPUT", "key": "2", "value": "2"},
-        {"topic": "OUTPUT", "key": "1", "value": "3"}
       ],
       "post": {
         "topics": {
           "blacklist": ".*-repartition"
         }
+      }
+    },
+    {
+      "name": "only key column (stream->table)",
+      "statements": [
+        "CREATE STREAM TEST (ID INT KEY, ignored VARCHAR) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "CREATE TABLE OUTPUT AS SELECT COUNT(*) FROM TEST GROUP BY ID;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": "-"},
+        {"topic": "test_topic", "key": 2, "value": "-"},
+        {"topic": "test_topic", "key": 1, "value": "-"},
+        {"topic": "test_topic", "key": 2, "value": "-"},
+        {"topic": "test_topic", "key": 1, "value": "-"}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": "1"},
+        {"topic": "OUTPUT", "key": 2, "value": "1"},
+        {"topic": "OUTPUT", "key": 1, "value": "2"},
+        {"topic": "OUTPUT", "key": 2, "value": "2"},
+        {"topic": "OUTPUT", "key": 1, "value": "3"}
+      ],
+      "post": {
+        "topics": {
+          "blacklist": ".*-repartition"
+        },
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "schema": "ID INT KEY, KSQL_COL_0 BIGINT"}
+        ]
       }
     },
     {
@@ -1424,7 +1432,73 @@
             "name": "OUTPUT",
             "type": "table",
             "keyFormat": {"format": "KAFKA"},
-            "schema": "`ROWKEY` INTEGER KEY, `KSQL_COL_0` BIGINT"
+            "schema": "ROWKEY INTEGER KEY, KSQL_COL_0 BIGINT"
+          }
+        ]
+      }
+    },
+    {
+      "name": "only key column",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT COUNT(1) AS COUNT FROM INPUT GROUP BY ID;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": 11, "value": {}},
+        {"topic": "test_topic", "timestamp": 12365, "key": 10, "value": {}},
+        {"topic": "test_topic", "timestamp": 12375, "key": 11, "value": {}}
+      ],
+      "outputs": [
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "timestamp": 12345, "key": 11, "value": {"KSQL_INTERNAL_COL_0": 11, "KSQL_AGG_VARIABLE_0": 1}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "timestamp": 12365, "key": 10, "value": {"KSQL_INTERNAL_COL_0": 10, "KSQL_AGG_VARIABLE_0": 1}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "timestamp": 12375, "key": 11, "value": {"KSQL_INTERNAL_COL_0": 11, "KSQL_AGG_VARIABLE_0": 2}},
+        {"topic": "OUTPUT", "key": 11, "value": {"COUNT": 1}},
+        {"topic": "OUTPUT", "key": 10, "value": {"COUNT": 1}},
+        {"topic": "OUTPUT", "key": 11, "value": {"COUNT": 2}}
+      ],
+      "post": {
+        "sources": [
+          {
+            "name": "OUTPUT",
+            "type": "table",
+            "keyFormat": {"format": "KAFKA"},
+            "schema": "ID INT KEY, COUNT BIGINT"
+          }
+        ]
+      }
+    },
+    {
+      "name": "should handled quoted key and value",
+      "statements": [
+        "CREATE STREAM INPUT (`Key` STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT COUNT(1) AS `Value` FROM INPUT GROUP BY `Key`;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": "11", "value": {}},
+        {"topic": "test_topic", "timestamp": 12365, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 12375, "key": "11", "value": {}}
+      ],
+      "outputs": [
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "timestamp": 12345, "key": "11", "value": {"KSQL_INTERNAL_COL_0": "11", "KSQL_AGG_VARIABLE_0": 1}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "timestamp": 12365, "key": "10", "value": {"KSQL_INTERNAL_COL_0": "10", "KSQL_AGG_VARIABLE_0": 1}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "timestamp": 12375, "key": "11", "value": {"KSQL_INTERNAL_COL_0": "11", "KSQL_AGG_VARIABLE_0": 2}},
+        {"topic": "OUTPUT", "key": "11", "value": {"Value": 1}},
+        {"topic": "OUTPUT", "key": "10", "value": {"Value": 1}},
+        {"topic": "OUTPUT", "key": "11", "value": {"Value": 2}}
+      ],
+      "post": {
+        "sources": [
+          {
+            "name": "OUTPUT",
+            "type": "table",
+            "keyFormat": {"format": "KAFKA"},
+            "schema": "`Key` STRING KEY, `Value` BIGINT"
           }
         ]
       }

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/joins.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/joins.json
@@ -1,6 +1,1664 @@
 {
   "tests": [
     {
+      "name": "stream-stream left join",
+      "format": ["AVRO", "JSON"],
+      "statements": [
+        "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
+        "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
+        "CREATE STREAM LEFT_OUTER_JOIN as SELECT name, value, f1, f2 FROM test t left join TEST_STREAM tt WITHIN 11 seconds ON t.id = tt.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "zero", "VALUE": 0}, "timestamp": 0},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "left_topic", "key": 10, "value": {"NAME": "100", "VALUE": 5}, "timestamp": 11000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "foo", "VALUE": 100}, "timestamp": 13000},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "right_topic", "key": 100, "value": {"F1": "newblah", "F2": 150}, "timestamp": 16000},
+        {"topic": "left_topic", "key": 90, "value": {"NAME": "ninety", "VALUE": 90}, "timestamp": 17000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "bar", "VALUE": 99}, "timestamp": 30000}
+      ],
+      "outputs": [
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 0, "end": 11000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 0, "T_ID": 0, "T_NAME": "zero", "T_VALUE": 0}, "timestamp": 0},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000009-store-changelog", "window": {"start": 10000, "end": 21000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 10000, "TT_ID": 0, "TT_F1": "blah", "TT_F2": 50}, "timestamp": 10000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 11000, "end": 22000, "type": "time"}, "key": 10, "value": {"T_ROWTIME": 11000, "T_ID": 10, "T_NAME": "100", "T_VALUE": 5}, "timestamp": 11000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 13000, "end": 24000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 13000, "T_ID": 0, "T_NAME": "foo", "T_VALUE": 100}, "timestamp": 13000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000009-store-changelog", "window": {"start": 15000, "end": 26000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 15000, "TT_ID": 0, "TT_F1": "a", "TT_F2": 10}, "timestamp": 15000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000009-store-changelog", "window": {"start": 16000, "end": 27000, "type": "time"}, "key": 100, "value": {"TT_ROWTIME": 16000, "TT_ID": 100, "TT_F1": "newblah", "TT_F2": 150}, "timestamp": 16000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 17000, "end": 28000, "type": "time"}, "key": 90, "value": {"T_ROWTIME": 17000, "T_ID": 90, "T_NAME": "ninety", "T_VALUE": 90}, "timestamp": 17000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 30000, "end": 41000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 30000, "T_ID": 0, "T_NAME": "bar", "T_VALUE": 99}, "timestamp": 30000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": null, "F2": null}, "timestamp": 0},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 10, "value": {"NAME": "100", "VALUE": 5, "F1": null, "F2": null}, "timestamp": 11000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 90, "value": {"NAME": "ninety", "VALUE": 90, "F1": null, "F2": null}, "timestamp": 17000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"NAME": "bar", "VALUE": 99, "F1": null, "F2": null}, "timestamp": 30000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "LEFT_OUTER_JOIN", "type": "stream", "schema": "ID BIGINT KEY, NAME STRING, VALUE BIGINT, F1 STRING, F2 BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "stream-stream left join",
+      "format": ["PROTOBUF"],
+      "statements": [
+        "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
+        "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
+        "CREATE STREAM LEFT_OUTER_JOIN as SELECT name, value, f1, f2 FROM test t left join TEST_STREAM tt WITHIN 11 seconds ON t.id = tt.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "zero", "VALUE": 0}, "timestamp": 0},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "left_topic", "key": 10, "value": {"NAME": "100", "VALUE": 5}, "timestamp": 11000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "foo", "VALUE": 100}, "timestamp": 13000},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "right_topic", "key": 100, "value": {"F1": "newblah", "F2": 150}, "timestamp": 16000},
+        {"topic": "left_topic", "key": 90, "value": {"NAME": "ninety", "VALUE": 90}, "timestamp": 17000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "bar", "VALUE": 99}, "timestamp": 30000}
+      ],
+      "outputs": [
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 0, "end": 11000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 0, "T_ID": 0, "T_NAME": "zero", "T_VALUE": 0}, "timestamp": 0},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000009-store-changelog", "window": {"start": 10000, "end": 21000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 10000, "TT_ID": 0, "TT_F1": "blah", "TT_F2": 50}, "timestamp": 10000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 11000, "end": 22000, "type": "time"}, "key": 10, "value": {"T_ROWTIME": 11000, "T_ID": 10, "T_NAME": "100", "T_VALUE": 5}, "timestamp": 11000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 13000, "end": 24000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 13000, "T_ID": 0, "T_NAME": "foo", "T_VALUE": 100}, "timestamp": 13000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000009-store-changelog", "window": {"start": 15000, "end": 26000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 15000, "TT_ID": 0, "TT_F1": "a", "TT_F2": 10}, "timestamp": 15000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000009-store-changelog", "window": {"start": 16000, "end": 27000, "type": "time"}, "key": 100, "value": {"TT_ROWTIME": 16000, "TT_ID": 100, "TT_F1": "newblah", "TT_F2": 150}, "timestamp": 16000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 17000, "end": 28000, "type": "time"}, "key": 90, "value": {"T_ROWTIME": 17000, "T_ID": 90, "T_NAME": "ninety", "T_VALUE": 90}, "timestamp": 17000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 30000, "end": 41000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 30000, "T_ID": 0, "T_NAME": "bar", "T_VALUE": 99}, "timestamp": 30000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": "", "F2": 0}, "timestamp": 0},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 10, "value": {"NAME": "100", "VALUE": 5, "F1": "", "F2": 0}, "timestamp": 11000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 90, "value": {"NAME": "ninety", "VALUE": 90, "F1": "", "F2": 0}, "timestamp": 17000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"NAME": "bar", "VALUE": 99, "F1": "", "F2": 0}, "timestamp": 30000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "LEFT_OUTER_JOIN", "type": "stream", "schema": "ID BIGINT KEY, NAME STRING, VALUE BIGINT, F1 STRING, F2 BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "stream-stream left join - KAFKA",
+      "statements": [
+        "CREATE STREAM S_LEFT (ID BIGINT KEY, NAME varchar) WITH (kafka_topic='left_topic', value_format='KAFKA');",
+        "CREATE STREAM S_RIGHT (ID BIGINT KEY, NAME varchar) WITH (kafka_topic='right_topic', value_format='KAFKA');",
+        "CREATE STREAM OUTPUT WITH(value_format='delimited') as SELECT * FROM s_left join s_right WITHIN 1 second ON s_left.id = s_right.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Source(s) S_LEFT, S_RIGHT are using the 'KAFKA' value format. This format does not yet support JOIN."
+      }
+    },
+    {
+      "name": "stream-stream left join with rowkey - rekey",
+      "format": ["AVRO", "JSON"],
+      "statements": [
+        "CREATE STREAM TEST (K STRING KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
+        "CREATE STREAM TEST_STREAM (K STRING KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
+        "CREATE STREAM LEFT_OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t left join TEST_STREAM tt WITHIN 11 seconds ON t.id = tt.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": "foo", "value": {"ID": 0, "NAME": "zero", "VALUE": 0}, "timestamp": 0},
+        {"topic": "right_topic", "key": "foo", "value": {"ID": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "left_topic", "key": "foo", "value": {"ID": 10, "NAME": "100", "VALUE": 5}, "timestamp": 11000},
+        {"topic": "left_topic", "key": "foo", "value": {"ID": 0, "NAME": "foo", "VALUE": 100}, "timestamp": 13000},
+        {"topic": "right_topic", "key": "foo", "value": {"ID": 0, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "right_topic", "key": "foo", "value": {"ID": 100, "F1": "newblah", "F2": 150}, "timestamp": 16000},
+        {"topic": "left_topic", "key": "foo", "value": {"ID": 90, "NAME": "ninety", "VALUE": 90}, "timestamp": 17000},
+        {"topic": "left_topic", "key": "foo", "value": {"ID": 0, "NAME": "bar", "VALUE": 99}, "timestamp": 30000}
+      ],
+      "outputs": [
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": null, "F2": null}, "timestamp": 0},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 10, "value": {"T_ID": 10, "NAME": "100", "VALUE": 5, "F1": null, "F2": null}, "timestamp": 11000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 90, "value": {"T_ID": 90, "NAME": "ninety", "VALUE": 90, "F1": null, "F2": null}, "timestamp": 17000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": null, "F2": null}, "timestamp": 30000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "LEFT_OUTER_JOIN", "type": "stream", "schema": "ROWKEY BIGINT KEY, T_ID BIGINT, NAME STRING, VALUE BIGINT, F1 STRING, F2 BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "stream-stream left join with rowkey - rekey",
+      "format": ["PROTOBUF"],
+      "statements": [
+        "CREATE STREAM TEST (K STRING KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
+        "CREATE STREAM TEST_STREAM (K STRING KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
+        "CREATE STREAM LEFT_OUTER_JOIN as SELECT t.id, t.k, name, value, f1, f2 FROM test t left join TEST_STREAM tt WITHIN 11 seconds ON t.id = tt.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": "foo", "value": {"ID": 0, "NAME": "zero", "VALUE": 0}, "timestamp": 0},
+        {"topic": "right_topic", "key": "foo", "value": {"ID": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "left_topic", "key": "foo", "value": {"ID": 10, "NAME": "100", "VALUE": 5}, "timestamp": 11000},
+        {"topic": "left_topic", "key": "foo", "value": {"ID": 0, "NAME": "foo", "VALUE": 100}, "timestamp": 13000},
+        {"topic": "right_topic", "key": "foo", "value": {"ID": 0, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "right_topic", "key": "foo", "value": {"ID": 100, "F1": "newblah", "F2": 150}, "timestamp": 16000},
+        {"topic": "left_topic", "key": "foo", "value": {"ID": 90, "NAME": "ninety", "VALUE": 90}, "timestamp": 17000},
+        {"topic": "left_topic", "key": "foo", "value": {"ID": 0, "NAME": "bar", "VALUE": 99}, "timestamp": 30000}
+      ],
+      "outputs": [
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "T_K": "foo","NAME": "zero", "VALUE": 0, "F1": "", "F2": 0}, "timestamp": 0},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "T_K": "foo", "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 10, "value": {"T_ID": 10, "T_K": "foo", "NAME": "100", "VALUE": 5, "F1": "", "F2": 0}, "timestamp": 11000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "T_K": "foo", "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "T_K": "foo", "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 90, "value": {"T_ID": 90, "T_K": "foo", "NAME": "ninety", "VALUE": 90, "F1": "", "F2": 0}, "timestamp": 17000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "T_K": "foo", "NAME": "bar", "VALUE": 99, "F1": "", "F2": 0}, "timestamp": 30000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "LEFT_OUTER_JOIN", "type": "stream", "schema": "ROWKEY BIGINT KEY, T_ID BIGINT, T_K STRING, NAME STRING, VALUE BIGINT, F1 STRING, F2 BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "stream-stream left join - rekey",
+      "format": ["AVRO", "JSON"],
+      "statements": [
+        "CREATE STREAM TEST (K STRING KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
+        "CREATE STREAM TEST_STREAM (K STRING KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
+        "CREATE STREAM LEFT_OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t left join TEST_STREAM tt WITHIN 11 seconds ON t.id = tt.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "value": {"ID": 0, "NAME": "zero", "VALUE": 0}, "timestamp": 0},
+        {"topic": "right_topic", "value": {"ID": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "left_topic", "value": {"ID": 10, "NAME": "100", "VALUE": 5}, "timestamp": 11000},
+        {"topic": "left_topic", "value": {"ID": 0, "NAME": "foo", "VALUE": 100}, "timestamp": 13000},
+        {"topic": "right_topic", "value": {"ID": 0, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "right_topic", "value": {"ID": 100, "F1": "newblah", "F2": 150}, "timestamp": 16000},
+        {"topic": "left_topic", "value": {"ID": 90, "NAME": "ninety", "VALUE": 90}, "timestamp": 17000},
+        {"topic": "left_topic", "value": {"ID": 0, "NAME": "bar", "VALUE": 99}, "timestamp": 30000}
+      ],
+      "outputs": [
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition", "key": 0, "value": {"T_ROWTIME": 0, "T_K": "", "T_ID": 0, "T_NAME": "zero", "T_VALUE": 0}, "timestamp": 0},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-right-repartition", "key": 0, "value": {"TT_ROWTIME": 10000, "TT_K": "", "TT_ID": 0, "TT_F1": "blah", "TT_F2": 50}, "timestamp": 10000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition", "key": 10, "value": {"T_ROWTIME": 11000, "T_K": "", "T_ID": 10, "T_NAME": "100", "T_VALUE": 5}, "timestamp": 11000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition", "key": 0, "value": {"T_ROWTIME": 13000, "T_K": "", "T_ID": 0, "T_NAME": "foo", "T_VALUE": 100}, "timestamp": 13000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-right-repartition", "key": 0, "value": {"TT_ROWTIME": 15000, "TT_K": "", "TT_ID": 0, "TT_F1": "a", "TT_F2": 10}, "timestamp": 15000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-right-repartition", "key": 100, "value": {"TT_ROWTIME": 16000, "TT_K": "", "TT_ID": 100, "TT_F1": "newblah", "TT_F2": 150}, "timestamp": 16000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition", "key": 90, "value": {"T_ROWTIME": 17000, "T_K": "", "T_ID": 90, "T_NAME": "ninety", "T_VALUE": 90}, "timestamp": 17000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition", "key": 0, "value": {"T_ROWTIME": 30000, "T_K": "", "T_ID": 0, "T_NAME": "bar", "T_VALUE": 99}, "timestamp": 30000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000018-store-changelog", "window": {"start": 0, "end": 11000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 0, "T_K": "", "T_ID": 0, "T_NAME": "zero", "T_VALUE": 0}, "timestamp": 0},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000019-store-changelog", "window": {"start": 10000, "end": 21000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 10000, "TT_K": "", "TT_ID": 0, "TT_F1": "blah", "TT_F2": 50}, "timestamp": 10000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000018-store-changelog", "window": {"start": 11000, "end": 22000, "type": "time"}, "key": 10, "value": {"T_ROWTIME": 11000, "T_K": "", "T_ID": 10, "T_NAME": "100", "T_VALUE": 5}, "timestamp": 11000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000018-store-changelog", "window": {"start": 13000, "end": 24000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 13000, "T_K": "", "T_ID": 0, "T_NAME": "foo", "T_VALUE": 100}, "timestamp": 13000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000019-store-changelog", "window": {"start": 15000, "end": 26000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 15000, "TT_K": "", "TT_ID": 0, "TT_F1": "a", "TT_F2": 10}, "timestamp": 15000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000019-store-changelog", "window": {"start": 16000, "end": 27000, "type": "time"}, "key": 100, "value": {"TT_ROWTIME": 16000, "TT_K": "", "TT_ID": 100, "TT_F1": "newblah", "TT_F2": 150}, "timestamp": 16000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000018-store-changelog", "window": {"start": 17000, "end": 28000, "type": "time"}, "key": 90, "value": {"T_ROWTIME": 17000, "T_K": "", "T_ID": 90, "T_NAME": "ninety", "T_VALUE": 90}, "timestamp": 17000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000018-store-changelog", "window": {"start": 30000, "end": 41000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 30000, "T_K": "", "T_ID": 0, "T_NAME": "bar", "T_VALUE": 99}, "timestamp": 30000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": null, "F2": null}, "timestamp": 0},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 10, "value": {"T_ID": 10, "NAME": "100", "VALUE": 5, "F1": null, "F2": null}, "timestamp": 11000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 90, "value": {"T_ID": 90, "NAME": "ninety", "VALUE": 90, "F1": null, "F2": null}, "timestamp": 17000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": null, "F2": null}, "timestamp": 30000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "LEFT_OUTER_JOIN", "type": "stream", "schema": "ROWKEY BIGINT KEY, T_ID BIGINT, NAME STRING, VALUE BIGINT, F1 STRING, F2 BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "stream-stream left join - rekey",
+      "format": ["PROTOBUF"],
+      "statements": [
+        "CREATE STREAM TEST (K STRING KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
+        "CREATE STREAM TEST_STREAM (K STRING KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
+        "CREATE STREAM LEFT_OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t left join TEST_STREAM tt WITHIN 11 seconds ON t.id = tt.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "value": {"ID": 0, "NAME": "zero", "VALUE": 0}, "timestamp": 0},
+        {"topic": "right_topic", "value": {"ID": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "left_topic", "value": {"ID": 10, "NAME": "100", "VALUE": 5}, "timestamp": 11000},
+        {"topic": "left_topic", "value": {"ID": 0, "NAME": "foo", "VALUE": 100}, "timestamp": 13000},
+        {"topic": "right_topic", "value": {"ID": 0, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "right_topic", "value": {"ID": 100, "F1": "newblah", "F2": 150}, "timestamp": 16000},
+        {"topic": "left_topic", "value": {"ID": 90, "NAME": "ninety", "VALUE": 90}, "timestamp": 17000},
+        {"topic": "left_topic", "value": {"ID": 0, "NAME": "bar", "VALUE": 99}, "timestamp": 30000}
+      ],
+      "outputs": [
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition", "key": 0, "value": {"T_ROWTIME": 0, "T_K": "", "T_ID": 0, "T_NAME": "zero", "T_VALUE": 0}, "timestamp": 0},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-right-repartition", "key": 0, "value": {"TT_ROWTIME": 10000, "TT_K": "", "TT_ID": 0, "TT_F1": "blah", "TT_F2": 50}, "timestamp": 10000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition", "key": 10, "value": {"T_ROWTIME": 11000, "T_K": "", "T_ID": 10, "T_NAME": "100", "T_VALUE": 5}, "timestamp": 11000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition", "key": 0, "value": {"T_ROWTIME": 13000, "T_K": "", "T_ID": 0, "T_NAME": "foo", "T_VALUE": 100}, "timestamp": 13000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-right-repartition", "key": 0, "value": {"TT_ROWTIME": 15000, "TT_K": "", "TT_ID": 0, "TT_F1": "a", "TT_F2": 10}, "timestamp": 15000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-right-repartition", "key": 100, "value": {"TT_ROWTIME": 16000, "TT_K": "", "TT_ID": 100, "TT_F1": "newblah", "TT_F2": 150}, "timestamp": 16000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition", "key": 90, "value": {"T_ROWTIME": 17000, "T_K": "", "T_ID": 90, "T_NAME": "ninety", "T_VALUE": 90}, "timestamp": 17000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition", "key": 0, "value": {"T_ROWTIME": 30000, "T_K": "", "T_ID": 0, "T_NAME": "bar", "T_VALUE": 99}, "timestamp": 30000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000018-store-changelog", "window": {"start": 0, "end": 11000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 0, "T_K": "", "T_ID": 0, "T_NAME": "zero", "T_VALUE": 0}, "timestamp": 0},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000019-store-changelog", "window": {"start": 10000, "end": 21000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 10000, "TT_K": "", "TT_ID": 0, "TT_F1": "blah", "TT_F2": 50}, "timestamp": 10000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000018-store-changelog", "window": {"start": 11000, "end": 22000, "type": "time"}, "key": 10, "value": {"T_ROWTIME": 11000, "T_K": "", "T_ID": 10, "T_NAME": "100", "T_VALUE": 5}, "timestamp": 11000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000018-store-changelog", "window": {"start": 13000, "end": 24000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 13000, "T_K": "", "T_ID": 0, "T_NAME": "foo", "T_VALUE": 100}, "timestamp": 13000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000019-store-changelog", "window": {"start": 15000, "end": 26000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 15000, "TT_K": "", "TT_ID": 0, "TT_F1": "a", "TT_F2": 10}, "timestamp": 15000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000019-store-changelog", "window": {"start": 16000, "end": 27000, "type": "time"}, "key": 100, "value": {"TT_ROWTIME": 16000, "TT_K": "", "TT_ID": 100, "TT_F1": "newblah", "TT_F2": 150}, "timestamp": 16000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000018-store-changelog", "window": {"start": 17000, "end": 28000, "type": "time"}, "key": 90, "value": {"T_ROWTIME": 17000, "T_K": "", "T_ID": 90, "T_NAME": "ninety", "T_VALUE": 90}, "timestamp": 17000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000018-store-changelog", "window": {"start": 30000, "end": 41000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 30000, "T_K": "", "T_ID": 0, "T_NAME": "bar", "T_VALUE": 99}, "timestamp": 30000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "", "F2": 0}, "timestamp": 0},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 10, "value": {"T_ID": 10, "NAME": "100", "VALUE": 5, "F1": "", "F2": 0}, "timestamp": 11000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 90, "value": {"T_ID": 90, "NAME": "ninety", "VALUE": 90, "F1": "", "F2": 0}, "timestamp": 17000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": "", "F2": 0}, "timestamp": 30000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "LEFT_OUTER_JOIN", "type": "stream", "schema": "ROWKEY BIGINT KEY, T_ID BIGINT, NAME STRING, VALUE BIGINT, F1 STRING, F2 BIGINT"}
+        ]
+      }
+    },
+     {
+      "name": "stream-stream inner join",
+      "format": ["AVRO", "JSON", "PROTOBUF"],
+      "statements": [
+        "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
+        "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
+        "CREATE STREAM INNER_JOIN as SELECT name, value, f1, f2 FROM test t join TEST_STREAM tt WITHIN 11 SECONDS ON t.id = tt.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "zero", "VALUE": 0}, "timestamp": 0},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "left_topic", "key": 10, "value": {"NAME": "100", "VALUE": 5}, "timestamp": 11000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "foo", "VALUE": 100}, "timestamp": 13000},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "right_topic", "key": 100, "value": {"F1": "newblah", "F2": 150}, "timestamp": 16000},
+        {"topic": "left_topic", "key": 90, "value": {"NAME": "ninety", "VALUE": 90}, "timestamp": 17000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "bar", "VALUE": 99}, "timestamp": 30000}
+      ],
+      "outputs": [
+        {"topic": "INNER_JOIN", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "INNER_JOIN", "type": "stream", "schema": "ID BIGINT KEY, NAME STRING, VALUE BIGINT, F1 STRING, F2 BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "stream-stream inner join all left fields some right",
+      "format": ["AVRO", "JSON", "PROTOBUF"],
+      "statements": [
+        "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
+        "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
+        "CREATE STREAM INNER_JOIN as SELECT t.*, tt.f1 FROM test t inner join TEST_STREAM tt WITHIN 11 SECONDS ON t.id = tt.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "zero", "VALUE": 0}, "timestamp": 0},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "left_topic", "key": 10, "value": {"NAME": "100", "VALUE": 5}, "timestamp": 11000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "foo", "VALUE": 100}, "timestamp": 13000},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "right_topic", "key": 100, "value": {"F1": "newblah", "F2": 150}, "timestamp": 16000},
+        {"topic": "left_topic", "key": 90, "value": {"NAME": "ninety", "VALUE": 90}, "timestamp": 17000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "bar", "VALUE": 99}, "timestamp": 30000}
+      ],
+      "outputs": [
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_NAME": "zero", "T_VALUE": 0, "F1": "blah", "T_ROWTIME": 0}, "timestamp": 10000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_NAME": "foo", "T_VALUE": 100, "F1": "blah", "T_ROWTIME": 13000}, "timestamp": 13000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_NAME": "foo", "T_VALUE": 100, "F1": "a", "T_ROWTIME": 13000}, "timestamp": 15000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "INNER_JOIN", "type": "stream", "schema": "ID BIGINT KEY, T_ROWTIME BIGINT, T_ID BIGINT, T_NAME STRING, T_VALUE BIGINT, F1 STRING"}
+        ]
+      }
+    },
+    {
+      "name": "stream-stream inner join all right fields some left",
+      "format": ["AVRO", "JSON", "PROTOBUF"],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
+        "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
+        "CREATE STREAM INNER_JOIN as SELECT t.*, tt.name FROM test tt inner join TEST_STREAM t WITHIN 11 SECONDS ON t.id = tt.id;"
+      ],
+      "inputs": [
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "zero", "VALUE": 0}, "timestamp": 0},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "left_topic", "key": 10, "value": {"NAME": "100", "VALUE": 5}, "timestamp": 11000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "foo", "VALUE": 100}, "timestamp": 13000},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "right_topic", "key": 100, "value": {"F1": "newblah", "F2": 150}, "timestamp": 16000},
+        {"topic": "left_topic", "key": 90, "value": {"NAME": "ninety", "VALUE": 90}, "timestamp": 17000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "bar", "VALUE": 99}, "timestamp": 30000}
+      ],
+      "outputs": [
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_F1": "blah", "T_F2": 50, "T_ROWTIME": 10000, "NAME": "zero"}, "timestamp": 10000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_F1": "blah", "T_F2": 50, "T_ROWTIME": 10000, "NAME": "foo"}, "timestamp": 13000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_F1": "a", "T_F2": 10, "T_ROWTIME": 15000, "NAME": "foo"}, "timestamp": 15000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "INNER_JOIN", "type": "stream", "schema": "ID BIGINT KEY, T_ROWTIME BIGINT, T_ID BIGINT, T_F1 STRING, T_F2 BIGINT, NAME STRING"}
+        ]
+      }
+    },
+    {
+      "name": "stream-stream inner join all fields",
+      "format": ["AVRO", "JSON", "PROTOBUF"],
+      "statements": [
+        "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
+        "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 varchar) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
+        "CREATE STREAM INNER_JOIN as SELECT * FROM test tt inner join TEST_STREAM t WITHIN 11 SECONDS ON t.id = tt.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "zero"}, "timestamp": 0},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "blah"}, "timestamp": 10000},
+        {"topic": "left_topic", "key": 10, "value": {"NAME": "100"}, "timestamp": 11000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "foo"}, "timestamp": 13000},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "a"}, "timestamp": 15000},
+        {"topic": "right_topic", "key": 100, "value": {"F1": "newblah"}, "timestamp": 16000},
+        {"topic": "left_topic", "key": 90, "value": {"NAME": "ninety"}, "timestamp": 17000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "bar"}, "timestamp": 30000}
+      ],
+      "outputs": [
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 0, "end": 11000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 0, "TT_ID": 0, "TT_NAME": "zero"}, "timestamp": 0},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINOTHER-0000000009-store-changelog", "window": {"start": 10000, "end": 21000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 10000, "T_ID": 0, "T_F1": "blah"}, "timestamp": 10000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 11000, "end": 22000, "type": "time"}, "key": 10, "value": {"TT_ROWTIME": 11000, "TT_ID": 10, "TT_NAME": "100"}, "timestamp": 11000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 13000, "end": 24000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 13000, "TT_ID": 0, "TT_NAME": "foo"}, "timestamp": 13000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINOTHER-0000000009-store-changelog", "window": {"start": 15000, "end": 26000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 15000, "T_ID": 0, "T_F1": "a"}, "timestamp": 15000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINOTHER-0000000009-store-changelog", "window": {"start": 16000, "end": 27000, "type": "time"}, "key": 100, "value": {"T_ROWTIME": 16000, "T_ID": 100, "T_F1": "newblah"}, "timestamp": 16000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 17000, "end": 28000, "type": "time"}, "key": 90, "value": {"TT_ROWTIME": 17000, "TT_ID": 90, "TT_NAME": "ninety"}, "timestamp": 17000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 30000, "end": 41000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 30000, "TT_ID": 0, "TT_NAME": "bar"}, "timestamp": 30000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_F1": "blah", "T_ROWTIME": 10000, "TT_ID": 0, "TT_NAME": "zero", "TT_ROWTIME": 0}, "timestamp": 10000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_F1": "blah", "T_ROWTIME": 10000, "TT_ID": 0, "TT_NAME": "foo", "TT_ROWTIME": 13000}, "timestamp": 13000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_F1": "a", "T_ROWTIME": 15000, "TT_ID": 0, "TT_NAME": "foo", "TT_ROWTIME": 13000}, "timestamp": 15000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "INNER_JOIN", "type": "stream", "schema": "ID BIGINT KEY, TT_ROWTIME BIGINT, TT_ID BIGINT, TT_NAME STRING, T_ROWTIME BIGINT, T_ID BIGINT, T_F1 STRING"}
+        ]
+      }
+    },
+    {
+      "name": "stream-stream inner join with different before and after windows",
+      "format": ["AVRO", "JSON", "PROTOBUF"],
+      "statements": [
+        "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
+        "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
+        "CREATE STREAM INNER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t join TEST_STREAM tt WITHIN (11 seconds, 10 seconds) on t.id = tt.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "zero", "VALUE": 0}, "timestamp": 0},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "blah", "F2": 50}, "timestamp": 11000},
+        {"topic": "left_topic", "key": 10, "value": {"NAME": "100", "VALUE": 5}, "timestamp": 12000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "foo", "VALUE": 100}, "timestamp": 13000},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "right_topic", "key": 100, "value": {"F1": "newblah", "F2": 150}, "timestamp": 16000},
+        {"topic": "left_topic", "key": 90, "value": {"NAME": "ninety", "VALUE": 90}, "timestamp": 17000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "bar", "VALUE": 99}, "timestamp": 30000}
+      ],
+      "outputs": [
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "INNER_JOIN", "type": "stream", "schema": "ID BIGINT KEY, T_ID BIGINT, NAME STRING, VALUE BIGINT, F1 STRING, F2 BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "stream-stream inner join with out of order messages",
+      "format": ["AVRO", "JSON", "PROTOBUF"],
+      "statements": [
+        "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
+        "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
+        "CREATE STREAM INNER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t join TEST_STREAM tt WITHIN 10 seconds on t.id = tt.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "zero", "VALUE": 0}, "timestamp": 0},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "blah", "F2": 50}, "timestamp": 9999},
+        {"topic": "left_topic", "key": 10, "value": {"NAME": "100", "VALUE": 5}, "timestamp": 11000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "foo", "VALUE": 100}, "timestamp": 13000},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "right_topic", "key": 100, "value": {"F1": "newblah", "F2": 150}, "timestamp": 16000},
+        {"topic": "left_topic", "key": 90, "value": {"NAME": "ninety", "VALUE": 90}, "timestamp": 17000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "bar", "VALUE": 99}, "timestamp": 30000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "late-message", "VALUE": 10000}, "timestamp": 6000}
+      ],
+      "outputs": [
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 9999},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "late-message", "VALUE": 10000, "F1": "blah", "F2": 50}, "timestamp": 9999},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "late-message", "VALUE": 10000, "F1": "a", "F2": 10}, "timestamp": 15000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "INNER_JOIN", "type": "stream", "schema": "ID BIGINT KEY, T_ID BIGINT, NAME STRING, VALUE BIGINT, F1 STRING, F2 BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "stream-stream outer join",
+      "format": ["AVRO", "JSON"],
+      "statements": [
+        "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
+        "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
+        "CREATE STREAM LEFT_OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t FULL OUTER join TEST_STREAM tt WITHIN 11 seconds on t.id = tt.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "zero", "VALUE": 0}, "timestamp": 0},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "left_topic", "key": 10, "value": {"NAME": "100", "VALUE": 5}, "timestamp": 11000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "foo", "VALUE": 100}, "timestamp": 13000},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "bar", "VALUE": 99}, "timestamp": 30000},
+        {"topic": "left_topic", "key": 90, "value": {"NAME": "ninety", "VALUE": 90}, "timestamp": 17000},
+        {"topic": "right_topic", "key": 100, "value": {"F1": "newblah", "F2": 150}, "timestamp": 20000}
+
+      ],
+      "outputs": [
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": null, "F2": null}, "timestamp": 0},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 10, "value": {"T_ID": 10, "NAME": "100", "VALUE": 5, "F1": null, "F2": null}, "timestamp": 11000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": null, "F2": null}, "timestamp": 30000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 90, "value": {"T_ID": 90, "NAME": "ninety", "VALUE": 90, "F1": null, "F2": null}, "timestamp": 17000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 100, "value": {"T_ID": null, "NAME": null, "VALUE": null, "F1": "newblah", "F2": 150}, "timestamp": 20000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "LEFT_OUTER_JOIN", "type": "stream", "schema": "ID BIGINT KEY, T_ID BIGINT, NAME STRING, VALUE BIGINT, F1 STRING, F2 BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "stream-stream outer join - PROTOBUF",
+      "statements": [
+        "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='PROTOBUF');",
+        "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='PROTOBUF');",
+        "CREATE STREAM LEFT_OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t FULL OUTER join TEST_STREAM tt WITHIN 11 seconds on t.id = tt.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "zero", "VALUE": 0}, "timestamp": 0},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "left_topic", "key": 10, "value": {"NAME": "100", "VALUE": 5}, "timestamp": 11000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "foo", "VALUE": 100}, "timestamp": 13000},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "bar", "VALUE": 99}, "timestamp": 30000},
+        {"topic": "left_topic", "key": 90, "value": {"NAME": "ninety", "VALUE": 90}, "timestamp": 17000},
+        {"topic": "right_topic", "key": 100, "value": {"F1": "newblah", "F2": 150}, "timestamp": 20000}
+
+      ],
+      "outputs": [
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "", "F2": 0}, "timestamp": 0},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 10, "value": {"T_ID": 10, "NAME": "100", "VALUE": 5, "F1": "", "F2": 0}, "timestamp": 11000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": "", "F2": 0}, "timestamp": 30000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 90, "value": {"T_ID": 90, "NAME": "ninety", "VALUE": 90, "F1": "", "F2": 0}, "timestamp": 17000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 100, "value": {"T_ID": 0, "NAME": "", "VALUE": 0, "F1": "newblah", "F2": 150}, "timestamp": 20000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "LEFT_OUTER_JOIN", "type": "stream", "schema": "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "table-table left join",
+      "format": ["AVRO", "JSON"],
+      "statements": [
+        "CREATE TABLE TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
+        "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
+        "CREATE TABLE LEFT_OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t left join TEST_TABLE tt on t.id = tt.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "zero", "VALUE": 0}, "timestamp": 0},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "left_topic", "key": 10, "value": {"NAME": "100", "VALUE": 5}, "timestamp": 11000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "foo", "VALUE": 100}, "timestamp": 13000},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "bar", "VALUE": 99}, "timestamp": 16000},
+        {"topic": "left_topic", "key": 90, "value": {"NAME": "ninety", "VALUE": 90}, "timestamp": 17000}
+      ],
+      "outputs": [
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": null, "F2": null}, "timestamp": 0},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 10, "value": {"T_ID": 10, "NAME": "100", "VALUE": 5, "F1": null, "F2": null}, "timestamp": 11000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": "a", "F2": 10}, "timestamp": 16000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 90, "value": {"T_ID": 90, "NAME": "ninety", "VALUE": 90, "F1": null, "F2": null}, "timestamp": 17000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "LEFT_OUTER_JOIN", "type": "table", "schema": "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "table-table left join - PROTOBUF",
+      "statements": [
+        "CREATE TABLE TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='PROTOBUF');",
+        "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='PROTOBUF');",
+        "CREATE TABLE LEFT_OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t left join TEST_TABLE tt on t.id = tt.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "zero", "VALUE": 0}, "timestamp": 0},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "left_topic", "key": 10, "value": {"NAME": "100", "VALUE": 5}, "timestamp": 11000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "foo", "VALUE": 100}, "timestamp": 13000},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "bar", "VALUE": 99}, "timestamp": 16000},
+        {"topic": "left_topic", "key": 90, "value": {"NAME": "ninety", "VALUE": 90}, "timestamp": 17000}
+      ],
+      "outputs": [
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "", "F2": 0}, "timestamp": 0},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 10, "value": {"T_ID": 10, "NAME": "100", "VALUE": 5, "F1": "", "F2": 0}, "timestamp": 11000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": "a", "F2": 10}, "timestamp": 16000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 90, "value": {"T_ID": 90, "NAME": "ninety", "VALUE": 90, "F1": "", "F2": 0}, "timestamp": 17000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "LEFT_OUTER_JOIN", "type": "table", "schema": "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "table-table inner join",
+      "format": ["AVRO", "JSON", "PROTOBUF"],
+      "statements": [
+        "CREATE TABLE TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
+        "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
+        "CREATE TABLE INNER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t join TEST_TABLE tt on t.id = tt.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "zero", "VALUE": 0}, "timestamp": 0},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "left_topic", "key": 10, "value": {"NAME": "100", "VALUE": 5}, "timestamp": 11000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "foo", "VALUE": 100}, "timestamp": 13000},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "right_topic", "key": 15, "value": {"F1": "c", "F2": 20}, "timestamp": 15500},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "bar", "VALUE": 99}, "timestamp": 16000},
+        {"topic": "left_topic", "key": 90, "value": {"NAME": "ninety", "VALUE": 90}, "timestamp": 17000}
+      ],
+      "outputs": [
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": "a", "F2": 10}, "timestamp": 16000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "INNER_JOIN", "type": "table", "schema": "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "table-table outer join",
+      "format": ["AVRO", "JSON"],
+      "statements": [
+        "CREATE TABLE TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
+        "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
+        "CREATE TABLE OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t FULL OUTER join TEST_TABLE tt on t.id = tt.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "zero", "VALUE": 0}, "timestamp": 0},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "left_topic", "key": 10, "value": {"NAME": "100", "VALUE": 5}, "timestamp": 11000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "foo", "VALUE": 100}, "timestamp": 13000},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "right_topic", "key": 15, "value": {"F1": "c", "F2": 20}, "timestamp": 15500},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "bar", "VALUE": 99}, "timestamp": 16000}
+      ],
+      "outputs": [
+        {"topic": "OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": null, "F2": null}, "timestamp": 0},
+        {"topic": "OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "OUTER_JOIN", "key": 10, "value": {"T_ID": 10, "NAME": "100", "VALUE": 5, "F1": null, "F2": null}, "timestamp": 11000},
+        {"topic": "OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "OUTER_JOIN", "key": 15, "value": {"T_ID": null, "NAME": null, "VALUE": null, "F1": "c", "F2": 20}, "timestamp": 15500},
+        {"topic": "OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": "a", "F2": 10}, "timestamp": 16000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTER_JOIN", "type": "table", "schema": "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "table-table outer join - PROTOBUF",
+      "statements": [
+        "CREATE TABLE TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='PROTOBUF');",
+        "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='PROTOBUF');",
+        "CREATE TABLE OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t FULL OUTER join TEST_TABLE tt on t.id = tt.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "zero", "VALUE": 0}, "timestamp": 0},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "left_topic", "key": 10, "value": {"NAME": "100", "VALUE": 5}, "timestamp": 11000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "foo", "VALUE": 100}, "timestamp": 13000},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "right_topic", "key": 15, "value": {"F1": "c", "F2": 20}, "timestamp": 15500},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "bar", "VALUE": 99}, "timestamp": 16000}
+      ],
+      "outputs": [
+        {"topic": "OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "", "F2": 0}, "timestamp": 0},
+        {"topic": "OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "OUTER_JOIN", "key": 10, "value": {"T_ID": 10, "NAME": "100", "VALUE": 5, "F1": "", "F2": 0}, "timestamp": 11000},
+        {"topic": "OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "OUTER_JOIN", "key": 15, "value": {"T_ID": 0, "NAME": "", "VALUE": 0, "F1": "c", "F2": 20}, "timestamp": 15500},
+        {"topic": "OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": "a", "F2": 10}, "timestamp": 16000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTER_JOIN", "type": "table", "schema": "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "stream-table left join",
+      "format": ["AVRO", "JSON"],
+      "statements": [
+        "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='test_topic', value_format='{FORMAT}');",
+        "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='{FORMAT}');",
+        "CREATE STREAM LEFT_JOIN as SELECT t.id, name, value, f1, f2 FROM test t left join test_table tt on t.id = tt.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "test_table", "key": 0, "value": {"F1": "zero", "F2": 0}, "timestamp": 0},
+        {"topic": "test_table", "key": 10, "value": {"F1": "100", "F2": 5}, "timestamp": 10000},
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "blah", "VALUE": 50}, "timestamp": 10000},
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "foo", "VALUE": 100}, "timestamp": 10000},
+        {"topic": "test_table", "key": 0, "value": {"F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "bar", "VALUE": 99}, "timestamp": 15000},
+        {"topic": "test_topic", "key": 90, "value": {"NAME": "ninety", "VALUE": 90}, "timestamp": 15000}
+      ],
+      "outputs": [
+        {"topic": "LEFT_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "blah", "VALUE": 50, "F1": "zero", "F2": 0}, "timestamp": 10000},
+        {"topic": "LEFT_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "zero", "F2": 0}, "timestamp": 10000},
+        {"topic": "LEFT_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "LEFT_JOIN", "key": 90, "value": {"T_ID": 90, "NAME": "ninety", "VALUE": 90, "F1": null, "F2": null}, "timestamp": 15000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "LEFT_JOIN", "type": "stream", "schema": "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "stream-table left join - PROTOBUF",
+      "statements": [
+        "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='test_topic', value_format='PROTOBUF');",
+        "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='PROTOBUF');",
+        "CREATE STREAM LEFT_JOIN as SELECT t.id, name, value, f1, f2 FROM test t left join test_table tt on t.id = tt.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "test_table", "key": 0, "value": {"F1": "zero", "F2": 0}, "timestamp": 0},
+        {"topic": "test_table", "key": 10, "value": {"F1": "100", "F2": 5}, "timestamp": 10000},
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "blah", "VALUE": 50}, "timestamp": 10000},
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "foo", "VALUE": 100}, "timestamp": 10000},
+        {"topic": "test_table", "key": 0, "value": {"F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "bar", "VALUE": 99}, "timestamp": 15000},
+        {"topic": "test_topic", "key": 90, "value": {"NAME": "ninety", "VALUE": 90}, "timestamp": 15000}
+      ],
+      "outputs": [
+        {"topic": "LEFT_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "blah", "VALUE": 50, "F1": "zero", "F2": 0}, "timestamp": 10000},
+        {"topic": "LEFT_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "zero", "F2": 0}, "timestamp": 10000},
+        {"topic": "LEFT_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "LEFT_JOIN", "key": 90, "value": {"T_ID": 90, "NAME": "ninety", "VALUE": 90, "F1": "", "F2": 0}, "timestamp": 15000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "LEFT_JOIN", "type": "stream", "schema": "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "stream-table inner join",
+      "format": ["AVRO", "JSON", "PROTOBUF"],
+      "statements": [
+        "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='test_topic', value_format='{FORMAT}');",
+        "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='{FORMAT}');",
+        "CREATE STREAM INNER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t join test_table tt on t.id = tt.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "test_table", "key": 0, "value": {"F1": "zero", "F2": 0}, "timestamp": 0},
+        {"topic": "test_table", "key": 10, "value": {"F1": "100", "F2": 5}, "timestamp": 10000},
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "blah", "VALUE": 50}, "timestamp": 10000},
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "foo", "VALUE": 100}, "timestamp": 10000},
+        {"topic": "test_table", "key": 0, "value": {"F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "bar", "VALUE": 99}, "timestamp": 15000},
+        {"topic": "test_topic", "key": 90, "value": {"NAME": "ninety", "VALUE": 90}, "timestamp": 15000}
+      ],
+      "outputs": [
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "blah", "VALUE": 50, "F1": "zero", "F2": 0}, "timestamp": 10000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "zero", "F2": 0}, "timestamp": 10000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": "a", "F2": 10}, "timestamp": 15000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "INNER_JOIN", "type": "stream", "schema": "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "a table join pipeline",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE TABLE TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
+        "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
+        "CREATE TABLE TEST_TABLE_2 (ID BIGINT KEY, F3 varchar) WITH (kafka_topic='right_topic_2', value_format='{FORMAT}');",
+        "CREATE TABLE INNER_JOIN WITH (PARTITIONS=4) as SELECT name, value, f1, f2 FROM test t join TEST_TABLE tt on t.id = tt.id;",
+        "CREATE TABLE INNER_JOIN_2 AS SELECT name, f1, f3 FROM inner_join tt join TEST_TABLE_2 t ON t.id = tt.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "topics": [
+        {
+          "name": "INNER_JOIN",
+          "format": "JSON",
+          "partitions": 4
+        }
+      ],
+      "inputs": [
+        {"topic": "INNER_JOIN", "key": 0, "value": {"NAME": "X", "VALUE": 0, "F1": "yo dawg", "F2": 50}, "timestamp": 0},
+        {"topic": "right_topic_2", "key": 0, "value": {"F3": "I heard you like joins"}, "timestamp": 10000},
+        {"topic": "INNER_JOIN", "key": 100, "value": {"NAME": "X", "VALUE": 0, "F1": "KSQL has table-table joins", "F2": 50}, "timestamp": 15000},
+        {"topic": "right_topic_2", "key": 100, "value": {"F3": "so now you can join your join"}, "timestamp": 20000}
+      ],
+      "outputs": [
+        {"topic": "INNER_JOIN_2", "key": 0, "value": {"NAME": "X", "F1": "yo dawg", "F3": "I heard you like joins"}, "timestamp": 10000},
+        {"topic": "INNER_JOIN_2", "key": 100, "value": {"NAME": "X", "F1": "KSQL has table-table joins", "F3": "so now you can join your join"}, "timestamp": 20000}
+      ]
+    },
+    {
+      "name": "table-table join with where clause",
+      "statements": [
+        "CREATE TABLE TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT as SELECT t.id, name, tt.f1, f2 FROM test t JOIN test_table tt ON t.id = tt.id WHERE t.value > 10 AND tt.f2 > 5;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "zero", "VALUE": 0}, "timestamp": 0},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "blah", "F2": 4}, "timestamp": 10000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "foo", "VALUE": 100}, "timestamp": 13000},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "bar", "VALUE": 99}, "timestamp": 16000},
+        {"topic": "left_topic", "key": 90, "value": {"NAME": "ninety", "VALUE": 90}, "timestamp": 17000},
+        {"topic": "right_topic", "key": 90, "value": {"F1": "b", "F2": 10}, "timestamp": 18000},
+        {"topic": "right_topic", "key": 90, "value": null, "timestamp": 19000}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": null, "timestamp": 10000},
+        {"topic": "OUTPUT", "key": 0, "value": null, "timestamp": 13000},
+        {"topic": "OUTPUT", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "OUTPUT", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "F1": "a", "F2": 10}, "timestamp": 16000},
+        {"topic": "OUTPUT", "key": 90, "value": {"T_ID": 90, "NAME": "ninety", "F1": "b", "F2": 10}, "timestamp": 18000},
+        {"topic": "OUTPUT", "key": 90, "value": null, "timestamp": 19000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "schema": "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `F1` STRING, `F2` BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "to table using something other than key column",
+      "statements": [
+        "CREATE STREAM S (ID bigint) WITH (kafka_topic='S', value_format='JSON');",
+        "CREATE TABLE NO_KEY (ID bigint, NAME string) WITH (kafka_topic='NO_KEY', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT s.id, name FROM S JOIN NO_KEY t ON s.id = t.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Cannot repartition a TABLE source. If this is a join, make sure that the criteria uses the TABLE's key column ROWKEY instead of ID"
+      }
+    },
+    {
+      "name": "stream-stream wrapped single field value schema on inputs",
+      "statements": [
+        "CREATE STREAM S1 (ID BIGINT KEY, NAME STRING) WITH (kafka_topic='S1', value_format='JSON');",
+        "CREATE STREAM S2 (ID BIGINT KEY, NAME STRING) WITH (kafka_topic='S2', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT s1.name name1, s2.name name2 FROM S1 JOIN S2 WITHIN 1 second ON s1.id = s2.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "S1", "key": 0, "value": {"NAME": "a"}, "timestamp": 0},
+        {"topic": "S2", "key": 0, "value": {"NAME": "b"}, "timestamp": 10},
+        {"topic": "S1", "key": 0, "value": {"ID": null}, "timestamp": 20},
+        {"topic": "S2", "key": 0, "value": {"ID": null}, "timestamp": 30}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME1": "a", "NAME2": "b"}, "timestamp": 10},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME1": null, "NAME2": "b"}, "timestamp": 20},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME1": "a", "NAME2": null}, "timestamp": 30},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME1": null, "NAME2": null}, "timestamp": 30}
+      ]
+    },
+    {
+      "name": "stream-stream unwrapped single field value schema on inputs",
+      "issues": [
+        "With the current implementation the null values are ignored by KS.",
+        "This is probably not what we want. We could treat null values as a null ID for streams.",
+        "Though this would not make sense for tables, where null is a tombstone"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM S1 (ID BIGINT KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='S1', value_format='JSON');",
+        "CREATE STREAM S2 (ID BIGINT KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='S2', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT s1.name name1, s2.name name2 FROM S1 JOIN S2 WITHIN 1 second ON s1.id = s2.id;"
+      ],
+      "inputs": [
+        {"topic": "S1", "key": 0, "value": "a", "timestamp": 0},
+        {"topic": "S2", "key": 0, "value": "b", "timestamp": 10},
+        {"topic": "S1", "key": 0, "value": null, "timestamp": 20},
+        {"topic": "S2", "key": 0, "value": null, "timestamp": 30}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME1": "a", "NAME2": "b"}, "timestamp": 10}
+      ]
+    },
+    {
+      "name": "stream-stream unwrapped single field value schema on inputs and output",
+      "issues": [
+        "With the current implementation the null values are ignored by KS.",
+        "This is probably not what we want. We could treat null values as a null ID for streams.",
+        "Though this would not make sense for tables, where null is a tombstone"
+      ],
+      "statements": [
+        "CREATE STREAM S1 (ID BIGINT KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='S1', value_format='JSON');",
+        "CREATE STREAM S2 (ID BIGINT KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='S2', value_format='JSON');",
+        "CREATE STREAM OUTPUT WITH (WRAP_SINGLE_VALUE=false) AS SELECT s1.name name FROM S1 JOIN S2 WITHIN 1 second ON s1.id = s2.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "S1", "key": 0, "value": "a", "timestamp": 0},
+        {"topic": "S2", "key": 0, "value": "b", "timestamp": 10},
+        {"topic": "S1", "key": 0, "value": null, "timestamp": 20},
+        {"topic": "S2", "key": 0, "value": null, "timestamp": 30}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": "a", "timestamp": 10}
+      ]
+    },
+    {
+      "name": "stream-table wrapped single field value schema on inputs",
+      "statements": [
+        "CREATE STREAM S (ID BIGINT KEY, NAME STRING) WITH (kafka_topic='S', value_format='JSON');",
+        "CREATE TABLE T (ID BIGINT KEY, NAME STRING) WITH (kafka_topic='T', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT s.name name1, t.name name2 FROM S JOIN T ON S.id = T.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "T", "key": 0, "value": {"NAME": "b"}, "timestamp": 0},
+        {"topic": "S", "key": 0, "value": {"NAME": "a"}, "timestamp": 10},
+        {"topic": "S", "key": 0, "value": {"NAME": null}, "timestamp": 20},
+        {"topic": "T", "key": 0, "value": {"NAME": null}, "timestamp": 30},
+        {"topic": "S", "key": 0, "value": {"NAME": null}, "timestamp": 40},
+        {"topic": "T", "key": 0, "value": null, "timestamp": 50},
+        {"topic": "S", "key": 0, "value": {"NAME": "a"}, "timestamp": 60}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME1": "a", "NAME2": "b"}, "timestamp": 10},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME1": null, "NAME2": "b"}, "timestamp": 20},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME1": null, "NAME2": null}, "timestamp": 40}
+      ]
+    },
+    {
+      "name": "stream-table unwrapped single field value schema on inputs",
+      "issues": [
+        "With the current implementation the null values of the stream are ignored by KS.",
+        "This is probably not what we want. We could treat null values as a null ID for streams.",
+        "Though this would not make sense for tables, where null is a tombstone"
+      ],
+      "statements": [
+        "CREATE STREAM S (ID BIGINT KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='S', value_format='JSON');",
+        "CREATE TABLE T (ID BIGINT KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='T', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT s.name name1, t.name name2 FROM S JOIN T ON S.id = T.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "T", "key": 0, "value": "b", "timestamp": 0},
+        {"topic": "S", "key": 0, "value": "a", "timestamp": 10},
+        {"topic": "S", "key": 0, "value": null, "timestamp": 20},
+        {"topic": "T", "key": 0, "value": null, "timestamp": 30},
+        {"topic": "S", "key": 0, "value": null, "timestamp": 40}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME1": "a", "NAME2": "b"}, "timestamp": 10}
+      ]
+    },
+    {
+      "name": "stream-table unwrapped single field value schema on inputs and output",
+      "issues": [
+        "With the current implementation the null values of the stream are ignored by KS.",
+        "This is probably not what we want. We could treat null values as a null ID for streams.",
+        "Though this would not make sense for tables, where null is a tombstone."
+      ],
+      "statements": [
+        "CREATE STREAM S (ID BIGINT KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='S', value_format='JSON');",
+        "CREATE TABLE T (ID BIGINT KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='T', value_format='JSON');",
+        "CREATE STREAM OUTPUT WITH (WRAP_SINGLE_VALUE=false) AS SELECT s.name name FROM S JOIN T ON S.id = T.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "T", "key": 0, "value": "b", "timestamp": 0},
+        {"topic": "S", "key": 0, "value": "a", "timestamp": 10},
+        {"topic": "S", "key": 0, "value": null, "timestamp": 20},
+        {"topic": "T", "key": 0, "value": null, "timestamp": 30},
+        {"topic": "S", "key": 0, "value": null, "timestamp": 40}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": "a", "timestamp": 10}
+      ]
+    },
+    {
+      "name": "table-table wrapped single field value schema on inputs",
+      "statements": [
+        "CREATE TABLE T1 (ID BIGINT KEY, NAME STRING) WITH (kafka_topic='T1', value_format='JSON');",
+        "CREATE TABLE T2 (ID BIGINT KEY, NAME STRING) WITH (kafka_topic='T2', value_format='JSON');",
+        "CREATE TABLE OUTPUT as SELECT t1.name name1, t2.name name2 FROM T1 JOIN T2 ON T1.id = T2.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "T1", "key": 0, "value": {"NAME": "a"}, "timestamp": 0},
+        {"topic": "T2", "key": 0, "value": {"NAME": "b"}, "timestamp": 10},
+        {"topic": "T1", "key": 0, "value": {"NAME": null}, "timestamp": 20},
+        {"topic": "T2", "key": 0, "value": {"NAME": null}, "timestamp": 30},
+        {"topic": "T1", "key": 0, "value": {"NAME": null}, "timestamp": 40},
+        {"topic": "T1", "key": 0, "value": null, "timestamp": 50},
+        {"topic": "T2", "key": 0, "value": null, "timestamp": 60}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME1": "a", "NAME2": "b"}, "timestamp": 10},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME1": null, "NAME2": "b"}, "timestamp": 20},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME1": null, "NAME2": null}, "timestamp": 30},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME1": null, "NAME2": null}, "timestamp": 40},
+        {"topic": "OUTPUT", "key": 0, "value": null, "timestamp": 50}
+      ]
+    },
+    {
+      "name": "table-table unwrapped single field value schema on inputs",
+      "statements": [
+        "CREATE TABLE T1 (ID BIGINT KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='T1', value_format='JSON');",
+        "CREATE TABLE T2 (ID BIGINT KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='T2', value_format='JSON');",
+        "CREATE TABLE OUTPUT as SELECT t1.name name1, t2.name name2 FROM T1 JOIN T2 ON T1.id = T2.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "T1", "key": 0, "value": "a", "timestamp": 0},
+        {"topic": "T2", "key": 0, "value": "b", "timestamp": 10},
+        {"topic": "T1", "key": 0, "value": null, "timestamp": 20},
+        {"topic": "T2", "key": 0, "value": null, "timestamp": 30},
+        {"topic": "T1", "key": 0, "value": null, "timestamp": 40}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME1": "a", "NAME2": "b"}, "timestamp": 10},
+        {"topic": "OUTPUT", "key": 0, "value": null, "timestamp": 20}
+      ]
+    },
+    {
+      "name": "table-table unwrapped single field value schema on inputs and output",
+      "statements": [
+        "CREATE TABLE T1 (ID BIGINT KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='T1', value_format='JSON');",
+        "CREATE TABLE T2 (ID BIGINT KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='T2', value_format='JSON');",
+        "CREATE TABLE OUTPUT WITH (WRAP_SINGLE_VALUE=false) AS SELECT t1.name name FROM T1 JOIN T2 ON T1.id = T2.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "T1", "key": 0, "value": "a", "timestamp": 0},
+        {"topic": "T2", "key": 0, "value": "b", "timestamp": 10},
+        {"topic": "T1", "key": 0, "value": null, "timestamp": 20},
+        {"topic": "T2", "key": 0, "value": null, "timestamp": 30},
+        {"topic": "T1", "key": 0, "value": null, "timestamp": 40}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": "a", "timestamp": 10},
+        {"topic": "OUTPUT", "key": 0, "value": null, "timestamp": 20}
+      ]
+    },
+    {
+      "name": "stream-stream left join - invalid join field - contains literal",
+      "statements": [
+        "CREATE STREAM TEST1 (ID BIGINT KEY, NAME STRING) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE STREAM TEST2 (ID BIGINT KEY, NAME STRING) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE STREAM LEFT_OUTER_JOIN as SELECT * FROM test1 t left join test2 tt ON t.id = 0;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid comparison expression '0' in join '(T.ID = 0)'. Each side of the join comparision must contain references from exactly one source."
+      }
+    },
+    {
+      "name": "stream-stream left join - invalid join field on lhs- contains literal",
+      "statements": [
+        "CREATE STREAM TEST1 (ID BIGINT KEY, NAME STRING) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE STREAM TEST2 (ID BIGINT KEY, NAME STRING) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE STREAM LEFT_OUTER_JOIN as SELECT * FROM test1 t left join test2 tt ON 0 = t.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid comparison expression '0' in join '(0 = T.ID)'. Each side of the join comparision must contain references from exactly one source."
+      }
+    },
+    {
+      "name": "stream-stream join - contains function",
+      "statements": [
+        "CREATE STREAM TEST1 (ID varchar) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE STREAM TEST2 (ID varchar) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT T.ID FROM test1 t join test2 tt WITHIN 30 SECONDS ON t.id = SUBSTRING(tt.id, 2);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": "foo", "value": {"id": "foo"}, "timestamp": 0},
+        {"topic": "right_topic", "key": "!foo", "value": {"id": "!foo"}, "timestamp": 10}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "foo", "value": {"T_ID":  "foo"}, "timestamp": 10}
+      ]
+    },
+    {
+      "name": "stream-stream join - contains CAST",
+      "statements": [
+        "CREATE STREAM TEST1 (ID bigint KEY, x bigint) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE STREAM TEST2 (ID int KEY, x int) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT t.x FROM test1 t JOIN test2 tt WITHIN 30 seconds ON t.id = CAST(tt.id AS BIGINT);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 1, "value": {"x": 2}, "timestamp": 10},
+        {"topic": "right_topic", "key": 1, "value": {"x": 3}, "timestamp": 10}
+      ],
+      "outputs": [
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-right-repartition", "key": 1, "value": {"TT_X": 3, "TT_ROWTIME": 10, "TT_ID": 1}, "timestamp": 10},
+        {"topic": "OUTPUT", "key": 1, "value": {"T_X": 2}, "timestamp": 10}
+      ]
+    },
+    {
+      "name": "stream-stream join - contains CAST double to int",
+      "statements": [
+        "CREATE STREAM L (ID INT KEY, x bigint) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE STREAM R (ID DOUBLE KEY, x bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT L.x FROM L JOIN R WITHIN 30 seconds ON L.id = CAST(R.id AS INT);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 1, "value": {"x": 2}, "timestamp": 10},
+        {"topic": "right_topic", "key": 1.0, "value": {"x": 3}, "timestamp": 11}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"L_X": 2}, "timestamp": 11}
+      ]
+    },
+    {
+      "name": "stream-stream join - contains subscript",
+      "statements": [
+        "CREATE STREAM TEST1 (ID INT KEY, NAME STRING) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE STREAM TEST2 (K STRING KEY, ID ARRAY<INT>) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT T.ID FROM test1 t JOIN test2 tt WITHIN 30 SECONDS ON t.id = tt.id[1];"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 1, "value": {"name": "-"}, "timestamp": 0},
+        {"topic": "left_topic", "key": 2, "value": {"name": "-"}, "timestamp": 5},
+        {"topic": "right_topic", "key": "k", "value": {"id": [1,2,3]}, "timestamp": 10}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"T_ID": 1}, "timestamp": 10}
+      ]
+    },
+    {
+      "name": "stream-stream join - contains arithmetic binary expression",
+      "statements": [
+        "CREATE STREAM TEST1 (ID INT KEY, NAME STRING) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE STREAM TEST2 (ID INT KEY, NAME STRING) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT T.ID, TT.ID FROM test1 t join test2 tt WITHIN 30 seconds ON t.id = tt.id + 1;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 1, "value": {"name": "-"}, "timestamp": 0},
+        {"topic": "right_topic", "key": 0, "value": {"name": "-"}, "timestamp": 10}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"T_ID": 1, "TT_ID": 0}, "timestamp": 10}
+      ]
+    },
+    {
+      "name": "stream-stream join - contains arithmetic unary expression",
+      "statements": [
+        "CREATE STREAM TEST1 (ID INT KEY, NAME STRING) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE STREAM TEST2 (ID INT KEY, NAME STRING) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT T.NAME, TT.NAME FROM test1 t join test2 tt WITHIN 30 seconds ON t.id = -tt.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 1, "value": {"name": "a"}, "timestamp": 0},
+        {"topic": "right_topic", "key": -1, "value": {"name":  "b"}, "timestamp": 10}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"T_NAME": "a", "TT_NAME": "b"}, "timestamp": 10}
+      ]
+    },
+    {
+      "name": "stream-stream join - contains CASE expression",
+      "statements": [
+        "CREATE STREAM TEST1 (ID INT KEY, IGNORED STRING) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE STREAM TEST2 (ID INT KEY, IGNORED STRING) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT T.ID FROM test1 t join test2 tt WITHIN 30 SECONDS ON t.id = (CASE WHEN tt.id = 2 THEN 1 ELSE 3 END);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 1, "value": {}, "timestamp": 0},
+        {"topic": "left_topic", "key": 3, "value": {}, "timestamp": 5},
+        {"topic": "right_topic", "key": 2, "value": {}, "timestamp": 10}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"T_ID": 1}, "timestamp": 10}
+      ]
+    },
+    {
+      "name": "stream-stream join - contains arithmetic unary expression flipped sides",
+      "statements": [
+        "CREATE STREAM TEST1 (ID INT KEY, IGNORED STRING) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE STREAM TEST2 (ID INT KEY, IGNORED STRING) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT T.ID FROM test1 t join test2 tt WITHIN 30 seconds ON -tt.id = t.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 1, "value": {}, "timestamp": 0},
+        {"topic": "right_topic", "key": -1, "value": {}, "timestamp": 10}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"T_ID": 1}, "timestamp": 10}
+      ]
+    },
+    {
+      "name": "stream-stream left join - invalid left join expression - field does not exist",
+      "statements": [
+        "CREATE STREAM TEST1 (ID INT KEY, IGNORED STRING) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE STREAM TEST2 (ID INT KEY, IGNORED STRING) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE STREAM LEFT_OUTER_JOIN as SELECT * FROM test1 t left join test2 tt ON t.iid= tt.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Column 'T.IID' cannot be resolved."
+      }
+    },
+    {
+      "name": "stream-stream left join - invalid right join expression - field does not exist",
+      "statements": [
+        "CREATE STREAM TEST1 (ID INT KEY, IGNORED STRING) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE STREAM TEST2 (ID INT KEY, IGNORED STRING) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE STREAM LEFT_OUTER_JOIN as SELECT * FROM test1 t left join test2 tt ON t.id= tt.iid;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Column 'TT.IID' cannot be resolved."
+      }
+    },
+    {
+      "name": "on unqualified join criteria",
+      "statements": [
+        "CREATE STREAM TEST (LEFT_ID BIGINT KEY, NAME varchar) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE STREAM TEST_STREAM (RIGHT_ID BIGINT KEY, F1 varchar) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE STREAM LEFT_OUTER_JOIN as SELECT name, f1 FROM test t left join TEST_STREAM tt WITHIN 11 seconds ON left_id = right_id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "zero"}, "timestamp": 0},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "blah"}, "timestamp": 10000},
+        {"topic": "left_topic", "key": 10, "value": {"NAME": "100"}, "timestamp": 11000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "foo"}, "timestamp": 13000},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "a"}, "timestamp": 15000},
+        {"topic": "right_topic", "key": 100, "value": {"F1": "newblah"}, "timestamp": 16000},
+        {"topic": "left_topic", "key": 90, "value": {"NAME": "ninety"}, "timestamp": 17000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "bar"}, "timestamp": 30000}
+      ],
+      "outputs": [
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"NAME": "zero", "F1": null}, "timestamp": 0},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"NAME": "zero", "F1": "blah"}, "timestamp": 10000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 10, "value": {"NAME": "100", "F1": null}, "timestamp": 11000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"NAME": "foo", "F1": "blah"}, "timestamp": 13000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"NAME": "foo", "F1": "a"}, "timestamp": 15000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 90, "value": {"NAME": "ninety", "F1": null}, "timestamp": 17000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"NAME": "bar", "F1": null}, "timestamp": 30000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "LEFT_OUTER_JOIN", "type": "stream", "schema": "LEFT_ID BIGINT KEY, NAME STRING, F1 STRING"}
+        ]
+      }
+    },
+    {
+      "name": "on non STRING value column",
+      "statements": [
+        "CREATE STREAM INPUT_STREAM (K STRING KEY, SF BIGINT) WITH (kafka_topic='stream_topic', value_format='JSON');",
+        "CREATE TABLE INPUT_TABLE (ID BIGINT KEY, TF INT) WITH (kafka_topic='table_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT_STREAM S JOIN INPUT_TABLE T on S.SF = T.ID;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "table_topic", "key": 26589, "value": {"TF": 1}, "timestamp": 0},
+        {"topic": "stream_topic", "key": "a", "value": {"SF": 12589}, "timestamp": 100},
+        {"topic": "table_topic", "key": 12589, "value": {"TF": 12}, "timestamp": 200},
+        {"topic": "stream_topic", "key": "b", "value": {"SF": 12589}, "timestamp": 300}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 12589, "value": {"S_K": "b", "S_ROWTIME": 300, "S_SF": 12589, "T_ROWTIME": 300, "T_ID": 12589, "T_TF": 12}, "timestamp": 300}
+      ],
+      "post": {
+        "sources": [
+          {
+            "name": "OUTPUT",
+            "type": "stream",
+            "keyFormat": {"format": "KAFKA"},
+            "schema": "ROWKEY BIGINT KEY, S_ROWTIME BIGINT, S_K STRING, S_SF BIGINT, T_ROWTIME BIGINT, T_ID BIGINT, T_TF INT"
+          }
+        ]
+      }
+    },
+    {
+      "name": "on non key table column",
+      "statements": [
+        "CREATE STREAM INPUT_STREAM (ID BIGINT KEY, SF BIGINT) WITH (kafka_topic='stream_topic', value_format='JSON');",
+        "CREATE TABLE INPUT_TABLE (K BIGINT KEY, ID BIGINT, TF INT) WITH (kafka_topic='table_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT_STREAM S JOIN INPUT_TABLE T on S.ID = T.ID;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Cannot repartition a TABLE source. If this is a join, make sure that the criteria uses the TABLE's key column K instead of ID"
+      }
+    },
+    {
+      "name": "on KAFKA INT column",
+      "format": ["AVRO", "JSON", "PROTOBUF"],
+      "statements": [
+        "CREATE STREAM L (ID STRING KEY, l0 INT, l1 INT) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
+        "CREATE STREAM R (ID STRING KEY, r0 INT, r1 INT) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
+        "CREATE STREAM OUTPUT as SELECT L.ID, L1, R1 FROM L join R WITHIN 11 SECONDS ON L.l0 = R.r0;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": "a", "value": {"L0": 10, "L1": 1}, "timestamp": 0},
+        {"topic": "right_topic", "key": "b" ,"value": {"R0": 10, "R1": 2}, "timestamp": 10000}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 10, "value": {"L_ID": "a", "L1": 1, "R1": 2}, "timestamp": 10000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ROWKEY INT KEY, L_ID STRING, L1 INT, R1 INT"}
+        ]
+      }
+    },
+    {
+      "name": "on KAFKA BIGINT column",
+      "format": ["AVRO", "JSON", "PROTOBUF"],
+      "statements": [
+        "CREATE STREAM L (ID STRING KEY, l0 BIGINT, l1 INT) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
+        "CREATE STREAM R (ID STRING KEY, r0 BIGINT, r1 INT) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
+        "CREATE STREAM OUTPUT as SELECT L.ID, L1, R1 FROM L join R WITHIN 11 SECONDS ON L.l0 = R.r0;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": "a", "value": {"L0": 1000000000, "L1": 1}, "timestamp": 0},
+        {"topic": "right_topic", "key": "b" ,"value": {"R0": 1000000000, "R1": 2}, "timestamp": 10000}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1000000000, "value": {"L_ID": "a", "L1": 1, "R1": 2}, "timestamp": 10000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ROWKEY BIGINT KEY, L_ID STRING, L1 INT, R1 INT"}
+        ]
+      }
+    },
+    {
+      "name": "on KAFKA DOUBLE column",
+      "format": ["AVRO", "JSON", "PROTOBUF"],
+      "statements": [
+        "CREATE STREAM L (ID STRING KEY, l0 DOUBLE, l1 INT) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
+        "CREATE STREAM R (ID STRING KEY, r0 DOUBLE, r1 INT) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
+        "CREATE STREAM OUTPUT as SELECT L.ID, L1, R1 FROM L join R WITHIN 11 SECONDS ON L.l0 = R.r0;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": "a", "value": {"L0": 1.23, "L1": 1}, "timestamp": 0},
+        {"topic": "right_topic", "key": "b" ,"value": {"R0": 1.23, "R1": 2}, "timestamp": 10000}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1.23, "value": {"L_ID": "a", "L1": 1, "R1": 2}, "timestamp": 10000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ROWKEY DOUBLE KEY, L_ID STRING, L1 INT, R1 INT"}
+        ]
+      }
+    },
+    {
+      "name": "on KAFKA STRING column",
+      "format": ["AVRO", "JSON", "PROTOBUF"],
+      "statements": [
+        "CREATE STREAM L (ID STRING KEY, l0 STRING, l1 INT) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
+        "CREATE STREAM R (ID STRING KEY, r0 STRING, r1 INT) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
+        "CREATE STREAM OUTPUT as SELECT L.ID, L1, R1 FROM L join R WITHIN 11 SECONDS ON L.l0 = R.r0;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": "a", "value": {"L0": "x", "L1": 1}, "timestamp": 0},
+        {"topic": "right_topic", "key": "b" ,"value": {"R0": "x", "R1": 2}, "timestamp": 10000}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "x", "value": {"L_ID": "a", "L1": 1, "R1": 2}, "timestamp": 10000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ROWKEY STRING KEY, L_ID STRING, L1 INT, R1 INT"}
+        ]
+      }
+    },
+    {
+      "name": "self-join",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, ID bigint) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT * FROM INPUT s1 JOIN INPUT s2 WITHIN 1 HOUR ON s1.id = s2.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Can not join 'INPUT' to 'INPUT': self joins are not yet supported."
+      }
+    },
+    {
+      "name": "matching session windowed",
+      "comments": [
+        "Note: the first record on the right topic intersects with the session on the right side, but no row is output as keys must",
+        "be an EXACT BINARY match"
+      ],
+      "statements": [
+        "CREATE STREAM S1 (ID INT KEY, V bigint) WITH (kafka_topic='left_topic', value_format='JSON', WINDOW_TYPE='SESSION');",
+        "CREATE STREAM S2 (ID INT KEY, V bigint) WITH (kafka_topic='right_topic', value_format='JSON', WINDOW_TYPE='SESSION');",
+        "CREATE STREAM OUTPUT as SELECT S1.V, S2.V FROM S1 JOIN S2 WITHIN 1 MINUTE ON S1.ID = S2.ID;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 1, "value": {"V": 1}, "timestamp": 765, "window": {"start": 234, "end": 765, "type": "session"}},
+        {"topic": "right_topic", "key": 1, "value": {"V": 2}, "timestamp": 567, "window": {"start": 234, "end": 567, "type": "session"}},
+        {"topic": "right_topic", "key": 1, "value": {"V": 3}, "timestamp": 765, "window": {"start": 234, "end": 765, "type": "session"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"S1_V": 1, "S2_V": 3}, "timestamp": 765, "window": {"start": 234, "end": 765, "type": "session"}}
+      ],
+      "post": {
+        "sources": [
+          {
+            "name": "OUTPUT",
+            "type": "stream",
+            "keyFormat": {"format": "KAFKA", "windowType": "SESSION"},
+            "schema": "ID INT KEY, S1_V BIGINT, S2_V BIGINT"
+          }
+        ]
+      }
+    },
+    {
+      "name": "matching time windowed",
+      "comments": [
+        "Note: the two streams use a different window size. However, only the start of the window is serialized, so its possible to get a matching binary key",
+        "This may meet users requirements, hence KSQL allows such joins",
+        "Note: the key format is currently taken from the left source."
+      ],
+      "statements": [
+        "CREATE STREAM S1 (ID INT KEY, V bigint) WITH (kafka_topic='left_topic', value_format='JSON', WINDOW_TYPE='Hopping', WINDOW_SIZE='5 SECONDS');",
+        "CREATE STREAM S2 (ID INT KEY, V bigint) WITH (kafka_topic='right_topic', value_format='JSON', WINDOW_TYPE='Tumbling', WINDOW_SIZE='2 SECOND');",
+        "CREATE STREAM OUTPUT as SELECT * FROM S1 JOIN S2 WITHIN 1 MINUTE ON S1.ID = S2.ID;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 1, "value": {"V": 1}, "timestamp": 0, "window": {"start": 0, "end": 5000, "type": "time"}},
+        {"topic": "left_topic", "key": 1, "value": {"V": 2}, "timestamp": 1000, "window": {"start": 1000, "end": 6000, "type": "time"}},
+        {"topic": "left_topic", "key": 1, "value": {"V": 3}, "timestamp": 2000, "window": {"start": 2000, "end": 7000, "type": "time"}},
+        {"topic": "right_topic", "key": 1, "value": {"V": 4}, "timestamp": 0, "window": {"start": 0, "end": 2000, "type": "time"}},
+        {"topic": "right_topic", "key": 1, "value": {"V": 5}, "timestamp": 2000, "window": {"start": 2000, "end": 4000, "type": "time"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"S1_ROWTIME": 0, "S1_WINDOWSTART": 0, "S1_WINDOWEND": 5000, "S1_ID": 1, "S1_V": 1, "S2_ROWTIME": 0, "S2_WINDOWSTART": 0, "S2_WINDOWEND": 2000, "S2_ID": 1, "S2_V": 4}, "timestamp": 0, "window": {"start": 0, "end":5000, "type": "time"}},
+        {"topic": "OUTPUT", "key": 1, "value": {"S1_ROWTIME": 2000, "S1_WINDOWSTART": 2000, "S1_WINDOWEND": 7000, "S1_ID": 1, "S1_V": 3, "S2_ROWTIME": 2000, "S2_WINDOWSTART": 2000, "S2_WINDOWEND": 4000, "S2_ID": 1, "S2_V": 5}, "timestamp": 2000, "window": {"start": 2000, "end":7000, "type": "time"}}
+      ],
+      "post": {
+        "sources": [
+          {
+            "name": "OUTPUT",
+            "type": "stream",
+            "keyFormat": {"format": "KAFKA", "windowType": "HOPPING", "windowSize": 5000},
+            "schema": "`ID` INTEGER KEY, `S1_ROWTIME` BIGINT, `S1_ID` INTEGER, `S1_WINDOWSTART` BIGINT, `S1_WINDOWEND` BIGINT, `S1_V` BIGINT, `S2_ROWTIME` BIGINT, `S2_ID` INTEGER, `S2_WINDOWSTART` BIGINT, `S2_WINDOWEND` BIGINT, `S2_V` BIGINT"
+          }
+        ]
+      }
+    },
+    {
+      "name": "session and timed windowed",
+      "comments": [
+        "Session windows serialize both start and end window bounds, where as tumbling/hopping only serialize the start time.",
+        "Keys will never be binary compatible, and hence KSQL should disallow such joins"
+      ],
+      "statements": [
+        "CREATE STREAM S1 (ID INT KEY, V bigint) WITH (kafka_topic='left_topic', value_format='JSON', WINDOW_TYPE='Session');",
+        "CREATE STREAM S2 (ID INT KEY, V bigint) WITH (kafka_topic='right_topic', value_format='JSON', WINDOW_TYPE='TUMBLING', WINDOW_SIZE='1 SECOND');",
+        "CREATE STREAM OUTPUT as SELECT * FROM S1 JOIN S2 WITHIN 1 MINUTE ON S1.ID = S2.ID;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Incompatible windowed sources.\nLeft source: SESSION\nRight source: TUMBLING\nSession windowed sources can only be joined to other session windowed sources, and may still not result in expected behaviour as session bounds must be an exact match for the join to work\nHopping and tumbling windowed sources can only be joined to other hopping and tumbling windowed sources"
+      }
+    },
+    {
+      "name": "windowed vand non-windowed - INT",
+      "statements": [
+        "CREATE STREAM S1 (ID INT KEY, V bigint) WITH (kafka_topic='left_topic', value_format='JSON', WINDOW_TYPE='SESSION');",
+        "CREATE STREAM S2 (ID INT KEY, V bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT * FROM S1 JOIN S2 WITHIN 1 MINUTE ON S1.ID = S2.ID;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Can not join windowed source to non-windowed source.\n`S1` is SESSION windowed\n`S2` is not windowed"
+      }
+    },
+    {
+      "name": "windowed and non-windowed - STRING",
+      "statements": [
+        "CREATE STREAM S1 (ID STRING KEY, V bigint) WITH (kafka_topic='left_topic', value_format='JSON', WINDOW_TYPE='SESSION');",
+        "CREATE STREAM S2 (ID STRING KEY, V bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT * FROM S1 JOIN S2 WITHIN 1 MINUTE ON S1.ID = S2.ID;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Can not join windowed source to non-windowed source.\n`S1` is SESSION windowed\n`S2` is not windowed"
+      }
+    },
+    {
+      "name": "requiring repartition of windowed source",
+      "statements": [
+        "CREATE STREAM S1 (K INT KEY, ID INT, V bigint) WITH (kafka_topic='left_topic', value_format='JSON', WINDOW_TYPE='SESSION');",
+        "CREATE STREAM S2 (K INT KEY, ID INT, V bigint) WITH (kafka_topic='right_topic', value_format='JSON', WINDOW_TYPE='SESSION');",
+        "CREATE STREAM OUTPUT as SELECT * FROM S1 JOIN S2 WITHIN 1 MINUTE ON S1.ID = S2.ID;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Implicit repartitioning of windowed sources is not supported. See https://github.com/confluentinc/ksql/issues/4385."
+      }
+    },
+
+
+
+
+
+    {
       "name": "stream stream left join",
       "format": ["AVRO", "JSON"],
       "statements": [
@@ -1531,7 +3189,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Cannot repartition a TABLE source. If this is a join, make sure that the criteria uses the TABLE key ROWKEY instead of ID"
+        "message": "Cannot repartition a TABLE source. If this is a join, make sure that the criteria uses the TABLE's key column ROWKEY instead of ID"
       }
     },
     {
@@ -2032,7 +3690,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Cannot repartition a TABLE source. If this is a join, make sure that the criteria uses the TABLE key ROWKEY instead of ID"
+        "message": "Cannot repartition a TABLE source. If this is a join, make sure that the criteria uses the TABLE's key column ROWKEY instead of ID"
       }
     },
     {

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/key-field.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/key-field.json
@@ -831,7 +831,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "The KEY field (FOO) identified in the WITH clause is of a different type to the actual key column.\nEither change the type of the KEY field to match ROWKEY, or explicitly set ROWKEY to the type of the KEY field by adding 'ROWKEY INTEGER KEY' in the schema.\nKEY field type: INTEGER\nROWKEY type: STRING"
+        "message": "The KEY field (FOO) identified in the WITH clause is of a different type to the actual key column.\nUse of the KEY field is deprecated. Remove the KEY field from the WITH clause and specify the name of the key column by adding 'FOO INTEGER KEY' to the schema.\nKEY field type: INTEGER\nkey column type: STRING"
       }
     },
     {

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/key-schemas.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/key-schemas.json
@@ -319,6 +319,59 @@
     {
       "name": "explicit key field named other than ROWKEY",
       "statements": [
+        "CREATE STREAM INPUT (OTHER DOUBLE KEY, ID bigint) WITH (kafka_topic='input',value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT ID, OTHER as KEY FROM INPUT;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "input", "key": 3.0, "value": {"id": 1}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 3.0, "value": {"ID": 1, "KEY": 3.0}}
+      ],
+      "post": {
+        "sources": [
+          {
+            "name": "OUTPUT",
+            "type": "stream",
+            "keyFormat": {"format": "KAFKA"},
+            "schema": "OTHER DOUBLE KEY, ID BIGINT, KEY DOUBLE"
+          }
+        ]
+      }
+    },
+    {
+      "name": "KEY key field name",
+      "comment": "tests that `KEY` is allowed as a KEY column name",
+      "statements": [
+        "CREATE STREAM INPUT (KEY STRING KEY, ID bigint) WITH (kafka_topic='input',value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT ID, KEY as KEY2 FROM INPUT;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "input", "key": "a", "value": {"id": 1}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "a", "value": {"ID": 1, "KEY2": "a"}}
+      ],
+      "post": {
+        "sources": [
+          {
+            "name": "OUTPUT",
+            "type": "stream",
+            "keyFormat": {"format": "KAFKA"},
+            "schema": "KEY STRING KEY, ID BIGINT, KEY2 STRING"
+          }
+        ]
+      }
+    },
+    {
+      "name": "explicit key field named other than ROWKEY - old",
+      "statements": [
         "CREATE STREAM INPUT (OTHER STRING KEY, ID bigint) WITH (kafka_topic='input',value_format='JSON');"
       ],
       "expectedException": {
@@ -327,7 +380,7 @@
       }
     },
     {
-      "name": "KEY key field name",
+      "name": "KEY key field name- old",
       "comment": "tests that `KEY` is allowed as a KEY column name",
       "statements": [
         "CREATE STREAM INPUT (KEY STRING KEY, ID bigint) WITH (kafka_topic='input',value_format='JSON');"

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/partition-by.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/partition-by.json
@@ -187,7 +187,30 @@
       "post": {
         "topics": {
           "blacklist": ".*-repartition"
-        }
+        },
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ROWKEY STRING KEY, ID BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "partition by only key column",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT KEY, NAME STRING) with (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS select * from INPUT partition by ID;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [{"topic": "input", "key": 10, "value": {"NAME": "bob"}}],
+      "outputs": [{"topic": "OUTPUT", "key": 10, "value": {"NAME": "bob"}}],
+      "post": {
+        "topics": {
+          "blacklist": ".*-repartition"
+        },
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, NAME STRING"}
+        ]
       }
     },
     {
@@ -302,6 +325,66 @@
       "post": {
         "sources": [
           {"name": "OUTPUT", "type": "stream", "keyField": null}
+        ]
+      }
+    },
+    {
+      "name": "only key column",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT KEY, NAME STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT PARTITION BY ID;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": 11, "value": {"name": "a"}},
+        {"topic": "test_topic", "timestamp": 12365, "key": 10, "value": {"name": "b"}},
+        {"topic": "test_topic", "timestamp": 12375, "key": 11, "value": {"name": "c"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 11, "value": {"NAME": "a"}},
+        {"topic": "OUTPUT", "key": 10, "value": {"NAME": "b"}},
+        {"topic": "OUTPUT", "key": 11, "value": {"NAME": "c"}}
+      ],
+      "post": {
+        "sources": [
+          {
+            "name": "OUTPUT",
+            "type": "stream",
+            "keyFormat": {"format": "KAFKA"},
+            "schema": "ID INT KEY, NAME STRING"
+          }
+        ]
+      }
+    },
+    {
+      "name": "should handled quoted key and value",
+      "statements": [
+        "CREATE STREAM INPUT (`Key` STRING KEY, `Name` STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT *, `Name` AS `Name2` FROM INPUT PARTITION BY `Key`;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": "x", "value": {"Name": "a"}},
+        {"topic": "test_topic", "timestamp": 12365, "key": "y", "value": {"Name": "b"}},
+        {"topic": "test_topic", "timestamp": 12375, "key": "x", "value": {"Name": "c"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "x", "value": {"Name": "a", "Name2": "a"}},
+        {"topic": "OUTPUT", "key": "y", "value": {"Name": "b", "Name2": "b"}},
+        {"topic": "OUTPUT", "key": "x", "value": {"Name": "c", "Name2": "c"}}
+      ],
+      "post": {
+        "sources": [
+          {
+            "name": "OUTPUT",
+            "type": "stream",
+            "keyFormat": {"format": "KAFKA"},
+            "schema": "`Key` STRING KEY, `Name` STRING, `Name2` STRING"
+          }
         ]
       }
     }

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/select.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/select.json
@@ -1,0 +1,91 @@
+{
+  "comments": [
+    "Tests covering general SELECT clause, a.k.a projection, handling"
+  ],
+  "tests": [
+    {
+      "name": "key column",
+      "statements": [
+        "CREATE STREAM INPUT (id int KEY, name STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT id as ID_COPY FROM INPUT;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic":  "test_topic", "key": 8, "value": {"name": "a"}}
+      ],
+      "outputs": [
+        {"topic":  "OUTPUT", "key": 8, "value": {"ID_COPY": 8}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, ID_COPY INT"}
+        ]
+      }
+    },
+    {
+      "name": "value column",
+      "statements": [
+        "CREATE STREAM INPUT (id int KEY, name STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT NAME FROM INPUT;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic":  "test_topic", "key": 8, "value": {"name": "a"}}
+      ],
+      "outputs": [
+        {"topic":  "OUTPUT", "key": 8, "value": {"NAME": "a"}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, NAME STRING"}
+        ]
+      }
+    },
+    {
+      "name": "all columns - star",
+      "statements": [
+        "CREATE STREAM INPUT (id int KEY, name STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic":  "test_topic", "key": 8, "value": {"name": "a"}}
+      ],
+      "outputs": [
+        {"topic":  "OUTPUT", "key": 8, "value": {"NAME": "a"}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, NAME STRING"}
+        ]
+      }
+    },
+    {
+      "name": "all columns - explicit",
+      "statements": [
+        "CREATE STREAM INPUT (id int KEY, name STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT ID AS ID_COPY, ROWTIME AS ROWTIME_COPY, NAME FROM INPUT;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic":  "test_topic", "timestamp": 1234, "key": 8, "value": {"name": "a"}}
+      ],
+      "outputs": [
+        {"topic":  "OUTPUT", "timestamp": 1234, "key": 8, "value": {"ID_COPY": 8, "ROWTIME_COPY": 1234, "NAME": "a"}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, ID_COPY INT, ROWTIME_COPY BIGINT, NAME STRING"}
+        ]
+      }
+    }
+  ]
+}

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/system-columns.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/system-columns.json
@@ -4,7 +4,17 @@
   ],
   "tests": [
     {
-      "name": "should fail if ROWKEY used as column name",
+      "name": "should fail if ROWKEY used as key column name",
+      "statements": [
+        "CREATE STREAM INPUT (ROWKEY int) WITH (kafka_topic='test', value_format='JSON');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "'ROWKEY' is a reserved column name. It can only be used for KEY columns."
+      }
+    },
+    {
+      "name": "should fail if ROWKEY used as value column name",
       "statements": [
         "CREATE STREAM INPUT (x int) WITH (kafka_topic='test', value_format='JSON');",
         "CREATE STREAM OUTPUT AS SELECT x AS rowkey FROM INPUT;"

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/table-functions.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/table-functions.json
@@ -153,6 +153,27 @@
       ]
     },
     {
+      "name": "test_udtf - key column",
+      "statements": [
+        "CREATE STREAM TEST (ID INT KEY, NAME STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT TEST_UDTF(ID) FROM TEST;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "test_topic", "key": 10, "value": {"NAME": "bob"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 10, "value": {"KSQL_COL_0": 10}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, KSQL_COL_0 INT"}
+        ]
+      }
+    },
+    {
       "name": "test_udtf - array params",
       "statements": [
         "CREATE STREAM TEST (F0 ARRAY<INT>, F1 ARRAY<BIGINT>, F2 ARRAY<DOUBLE>, F3 ARRAY<BOOLEAN>, F4 ARRAY<STRING>, F5 ARRAY<DECIMAL(20, 10)>, F6 ARRAY<STRUCT<A VARCHAR>>) WITH (kafka_topic='test_topic', value_format='JSON');",

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/where.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/where.json
@@ -1,0 +1,57 @@
+{
+  "comments": [
+    "Tests covering general WHERE clause handling"
+  ],
+  "tests": [
+    {
+      "name": "on key column",
+      "statements": [
+        "CREATE STREAM INPUT (id int KEY, name STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT WHERE id < 10;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic":  "test_topic", "key": 8, "value": {"name": "a"}},
+        {"topic":  "test_topic", "key": 9, "value": {"name": "a"}},
+        {"topic":  "test_topic", "key": 10, "value": {"name": "b"}},
+        {"topic":  "test_topic", "key": 11, "value": {"name": "c"}}
+      ],
+      "outputs": [
+        {"topic":  "OUTPUT", "key": 8, "value": {"NAME": "a"}},
+        {"topic":  "OUTPUT", "key": 9, "value": {"NAME": "a"}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, NAME STRING"}
+        ]
+      }
+    },
+    {
+      "name": "on value column",
+      "statements": [
+        "CREATE STREAM INPUT (id int KEY, name STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT WHERE name not like '%not%';"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic":  "test_topic", "key": 8, "value": {"name": "this one"}},
+        {"topic":  "test_topic", "key": 9, "value": {"name": "not this one"}},
+        {"topic":  "test_topic", "key": 10, "value": {"name": "and this one"}},
+        {"topic":  "test_topic", "key": 11, "value": {"name": "but not this one"}}
+      ],
+      "outputs": [
+        {"topic":  "OUTPUT", "key": 8, "value": {"NAME": "this one"}},
+        {"topic":  "OUTPUT", "key": 10, "value": {"NAME": "and this one"}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, NAME STRING"}
+        ]
+      }
+    }
+  ]
+}

--- a/ksql-functional-tests/src/test/resources/rest-query-validation-tests/insert-values.json
+++ b/ksql-functional-tests/src/test/resources/rest-query-validation-tests/insert-values.json
@@ -6,6 +6,402 @@
     {
       "name": "explicitly supply all column values",
       "statements": [
+        "CREATE STREAM TEST (K STRING KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "INSERT INTO TEST (ROWTIME, K, ID) VALUES (1234, 'key', 10);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "timestamp": 1234, "key": "key", "value": {"ID": 10}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus", "statementText": "{STATEMENT}"}}
+      ]
+    },
+    {
+      "name": "explicitly supply values out of order",
+      "statements": [
+        "CREATE STREAM TEST (K STRING KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "INSERT INTO TEST (ID, ROWTIME, K) VALUES (10, 1234, 'key');"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "timestamp": 1234, "key": "key", "value": {"ID": 10}}
+      ]
+    },
+    {
+      "name": "explicitly supply default set of column values",
+      "statements": [
+        "CREATE STREAM TEST (K STRING KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "INSERT INTO TEST (K, ID) VALUES ('key', 10);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": "key", "value": {"ID": 10}}
+      ]
+    },
+    {
+      "name": "implicitly supply default set of column values",
+      "statements": [
+        "CREATE STREAM TEST (K STRING KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "INSERT INTO TEST VALUES ('key', 10);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": "key", "value": {"ID": 10}}
+      ]
+    },
+    {
+      "name": "should insert nulls for any fields not provided",
+      "statements": [
+        "CREATE STREAM TEST (K STRING KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "INSERT INTO TEST (K) VALUES ('10');"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": "10", "value": {"ID": null}}
+      ]
+    },
+    {
+      "name": "should insert null key",
+      "statements": [
+        "CREATE STREAM TEST (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "INSERT INTO TEST (ID) VALUES (10);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": null, "value": {"ID": 10}}
+      ]
+    },
+    {
+      "name": "rowkey should be set when stream has int key and only key specified in insert",
+      "statements": [
+        "CREATE STREAM TEST (K INT KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "INSERT INTO TEST (ID) VALUES (10);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": 10, "value": {"ID": 10}}
+      ]
+    },
+    {
+      "name": "rowkey should be set when stream has String key and only key specified in insert",
+      "statements": [
+        "CREATE STREAM TEST (ID VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "INSERT INTO TEST (ID) VALUES ('10');"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": "10", "value": {"ID": "10"}}
+      ]
+    },
+    {
+      "name": "rowkey should be set when stream has double key and only key specified in insert",
+      "statements": [
+        "CREATE STREAM TEST (K DOUBLE KEY, ID DOUBLE) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "INSERT INTO TEST (ID) VALUES (1.23);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": 1.23, "value": {"ID": 1.23}}
+      ]
+    },
+    {
+      "name": "rowkey should be set when stream has bigint key and only key specified in insert",
+      "statements": [
+        "CREATE STREAM TEST (K BIGINT KEY, ID BIGINT) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "INSERT INTO TEST (ID) VALUES (10);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": 10, "value": {"ID": 10}}
+      ]
+    },
+    {
+      "name": "keyfield should be set when stream has string key and only rowkey specified in insert",
+      "statements": [
+        "CREATE STREAM TEST (K STRING KEY, ID STRING) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "INSERT INTO TEST (K) VALUES ('10');"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": "10", "value": {"ID": "10"}}
+      ]
+    },
+    {
+      "name": "rowkey and key should match when stream has int key",
+      "statements": [
+        "CREATE STREAM TEST (K INT KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "INSERT INTO TEST (K, ID) VALUES (10, 10);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": 10, "value": {"ID": 10}}
+      ]
+    },
+    {
+      "name": "rowkey and key should match when stream has String key",
+      "statements": [
+        "CREATE STREAM TEST (K STRING KEY, ID STRING) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "INSERT INTO TEST (K, ID) VALUES ('10', '10');"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": "10", "value": {"ID": "10"}}
+      ]
+    },
+    {
+      "name": "rowkey and key should match when stream has double key",
+      "statements": [
+        "CREATE STREAM TEST (K DOUBLE KEY, ID DOUBLE) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "INSERT INTO TEST (K, ID) VALUES (1.23, 1.23);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": 1.23, "value": {"ID": 1.23}}
+      ]
+    },
+    {
+      "name": "rowkey and key should match when stream has bigint key",
+      "statements": [
+        "CREATE STREAM TEST (K BIGINT KEY, ID BIGINT) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "INSERT INTO TEST (K, ID) VALUES (10, 10);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": 10, "value": {"ID": 10}}
+      ]
+    },
+    {
+      "name": "should fail on mismatch between explicit columns and value counts",
+      "statements": [
+        "CREATE STREAM TEST (K STRING KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "INSERT INTO TEST (K, ID) VALUES ('10');"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
+        "message": "Failed to prepare statement: Expected number columns and values to match: [K, ID], ['10']",
+        "status": 400
+      }
+    },
+    {
+      "name": "should fail on mismatch between rowkey and key values when stream has key",
+      "statements": [
+        "CREATE STREAM TEST (K INT KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "INSERT INTO TEST (K, ID) VALUES (10, 5);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
+        "message": "Failed to insert values into 'TEST'. Expected K and ID to match but got 10 and 5 respectively.",
+        "status": 400
+      }
+    },
+    {
+      "name": "should coerce numbers",
+      "statements": [
+        "CREATE STREAM TEST (K STRING KEY, I INT, BI BIGINT, D DOUBLE) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "INSERT INTO TEST (I, BI, D) VALUES (1, 2, 3);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": null, "value": {"I": 1, "BI": 2, "D": 3.0}}
+      ]
+    },
+    {
+      "name": "should handle arbitrary expressions",
+      "statements": [
+        "CREATE STREAM TEST (K STRING KEY, I INT, A ARRAY<INT>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "INSERT INTO TEST (I, A) VALUES (-1, ARRAY[1, 1 + 1, 3]);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": null, "value": {"I": -1, "A": [1, 2, 3]}}
+      ]
+    },
+    {
+      "name": "should handle arbitrary nested expressions",
+      "statements": [
+        "CREATE STREAM TEST (K STRING KEY, I INT, A ARRAY<ARRAY<BIGINT>>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "INSERT INTO TEST (I, A) VALUES (-1, ARRAY[ARRAY[1]]);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": null, "value": {"I": -1, "A": [[1]]}}
+      ]
+    },
+    {
+      "name": "should handle map expressions",
+      "statements": [
+        "CREATE STREAM TEST (K STRING KEY, I INT, A MAP<VARCHAR, BIGINT>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "INSERT INTO TEST (I, A) VALUES (-1, MAP('a':=0, 'b':=1));"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": null, "value": {"I": -1, "A": {"a": 0, "b": 1}}}
+      ]
+    },
+    {
+      "name": "should handle quoted identifiers",
+      "statements": [
+        "CREATE STREAM `test` (`@key` STRING KEY, `id!` INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "INSERT INTO `test` (ROWTIME, `@key`, `id!`) VALUES (1234, 'key', 10);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "timestamp": 1234, "key": "key", "value": {"id!": 10}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus", "statementText": "{STATEMENT}"}}
+      ]
+    },
+    {
+      "name": "should handle struct expressions",
+      "statements": [
+        "CREATE STREAM TEST (K STRING KEY, val STRUCT<foo DECIMAL(2, 1), `bar` ARRAY<VARCHAR>>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "INSERT INTO TEST (val) VALUES (STRUCT(FOO := 2.1, `bar` := ARRAY['bar']));"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": null, "value": {"VAL": {"FOO": 2.1, "bar": ["bar"]}}}
+      ]
+    },
+    {
+      "name": "should handle struct coercion",
+      "statements": [
+        "CREATE STREAM TEST (K STRING KEY, val STRUCT<foo BIGINT, bar ARRAY<BIGINT>, baz DOUBLE>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "INSERT INTO TEST (val) VALUES (STRUCT(FOO := 2, BAR := ARRAY[2], BAZ := 2));"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": null, "value": {"VAL": {"FOO": 2, "BAR": [2], "BAZ": 2.0}}}
+      ]
+    },
+    {
+      "name": "should handle empty struct expressions",
+      "statements": [
+        "CREATE STREAM TEST (K STRING KEY, val STRUCT<foo DECIMAL(2, 1), `bar` ARRAY<VARCHAR>>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "INSERT INTO TEST (val) VALUES (STRUCT());"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": null, "value": {"VAL": {"FOO": null, "bar": null}}}
+      ]
+    },
+    {
+      "name": "should handled quoted key and value",
+      "statements": [
+        "CREATE STREAM TEST (`Key` STRING KEY, `Value` INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "INSERT INTO TEST (`Key`, `Value`) VALUES ('key', 10);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": "key", "value": {"Value": 10}}
+      ]
+    },
+    {
+      "name": "explicitly supply all column values - old`",
+      "statements": [
         "CREATE STREAM TEST (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "INSERT INTO TEST (ROWTIME, ROWKEY, ID) VALUES (1234, 'key', 10);"
       ],
@@ -19,7 +415,7 @@
       ]
     },
     {
-      "name": "explicitly supply values out of order",
+      "name": "explicitly supply values out of order - old",
       "statements": [
         "CREATE STREAM TEST (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "INSERT INTO TEST (ID, ROWTIME, ROWKEY) VALUES (10, 1234, 'key');"
@@ -31,7 +427,7 @@
       ]
     },
     {
-      "name": "explicitly supply default set of column values",
+      "name": "explicitly supply default set of column values - old",
       "statements": [
         "CREATE STREAM TEST (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "INSERT INTO TEST (ROWKEY, ID) VALUES ('key', 10);"
@@ -43,7 +439,7 @@
       ]
     },
     {
-      "name": "implicitly supply default set of column values",
+      "name": "implicitly supply default set of column values - old",
       "statements": [
         "CREATE STREAM TEST (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "INSERT INTO TEST VALUES ('key', 10);"
@@ -55,7 +451,7 @@
       ]
     },
     {
-      "name": "should insert nulls for any fields not provided",
+      "name": "should insert nulls for any fields not provided - old",
       "statements": [
         "CREATE STREAM TEST (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "INSERT INTO TEST (ROWKEY) VALUES ('10');"
@@ -67,7 +463,7 @@
       ]
     },
     {
-      "name": "should insert null key",
+      "name": "should insert null key - old",
       "statements": [
         "CREATE STREAM TEST (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "INSERT INTO TEST (ID) VALUES (10);"
@@ -79,7 +475,7 @@
       ]
     },
     {
-      "name": "rowkey should be set when stream has int key and only key specified in insert",
+      "name": "rowkey should be set when stream has int key and only key specified in insert - old",
       "statements": [
         "CREATE STREAM TEST (ROWKEY INT KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
         "INSERT INTO TEST (ID) VALUES (10);"
@@ -91,7 +487,7 @@
       ]
     },
     {
-      "name": "rowkey should be set when stream has String key and only key specified in insert",
+      "name": "rowkey should be set when stream has String key and only key specified in insert - old",
       "statements": [
         "CREATE STREAM TEST (ID VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
         "INSERT INTO TEST (ID) VALUES ('10');"
@@ -103,7 +499,7 @@
       ]
     },
     {
-      "name": "rowkey should be set when stream has double key and only key specified in insert",
+      "name": "rowkey should be set when stream has double key and only key specified in insert - old",
       "statements": [
         "CREATE STREAM TEST (ROWKEY DOUBLE KEY, ID DOUBLE) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
         "INSERT INTO TEST (ID) VALUES (1.23);"
@@ -115,7 +511,7 @@
       ]
     },
     {
-      "name": "rowkey should be set when stream has bigint key and only key specified in insert",
+      "name": "rowkey should be set when stream has bigint key and only key specified in insert - old",
       "statements": [
         "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID BIGINT) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
         "INSERT INTO TEST (ID) VALUES (10);"
@@ -127,7 +523,7 @@
       ]
     },
     {
-      "name": "keyfield should be set when stream has string key and only rowkey specified in insert",
+      "name": "keyfield should be set when stream has string key and only rowkey specified in insert - old",
       "statements": [
         "CREATE STREAM TEST (ID STRING) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
         "INSERT INTO TEST (ROWKEY) VALUES ('10');"
@@ -139,7 +535,7 @@
       ]
     },
     {
-      "name": "rowkey and key should match when stream has int key",
+      "name": "rowkey and key should match when stream has int key - old",
       "statements": [
         "CREATE STREAM TEST (ROWKEY INT KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
         "INSERT INTO TEST (ROWKEY, ID) VALUES (10, 10);"
@@ -151,7 +547,7 @@
       ]
     },
     {
-      "name": "rowkey and key should match when stream has String key",
+      "name": "rowkey and key should match when stream has String key - old",
       "statements": [
         "CREATE STREAM TEST (ID STRING) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
         "INSERT INTO TEST (ROWKEY, ID) VALUES ('10', '10');"
@@ -163,7 +559,7 @@
       ]
     },
     {
-      "name": "rowkey and key should match when stream has double key",
+      "name": "rowkey and key should match when stream has double key - old",
       "statements": [
         "CREATE STREAM TEST (ROWKEY DOUBLE KEY, ID DOUBLE) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
         "INSERT INTO TEST (ROWKEY, ID) VALUES (1.23, 1.23);"
@@ -175,7 +571,7 @@
       ]
     },
     {
-      "name": "rowkey and key should match when stream has bigint key",
+      "name": "rowkey and key should match when stream has bigint key - old",
       "statements": [
         "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID BIGINT) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
         "INSERT INTO TEST (ROWKEY, ID) VALUES (10, 10);"
@@ -187,7 +583,7 @@
       ]
     },
     {
-      "name": "should fail on mismatch between explicit columns and value counts",
+      "name": "should fail on mismatch between explicit columns and value counts - old",
       "statements": [
         "CREATE STREAM TEST (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "INSERT INTO TEST (ROWKEY, ID) VALUES ('10');"
@@ -199,7 +595,7 @@
       }
     },
     {
-      "name": "should fail on mismatch between rowkey and key values when stream has key",
+      "name": "should fail on mismatch between rowkey and key values when stream has key - old",
       "statements": [
         "CREATE STREAM TEST (ROWKEY INT KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
         "INSERT INTO TEST (ROWKEY, ID) VALUES (10, 5);"
@@ -211,7 +607,7 @@
       }
     },
     {
-      "name": "should coerce numbers",
+      "name": "should coerce numbers - old",
       "statements": [
         "CREATE STREAM TEST (I INT, BI BIGINT, D DOUBLE) WITH (kafka_topic='test_topic', value_format='JSON');",
         "INSERT INTO TEST (I, BI, D) VALUES (1, 2, 3);"
@@ -223,7 +619,7 @@
       ]
     },
     {
-      "name": "should handle arbitrary expressions",
+      "name": "should handle arbitrary expressions - old",
       "statements": [
         "CREATE STREAM TEST (I INT, A ARRAY<INT>) WITH (kafka_topic='test_topic', value_format='JSON');",
         "INSERT INTO TEST (I, A) VALUES (-1, ARRAY[1, 1 + 1, 3]);"
@@ -235,7 +631,7 @@
       ]
     },
     {
-      "name": "should handle arbitrary nested expressions",
+      "name": "should handle arbitrary nested expressions - old",
       "statements": [
         "CREATE STREAM TEST (I INT, A ARRAY<ARRAY<BIGINT>>) WITH (kafka_topic='test_topic', value_format='JSON');",
         "INSERT INTO TEST (I, A) VALUES (-1, ARRAY[ARRAY[1]]);"
@@ -247,7 +643,7 @@
       ]
     },
     {
-      "name": "should handle map expressions",
+      "name": "should handle map expressions - old",
       "statements": [
         "CREATE STREAM TEST (I INT, A MAP<VARCHAR, BIGINT>) WITH (kafka_topic='test_topic', value_format='JSON');",
         "INSERT INTO TEST (I, A) VALUES (-1, MAP('a':=0, 'b':=1));"
@@ -259,7 +655,7 @@
       ]
     },
     {
-      "name": "should handle quoted identifiers",
+      "name": "should handle quoted identifiers - old",
       "statements": [
         "CREATE STREAM `test` (`id!` INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "INSERT INTO `test` (ROWTIME, ROWKEY, `id!`) VALUES (1234, 'key', 10);"
@@ -274,7 +670,7 @@
       ]
     },
     {
-      "name": "should handle struct expressions",
+      "name": "should handle struct expressions - old",
       "statements": [
         "CREATE STREAM TEST (val STRUCT<foo DECIMAL(2, 1), `bar` ARRAY<VARCHAR>>) WITH (kafka_topic='test_topic', value_format='JSON');",
         "INSERT INTO TEST (val) VALUES (STRUCT(FOO := 2.1, `bar` := ARRAY['bar']));"
@@ -286,7 +682,7 @@
       ]
     },
     {
-      "name": "should handle struct coercion",
+      "name": "should handle struct coercion - old",
       "statements": [
         "CREATE STREAM TEST (val STRUCT<foo BIGINT, bar ARRAY<BIGINT>, baz DOUBLE>) WITH (kafka_topic='test_topic', value_format='JSON');",
         "INSERT INTO TEST (val) VALUES (STRUCT(FOO := 2, BAR := ARRAY[2], BAZ := 2));"
@@ -298,7 +694,7 @@
       ]
     },
     {
-      "name": "should handle empty struct expressions",
+      "name": "should handle empty struct expressions - old",
       "statements": [
         "CREATE STREAM TEST (val STRUCT<foo DECIMAL(2, 1), `bar` ARRAY<VARCHAR>>) WITH (kafka_topic='test_topic', value_format='JSON');",
         "INSERT INTO TEST (val) VALUES (STRUCT());"

--- a/ksql-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
+++ b/ksql-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
@@ -105,7 +105,7 @@
       ]
     },
     {
-      "name": "non-windowed lookup on wrong type type",
+      "name": "non-windowed lookup on wrong type",
       "statements": [
         "CREATE STREAM INPUT (ROWKEY INT KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE TABLE AGGREGATE AS SELECT COUNT(1) AS COUNT FROM INPUT GROUP BY ROWKEY;",
@@ -113,7 +113,7 @@
       ],
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "'10' can not be converted to the type of column ROWKEY: INTEGER",
+        "message": "'10' can not be converted to the type of the key column: ROWKEY INTEGER KEY",
         "status": 400
       }
     },
@@ -222,7 +222,7 @@
       ],
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "'10' can not be converted to the type of column ROWKEY: INTEGER",
+        "message": "'10' can not be converted to the type of the key column: ROWKEY INTEGER KEY",
         "status": 400
       }
     },
@@ -901,7 +901,7 @@
       ],
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "Multiple bounds on ROWKEY",
+        "message": "Multiple bounds on key column",
         "status": 400
       }
     },
@@ -914,7 +914,7 @@
       ],
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "ROWKEY bound must currently be '='.",
+        "message": "Bound on 'ROWKEY' must currently be '='.",
         "status": 400
       }
     },
@@ -927,7 +927,7 @@
       ],
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "WHERE clause on unsupported field: COUNT",
+        "message": "WHERE clause on unsupported column: COUNT",
         "status": 400
       }
     },
@@ -1013,6 +1013,29 @@
         {"query": [
           {"header":{"schema":"`ROWTIME` BIGINT, `ROWKEY` DOUBLE KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY"}},
           {"row":{"columns":[12345, 10.1, 12000, 13000]}}
+        ]}
+      ]
+    },
+    {
+      "name": "should handled quoted key and value",
+      "statements": [
+        "CREATE STREAM INPUT (`Key` STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT COUNT(1) AS `Value` FROM INPUT GROUP BY `Key`;",
+        "SELECT * FROM AGGREGATE WHERE `Key`='10';"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": "11", "value": {}},
+        {"topic": "test_topic", "timestamp": 12365, "key": "10", "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`Key` STRING KEY, `ROWTIME` BIGINT, `Value` BIGINT"}},
+          {"row":{"columns":["10", 12365, 1]}}
         ]}
       ]
     }

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/StructuredDataSource.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/StructuredDataSource.java
@@ -21,12 +21,15 @@ import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.execution.timestamp.TimestampColumn;
+import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.util.SchemaUtil;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Immutable
 abstract class StructuredDataSource<K> implements DataSource {
@@ -65,6 +68,14 @@ abstract class StructuredDataSource<K> implements DataSource {
 
     if (schema.valueContainsAny(SchemaUtil.systemColumnNames())) {
       throw new IllegalArgumentException("Schema contains system columns in value schema");
+    }
+
+    final Set<ColumnName> keyNames = schema.key().stream()
+        .map(Column::name)
+        .collect(Collectors.toSet());
+
+    if (schema.valueContainsAny(keyNames)) {
+      throw new IllegalArgumentException("Schema contains duplicate column names");
     }
   }
 

--- a/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/StructuredDataSourceTest.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/StructuredDataSourceTest.java
@@ -36,7 +36,7 @@ public class StructuredDataSourceTest {
 
   private static final LogicalSchema SOME_SCHEMA = LogicalSchema.builder()
       .withRowTime()
-      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
+      .keyColumn(ColumnName.of("k0"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("f0"), SqlTypes.BIGINT)
       .build();
 
@@ -60,7 +60,7 @@ public class StructuredDataSourceTest {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
         .withRowTime()
-        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
+        .keyColumn(ColumnName.of("k0"), SqlTypes.INTEGER)
         .valueColumn(SchemaUtil.ROWTIME_NAME, SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("f0"), SqlTypes.BIGINT)
         .build();
@@ -73,12 +73,11 @@ public class StructuredDataSourceTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void shouldThrowIfSchemaContainsRowKey() {
+  public void shouldThrowOnDuplicateColumnNames() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .withRowTime()
-        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
-        .valueColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
+        .keyColumn(ColumnName.of("dup"), SqlTypes.INTEGER)
+        .valueColumn(ColumnName.of("dup"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("f0"), SqlTypes.BIGINT)
         .build();
 
@@ -94,7 +93,7 @@ public class StructuredDataSourceTest {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
         .withRowTime()
-        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
+        .keyColumn(ColumnName.of("k0"), SqlTypes.INTEGER)
         .valueColumn(SchemaUtil.WINDOWSTART_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("f0"), SqlTypes.BIGINT)
         .build();
@@ -111,9 +110,25 @@ public class StructuredDataSourceTest {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
         .withRowTime()
-        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
+        .keyColumn(ColumnName.of("k0"), SqlTypes.INTEGER)
         .valueColumn(SchemaUtil.WINDOWEND_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("f0"), SqlTypes.BIGINT)
+        .build();
+
+    // When:
+    new TestStructuredDataSource(
+        schema,
+        keyField
+    );
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldThrowIfSchemaContainsValueColumnsWithSameNameAsKeyColumns() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        .keyColumn(ColumnName.of("k0"), SqlTypes.INTEGER)
+        .valueColumn(SchemaUtil.WINDOWEND_NAME, SqlTypes.STRING)
+        .valueColumn(ColumnName.of("k0"), SqlTypes.BIGINT)
         .build();
 
     // When:

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -92,7 +92,6 @@ import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.util.MetaStoreFixture;
-import io.confluent.ksql.util.SchemaUtil;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Objects;
@@ -136,7 +135,7 @@ public class KsqlParserTest {
       .build();
 
   private static final LogicalSchema ORDERS_SCHEMA = LogicalSchema.builder()
-      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
+      .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("ORDERTIME"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("ORDERID"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("ITEMID"), SqlTypes.STRING)

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/SchemaParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/SchemaParserTest.java
@@ -72,7 +72,7 @@ public class SchemaParserTest {
   }
 
   @Test
-  public void shouldParseValidSchemaWithKeyField() {
+  public void shouldParseValidSchemaWithRowKeyField() {
     // Given:
     final String schema = "ROWKEY STRING KEY, bar INT";
 
@@ -82,6 +82,21 @@ public class SchemaParserTest {
     // Then:
     assertThat(elements, contains(
         new TableElement(Namespace.KEY, SchemaUtil.ROWKEY_NAME, new Type(SqlTypes.STRING)),
+        new TableElement(Namespace.VALUE, BAR, new Type(SqlTypes.INTEGER))
+    ));
+  }
+
+  @Test
+  public void shouldParseValidSchemaWithKeyField() {
+    // Given:
+    final String schema = "K STRING KEY, bar INT";
+
+    // When:
+    final TableElements elements = parser.parse(schema);
+
+    // Then:
+    assertThat(elements, contains(
+        new TableElement(Namespace.KEY, ColumnName.of("K"), new Type(SqlTypes.STRING)),
         new TableElement(Namespace.VALUE, BAR, new Type(SqlTypes.INTEGER))
     ));
   }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
@@ -67,7 +67,6 @@ import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.util.MetaStoreFixture;
-import io.confluent.ksql.util.SchemaUtil;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
@@ -109,7 +108,7 @@ public class SqlFormatterTest {
       .build();
 
   private static final LogicalSchema ITEM_INFO_SCHEMA = LogicalSchema.builder()
-      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.BIGINT)
+      .keyColumn(ColumnName.of("K0"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("ITEMID"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("NAME"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("CATEGORY"), categorySchema)
@@ -122,7 +121,7 @@ public class SqlFormatterTest {
       .build();
 
   private static final LogicalSchema ORDERS_SCHEMA = LogicalSchema.builder()
-      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.BIGINT)
+      .keyColumn(ColumnName.of("K1"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("ORDERTIME"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("ORDERID"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("ITEMID"), SqlTypes.STRING)
@@ -142,7 +141,7 @@ public class SqlFormatterTest {
   );
 
   private static final TableElements ELEMENTS_WITH_KEY = TableElements.of(
-      new TableElement(Namespace.KEY, ColumnName.of("ROWKEY"), new Type(SqlTypes.STRING)),
+      new TableElement(Namespace.KEY, ColumnName.of("k3"), new Type(SqlTypes.STRING)),
       new TableElement(Namespace.VALUE, ColumnName.of("Foo"), new Type(SqlTypes.STRING))
   );
 
@@ -170,7 +169,7 @@ public class SqlFormatterTest {
         ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name()))
     );
 
-    final KsqlStream ksqlStreamOrders = new KsqlStream<>(
+    final KsqlStream<?> ksqlStreamOrders = new KsqlStream<>(
         "sqlexpression",
         SourceName.of("ADDRESS"),
         ORDERS_SCHEMA,
@@ -228,7 +227,7 @@ public class SqlFormatterTest {
     final String sql = SqlFormatter.formatSql(createStream);
 
     // Then:
-    assertThat(sql, is("CREATE STREAM TEST (ROWKEY STRING KEY, `Foo` STRING) "
+    assertThat(sql, is("CREATE STREAM TEST (`k3` STRING KEY, `Foo` STRING) "
         + "WITH (KAFKA_TOPIC='topic_test', KEY='ORDERID', VALUE_FORMAT='JSON');"));
   }
 
@@ -269,7 +268,7 @@ public class SqlFormatterTest {
     final String sql = SqlFormatter.formatSql(createTable);
 
     // Then:
-    assertThat(sql, is("CREATE TABLE TEST (ROWKEY STRING KEY, `Foo` STRING) "
+    assertThat(sql, is("CREATE TABLE TEST (`k3` STRING KEY, `Foo` STRING) "
         + "WITH (KAFKA_TOPIC='topic_test', KEY='ORDERID', "
         + "TIMESTAMP='Foo', TIMESTAMP_FORMAT='%s', VALUE_FORMAT='JSON');"));
   }
@@ -287,7 +286,7 @@ public class SqlFormatterTest {
     final String sql = SqlFormatter.formatSql(createTable);
 
     // Then:
-    assertThat(sql, is("CREATE TABLE TEST (ROWKEY STRING KEY, `Foo` STRING) "
+    assertThat(sql, is("CREATE TABLE TEST (`k3` STRING KEY, `Foo` STRING) "
         + "WITH (KAFKA_TOPIC='topic_test', KEY='ORDERID', VALUE_FORMAT='JSON');"));
   }
 

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/TableElementTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/TableElementTest.java
@@ -25,7 +25,6 @@ import io.confluent.ksql.execution.expression.tree.Type;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.parser.NodeLocation;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.util.SchemaUtil;
 import java.util.Optional;
 import org.junit.Rule;
 import org.junit.Test;
@@ -41,6 +40,7 @@ public class TableElementTest {
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
 
+  @SuppressWarnings("UnstableApiUsage")
   @Test
   public void shouldImplementEquals() {
     new EqualsTester()
@@ -55,7 +55,7 @@ public class TableElementTest {
             new TableElement(VALUE, NAME, new Type(SqlTypes.INTEGER))
         )
         .addEqualityGroup(
-            new TableElement(KEY, SchemaUtil.ROWKEY_NAME, new Type(SqlTypes.STRING))
+            new TableElement(KEY, NAME, new Type(SqlTypes.STRING))
         )
         .testEquals();
   }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/TableElementsTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/TableElementsTest.java
@@ -224,6 +224,26 @@ public class TableElementsTest {
   }
 
   @Test
+  public void shouldBuildLogicalSchemaWithImplicitsAndExplicitKey() {
+    // Given:
+    final TableElements tableElements = TableElements.of(
+        tableElement(VALUE, "v0", INT_TYPE),
+        tableElement(KEY, "k0", INT_TYPE)
+    );
+
+    // When:
+    final LogicalSchema schema = tableElements.toLogicalSchema(true);
+
+    // Then:
+    assertThat(schema, is(LogicalSchema.builder()
+        .withRowTime()
+        .valueColumn(ColumnName.of("v0"), SqlTypes.INTEGER)
+        .keyColumn(ColumnName.of("k0"), SqlTypes.INTEGER)
+        .build()
+    ));
+  }
+
+  @Test
   public void shouldBuildLogicalSchemaWithOutImplicits() {
     // Given:
     final TableElements tableElements = TableElements.of(

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
@@ -308,7 +308,7 @@ public class ApiIntegrationTest {
     String sql = "SELECT * from " + AGG_TABLE + " WHERE ROWTIME=12345;";
 
     // Then:
-    shouldFailToExecuteQuery(sql, "WHERE clause on unsupported field: ROWTIME.");
+    shouldFailToExecuteQuery(sql, "WHERE clause on unsupported column: ROWTIME.");
   }
 
   @Test

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/TableRowsEntityFactoryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/TableRowsEntityFactoryTest.java
@@ -41,17 +41,20 @@ import org.junit.Test;
 
 public class TableRowsEntityFactoryTest {
 
-  private static final KeyBuilder STRING_KEY_BUILDER = StructKeyUtil.keyBuilder(SqlTypes.STRING);
+  private static final ColumnName K0 = ColumnName.of("k0");
+
+  private static final KeyBuilder KEY_BUILDER = StructKeyUtil
+      .keyBuilder(K0, SqlTypes.STRING);
 
   private static final LogicalSchema SIMPLE_SCHEMA = LogicalSchema.builder()
       .withRowTime()
-      .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
+      .keyColumn(K0, SqlTypes.STRING)
       .valueColumn(ColumnName.of("v0"), SqlTypes.BOOLEAN)
       .build();
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
       .withRowTime()
-      .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
+      .keyColumn(K0, SqlTypes.STRING)
       .keyColumn(ColumnName.of("k1"), SqlTypes.BOOLEAN)
       .valueColumn(ColumnName.of("v0"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("v1"), SqlTypes.BOOLEAN)
@@ -59,7 +62,7 @@ public class TableRowsEntityFactoryTest {
 
   private static final LogicalSchema SCHEMA_NULL = LogicalSchema.builder()
       .withRowTime()
-      .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
+      .keyColumn(K0, SqlTypes.STRING)
       .valueColumn(ColumnName.of("v0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("v1"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("v2"), SqlTypes.DOUBLE)
@@ -74,7 +77,7 @@ public class TableRowsEntityFactoryTest {
     final List<? extends TableRow> input = ImmutableList.of(
         Row.of(
             SIMPLE_SCHEMA,
-            STRING_KEY_BUILDER.build("x"),
+            KEY_BUILDER.build("x"),
             genericRow(false),
             ROWTIME
         )
@@ -98,13 +101,13 @@ public class TableRowsEntityFactoryTest {
     final List<? extends TableRow> input = ImmutableList.of(
         WindowedRow.of(
             SIMPLE_SCHEMA,
-            new Windowed<>(STRING_KEY_BUILDER.build("x"), window0),
+            new Windowed<>(KEY_BUILDER.build("x"), window0),
             genericRow(true),
             ROWTIME
         ),
         WindowedRow.of(
             SIMPLE_SCHEMA,
-            new Windowed<>(STRING_KEY_BUILDER.build("y"), window1),
+            new Windowed<>(KEY_BUILDER.build("y"), window1),
             genericRow(false),
             ROWTIME
         )
@@ -127,7 +130,7 @@ public class TableRowsEntityFactoryTest {
     final GenericRow row = genericRow(null, null, null, null);
 
     final Builder<Row> builder = ImmutableList.builder();
-    builder.add(Row.of(SCHEMA_NULL, STRING_KEY_BUILDER.build("k"), row, ROWTIME));
+    builder.add(Row.of(SCHEMA_NULL, KEY_BUILDER.build("k"), row, ROWTIME));
 
     // When:
     final List<List<?>> output = TableRowsEntityFactory.createRows(builder.build());
@@ -144,7 +147,7 @@ public class TableRowsEntityFactoryTest {
 
     // Then:
     assertThat(result, is(LogicalSchema.builder()
-        .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
+        .keyColumn(K0, SqlTypes.STRING)
         .keyColumn(ColumnName.of("k1"), SqlTypes.BOOLEAN)
         .valueColumn(SchemaUtil.ROWTIME_NAME, SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("v0"), SqlTypes.INTEGER)
@@ -160,7 +163,7 @@ public class TableRowsEntityFactoryTest {
 
     // Then:
     assertThat(result, is(LogicalSchema.builder()
-        .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
+        .keyColumn(K0, SqlTypes.STRING)
         .keyColumn(ColumnName.of("k1"), SqlTypes.BOOLEAN)
         .keyColumn(ColumnName.of("WINDOWSTART"), SqlTypes.BIGINT)
         .keyColumn(ColumnName.of("WINDOWEND"), SqlTypes.BIGINT)

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/GenericRowSerDe.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/GenericRowSerDe.java
@@ -55,7 +55,7 @@ public final class GenericRowSerDe implements ValueSerdeFactory {
    * <p>Count covers the following additional columns:
    * <ol>
    *   <li>{@link SchemaUtil#ROWTIME_NAME}</li>
-   *   <li>{@link SchemaUtil#ROWKEY_NAME}</li>
+   *   <li>A single key column. (Which is the most common case)</li>
    *   <li>{@link SchemaUtil#WINDOWSTART_NAME}</li>
    *   <li>{@link SchemaUtil#WINDOWEND_NAME}</li>
    * </ol>

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/GroupByParamsFactoryTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/GroupByParamsFactoryTest.java
@@ -38,6 +38,7 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.util.SchemaUtil;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
@@ -54,8 +55,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class GroupByParamsFactoryTest {
 
-  private static final KeyBuilder INT_KEY_BUILDER = StructKeyUtil.keyBuilder(SqlTypes.INTEGER);
-  private static final KeyBuilder STRING_KEY_BUILDER = StructKeyUtil.keyBuilder(SqlTypes.STRING);
+  private static final KeyBuilder INT_KEY_BUILDER = StructKeyUtil
+      .keyBuilder(SchemaUtil.ROWKEY_NAME, SqlTypes.INTEGER);
+  private static final KeyBuilder STRING_KEY_BUILDER = StructKeyUtil
+      .keyBuilder(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING);
 
   private static final LogicalSchema SOURCE_SCHEMA = LogicalSchema.builder()
       .valueColumn(ColumnName.of("v0"), SqlTypes.DOUBLE)

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/JoinParamsFactoryTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/JoinParamsFactoryTest.java
@@ -9,7 +9,6 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlException;
-import io.confluent.ksql.util.SchemaUtil;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -17,13 +16,13 @@ import org.junit.rules.ExpectedException;
 public class JoinParamsFactoryTest {
 
   private static final LogicalSchema LEFT_SCHEMA = LogicalSchema.builder()
-      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
+      .keyColumn(ColumnName.of("LK"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("BLUE"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("GREEN"), SqlTypes.INTEGER)
       .build();
 
   private static final LogicalSchema RIGHT_SCHEMA = LogicalSchema.builder()
-      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
+      .keyColumn(ColumnName.of("RK"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("RED"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("ORANGE"), SqlTypes.DOUBLE)
       .build();
@@ -41,7 +40,7 @@ public class JoinParamsFactoryTest {
     // Then:
     assertThat(joinParams.getSchema(), is(LogicalSchema.builder()
         .withRowTime()
-        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
+        .keyColumn(ColumnName.of("LK"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("BLUE"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("GREEN"), SqlTypes.INTEGER)
         .valueColumn(ColumnName.of("RED"), SqlTypes.BIGINT)

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/SourceBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/SourceBuilderTest.java
@@ -58,7 +58,6 @@ import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.WindowInfo;
 import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.SchemaUtil;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -98,20 +97,22 @@ import org.mockito.junit.MockitoRule;
 
 public class SourceBuilderTest {
 
+  private static final ColumnName K0 = ColumnName.of("k0");
+
   private static final LogicalSchema SOURCE_SCHEMA = LogicalSchema.builder()
-      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.BIGINT)
+      .keyColumn(K0, SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("field1"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("field2"), SqlTypes.BIGINT)
       .build();
 
   private static final Schema KEY_SCHEMA = SchemaBuilder.struct()
-      .field(SchemaUtil.ROWKEY_NAME.text(), Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .field(K0.text(), Schema.OPTIONAL_FLOAT64_SCHEMA)
       .build();
 
   private static final double A_KEY = 10.11;
 
   private static final Struct KEY = new Struct(KEY_SCHEMA)
-      .put(SchemaUtil.ROWKEY_NAME.text(), A_KEY);
+      .put(K0.text(), A_KEY);
 
   private static final LogicalSchema SCHEMA = SOURCE_SCHEMA
       .withMetaAndKeyColsInValue(false);

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StepSchemaResolverTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StepSchemaResolverTest.java
@@ -85,7 +85,7 @@ public class StepSchemaResolverTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
       .withRowTime()
-      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
+      .keyColumn(ColumnName.of("K0"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("ORANGE"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("APPLE"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("BANANA"), SqlTypes.STRING)
@@ -136,7 +136,7 @@ public class StepSchemaResolverTest {
     assertThat(result, is(
         LogicalSchema.builder()
             .withRowTime()
-            .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
+            .keyColumn(ColumnName.of("K0"), SqlTypes.INTEGER)
             .valueColumn(ColumnName.of("ORANGE"), SqlTypes.INTEGER)
             .valueColumn(ColumnName.aggregateColumn(0), SqlTypes.BIGINT)
             .build())
@@ -146,13 +146,13 @@ public class StepSchemaResolverTest {
   @Test
   public void shouldResolveSchemaForStreamWindowedAggregate() {
     // Given:
-    givenAggregateFunction("SUM", SqlTypes.BIGINT);
+    givenAggregateFunction("COUNT", SqlTypes.BIGINT);
     final StreamWindowedAggregate step = new StreamWindowedAggregate(
         PROPERTIES,
         groupedStreamSource,
         formats,
         ImmutableList.of(ColumnName.of("ORANGE")),
-        ImmutableList.of(functionCall("SUM", "APPLE")),
+        ImmutableList.of(functionCall("COUNT", "APPLE")),
         new TumblingWindowExpression(10, TimeUnit.SECONDS)
     );
 
@@ -163,7 +163,7 @@ public class StepSchemaResolverTest {
     assertThat(result, is(
         LogicalSchema.builder()
             .withRowTime()
-            .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
+            .keyColumn(ColumnName.of("K0"), SqlTypes.INTEGER)
             .valueColumn(ColumnName.of("ORANGE"), SqlTypes.INTEGER)
             .valueColumn(ColumnName.aggregateColumn(0), SqlTypes.BIGINT)
             .valueColumn(SchemaUtil.WINDOWSTART_NAME, SchemaUtil.WINDOWBOUND_TYPE)
@@ -191,7 +191,7 @@ public class StepSchemaResolverTest {
     assertThat(result, is(
         LogicalSchema.builder()
             .withRowTime()
-            .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
+            .keyColumn(ColumnName.of("K0"), SqlTypes.INTEGER)
             .valueColumn(ColumnName.of("JUICE"), SqlTypes.BIGINT)
             .valueColumn(ColumnName.of("PLANTAIN"), SqlTypes.STRING)
             .valueColumn(ColumnName.of("CITRUS"), SqlTypes.INTEGER)
@@ -216,7 +216,7 @@ public class StepSchemaResolverTest {
     assertThat(result, is(
         LogicalSchema.builder()
             .withRowTime()
-            .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
+            .keyColumn(ColumnName.of("K0"), SqlTypes.INTEGER)
             .valueColumn(ColumnName.of("ORANGE"), SqlTypes.INTEGER)
             .valueColumn(ColumnName.of("APPLE"), SqlTypes.BIGINT)
             .valueColumn(ColumnName.of("BANANA"), SqlTypes.STRING)
@@ -356,7 +356,7 @@ public class StepSchemaResolverTest {
     assertThat(result, is(
         LogicalSchema.builder()
             .withRowTime()
-            .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
+            .keyColumn(ColumnName.of("K0"), SqlTypes.INTEGER)
             .valueColumn(ColumnName.of("ORANGE"), SqlTypes.INTEGER)
             .valueColumn(ColumnName.aggregateColumn(0), SqlTypes.BIGINT)
             .build())
@@ -403,7 +403,7 @@ public class StepSchemaResolverTest {
     assertThat(result, is(
         LogicalSchema.builder()
             .withRowTime()
-            .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
+            .keyColumn(ColumnName.of("K0"), SqlTypes.INTEGER)
             .valueColumn(ColumnName.of("JUICE"), SqlTypes.BIGINT)
             .valueColumn(ColumnName.of("PLANTAIN"), SqlTypes.STRING)
             .valueColumn(ColumnName.of("CITRUS"), SqlTypes.INTEGER)

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderTest.java
@@ -58,11 +58,11 @@ import org.mockito.junit.MockitoRule;
 
 public class StreamGroupByBuilderTest {
 
-  private static final KeyBuilder STRING_KEY_BUILDER = StructKeyUtil.keyBuilder(SqlTypes.STRING);
-
+  private static final KeyBuilder STRING_KEY_BUILDER = StructKeyUtil
+      .keyBuilder(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING);
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
       .withRowTime()
-      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
+      .keyColumn(ColumnName.of("K0"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("PAC"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("MAN"), SqlTypes.STRING)
       .build()

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderTest.java
@@ -64,7 +64,7 @@ public class StreamSelectKeyBuilderTest {
 
   private static final LogicalSchema SOURCE_SCHEMA = LogicalSchema.builder()
       .withRowTime()
-      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
+      .keyColumn(ColumnName.of("k0"), SqlTypes.DOUBLE)
       .valueColumn(ColumnName.of("BIG"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("BOI"), SqlTypes.BIGINT)
       .build()
@@ -79,17 +79,16 @@ public class StreamSelectKeyBuilderTest {
       .valueColumn(ColumnName.of("BIG"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("BOI"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of(SchemaUtil.ROWTIME_NAME.text()), SqlTypes.BIGINT)
-      // Note: Type of ROWKEY is old key's type:
-      .valueColumn(ColumnName.of(SchemaUtil.ROWKEY_NAME.text()), SqlTypes.STRING)
+      .valueColumn(ColumnName.of("k0"), SqlTypes.DOUBLE)
       .build();
 
   private static final KeyBuilder RESULT_KEY_BUILDER = StructKeyUtil.keyBuilder(RESULT_SCHEMA);
 
-
   private static final long A_BOI = 5000;
   private static final long A_BIG = 3000;
 
-  private static final Struct SOURCE_KEY = StructKeyUtil.keyBuilder(SqlTypes.STRING)
+  private static final Struct SOURCE_KEY = StructKeyUtil
+      .keyBuilder(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .build("dre");
 
   @Mock

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableGroupByBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableGroupByBuilderTest.java
@@ -59,7 +59,7 @@ public class TableGroupByBuilderTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
       .withRowTime()
-      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
+      .keyColumn(ColumnName.of("k0"), SqlTypes.DOUBLE)
       .valueColumn(ColumnName.of("PAC"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("MAN"), SqlTypes.STRING)
       .build()
@@ -94,7 +94,8 @@ public class TableGroupByBuilderTest {
       SerdeOption.none()
   );
 
-  private static final Struct KEY = StructKeyUtil.keyBuilder(SqlTypes.STRING).build("key");
+  private static final Struct KEY = StructKeyUtil
+      .keyBuilder(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING).build("key");
 
   @Mock
   private KsqlQueryBuilder queryBuilder;

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/KsqlMaterializationTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/KsqlMaterializationTest.java
@@ -41,7 +41,6 @@ import io.confluent.ksql.model.WindowType;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.util.SchemaUtil;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -61,12 +60,13 @@ public class KsqlMaterializationTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
       .withRowTime()
-      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
+      .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("v0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("v1"), SqlTypes.STRING)
       .build();
 
-  private static final Struct A_KEY = StructKeyUtil.keyBuilder(SqlTypes.STRING).build("k");
+  private static final Struct A_KEY = StructKeyUtil
+      .keyBuilder(ColumnName.of("k0"), SqlTypes.STRING).build("k");
   private static final long A_ROWTIME = 12335L;
   private static final Range<Instant> WINDOW_START_BOUNDS = Range.closed(
       Instant.now(),

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedSessionTableTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedSessionTableTest.java
@@ -59,11 +59,12 @@ public class KsMaterializedSessionTableTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
       .withRowTime()
-      .keyColumn(ColumnName.of("ROWKEY"), SqlTypes.STRING)
+      .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("v0"), SqlTypes.STRING)
       .build();
 
-  private static final Struct A_KEY = StructKeyUtil.keyBuilder(SqlTypes.STRING).build("x");
+  private static final Struct A_KEY = StructKeyUtil
+      .keyBuilder(ColumnName.of("k0"), SqlTypes.STRING).build("x");
   private static final GenericRow A_VALUE = GenericRow.genericRow("c0l");
 
   private static final Instant LOWER_INSTANT = Instant.now();

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedTableTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedTableTest.java
@@ -52,11 +52,12 @@ public class KsMaterializedTableTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
       .withRowTime()
-      .keyColumn(ColumnName.of("ROWKEY"), SqlTypes.STRING)
+      .keyColumn(ColumnName.of("K0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("v0"), SqlTypes.STRING)
       .build();
 
-  private static final Struct A_KEY = StructKeyUtil.keyBuilder(SqlTypes.STRING).build("x");
+  private static final Struct A_KEY = StructKeyUtil
+      .keyBuilder(ColumnName.of("K0"), SqlTypes.STRING).build("x");
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedWindowTableTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedWindowTableTest.java
@@ -35,7 +35,6 @@ import io.confluent.ksql.execution.util.StructKeyUtil;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.util.SchemaUtil;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -64,11 +63,12 @@ public class KsMaterializedWindowTableTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
       .withRowTime()
-      .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
+      .keyColumn(ColumnName.of("K0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("v0"), SqlTypes.STRING)
       .build();
 
-  private static final Struct A_KEY = StructKeyUtil.keyBuilder(SqlTypes.STRING).build("x");
+  private static final Struct A_KEY = StructKeyUtil
+      .keyBuilder(ColumnName.of("K0"), SqlTypes.STRING).build("x");
 
   private static final Range<Instant> WINDOW_START_BOUNDS = Range.closed(
       Instant.now(),


### PR DESCRIPTION
### Description 

Partial fix for: #3536

First part of supporting key column names other than `ROWKEY`.

With this initial pass you can now name your key columns anything you want in your `CREATE TABLE` and `CREATE STREAM` statements, e.g.

```sql
CREATE STREAM S (ID INT KEY, NAME STRING) WITH (...);
```

Any GROUP BY, PARTITION BY or JOIN on the key column results any created data source having a key column with a matching name, e.g.

```sql
-- schema of T: ID INT KEY, COUNT BIGINT
CREATE TABLE T AS SELECT COUNT() AS COUNT FROM S GROUP BY ID;
```

Pull and push queries work as expected and quoted identifiers work too.

However, this functionality is not complete yet. Hence it is guarded by the `ksql.any.key.name.enabled` feature flag, which defaults to off. The following big ticket items are remaining:

* PARTITION BY a single value column should result in a stream with the key column that matches the value column name.
* GROUP BY a single value column should result in a table with the key column that matches the value column name.
* JOIN on a single value column should  result in a stream/table with the key column that matches the value column name.

This additional work will be tracked under the same ticket, e.g. #3536

### Reviewing notes:

Documentation changes will be done in a separate PR: https://github.com/confluentinc/ksql/pull/4686 (WIP)

Some changes are just renaming vars/funcs so that they no longer contain 'rowkey' in their names. This may seem unnecessary. However, use of `ROWKEY` is _deeply_ ingrained in the code base. I'm having to search for 'rowkey' as part of this work. So these renames are mainly just so that they don't show up in my next search.

PR is broken down into the following commits to help with reviewing:

1. Production code changes.
2. Test code, including JSON based tests, changes.
     - Note: some of the QTT / RQTT tests now have duplicate versions: 1 version using `ROWKEY` and a new version using a custom key column name.  The old `ROWKEY` version will be removed once this feature is complete.
3. Historical test plans committed.

### Testing done 

Extensive (R)QTT testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

