### PR TITLE
docs: call out PARTITION BY applied before SELECT

### DIFF
--- a/docs-md/developer-guide/ksqldb-reference/create-stream-as-select.md
+++ b/docs-md/developer-guide/ksqldb-reference/create-stream-as-select.md
@@ -30,9 +30,9 @@ Create a new stream along with the corresponding Kafka topic, and
 continuously write the result of the SELECT query into the stream and
 its corresponding topic.
 
-If the PARTITION BY clause is present, then the resulting stream will
-have the specified column as its key. The `column_name` must be present
-in the `from_stream`. For more information, see
+If the PARTITION BY clause is present, then the resulting stream will have the specified column as
+its key. The PARTITION BY clause is applied to the source _after_ any JOIN or WHERE clauses, and
+_before_ the SELECT clause, in much the same way as GROUP BY. For more information, see
 [Partition Data to Enable Joins](../joins/partition-data.md).
 
 For joins, the key of the resulting stream will be the value from the

--- a/docs-md/developer-guide/ksqldb-reference/insert-into.md
+++ b/docs-md/developer-guide/ksqldb-reference/insert-into.md
@@ -16,6 +16,7 @@ Synopsis
 INSERT INTO stream_name
   SELECT select_expr [., ...]
   FROM from_stream
+  [ LEFT | FULL | INNER ] JOIN [join_table | join_stream] [ WITHIN [(before TIMEUNIT, after TIMEUNIT) | N TIMEUNIT] ] ON join_criteria
   [ WHERE condition ]
   [ PARTITION BY column_name ]
   EMIT CHANGES;
@@ -34,6 +35,9 @@ an error.
 
 The `stream_name` and `from_item` parameters must both refer to a Stream.
 Tables are not supported.
+
+If the PARTITION BY clause is present, it is applied to the source _after_ any JOIN or WHERE clauses, and
+_before_ the SELECT clause, in much the same way as GROUP BY.
 
 Records written into the stream are not timestamp-ordered with respect
 to other queries. Therefore, the topic partitions of the output stream

--- a/docs-md/developer-guide/syntax-reference.md
+++ b/docs-md/developer-guide/syntax-reference.md
@@ -472,6 +472,7 @@ CREATE STREAM users_with_wrong_key (userid INT, username VARCHAR, email VARCHAR)
 -- Derive a new stream with the required key changes.
 -- 1) The CAST statement converts the key to the required format.
 -- 2) The PARTITION BY clause re-partitions the stream based on the new, converted key.
