### PR TITLE
chore: add print topic support for JSON_SR

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/RecordFormatter.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/RecordFormatter.java
@@ -25,6 +25,7 @@ import com.google.protobuf.TextFormat;
 import com.google.protobuf.TextFormat.Printer;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer;
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializer;
 import io.confluent.ksql.json.JsonMapper;
 import java.io.IOException;
@@ -326,6 +327,7 @@ public final class RecordFormatter {
     AVRO(0, KafkaAvroDeserializer::new),
     PROTOBUF(0, RecordFormatter::newProtobufDeserializer),
     JSON(RecordFormatter::newJsonDeserializer),
+    JSON_SR(0, KafkaJsonSchemaDeserializer::new),
     KAFKA_INT(IntegerDeserializer::new),
     KAFKA_BIGINT(LongDeserializer::new),
     KAFKA_DOUBLE(DoubleDeserializer::new),


### PR DESCRIPTION
### Description 

fixes #4555 by adding support for `JSON_SR` in the print topic format detection

### Testing done 

unit tests, end-to-end testing:

```
ksql> print jsonsr from beginning;
Key format: ...
Value format: JSON_SR or KAFKA_STRING
rowtime: 3/4/20 2:34:43 PM PST, key: <null>, value: {"FOO":"123","BAR":123}
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

