### PR TITLE
fix: docker image directories in light of renames (MINOR)

### DIFF
--- a/bin/ksql-run-class
+++ b/bin/ksql-run-class
@@ -48,10 +48,10 @@ if [ -z "$KSQL_LOG4J_OPTS" ]; then
   # installed
   if [ -e "$base_dir/config/log4j.properties" ]; then # Dev environment
     KSQL_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/config/log4j.properties"
-  elif [ -e "$base_dir/etc/ksqldb/log4j.properties" ]; then # Simple zip file layout
-    KSQL_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/etc/ksqldb/log4j.properties"
-  elif [ -e "/etc/ksqldb/log4j.properties" ]; then # Normal install layout
-    KSQL_LOG4J_OPTS="-Dlog4j.configuration=file:/etc/ksqldb/log4j.properties"
+  elif [ -e "$base_dir/etc/ksql/log4j.properties" ]; then # Simple zip file layout
+    KSQL_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/etc/ksql/log4j.properties"
+  elif [ -e "/etc/ksql/log4j.properties" ]; then # Normal install layout
+    KSQL_LOG4J_OPTS="-Dlog4j.configuration=file:/etc/ksql/log4j.properties"
   fi
 fi
 

--- a/ksqldb-docker/Dockerfile
+++ b/ksqldb-docker/Dockerfile
@@ -6,7 +6,9 @@ FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 
-ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${ARTIFACT_ID}/
+# target directory must be one of the projects that ksql-run-class sets on the KSQL_CLASSPATH,
+# of which the artifact ID (ksqldb-docker) is not one. thus the workaround of using ksqldb-rest-app
+ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/ksqldb-rest-app/
 ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/bin/* /usr/bin/
 ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/bin/docker/* /usr/bin/docker/
 ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/etc/* /etc/ksql/


### PR DESCRIPTION
### Description 

Two fixes to the Docker image:
- The directory that jars need to be copied to needs to be one of the jars that gets added to the classpath here: https://github.com/confluentinc/ksql/blob/bfc90e1df75eb026f444212d98a4399b314322a6/bin/ksql-run-class#L28 or else the server fails to start with `Error: Could not find or load main class io.confluent.ksql.rest.server.KsqlServerMain`. This PR undoes the change that updated the directory name from `ksql-rest-app` to `$ARTIFACT_ID` since the artifact ID is ksqldb-docker, which is not in the list.
- Our docker images place config files in `/etc/ksql` whereas ksql-run-class was recently updated to look for log4j configs in `/etc/ksqldb` instead, so server logs were not properly printed. This PR reverts the change to ksql-run-class for the sake of fixing this for the release, though we should probably update all instances to `/etc/ksqldb` going forward. This would be a larger change, however, since we'd have to update the directory for all config files in all places we build docker images cc @agavra 

### Testing done 

Built image locally and verified the server starts and logs are printed.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

