### PR TITLE
chore: do not reserve ROWKEY as system column name

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
@@ -57,7 +57,6 @@ public final class SchemaUtil {
   );
 
   private static final Set<ColumnName> SYSTEM_COLUMN_NAMES = ImmutableSet.<ColumnName>builder()
-      .add(ROWKEY_NAME)
       .add(ROWTIME_NAME)
       .addAll(WINDOW_BOUNDS_COLUMN_NAMES)
       .build();

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
@@ -174,18 +174,12 @@ public final class CreateSourceFactory {
     }
 
     tableElements.forEach(e -> {
-      final boolean isRowKey = e.getName().equals(SchemaUtil.ROWKEY_NAME);
-
-      if (!isRowKey && SchemaUtil.isSystemColumn(e.getName())) {
+      if (SchemaUtil.isSystemColumn(e.getName())) {
         throw new KsqlException("'" + e.getName().text() + "' is a reserved column name.");
       }
 
-      if (ksqlConfig.getBoolean(KsqlConfig.KSQL_ANY_KEY_NAME_ENABLED)) {
-        if (isRowKey && e.getNamespace() != Namespace.KEY) {
-          throw new KsqlException("'" + e.getName().text() + "' is a reserved column name. "
-              + "It can only be used for KEY columns.");
-        }
-      } else {
+      if (!ksqlConfig.getBoolean(KsqlConfig.KSQL_ANY_KEY_NAME_ENABLED)) {
+        final boolean isRowKey = e.getName().equals(SchemaUtil.ROWKEY_NAME);
         if (e.getNamespace() == Namespace.KEY) {
           if (!isRowKey) {
             throw new KsqlException("'" + e.getName().text() + "' is an invalid KEY column name. "

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
@@ -140,8 +140,9 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
         .collect(Collectors.joining(", "));
 
     if (!duplicates.isEmpty()) {
-      throw new KsqlException("Value column name(s) " + duplicates
-          + " clashes with key column name(s). Please remove or alias the column(s).");
+      throw new KsqlException("Value column name(s) " + duplicates + " clashes with key column "
+          + "name(s). Key column(s) are always copied to the output schema, unless there is a "
+          + "GROUP BY or PARTITION BY clause. Please remove or alias the duplicate column(s).");
     }
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -191,6 +191,8 @@ public class SchemaKStream<K> {
     final Optional<ColumnName> filtered = found
         // System columns can not be key fields:
         .filter(f -> !SchemaUtil.isSystemColumn(f.name()))
+        // Key columns can not be key fields:
+        .filter(f -> !schema.isKeyColumn(f.name()))
         .map(Column::name);
 
     return KeyField.of(filtered);

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -136,7 +136,7 @@ public class KsqlStructuredDataOutputNodeTest {
     // Expect:
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage("Value column name(s) `k0` "
-        + "clashes with key column name(s). Please remove or alias the column(s).");
+        + "clashes with key column name(s).");
 
     // When:
     buildNode();

--- a/ksql-functional-tests/src/test/resources/historical_plans/elements_-_should_allow_ROWKEY_as_value_column/6.0.0_1583762137584/plan.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/elements_-_should_allow_ROWKEY_as_value_column/6.0.0_1583762137584/plan.json
@@ -1,0 +1,146 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID INTEGER KEY, ROWKEY STRING) WITH (KAFKA_TOPIC='input', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` INTEGER KEY, `ROWKEY` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` INTEGER KEY, `ROWKEY` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`ID` INTEGER KEY, `ROWKEY` STRING"
+          },
+          "selectExpressions" : [ "ROWKEY AS ROWKEY" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent3637133868730669312",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/elements_-_should_allow_ROWKEY_as_value_column/6.0.0_1583762137584/spec.json
+++ b/ksql-functional-tests/src/test/resources/historical_plans/elements_-_should_allow_ROWKEY_as_value_column/6.0.0_1583762137584/spec.json
@@ -1,0 +1,22 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1583762137584,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<ROWKEY VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<ROWKEY VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "input",
+    "key" : 42,
+    "value" : {
+      "rowkey" : "a"
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 42,
+    "value" : {
+      "ROWKEY" : "a"
+    }
+  } ]
+}

--- a/ksql-functional-tests/src/test/resources/historical_plans/elements_-_should_allow_ROWKEY_as_value_column/6.0.0_1583762137584/topology
+++ b/ksql-functional-tests/src/test/resources/historical_plans/elements_-_should_allow_ROWKEY_as_value_column/6.0.0_1583762137584/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/elements.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/elements.json
@@ -603,7 +603,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Reserved column name in select: `ROWKEY`. Please remove or alias the column."
+        "message": "Value column name(s) `ROWKEY` clashes with key column name(s)."
       }
     },
     {
@@ -678,7 +678,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Reserved column name in select: `ROWKEY`. Please remove or alias the column."
+        "message": "Value column name(s) `ROWKEY` clashes with key column name(s)."
       }
     },
     {
@@ -747,7 +747,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlException",
-        "message": "Reserved column name in select: `ROWKEY`. Please remove or alias the column."
+        "message": "Value column name(s) `ROWKEY` clashes with key column name(s)."
       }
     },
     {
@@ -877,6 +877,33 @@
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlException",
         "message": "Column 'F0' is ambiguous."
+      }
+    },
+    {
+      "name": "should allow ROWKEY as value column",
+      "statements": [
+        "CREATE STREAM INPUT (id int key, rowkey string) WITH (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM input;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [{"topic": "input", "key": 42, "value": {"rowkey": "a"}}],
+      "outputs": [{"topic": "OUTPUT", "key": 42, "value": {"ROWKEY": "a"}}],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, ROWKEY STRING"}
+        ]
+      }
+    },
+    {
+      "name": "should not allow ROWKEY as value column - legacy",
+      "statements": [
+        "CREATE STREAM INPUT (rowkey int) WITH (kafka_topic='input', value_format='JSON');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "'ROWKEY' is a reserved column name. It can only be used for KEY columns."
       }
     }
   ]

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/system-columns.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/system-columns.json
@@ -20,8 +20,8 @@
         "CREATE STREAM OUTPUT AS SELECT x AS rowkey FROM INPUT;"
       ],
       "expectedException": {
-        "type": "io.confluent.ksql.parser.exception.ParseFailedException",
-        "message": "ROWKEY is a reserved system column name. You cannot use it as an alias for a column."
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Value column name(s) `ROWKEY` clashes with key column name(s)."
       }
     },
     {

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -443,15 +443,6 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void testReservedRowKeyAlias() {
-    expectedException.expect(ParseFailedException.class);
-    expectedException.expectMessage(containsString(
-        "ROWKEY is a reserved system column name. You cannot use it as an alias for a column."));
-
-    KsqlParserTestUtil.buildSingleAst("SELECT C2 as ROWKEY FROM test1 t1;", metaStore);
-  }
-
-  @Test
   public void shouldThrowOnNonAlphanumericSourceName() {
     // Expect:
     expectedException.expect(ParseFailedException.class);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PullQueryExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PullQueryExecutor.java
@@ -318,8 +318,7 @@ public final class PullQueryExecutor {
     );
   }
 
-  @VisibleForTesting
-  TableRowsEntity forwardTo(
+  private static TableRowsEntity forwardTo(
       final KsqlNode owner,
       final ConfiguredStatement<Query> statement,
       final ServiceContext serviceContext
@@ -775,9 +774,12 @@ public final class PullQueryExecutor {
     final boolean noSystemColumns = analysis.getSelectColumnRefs().stream()
         .noneMatch(SchemaUtil::isSystemColumn);
 
+    final boolean noKeyColumns = analysis.getSelectColumnRefs().stream()
+        .noneMatch(input.schema::isKeyColumn);
+
     final LogicalSchema intermediateSchema;
     final Function<TableRow, GenericRow> preSelectTransform;
-    if (noSystemColumns) {
+    if (noSystemColumns && noKeyColumns) {
       intermediateSchema = input.schema;
       preSelectTransform = TableRow::value;
     } else {


### PR DESCRIPTION
### Description 

With the work to allow key column names other than ROWKEY, suddenly `ROWKEY` is actually not a system column. It's just the default name of the key column. It shouldn't be treated any differently to any other key column name.

This change removes `ROWKEY` as a system column. This results in a few error messages changing, but little else.

Note: use of any key column name is still guarded by the `KsqlConfig.KSQL_ANY_KEY_NAME_ENABLED` feature flag.

### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

