### PR TITLE
fix: adapt unit tests to the upgrade to junit 4.13

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
@@ -298,13 +298,13 @@ public class CliTest {
 
   private static void runStatement(final String statement, final KsqlRestClient restClient) {
     final RestResponse response = restClient.makeKsqlRequest(statement);
-    Assert.assertThat(response.isSuccessful(), is(true));
+    assertThat(response.isSuccessful(), is(true));
     final KsqlEntityList entityList = ((KsqlEntityList) response.get());
-    Assert.assertThat(entityList.size(), equalTo(1));
-    Assert.assertThat(entityList.get(0), instanceOf(CommandStatusEntity.class));
+    assertThat(entityList.size(), equalTo(1));
+    assertThat(entityList.get(0), instanceOf(CommandStatusEntity.class));
     final CommandStatusEntity entity = (CommandStatusEntity) entityList.get(0);
     final CommandStatus status = entity.getCommandStatus();
-    Assert.assertThat(status, not(CommandStatus.Status.ERROR));
+    assertThat(status, not(CommandStatus.Status.ERROR));
 
     if (status.getStatus() != Status.SUCCESS) {
       assertThatEventually(
@@ -312,8 +312,8 @@ public class CliTest {
           () -> {
             final RestResponse statusResponse = restClient
                 .makeStatusRequest(entity.getCommandId().toString());
-            Assert.assertThat(statusResponse.isSuccessful(), is(true));
-            Assert.assertThat(statusResponse.get(), instanceOf(CommandStatus.class));
+            assertThat(statusResponse.isSuccessful(), is(true));
+            assertThat(statusResponse.get(), instanceOf(CommandStatus.class));
             return ((CommandStatus) statusResponse.get()).getStatus();
           },
           anyOf(
@@ -673,10 +673,10 @@ public class CliTest {
     new Cli(1L, 1L, mockRestClient, terminal)
         .runInteractively();
 
-    Assert.assertThat(
+    assertThat(
         terminal.getOutputString(),
         containsString("This CLI version no longer supported"));
-    Assert.assertThat(
+    assertThat(
         terminal.getOutputString(),
         containsString("Minimum supported client version: 1.0"));
   }

--- a/ksql-cli/src/test/java/io/confluent/ksql/util/CliUtilsTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/util/CliUtilsTest.java
@@ -16,8 +16,8 @@
 package io.confluent.ksql.util;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableList;

--- a/ksql-common/src/test/java/io/confluent/ksql/config/ConfigItemTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/config/ConfigItemTest.java
@@ -15,10 +15,10 @@
 
 package io.confluent.ksql.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConstants;

--- a/ksql-common/src/test/java/io/confluent/ksql/metrics/ConsumerCollectorTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/metrics/ConsumerCollectorTest.java
@@ -1,8 +1,8 @@
 package io.confluent.ksql.metrics;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.common.utils.SystemTime;

--- a/ksql-common/src/test/java/io/confluent/ksql/metrics/MetricCollectorsTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/metrics/MetricCollectorsTest.java
@@ -1,8 +1,8 @@
 package io.confluent.ksql.metrics;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;

--- a/ksql-common/src/test/java/io/confluent/ksql/metrics/ProducerCollectorTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/metrics/ProducerCollectorTest.java
@@ -1,7 +1,7 @@
 package io.confluent.ksql.metrics;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Collection;
 import org.apache.kafka.clients.producer.ProducerRecord;

--- a/ksql-common/src/test/java/io/confluent/ksql/metrics/StreamsErrorCollectorTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/metrics/StreamsErrorCollectorTest.java
@@ -26,10 +26,10 @@ import static io.confluent.ksql.metrics.StreamsErrorCollector.CONSUMER_FAILED_ME
 import static io.confluent.ksql.metrics.StreamsErrorCollector.CONSUMER_FAILED_MESSAGES_PER_SEC;
 import static io.confluent.ksql.metrics.StreamsErrorCollector.notifyApplicationClose;
 import static io.confluent.ksql.metrics.StreamsErrorCollector.recordError;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
-import static org.junit.Assert.assertThat;
 
 public class StreamsErrorCollectorTest {
   private final static String TOPIC_NAME = "test-topic";

--- a/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
@@ -18,8 +18,8 @@ import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.junit.matchers.JUnitMatchers.isThrowable;
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/DropSourceCommandTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/DropSourceCommandTest.java
@@ -1,7 +1,7 @@
 package io.confluent.ksql.ddl.commands;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/InternalFunctionRegistryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/InternalFunctionRegistryTest.java
@@ -15,11 +15,13 @@
 
 package io.confluent.ksql.function;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -30,9 +32,7 @@ import java.util.List;
 import java.util.function.Supplier;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.kstream.Merger;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class InternalFunctionRegistryTest {
 
@@ -55,9 +55,6 @@ public class InternalFunctionRegistryTest {
       Collections.emptyList(),
       "func",
       Func1.class);
-
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void shouldAddFunction() {
@@ -196,8 +193,7 @@ public class InternalFunctionRegistryTest {
 
   @Test
   public void shouldThrowExceptionIfNoFunctionsWithNameExist() {
-    expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("'foo_bar'");
-    functionRegistry.getUdfFactory("foo_bar");
+    Exception e = assertThrows(KsqlException.class, () -> functionRegistry.getUdfFactory("foo_bar"));
+    assertThat(e.getMessage(), containsString("'foo_bar'"));
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/KudafUndoAggregatorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/KudafUndoAggregatorTest.java
@@ -17,7 +17,7 @@ package io.confluent.ksql.function;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.function.udaf.KudafUndoAggregator;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/array/CollectListUdafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/array/CollectListUdafTest.java
@@ -15,11 +15,11 @@
 
 package io.confluent.ksql.function.udaf.array;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
 
 import io.confluent.ksql.function.udaf.TableUdaf;
 import java.util.List;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/array/CollectSetUdafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/array/CollectSetUdafTest.java
@@ -15,11 +15,11 @@
 
 package io.confluent.ksql.function.udaf.array;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
 import io.confluent.ksql.function.udaf.Udaf;
 import java.util.List;
 import org.junit.Test;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/map/HistogramUdafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/map/HistogramUdafTest.java
@@ -15,10 +15,10 @@
 
 package io.confluent.ksql.function.udaf.map;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
 import io.confluent.ksql.function.udaf.TableUdaf;
 import java.util.Map;
 import org.junit.Test;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/max/IntegerMaxKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/max/IntegerMaxKudafTest.java
@@ -17,7 +17,7 @@ package io.confluent.ksql.function.udaf.max;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import java.util.Collections;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/min/IntegerMinKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/min/IntegerMinKudafTest.java
@@ -17,7 +17,7 @@ package io.confluent.ksql.function.udaf.min;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import java.util.Collections;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/placeholder/PlaceholderTableUdafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/placeholder/PlaceholderTableUdafTest.java
@@ -15,9 +15,9 @@
 
 package io.confluent.ksql.function.udaf.placeholder;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 
 import io.confluent.ksql.function.udaf.TableUdaf;
 import org.junit.Test;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/BaseSumKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/BaseSumKudafTest.java
@@ -1,7 +1,7 @@
 package io.confluent.ksql.function.udaf.sum;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.confluent.ksql.function.TableAggregationFunction;
 import java.util.List;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/DoubleSumKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/DoubleSumKudafTest.java
@@ -1,7 +1,7 @@
 package io.confluent.ksql.function.udaf.sum;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import java.util.Collections;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/IntegerSumKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/IntegerSumKudafTest.java
@@ -1,7 +1,7 @@
 package io.confluent.ksql.function.udaf.sum;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import java.util.Collections;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/LongSumKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/LongSumKudafTest.java
@@ -1,7 +1,7 @@
 package io.confluent.ksql.function.udaf.sum;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import java.util.Collections;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/DoubleTopkKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/DoubleTopkKudafTest.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.function.udaf.topk;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.function.KsqlAggregateFunction;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/IntTopkKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/IntTopkKudafTest.java
@@ -17,7 +17,7 @@ package io.confluent.ksql.function.udaf.topk;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.function.KsqlAggregateFunction;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/LongTopkKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/LongTopkKudafTest.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.function.udaf.topk;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.function.KsqlAggregateFunction;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/StringTopkKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/StringTopkKudafTest.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.function.udaf.topk;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.function.KsqlAggregateFunction;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/DoubleTopkDistinctKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/DoubleTopkDistinctKudafTest.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.function.udaf.topkdistinct;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/IntTopkDistinctKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/IntTopkDistinctKudafTest.java
@@ -17,7 +17,7 @@ package io.confluent.ksql.function.udaf.topkdistinct;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/LongTopkDistinctKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/LongTopkDistinctKudafTest.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.function.udaf.topkdistinct;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/StringTopkDistinctKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/StringTopkDistinctKudafTest.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.function.udaf.topkdistinct;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/DateToStringTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/DateToStringTest.java
@@ -16,22 +16,19 @@
 package io.confluent.ksql.function.udf.datetime;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import io.confluent.ksql.function.KsqlFunctionException;
 import java.util.stream.IntStream;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class DateToStringTest {
 
   private DateToString udf;
-
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
 
   @Before
   public void setUp() {
@@ -71,9 +68,8 @@ public class DateToStringTest {
 
   @Test
   public void shouldThrowIfFormatInvalid() {
-    expectedException.expect(KsqlFunctionException.class);
-    expectedException.expectMessage("Failed to format date 44444 with formatter 'invalid'");
-    udf.dateToString(44444, "invalid");
+    Exception e = assertThrows(KsqlFunctionException.class, () -> udf.dateToString(44444, "invalid"));
+    assertEquals("Failed to format date 44444 with formatter 'invalid'", e.getMessage());
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/StringToDateTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/StringToDateTest.java
@@ -16,22 +16,19 @@
 package io.confluent.ksql.function.udf.datetime;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import io.confluent.ksql.function.KsqlFunctionException;
 import java.util.stream.IntStream;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class StringToDateTest {
 
   private StringToDate udf;
-
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
 
   @Before
   public void setUp() {
@@ -58,23 +55,20 @@ public class StringToDateTest {
 
   @Test
   public void shouldThrowIfFormatInvalid() {
-    expectedException.expect(KsqlFunctionException.class);
-    expectedException.expectMessage("Failed to parse date '2021-12-01' with formatter 'invalid'");
-    udf.stringToDate("2021-12-01", "invalid");
+    Exception e = assertThrows(KsqlFunctionException.class, () -> udf.stringToDate("2021-12-01", "invalid"));
+    assertEquals("Failed to parse date '2021-12-01' with formatter 'invalid'", e.getMessage());
   }
 
   @Test
   public void shouldThrowIfParseFails() {
-    expectedException.expect(KsqlFunctionException.class);
-    expectedException.expectMessage("Failed to parse date 'invalid' with formatter 'yyyy-MM-dd'");
-    udf.stringToDate("invalid", "yyyy-MM-dd");
+    Exception e = assertThrows(KsqlFunctionException.class, () -> udf.stringToDate("invalid", "yyyy-MM-dd"));
+    assertEquals("Failed to parse date 'invalid' with formatter 'yyyy-MM-dd'", e.getMessage());
   }
 
   @Test
   public void shouldThrowOnEmptyString() {
-    expectedException.expect(KsqlFunctionException.class);
-    expectedException.expectMessage("Failed to parse date '' with formatter 'yyyy-MM-dd'");
-    udf.stringToDate("", "yyyy-MM-dd");
+    Exception e = assertThrows(KsqlFunctionException.class, () -> udf.stringToDate("", "yyyy-MM-dd"));
+    assertEquals("Failed to parse date '' with formatter 'yyyy-MM-dd'", e.getMessage());
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/StringToTimestampTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/StringToTimestampTest.java
@@ -16,7 +16,9 @@
 package io.confluent.ksql.function.udf.datetime;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import io.confluent.ksql.function.KsqlFunctionException;
 import java.text.ParseException;
@@ -24,16 +26,11 @@ import java.text.SimpleDateFormat;
 import java.util.stream.IntStream;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class StringToTimestampTest {
 
   private StringToTimestamp udf;
-
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
 
   @Before
   public void setUp() {
@@ -86,23 +83,20 @@ public class StringToTimestampTest {
 
   @Test
   public void shouldThrowIfFormatInvalid() {
-    expectedException.expect(KsqlFunctionException.class);
-    expectedException.expectMessage("Unknown pattern letter: i");
-    udf.stringToTimestamp("2021-12-01 12:10:11.123", "invalid");
+    Exception e = assertThrows(KsqlFunctionException.class, () -> udf.stringToTimestamp("2021-12-01 12:10:11.123", "invalid"));
+    assertEquals("Unknown pattern letter: i", e.getMessage());
   }
 
   @Test
   public void shouldThrowIfParseFails() {
-    expectedException.expect(KsqlFunctionException.class);
-    expectedException.expectMessage("Text 'invalid' could not be parsed at index 0");
-    udf.stringToTimestamp("invalid", "yyyy-MM-dd'T'HH:mm:ss.SSS");
+    Exception e = assertThrows(KsqlFunctionException.class, () -> udf.stringToTimestamp("invalid", "yyyy-MM-dd'T'HH:mm:ss.SSS"));
+    assertEquals("Text 'invalid' could not be parsed at index 0", e.getMessage());
   }
 
   @Test
   public void shouldThrowOnEmptyString() {
-    expectedException.expect(KsqlFunctionException.class);
-    expectedException.expectMessage("Text '' could not be parsed at index 0");
-    udf.stringToTimestamp("", "yyyy-MM-dd'T'HH:mm:ss.SSS");
+    Exception e = assertThrows(KsqlFunctionException.class, () -> udf.stringToTimestamp("", "yyyy-MM-dd'T'HH:mm:ss.SSS"));
+    assertEquals("Text '' could not be parsed at index 0", e.getMessage());
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/TimestampToStringTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/TimestampToStringTest.java
@@ -16,7 +16,9 @@
 package io.confluent.ksql.function.udf.datetime;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import io.confluent.ksql.function.KsqlFunctionException;
 import java.text.SimpleDateFormat;
@@ -24,16 +26,11 @@ import java.util.Date;
 import java.util.stream.IntStream;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class TimestampToStringTest {
 
   private TimestampToString udf;
-
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
 
   @Before
   public void setUp() {
@@ -94,10 +91,8 @@ public class TimestampToStringTest {
 
   @Test
   public void shouldThrowIfInvalidTimeZone() {
-    expectedException.expect(KsqlFunctionException.class);
-    expectedException.expectMessage("Unknown time-zone ID: PST");
-    udf.timestampToString(1638360611123L,
-        "yyyy-MM-dd HH:mm:ss.SSS", "PST");
+    Exception e = assertThrows(KsqlFunctionException.class, () -> udf.timestampToString(1638360611123L, "yyyy-MM-dd HH:mm:ss.SSS", "PST"));
+    assertEquals("Unknown time-zone ID: PST", e.getMessage());
   }
 
   @Test
@@ -114,9 +109,8 @@ public class TimestampToStringTest {
 
   @Test
   public void shouldThrowIfFormatInvalid() {
-    expectedException.expect(KsqlFunctionException.class);
-    expectedException.expectMessage("Unknown pattern letter: i");
-    udf.timestampToString(1638360611123L, "invalid");
+    Exception e = assertThrows(KsqlFunctionException.class, () -> udf.timestampToString(1638360611123L, "invalid"));
+    assertEquals("Unknown pattern letter: i", e.getMessage());
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/geo/GeoDistanceKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/geo/GeoDistanceKudfTest.java
@@ -1,17 +1,15 @@
 package io.confluent.ksql.function.udf.geo;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import io.confluent.ksql.function.KsqlFunctionException;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class GeoDistanceKudfTest {
   private GeoDistanceKudf distanceUdf = new GeoDistanceKudf();
-
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
 
   /*
    * Compute distance between Palo Alto and London Confluent offices.
@@ -55,31 +53,31 @@ public class GeoDistanceKudfTest {
 
   @Test
   public void shouldFailWithTooFewParams() {
-    expectedException.expect(KsqlFunctionException.class);
-    expectedException.expectMessage("GeoDistance function expects either 4 or 5 arguments");
-    distanceUdf.evaluate(37.4439, -122.1663);
+    Exception e = assertThrows(KsqlFunctionException.class,
+        () -> distanceUdf.evaluate(37.4439, -122.1663));
+    assertEquals("GeoDistance function expects either 4 or 5 arguments", e.getMessage());
   }
 
   @Test
   public void shouldFailWithTooManyParams() {
-    expectedException.expect(KsqlFunctionException.class);
-    expectedException.expectMessage("GeoDistance function expects either 4 or 5 arguments");
-    distanceUdf.evaluate(37.4439, -122.1663, 51.5257, -0.1122, "Foo", "Bar");
+    Exception e = assertThrows(KsqlFunctionException.class,
+        () -> distanceUdf.evaluate(37.4439, -122.1663, 51.5257, -0.1122, "Foo", "Bar"));
+    assertEquals("GeoDistance function expects either 4 or 5 arguments", e.getMessage());
   }
   /**
    * Valid values for latitude range from -90->90 decimal degrees, and longitude is from -180->180
    */
   @Test
   public void shouldFailOutOfBoundsCoordinates() {
-    expectedException.expect(KsqlFunctionException.class);
-    expectedException.expectMessage("valid latitude values");
-    distanceUdf.evaluate(90.1, -122.1663, -91.5257, -0.1122);
+    Exception e = assertThrows(KsqlFunctionException.class,
+        () -> distanceUdf.evaluate(90.1, -122.1663, -91.5257, -0.1122));
+    assertThat(e.getMessage(), containsString("valid latitude values"));
   }
 
   @Test
   public void shouldFailInvalidUnitOfMeasure() {
-    expectedException.expect(KsqlFunctionException.class);
-    expectedException.expectMessage("GeoDistance function fifth parameter must be");
-    distanceUdf.evaluate(37.4439, -122.1663, 51.5257, -0.1122, "Widget");
+    Exception e = assertThrows(KsqlFunctionException.class,
+        () -> distanceUdf.evaluate(37.4439, -122.1663, 51.5257, -0.1122, "Widget"));
+    assertThat(e.getMessage(), containsString("GeoDistance function fifth parameter must be"));
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/json/JsonExtractStringKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/json/JsonExtractStringKudfTest.java
@@ -17,7 +17,7 @@ package io.confluent.ksql.function.udf.json;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.KudfTester;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/math/AbsKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/math/AbsKudfTest.java
@@ -15,9 +15,9 @@
 
 package io.confluent.ksql.function.udf.math;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 
 import io.confluent.ksql.function.udf.KudfTester;
 import org.junit.Before;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/ConcatKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/ConcatKudfTest.java
@@ -15,8 +15,8 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import io.confluent.ksql.function.udf.KudfTester;
 import org.junit.Before;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/MaskKeepLeftKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/MaskKeepLeftKudfTest.java
@@ -15,20 +15,17 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import io.confluent.ksql.function.KsqlFunctionException;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class MaskKeepLeftKudfTest {
   private final MaskKeepLeftKudf udf = new MaskKeepLeftKudf();
-
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void shouldNotMaskFirstNChars() {
@@ -44,9 +41,8 @@ public class MaskKeepLeftKudfTest {
 
   @Test
   public void shouldThrowIfLengthIsNegative() {
-    expectedException.expect(KsqlFunctionException.class);
-    expectedException.expectMessage("mask_keep_left requires a non-negative number");
-    final String result = udf.mask("AbCd#$123xy Z", -1);
+    Exception e = assertThrows(KsqlFunctionException.class, () -> udf.mask("AbCd#$123xy Z", -1));
+    assertThat(e.getMessage(), containsString("mask_keep_left requires a non-negative number"));
  }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/MaskKeepRightKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/MaskKeepRightKudfTest.java
@@ -15,20 +15,17 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import io.confluent.ksql.function.KsqlFunctionException;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class MaskKeepRightKudfTest {
   private final MaskKeepRightKudf udf = new MaskKeepRightKudf();
-
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void shouldNotMaskLastNChars() {
@@ -44,9 +41,8 @@ public class MaskKeepRightKudfTest {
 
   @Test
   public void shouldThrowIfLengthIsNegative() {
-    expectedException.expect(KsqlFunctionException.class);
-    expectedException.expectMessage("mask_keep_right requires a non-negative number");
-    final String result = udf.mask("AbCd#$123xy Z", -1);
+    Exception e = assertThrows(KsqlFunctionException.class, () -> udf.mask("AbCd#$123xy Z", -1));
+    assertThat(e.getMessage(), containsString("mask_keep_right requires a non-negative number"));
  }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/MaskKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/MaskKudfTest.java
@@ -17,7 +17,7 @@ package io.confluent.ksql.function.udf.string;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/MaskLeftKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/MaskLeftKudfTest.java
@@ -15,20 +15,17 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import io.confluent.ksql.function.KsqlFunctionException;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class MaskLeftKudfTest {
   private final MaskLeftKudf udf = new MaskLeftKudf();
-
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void shouldMaskFirstNChars() {
@@ -44,9 +41,8 @@ public class MaskLeftKudfTest {
 
   @Test
   public void shouldThrowIfLengthIsNegative() {
-    expectedException.expect(KsqlFunctionException.class);
-    expectedException.expectMessage("mask_left requires a non-negative number");
-    final String result = udf.mask("AbCd#$123xy Z", -1);
+    Exception e = assertThrows(KsqlFunctionException.class, () -> udf.mask("AbCd#$123xy Z", -1));
+    assertThat(e.getMessage(), containsString("mask_left requires a non-negative number"));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/MaskRightKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/MaskRightKudfTest.java
@@ -15,20 +15,17 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import io.confluent.ksql.function.KsqlFunctionException;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class MaskRightKudfTest {
   private final MaskRightKudf udf = new MaskRightKudf();
-
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void shouldMaskLastNChars() {
@@ -44,9 +41,8 @@ public class MaskRightKudfTest {
 
   @Test
   public void shouldThrowIfLengthIsNegative() {
-    expectedException.expect(KsqlFunctionException.class);
-    expectedException.expectMessage("mask_right requires a non-negative number");
-    final String result = udf.mask("AbCd#$123xy Z", -1);
+    Exception e = assertThrows(KsqlFunctionException.class, () -> udf.mask("AbCd#$123xy Z", -1));
+    assertThat(e.getMessage(), containsString("mask_right requires a non-negative number"));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/SubstringTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/SubstringTest.java
@@ -17,7 +17,7 @@ package io.confluent.ksql.function.udf.string;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.util.KsqlConfig;

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
@@ -15,13 +15,13 @@
 package io.confluent.ksql.integration;
 
 import static java.lang.String.format;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.GenericRow;

--- a/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -409,13 +409,13 @@ public class PhysicalPlanBuilderTest {
     final Properties props = calls.get(0).props;
 
     Object val = props.get(StreamsConfig.consumerPrefix(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG));
-    Assert.assertThat(val, instanceOf(List.class));
+    assertThat(val, instanceOf(List.class));
     final List<String> consumerInterceptors = (List<String>) val;
     assertThat(consumerInterceptors.size(), equalTo(1));
     assertThat(ConsumerCollector.class, equalTo(Class.forName(consumerInterceptors.get(0))));
 
     val = props.get(StreamsConfig.producerPrefix(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG));
-    Assert.assertThat(val, instanceOf(List.class));
+    assertThat(val, instanceOf(List.class));
     final List<String> producerInterceptors = (List<String>) val;
     assertThat(producerInterceptors.size(), equalTo(1));
     assertThat(ProducerCollector.class, equalTo(Class.forName(producerInterceptors.get(0))));
@@ -494,14 +494,14 @@ public class PhysicalPlanBuilderTest {
     final Properties props = calls.get(0).props;
 
     Object val = props.get(StreamsConfig.consumerPrefix(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG));
-    Assert.assertThat(val, instanceOf(List.class));
+    assertThat(val, instanceOf(List.class));
     consumerInterceptors = (List<String>) val;
     assertThat(consumerInterceptors.size(), equalTo(2));
     assertThat(DummyConsumerInterceptor.class.getName(), equalTo(consumerInterceptors.get(0)));
     assertThat(ConsumerCollector.class, equalTo(Class.forName(consumerInterceptors.get(1))));
 
     val = props.get(StreamsConfig.producerPrefix(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG));
-    Assert.assertThat(val, instanceOf(List.class));
+    assertThat(val, instanceOf(List.class));
     producerInterceptors = (List<String>) val;
     assertThat(producerInterceptors.size(), equalTo(2));
     assertThat(DummyProducerInterceptor.class.getName(), equalTo(producerInterceptors.get(0)));
@@ -525,14 +525,14 @@ public class PhysicalPlanBuilderTest {
     final Properties props = calls.get(0).props;
 
     Object val = props.get(StreamsConfig.consumerPrefix(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG));
-    Assert.assertThat(val, instanceOf(List.class));
+    assertThat(val, instanceOf(List.class));
     final List<String> consumerInterceptors = (List<String>) val;
     assertThat(consumerInterceptors.size(), equalTo(2));
     assertThat(DummyConsumerInterceptor.class.getName(), equalTo(consumerInterceptors.get(0)));
     assertThat(ConsumerCollector.class, equalTo(Class.forName(consumerInterceptors.get(1))));
 
     val = props.get(StreamsConfig.producerPrefix(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG));
-    Assert.assertThat(val, instanceOf(List.class));
+    assertThat(val, instanceOf(List.class));
     final List<String> producerInterceptors = (List<String>) val;
     assertThat(producerInterceptors.size(), equalTo(2));
     assertThat(DummyProducerInterceptor.class.getName(), equalTo(producerInterceptors.get(0)));
@@ -573,7 +573,7 @@ public class PhysicalPlanBuilderTest {
 
     final Object val = props.get(
         StreamsConfig.consumerPrefix(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG));
-    Assert.assertThat(val, instanceOf(List.class));
+    assertThat(val, instanceOf(List.class));
     final List<String> consumerInterceptors = (List<String>) val;
     assertThat(consumerInterceptors.size(), equalTo(3));
     assertThat(DummyConsumerInterceptor.class.getName(), equalTo(consumerInterceptors.get(0)));

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
@@ -222,7 +222,7 @@ public class JoinNodeTest {
     try {
       buildJoin("SELECT t1.col0, t2.col0, t2.col1 FROM test1 t1 LEFT JOIN test2 t2 ON t1.col0 = t2.col0;");
     } catch (final KsqlException e) {
-      Assert.assertThat(e.getMessage(), equalTo(
+      assertThat(e.getMessage(), equalTo(
           "Can't join TEST1 with TEST2 since the number of partitions don't match. TEST1 "
           + "partitions = 1; TEST2 partitions = 2. Please repartition either one so that the "
           + "number of partitions match."

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
@@ -2,6 +2,7 @@ package io.confluent.ksql.structured;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.ksql.GenericRow;
@@ -77,7 +78,7 @@ public class SchemaKGroupedTableTest {
         initialSchemaKTable.getSchema(), null, false, () -> null);
     final SchemaKGroupedStream groupedSchemaKTable = initialSchemaKTable.groupBy(
         Serdes.String(), rowSerde, groupByExpressions);
-    Assert.assertThat(groupedSchemaKTable, instanceOf(SchemaKGroupedTable.class));
+    assertThat(groupedSchemaKTable, instanceOf(SchemaKGroupedTable.class));
     return (SchemaKGroupedTable)groupedSchemaKTable;
   }
 
@@ -101,7 +102,7 @@ public class SchemaKGroupedTableTest {
       );
       Assert.fail("Should fail to build topology for aggregation with window");
     } catch(final KsqlException e) {
-      Assert.assertThat(e.getMessage(), equalTo("Windowing not supported for table aggregations."));
+      assertThat(e.getMessage(), equalTo("Windowing not supported for table aggregations."));
     }
   }
 
@@ -126,7 +127,7 @@ public class SchemaKGroupedTableTest {
       );
       Assert.fail("Should fail to build topology for aggregation with unsupported function");
     } catch(final KsqlException e) {
-      Assert.assertThat(
+      assertThat(
           e.getMessage(),
           equalTo(
               "The aggregation function(s) (MAX, MIN) cannot be applied to a table."));

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
@@ -24,8 +24,8 @@ import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.ksql.GenericRow;

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SelectValueMapperTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SelectValueMapperTest.java
@@ -17,7 +17,7 @@ package io.confluent.ksql.structured;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.codegen.CodeGenRunner;

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/ArrayUtilTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/ArrayUtilTest.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.util;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Assert;
 import org.junit.Test;

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/AvroSchemaInferenceTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/AvroSchemaInferenceTest.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.util;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.confluent.connect.avro.AvroData;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/json/JsonPathTokenizerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/json/JsonPathTokenizerTest.java
@@ -17,7 +17,7 @@ package io.confluent.ksql.util.json;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;

--- a/ksql-examples/src/test/java/io/confluent/ksql/datagen/DataGenTest.java
+++ b/ksql-examples/src/test/java/io/confluent/ksql/datagen/DataGenTest.java
@@ -18,18 +18,17 @@ package io.confluent.ksql.datagen;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
-import org.junit.Rule;
+import io.confluent.ksql.util.KsqlException;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.Properties;
 
 import io.confluent.ksql.util.KsqlConfig;
 
 public class DataGenTest {
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
 
   @Test(expected = DataGen.Arguments.ArgumentParseException.class)
   public void shouldThrowOnUnknownFormat() throws Exception {
@@ -42,14 +41,12 @@ public class DataGenTest {
 
   @Test
   public void shouldThrowIfSchemaFileDoesNotExist() throws Exception {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage(containsString("File not found: you/won't/find/me/right?"));
-
-    DataGen.run(
+    Exception e = assertThrows(KsqlException.class, () -> DataGen.run(
         "schema=you/won't/find/me/right?",
         "format=avro",
         "topic=foo",
-        "key=id");
+        "key=id"));
+    assertThat(e.getMessage(), containsString("File not found: you/won't/find/me/right?"));
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/ExpressionFormatterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/ExpressionFormatterTest.java
@@ -15,8 +15,8 @@
 
 package io.confluent.ksql.parser;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.parser.tree.ArithmeticBinaryExpression;

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -20,10 +20,11 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -72,19 +73,13 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Ignore;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 
 public class KsqlParserTest {
 
   private static final KsqlParser KSQL_PARSER = new KsqlParser();
-
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
 
   private MetaStore metaStore;
 
@@ -729,7 +724,7 @@ public class KsqlParserTest {
     Assert.assertTrue(statement instanceof ListStreams);
     final ListStreams listStreams = (ListStreams) statement;
     Assert.assertTrue(listStreams.toString().equalsIgnoreCase("ListStreams{}"));
-    Assert.assertThat(listStreams.getShowExtended(), is(false));
+    assertThat(listStreams.getShowExtended(), is(false));
   }
 
   @Test
@@ -739,7 +734,7 @@ public class KsqlParserTest {
     Assert.assertTrue(statement instanceof ListTables);
     final ListTables listTables = (ListTables) statement;
     Assert.assertTrue(listTables.toString().equalsIgnoreCase("ListTables{}"));
-    Assert.assertThat(listTables.getShowExtended(), is(false));
+    assertThat(listTables.getShowExtended(), is(false));
   }
 
   @Test
@@ -747,9 +742,9 @@ public class KsqlParserTest {
     final String statementString = "SHOW QUERIES;";
     final Statement statement = KSQL_PARSER.buildAst(statementString, metaStore).get(0)
         .getStatement();
-    Assert.assertThat(statement, instanceOf(ListQueries.class));
+    assertThat(statement, instanceOf(ListQueries.class));
     final ListQueries listQueries = (ListQueries)statement;
-    Assert.assertThat(listQueries.getShowExtended(), is(false));
+    assertThat(listQueries.getShowExtended(), is(false));
   }
 
   @Test
@@ -856,9 +851,9 @@ public class KsqlParserTest {
     final String statementString = "SHOW STREAMS EXTENDED;";
     final Statement statement = KSQL_PARSER.buildAst(statementString, metaStore).get(0)
         .getStatement();
-    Assert.assertThat(statement, instanceOf(ListStreams.class));
+    assertThat(statement, instanceOf(ListStreams.class));
     final ListStreams listStreams = (ListStreams)statement;
-    Assert.assertThat(listStreams.getShowExtended(), is(true));
+    assertThat(listStreams.getShowExtended(), is(true));
   }
 
   @Test
@@ -866,9 +861,9 @@ public class KsqlParserTest {
     final String statementString = "SHOW TABLES EXTENDED;";
     final Statement statement = KSQL_PARSER.buildAst(statementString, metaStore).get(0)
         .getStatement();
-    Assert.assertThat(statement, instanceOf(ListTables.class));
+    assertThat(statement, instanceOf(ListTables.class));
     final ListTables listTables = (ListTables)statement;
-    Assert.assertThat(listTables.getShowExtended(), is(true));
+    assertThat(listTables.getShowExtended(), is(true));
   }
 
   @Test
@@ -876,9 +871,9 @@ public class KsqlParserTest {
     final String statementString = "SHOW QUERIES EXTENDED;";
     final Statement statement = KSQL_PARSER.buildAst(statementString, metaStore).get(0)
         .getStatement();
-    Assert.assertThat(statement, instanceOf(ListQueries.class));
+    assertThat(statement, instanceOf(ListQueries.class));
     final ListQueries listQueries = (ListQueries)statement;
-    Assert.assertThat(listQueries.getShowExtended(), is(true));
+    assertThat(listQueries.getShowExtended(), is(true));
   }
   
   private void assertQuerySucceeds(final String sql) {
@@ -1161,28 +1156,22 @@ public class KsqlParserTest {
 
   @Test
   public void testSelectWithOnlyColumns() {
-    expectedException.expect(ParseFailedException.class);
-    expectedException.expectMessage("line 1:21: extraneous input ';' expecting {',', 'FROM', 'INTO'}");
-
     final String simpleQuery = "SELECT ONLY, COLUMNS;";
-    KSQL_PARSER.buildAst(simpleQuery, metaStore);
+    Exception e = assertThrows(ParseFailedException.class, () -> KSQL_PARSER.buildAst(simpleQuery, metaStore));
+    assertThat(e.getMessage(), containsString("line 1:21: extraneous input ';' expecting {',', 'FROM', 'INTO'}"));
   }
 
   @Test
   public void testSelectWithMissingComma() {
-    expectedException.expect(ParseFailedException.class);
-    expectedException.expectMessage(containsString("line 1:12: extraneous input 'C' expecting"));
-
     final String simpleQuery = "SELECT A B C FROM address;";
-    KSQL_PARSER.buildAst(simpleQuery, metaStore);
+    Exception e = assertThrows(ParseFailedException.class, () -> KSQL_PARSER.buildAst(simpleQuery, metaStore));
+    assertThat(e.getMessage(), containsString("line 1:12: extraneous input 'C' expecting"));
   }
 
   @Test
   public void testSelectWithMultipleFroms() {
-    expectedException.expect(ParseFailedException.class);
-    expectedException.expectMessage(containsString("line 1:22: mismatched input ',' expecting"));
-
     final String simpleQuery = "SELECT * FROM address, itemid;";
-    KSQL_PARSER.buildAst(simpleQuery, metaStore);
+    Exception e = assertThrows(ParseFailedException.class, () -> KSQL_PARSER.buildAst(simpleQuery, metaStore));
+    assertThat(e.getMessage(), containsString("line 1:22: mismatched input ',' expecting"));
   }
 }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/util/ParserUtilTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/util/ParserUtilTest.java
@@ -3,8 +3,8 @@ package io.confluent.ksql.parser.util;
 import io.confluent.ksql.util.ParserUtil;
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
 
 public class ParserUtilTest {
   @Test

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/client/properties/LocalPropertyValidatorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/client/properties/LocalPropertyValidatorTest.java
@@ -19,17 +19,16 @@ import com.google.common.collect.ImmutableList;
 import java.util.Collection;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 
 public class LocalPropertyValidatorTest {
 
   private static final Collection<String> IMMUTABLE_PROPS =
       ImmutableList.of("immutable-1", "immutable-2");
-
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
 
   private LocalPropertyValidator validator;
 
@@ -40,10 +39,9 @@ public class LocalPropertyValidatorTest {
 
   @Test
   public void shouldThrowOnImmutableProp() {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("Cannot override property 'immutable-2'");
-
-    validator.validate("immutable-2", "anything");
+    Exception e = assertThrows(IllegalArgumentException.class,
+        () -> validator.validate("immutable-2", "anything"));
+    assertThat(e.getMessage(), containsString("Cannot override property 'immutable-2'"));
   }
 
   @Test
@@ -53,10 +51,9 @@ public class LocalPropertyValidatorTest {
 
   @Test
   public void shouldThrowOnNoneOffsetReset() {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("'none' is not valid for this property within KSQL");
-
-    validator.validate(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "none");
+    Exception e = assertThrows(IllegalArgumentException.class,
+        () -> validator.validate(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "none"));
+    assertThat(e.getMessage(), containsString("'none' is not valid for this property within KSQL"));
   }
 
   @Test

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/EntityQueryIDTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/EntityQueryIDTest.java
@@ -1,7 +1,7 @@
 package io.confluent.ksql.rest.entity;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.ksql.rest.util.JsonMapper;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/KsqlRequestTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/KsqlRequestTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThrows;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
@@ -31,9 +32,8 @@ import io.confluent.ksql.util.KsqlException;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
-import org.junit.Rule;
+
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 @SuppressWarnings("SameParameterValue")
 public class KsqlRequestTest {
@@ -50,9 +50,6 @@ public class KsqlRequestTest {
   );
 
   private static final KsqlRequest A_REQUEST = new KsqlRequest("sql", SOME_PROPS);
-
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void shouldHandleNullStatement() {
@@ -114,12 +111,10 @@ public class KsqlRequestTest {
         SINK_NUMBER_OF_REPLICAS_PROPERTY, "not-parsable"
     ));
 
-    expectedException.expect(KsqlException.class);
-    expectedException.expectMessage(containsString(SINK_NUMBER_OF_REPLICAS_PROPERTY));
-    expectedException.expectMessage(containsString("not-parsable"));
-
     // When:
-    request.getStreamsProperties();
+    Exception e = assertThrows(KsqlException.class, () -> request.getStreamsProperties());
+    assertThat(e.getMessage(), containsString(SINK_NUMBER_OF_REPLICAS_PROPERTY));
+    assertThat(e.getMessage(), containsString("not-parsable"));
   }
 
   @Test

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionTest.java
@@ -5,7 +5,7 @@ import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.niceMock;
 import static org.easymock.EasyMock.replay;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.function.FunctionRegistry;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SchemaDescriptionFormatTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SchemaDescriptionFormatTest.java
@@ -1,7 +1,7 @@
 package io.confluent.ksql.rest.entity;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/ServerInfoTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/ServerInfoTest.java
@@ -16,11 +16,11 @@
 package io.confluent.ksql.rest.entity;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.ksql.rest.util.JsonMapper;
 import java.io.IOException;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class ServerInfoTest {
@@ -35,6 +35,6 @@ public class ServerInfoTest {
     final ObjectMapper mapper = JsonMapper.INSTANCE.mapper;
     final byte[] bytes = mapper.writeValueAsBytes(serverInfo);
     final ServerInfo deserializedServerInfo = mapper.readValue(bytes, ServerInfo.class);
-    Assert.assertThat(serverInfo, equalTo(deserializedServerInfo));
+    assertThat(serverInfo, equalTo(deserializedServerInfo));
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionTest.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.rest.entity;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.metastore.KsqlStream;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestConfigTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestConfigTest.java
@@ -17,9 +17,9 @@ package io.confluent.ksql.rest.server;
 
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.util.KsqlConfig;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandTest.java
@@ -17,7 +17,7 @@ package io.confluent.ksql.rest.server.computation;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.ksql.rest.util.JsonMapper;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
@@ -80,15 +80,10 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 @SuppressWarnings("ConstantConditions")
 public class StatementExecutorTest extends EasyMockSupport {
-  @Rule
-  public ExpectedException exceptionRule = ExpectedException.none();
-
   private static final Map<String, String> PRE_VERSION_5_NULL_ORIGNAL_PROPS = null;
 
   private KsqlEngine ksqlEngine;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlExceptionMapperTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlExceptionMapperTest.java
@@ -3,7 +3,7 @@ package io.confluent.ksql.rest.server.resources;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.confluent.ksql.rest.entity.KsqlErrorMessage;
 import javax.ws.rs.WebApplicationException;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -19,13 +19,13 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/RootDocumentTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/RootDocumentTest.java
@@ -19,7 +19,7 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.replay;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StatusResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StatusResourceTest.java
@@ -21,8 +21,8 @@ import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.replay;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 import io.confluent.ksql.rest.entity.CommandStatus;
 import io.confluent.ksql.rest.entity.CommandStatuses;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StreamedQueryResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StreamedQueryResourceTest.java
@@ -27,8 +27,8 @@ import static org.easymock.EasyMock.verify;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpointTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpointTest.java
@@ -11,7 +11,7 @@ import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.reset;
 import static org.easymock.EasyMock.verify;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.util.concurrent.ListenableScheduledFuture;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/EntityUtilTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/EntityUtilTest.java
@@ -1,7 +1,7 @@
 package io.confluent.ksql.rest.util;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.confluent.ksql.rest.entity.FieldInfo;
 import java.util.List;

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/AvroDataTranslatorTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/AvroDataTranslatorTest.java
@@ -3,7 +3,7 @@ package io.confluent.ksql.serde.avro;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlGenericRowAvroSerializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlGenericRowAvroSerializerTest.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.serde.avro;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/connect/ConnectSchemaTranslatorTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/connect/ConnectSchemaTranslatorTest.java
@@ -18,7 +18,7 @@ package io.confluent.ksql.serde.connect;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerializerTest.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.serde.delimited;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.confluent.ksql.GenericRow;
 import java.util.Arrays;

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonSerializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonSerializerTest.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.serde.json;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/tls/ThreadLocalCloseableTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/tls/ThreadLocalCloseableTest.java
@@ -28,7 +28,7 @@ import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.replay;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 public class ThreadLocalCloseableTest {

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/tls/ThreadLocalDeserializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/tls/ThreadLocalDeserializerTest.java
@@ -30,7 +30,7 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.replay;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ThreadLocalDeserializerTest {
   @Test

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/tls/ThreadLocalSerializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/tls/ThreadLocalSerializerTest.java
@@ -30,7 +30,7 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.replay;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ThreadLocalSerializerTest {
   @Test

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/util/SerdeUtilsTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/util/SerdeUtilsTest.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.serde.util;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.confluent.ksql.util.KsqlException;
 import org.junit.Test;

--- a/ksql-version-metrics-client/src/test/java/io/confluent/ksql/version/metrics/collector/BasicCollectorTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/ksql/version/metrics/collector/BasicCollectorTest.java
@@ -15,8 +15,8 @@
 
 package io.confluent.ksql.version.metrics.collector;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
 import io.confluent.ksql.version.metrics.KsqlVersionMetrics;

--- a/ksql-version-metrics-client/src/test/java/io/confluent/ksql/version/metrics/collector/KsqlModuleTypeTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/ksql/version/metrics/collector/KsqlModuleTypeTest.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.version.metrics.collector;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.confluent.support.metrics.validate.KSqlValidModuleType;
 import io.confluent.support.metrics.validate.MetricsValidation;


### PR DESCRIPTION
Adapt tests to the upgrade to junit 4.13 by replacing the deprecated method `assertThat` and the deprecated rule `ExpectedException` with hamcrest's `assertThat` and junit's `assertThrows`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

