### PR TITLE
fix: fix the half-fixed json decimal tests

### DIFF
--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonSerializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonSerializerTest.java
@@ -328,9 +328,13 @@ public class KsqlJsonSerializerTest {
     assertThat(asJsonString(bytes), is("1.234567890123456789"));
   }
 
-  @Ignore // Until https://github.com/confluentinc/ksql/issues/4710 is done.
   @Test
   public void shouldSerializeDecimalsWithoutStrippingTrailingZeros() {
+    // Get rid of this once currentlyDoesStripTrailingZerosButShouldNot is removed
+    if (!useSchemas) {
+      return;
+    }
+
     // Given:
     givenSerializerForSchema(DecimalUtil.builder(3,1).build());
 
@@ -348,6 +352,10 @@ public class KsqlJsonSerializerTest {
    */
   @Test
   public void currentlyDoesStripTrailingZerosButShouldNot() {
+    if (useSchemas) {
+      return;
+    }
+
     // Given:
     givenSerializerForSchema(DecimalUtil.builder(3,1).build());
 


### PR DESCRIPTION
One of our serializers has a fix for correctly formatting decimals,
the other one doesnt. So update the json test cases to reflect this

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