+-- 3) The SELECT clause selects the required value columns, (key columns are implicitly included).
 -- The resulting schema will be: ROWKEY INT, USERNAME STRING, EMAIL STRING
 -- the userId will be stored in ROWKEY.
 CREATE STREAM users_with_proper_key

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/insert-into_-_join/6.0.0_1584453227211/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/insert-into_-_join/6.0.0_1584453227211/plan.json
@@ -1,0 +1,292 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM SOURCE1 (DATA STRING) WITH (KAFKA_TOPIC='stream-source', VALUE_FORMAT='DELIMITED');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "SOURCE1",
+      "schema" : "`ROWKEY` STRING KEY, `DATA` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "stream-source",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM SOURCE2 (DATA STRING) WITH (KAFKA_TOPIC='insert-source', VALUE_FORMAT='DELIMITED');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "SOURCE2",
+      "schema" : "`ROWKEY` STRING KEY, `DATA` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "insert-source",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  SOURCE1.DATA DATA_1,\n  SOURCE1.DATA DATA_2\nFROM SOURCE1 SOURCE1\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` STRING KEY, `DATA_1` STRING, `DATA_2` STRING",
+      "keyField" : null,
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED",
+          "properties" : { }
+        },
+        "options" : [ ]
+      },
+      "windowInfo" : null
+    },
+    "queryPlan" : {
+      "sources" : [ "SOURCE1" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "stream-source",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "DELIMITED",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`ROWKEY` STRING KEY, `DATA` STRING"
+          },
+          "selectExpressions" : [ "DATA AS DATA_1", "DATA AS DATA_2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "INSERT INTO OUTPUT SELECT\n  S1.DATA DATA_1,\n  S2.DATA DATA_2\nFROM SOURCE1 S1\nINNER JOIN SOURCE2 S2 WITHIN 1 SECONDS ON ((S1.ROWKEY = S2.ROWKEY))\nEMIT CHANGES",
+    "ddlCommand" : null,
+    "queryPlan" : {
+      "sources" : [ "SOURCE2", "SOURCE1" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamStreamJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "DELIMITED",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "rightInternalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "DELIMITED",
+                "properties" : { }
+              },
+              "options" : [ ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "stream-source",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "DELIMITED",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ROWKEY` STRING KEY, `DATA` STRING"
+              },
+              "selectExpressions" : [ "DATA AS S1_DATA", "ROWTIME AS S1_ROWTIME", "ROWKEY AS S1_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "insert-source",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "DELIMITED",
+                    "properties" : { }
+                  },
+                  "options" : [ ]
+                },
+                "timestampColumn" : null,
+                "sourceSchema" : "`ROWKEY` STRING KEY, `DATA` STRING"
+              },
+              "selectExpressions" : [ "DATA AS S2_DATA", "ROWTIME AS S2_ROWTIME", "ROWKEY AS S2_ROWKEY" ]
+            },
+            "beforeMillis" : 1.000000000,
+            "afterMillis" : 1.000000000
+          },
+          "selectExpressions" : [ "S1_DATA AS DATA_1", "S2_DATA AS DATA_2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED",
+            "properties" : { }
+          },
+          "options" : [ ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "InsertQuery_1"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/confluent6162846720823380262",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.streamsstore.rebalancing.timeout.ms" : "10000",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/insert-into_-_join/6.0.0_1584453227211/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/insert-into_-_join/6.0.0_1584453227211/spec.json
@@ -1,0 +1,29 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1584453227211,
+  "schemas" : {
+    "InsertQuery_1.KafkaTopic_Left.Source" : "STRUCT<DATA VARCHAR> NOT NULL",
+    "InsertQuery_1.KafkaTopic_Right.Source" : "STRUCT<DATA VARCHAR> NOT NULL",
+    "InsertQuery_1.Join.Left" : "STRUCT<S1_DATA VARCHAR, S1_ROWTIME BIGINT, S1_ROWKEY VARCHAR> NOT NULL",
+    "InsertQuery_1.Join.Right" : "STRUCT<S2_DATA VARCHAR, S2_ROWTIME BIGINT, S2_ROWKEY VARCHAR> NOT NULL",
+    "InsertQuery_1.OUTPUT" : "STRUCT<DATA_1 VARCHAR, DATA_2 VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "stream-source",
+    "key" : "k1",
+    "value" : "v1"
+  }, {
+    "topic" : "insert-source",
+    "key" : "k1",
+    "value" : "v2"
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : "k1",
+    "value" : "v1,v1"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "k1",
+    "value" : "v1,v2"
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/insert-into_-_join/6.0.0_1584453227211/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/insert-into_-_join/6.0.0_1584453227211/topology
@@ -1,0 +1,39 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [stream-source])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [insert-source])
+      --> KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-this-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: PrependAliasRight (stores: [])
+      --> Join-other-windowed
+      <-- KSTREAM-TRANSFORMVALUES-0000000004
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-other-join
+      <-- PrependAliasRight
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-this-join
+      <-- PrependAliasLeft
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> Join-merge
+      <-- Join-other-windowed
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> Join-merge
+      <-- Join-this-windowed
+    Processor: Join-merge (stores: [])
+      --> Project
+      <-- Join-this-join, Join-other-join
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Join-merge
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/insert-into.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/insert-into.json
@@ -119,6 +119,23 @@
         {"topic": "sink", "key": "0", "value": {"A": 456, "B": "giraffe"}, "timestamp": 0},
         {"topic": "sink", "key": "0", "value": {"A": 789, "B": "turtle"}, "timestamp": 0}
       ]
+    },
+    {
+      "name": "join",
+      "statements": [
+        "CREATE STREAM SOURCE1 (data VARCHAR) WITH (kafka_topic='stream-source', value_format='DELIMITED');",
+        "CREATE STREAM SOURCE2 (data VARCHAR) WITH (kafka_topic='insert-source', value_format='DELIMITED');",
+        "CREATE STREAM OUTPUT AS SELECT DATA AS DATA_1, DATA AS DATA_2 FROM SOURCE1;",
+        "INSERT INTO OUTPUT SELECT S1.DATA AS DATA_1, S2.DATA AS DATA_2 FROM SOURCE1 S1 JOIN SOURCE2 S2 WITHIN 1 SECOND ON S1.ROWKEY = S2.ROWKEY;"
+      ],
+      "inputs": [
+        {"topic": "stream-source", "key": "k1", "value": "v1"},
+        {"topic": "insert-source", "key": "k1", "value": "v2"}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "k1", "value": "v1,v1"},
+        {"topic": "OUTPUT", "key": "k1", "value": "v1,v2"}
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Description 

Improve the docs to make it clear that, like GROUP BY, any PARTITION BY clause is applied after any JOIN or WHERE, but before the SELECT.

Also, include optional JOIN clause in INSERT INTO docs, as joins are supported, (QTT test added to prove this).

### Testing done 

Doc only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

