### PR TITLE
docs: fix annotation in UDTF example (MINOR)

### DIFF
--- a/docs-md/concepts/functions.md
+++ b/docs-md/concepts/functions.md
@@ -738,7 +738,7 @@ You can invoke this UDTF in two different ways:
 import io.confluent.ksql.function.udf.Udtf;
 import io.confluent.ksql.function.udf.UdtfDescription;
 
-@UdfDescription(name = "split_string", description = "splits a string into words")
+@UdtfDescription(name = "split_string", description = "splits a string into words")
 public class SplitString {
 
   @Udtf(description="Splits a string into words")


### PR DESCRIPTION
### Description 

The current example UDTF in our docs is broken since the class annotation is incorrect, as pointed by a user in the Community Slack: https://confluentcommunity.slack.com/archives/C6UJNMY67/p1584336800321900?thread_ts=1584180894.313000&cid=C6UJNMY67

This PR fixes the typo. Targeting the `0.7.1-docs` branch under the assumption that this branch is the one that's currently live in the docs, but this fix also needs to be ported around to the other branches (master, 5.5.x, probably also 5.4.x) -- @JimGalasyn would you mind helping with that? (Thanks in advance!)

UPDATE: Targeting `master` in light of review comment below.

### Testing done 

Docs-only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

