### PR TITLE
chore: prevent historical plans from showing up in the diff

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+ksql-functional-tests/src/test/resources/historical_plans/** linguist-generated=true
+ksql-functional-tests/src/test/resources/historical_plans/** -diff -merge

--- a/ksql-functional-tests/src/test/resources/historical_plans/floating-point_-_with_exponent/5.5.0_1581572089992/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/floating-point_-_with_exponent/5.5.0_1581572089992/spec.json
@@ -1,6 +1,7 @@
 {
   "version" : "5.5.0",
   "timestamp" : 1581572089992,
+
   "schemas" : {
     "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<ID INT> NOT NULL",
     "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<ID INT> NOT NULL"


### PR DESCRIPTION
### Description 
This adds a `.gitattributes` file so that historical plans will be treated as "binary" files (they won't show up in git diff as plain text). For example:
```
diff --git a/ksql-functional-tests/src/test/resources/historical_plans/floating-point_-_with_exponent/5.5.0_1581572089992/spec.json b/ksql-functional-tests/src/test/resources/historical_plans/floating-point_-_with_exponent/5.5.0_1581572089992/spec.json
index 569971548..6347dcd14 100644
Binary files a/ksql-functional-tests/src/test/resources/historical_plans/floating-point_-_with_exponent/5.5.0_1581572089992/spec.json and b/ksql-functional-tests/src/test/resources/historical_plans/floating-point_-_with_exponent/5.5.0_1581572089992/spec.json differ
```

see: https://git-scm.com/docs/gitattributes

### Testing done 
Ran `git diff` locally

![image](https://user-images.githubusercontent.com/3172405/75909812-a38b1200-5e01-11ea-89e5-331fffba08c9.png)


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

