### PR TITLE
docs: update window retention example to be persistent (MINOR)

### DIFF
--- a/docs-md/concepts/time-and-windows-in-ksqldb-queries.md
+++ b/docs-md/concepts/time-and-windows-in-ksqldb-queries.md
@@ -393,7 +393,8 @@ For example, to retain the computed windowed aggregation results for a week,
 you might run the following query:
 
 ```sql
-SELECT regionid, COUNT(*) FROM pageviews
+CREATE TABLE pageviews_per_region AS
+  SELECT regionid, COUNT(*) FROM pageviews
   WINDOW HOPPING (SIZE 30 SECONDS, ADVANCE BY 10 SECONDS, RETENTION 7 DAYS, GRACE PERIOD 30 MINUTES)
   WHERE UCASE(gender)='FEMALE' AND LCASE (regionid) LIKE '%_6'
   GROUP BY regionid


### PR DESCRIPTION
### Description 

Updates the example for configuring windowed aggregation retention period to be a persistent query, since window retention doesn't really make sense for transient queries. The rest of the examples in the file are still transient queries so there's a bit of an inconsistency here but I think this is still an improvement.

### Testing done 

Docs-only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

