### PR TITLE
test: include rows in row count mismatch error message in RQTT

### DIFF
--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
@@ -506,6 +506,8 @@ public class RestTestExecutor implements Closeable {
         new TypeReference<Map<String, Object>>() {
         };
 
+    private static final String INDENT = System.lineSeparator() + "\t";
+
     private final List<StreamedRow> rows;
 
     RqttQueryResponse(final List<StreamedRow> rows) {
@@ -525,7 +527,22 @@ public class RestTestExecutor implements Closeable {
 
       final List<?> expectedRows = (List<?>) expectedPayload;
 
-      assertThat("row count mismatch", rows.size(), is(expectedRows.size()));
+      assertThat(
+          "row count mismatch."
+              + System.lineSeparator()
+              + "Expected: "
+              + expectedRows.stream()
+              .map(Object::toString)
+              .collect(Collectors.joining(INDENT, INDENT, ""))
+              + System.lineSeparator()
+              + "Got: "
+              + rows.stream()
+              .map(Object::toString)
+              .collect(Collectors.joining(INDENT, INDENT, ""))
+              + System.lineSeparator(),
+          rows,
+          hasSize(expectedRows.size())
+      );
 
       for (int i = 0; i != rows.size(); ++i) {
         assertThat("Each row should JSON object", expectedRows.get(i), is(instanceOf(Map.class)));

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/StreamedRow.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/StreamedRow.java
@@ -134,6 +134,14 @@ public final class StreamedRow {
     return Objects.hash(header, row, errorMessage, finalMessage);
   }
 
+  @Override
+  public String toString() {
+    return header.map(Objects::toString)
+        .orElseGet(() -> row.map(Objects::toString)
+            .orElseGet(() -> errorMessage.map(Objects::toString)
+                .orElseGet(() -> finalMessage.map(Objects::toString).orElse(""))));
+  }
+
   private static void checkUnion(final Optional<?>... fs) {
     final long count = Arrays.stream(fs)
         .filter(Optional::isPresent)
@@ -188,6 +196,14 @@ public final class StreamedRow {
     @Override
     public int hashCode() {
       return Objects.hash(queryId, schema);
+    }
+
+    @Override
+    public String toString() {
+      return "Header{"
+          + "queryId=" + queryId
+          + ", schema=" + schema
+          + '}';
     }
   }
 }


### PR DESCRIPTION
### Description 

Improve the error message reported by RQTT when the row count does not match to include the expected and actual rows. This should aid tracking down issues when tests fail on the build server.

### Testing done 

Test only chage.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

