### PR TITLE
feat: add internal request to KsqlRequestConfig and SessionProperties

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlRequestConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlRequestConfig.java
@@ -28,9 +28,15 @@ public class KsqlRequestConfig extends AbstractConfig {
 
   public static final String KSQL_REQUEST_QUERY_PULL_SKIP_FORWARDING =
       "request.ksql.query.pull.skip.forwarding";
-  public static final Boolean KSQL_REQUEST_QUERY_PULL_SKIP_FORWARDING_DEFAULT = false;
+  public static final boolean KSQL_REQUEST_QUERY_PULL_SKIP_FORWARDING_DEFAULT = false;
   private static final String KSQL_REQUEST_QUERY_PULL_SKIP_FORWARDING_DOC =
       "Controls whether a ksql host forwards a pull query request to another host";
+
+  public static final String KSQL_REQUEST_INTERNAL_REQUEST =
+      "request.ksql.internal.request";
+  public static final boolean KSQL_REQUEST_INTERNAL_REQUEST_DEFAULT = false;
+  private static final String KSQL_REQUEST_INTERNAL_REQUEST_DOC =
+      "Indicates whether a KsqlRequest came from another server ";
 
   private static ConfigDef buildConfigDef() {
     final ConfigDef configDef = new ConfigDef()
@@ -40,6 +46,12 @@ public class KsqlRequestConfig extends AbstractConfig {
             KSQL_REQUEST_QUERY_PULL_SKIP_FORWARDING_DEFAULT,
             ConfigDef.Importance.MEDIUM,
             KSQL_REQUEST_QUERY_PULL_SKIP_FORWARDING_DOC
+        ).define(
+            KSQL_REQUEST_INTERNAL_REQUEST,
+            Type.BOOLEAN,
+            KSQL_REQUEST_INTERNAL_REQUEST_DEFAULT,
+            ConfigDef.Importance.LOW,
+            KSQL_REQUEST_INTERNAL_REQUEST_DOC
         );
     return configDef;
   }

--- a/ksqldb-common/src/test/java/io/confluent/ksql/util/KsqlRestConfigTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/util/KsqlRestConfigTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Collections;
+import org.junit.Test;
+
+public class KsqlRestConfigTest {
+  
+  @Test
+  public void shouldUseDefaultValuesWhenConfigNotPresent() {
+    final KsqlRequestConfig requestConfig = new KsqlRequestConfig(Collections.emptyMap());
+    assertThat(requestConfig.getBoolean(KsqlRequestConfig.KSQL_REQUEST_INTERNAL_REQUEST), is(false));
+    assertThat(requestConfig.getBoolean(KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_SKIP_FORWARDING), is(false));
+  }
+}

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutorUtil.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutorUtil.java
@@ -333,7 +333,8 @@ public final class TestExecutorUtil {
           new SessionProperties(
               requireNonNull(overrides, "overrides"),
               new KsqlHostInfo("host", 50),
-              buildUrl());
+              buildUrl(),
+              false);
       this.ksqlConfig = requireNonNull(ksqlConfig, "ksqlConfig");
       this.stubKafkaService = requireNonNull(stubKafkaService, "stubKafkaService");
       this.schemaInjector = requireNonNull(schemaInjector, "schemaInjector");

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -55,6 +55,7 @@ import io.confluent.ksql.statement.Injectors;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlHostInfo;
+import io.confluent.ksql.util.KsqlRequestConfig;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.version.metrics.ActivenessRegistrar;
 import java.net.URL;
@@ -218,7 +219,8 @@ public class KsqlResource implements KsqlConfigurable {
           new SessionProperties(
               request.getStreamsProperties(),
               localHost,
-              localUrl
+              localUrl,
+              false
           )
       );
       return Response.ok(entities).build();
@@ -245,6 +247,8 @@ public class KsqlResource implements KsqlConfigurable {
           request,
           distributedCmdResponseTimeout);
 
+      final KsqlRequestConfig requestConfig =
+          new KsqlRequestConfig(request.getRequestProperties());
       final List<ParsedStatement> statements = ksqlEngine.parse(request.getKsql());
       validator.validate(
           SandboxedServiceContext.create(securityContext.getServiceContext()),
@@ -252,7 +256,8 @@ public class KsqlResource implements KsqlConfigurable {
           new SessionProperties(
               request.getConfigOverrides(),
               localHost, 
-              localUrl
+              localUrl,
+              requestConfig.getBoolean(KsqlRequestConfig.KSQL_REQUEST_INTERNAL_REQUEST)
           ),
           request.getKsql()
       );
@@ -263,7 +268,8 @@ public class KsqlResource implements KsqlConfigurable {
           new SessionProperties(
               request.getConfigOverrides(),
               localHost,
-              localUrl
+              localUrl,
+              requestConfig.getBoolean(KsqlRequestConfig.KSQL_REQUEST_INTERNAL_REQUEST)
           )
       );
       return Response.ok(entities).build();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PropertyExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PropertyExecutorTest.java
@@ -46,7 +46,7 @@ public class PropertyExecutorTest {
   public void shouldSetProperty() {
     // Given:
     final SessionProperties sessionProperties =
-        new SessionProperties(new HashMap<>(), mock(KsqlHostInfo.class), mock(URL.class));
+        new SessionProperties(new HashMap<>(), mock(KsqlHostInfo.class), mock(URL.class), false);
     final Map<String, Object> properties = sessionProperties.getMutableScopedProperties();
 
     // When:
@@ -69,7 +69,8 @@ public class PropertyExecutorTest {
         new SessionProperties(
             Collections.singletonMap(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "none"),
             mock(KsqlHostInfo.class),
-            mock(URL.class));
+            mock(URL.class),
+            false);
     final Map<String, Object> properties = sessionProperties.getMutableScopedProperties();
 
     // When:

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/PropertyOverriderTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/PropertyOverriderTest.java
@@ -76,7 +76,7 @@ public class PropertyOverriderTest {
   public void shouldAllowSetKnownProperty() {
     // Given:
     final SessionProperties sessionProperties = 
-        new SessionProperties(new HashedMap<>(), mock(KsqlHostInfo.class), mock(URL.class));
+        new SessionProperties(new HashedMap<>(), mock(KsqlHostInfo.class), mock(URL.class), false);
     final Map<String, Object> properties = sessionProperties.getMutableScopedProperties();
 
     // When:
@@ -102,7 +102,7 @@ public class PropertyOverriderTest {
   public void shouldFailOnInvalidSetPropertyValue() {
     // Given:
     final SessionProperties sessionProperties =
-        new SessionProperties(new HashedMap<>(), mock(KsqlHostInfo.class), mock(URL.class));
+        new SessionProperties(new HashedMap<>(), mock(KsqlHostInfo.class), mock(URL.class), false);
 
     // Expect:
     expectedException.expect(KsqlStatementException.class);
@@ -128,7 +128,7 @@ public class PropertyOverriderTest {
     // Given:
     final Map<String, Object> properties = new HashMap<>();
     final SessionProperties sessionProperties =
-        new SessionProperties(properties, mock(KsqlHostInfo.class), mock(URL.class));
+        new SessionProperties(properties, mock(KsqlHostInfo.class), mock(URL.class), false);
 
     // Expect:
     expectedException.expect(KsqlStatementException.class);
@@ -156,7 +156,9 @@ public class PropertyOverriderTest {
         new SessionProperties(
             Collections.singletonMap(
                 ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"),
-                mock(KsqlHostInfo.class), mock(URL.class));
+            mock(KsqlHostInfo.class),
+            mock(URL.class),
+            false);
     final Map<String, Object> properties = sessionProperties.getMutableScopedProperties();
 
     // When:

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/SessionProperties.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/SessionProperties.java
@@ -32,20 +32,25 @@ public class SessionProperties {
   private final Map<String, Object> mutableScopedProperties;
   private final KsqlHostInfo ksqlHostInfo;
   private final URL localUrl;
+  private final boolean internalRequest;
 
   /**
    * @param mutableScopedProperties   The streamsProperties of the incoming request
    * @param ksqlHostInfo              The ksqlHostInfo of the server that handles the request 
    * @param localUrl                  The url of the server that handles the request
+   * @param internalRequest           Flag indicating if request is from within the KSQL cluster
    */
   public SessionProperties(
       final Map<String, Object> mutableScopedProperties,
       final KsqlHostInfo ksqlHostInfo,
-      final URL localUrl) {
+      final URL localUrl,
+      final boolean internalRequest
+  ) {
     this.mutableScopedProperties = 
         new HashMap<>(Objects.requireNonNull(mutableScopedProperties, "mutableScopedProperties"));
     this.ksqlHostInfo = Objects.requireNonNull(ksqlHostInfo, "ksqlHostInfo");
     this.localUrl = Objects.requireNonNull(localUrl, "localUrl");
+    this.internalRequest = internalRequest;
   }
 
   public Map<String, Object> getMutableScopedProperties() {
@@ -58,5 +63,9 @@ public class SessionProperties {
 
   public URL getLocalUrl() {
     return localUrl;
+  }
+
+  public boolean getInternalRequest() {
+    return internalRequest;
   }
 }


### PR DESCRIPTION
### Description 
Breaking up https://github.com/confluentinc/ksql/pull/4572 into smaller PR's
This PR adds an isInteralRequest flag to both KsqlRequestConfig and SessionProperties for use in any future scatter gather patterns among cluster servers.

### Testing done 
Unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

