### PR TITLE
test: avoid NPE if user puts input topic name in output

### DIFF
--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
@@ -209,7 +209,9 @@ public class TestExecutor implements Closeable {
         validateTopicData(
             kafkaTopic,
             expectedRecords,
-            actualByTopic.getOrDefault(kafkaTopic, ImmutableList.of()),
+            actualByTopic.getOrDefault(kafkaTopic, ImmutableList.of()).stream()
+                .filter(rec -> rec.getProducerRecord() != null)
+                .collect(Collectors.toList()),
             ranWithInsertStatements
         ));
   }


### PR DESCRIPTION
### Description 

Fixes an NPE when a user accidentally uses an input topic name in the output records section of a test case, e.g.

```json
{
      "name": "ooops - cut & paste error",
      "statements": [
        "CREATE STREAM INPUT (a DECIMAL(4,2), b DOUBLE) WITH (kafka_topic='input', value_format='AVRO');",
        "CREATE STREAM OUTPUT AS SELECT (a + b) AS RESULT FROM INPUT;"
      ],
      "inputs": [
        {"topic": "input", "key": "0", "value": {"A": "10.01", "B":  5.1}}
      ],
      "outputs": [
        {"topic": "input", "key": "0", "value": {"RESULT": 15.11}},
        {"topic": "TEST2", "key": "0", "value": {"RESULT": 5.01}},
        {"topic": "TEST2", "key": "0", "value": {"RESULT": 10.01}}
      ]
    }
```

Note: the reference to `input` in the `outputs`? This was causing an NPE. It now causes an error along the lines of:

```
Topic `input`: expected 1 message, got 0.
```

### Testing done 

Usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

