### PR TITLE
chore: rename config directory to ksqldb (MINOR)

### DIFF
--- a/bin/ksql-run-class
+++ b/bin/ksql-run-class
@@ -48,10 +48,10 @@ if [ -z "$KSQL_LOG4J_OPTS" ]; then
   # installed
   if [ -e "$base_dir/config/log4j.properties" ]; then # Dev environment
     KSQL_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/config/log4j.properties"
-  elif [ -e "$base_dir/etc/ksql/log4j.properties" ]; then # Simple zip file layout
-    KSQL_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/etc/ksql/log4j.properties"
-  elif [ -e "/etc/ksql/log4j.properties" ]; then # Normal install layout
-    KSQL_LOG4J_OPTS="-Dlog4j.configuration=file:/etc/ksql/log4j.properties"
+  elif [ -e "$base_dir/etc/ksqldb/log4j.properties" ]; then # Simple zip file layout
+    KSQL_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/etc/ksqldb/log4j.properties"
+  elif [ -e "/etc/ksqldb/log4j.properties" ]; then # Normal install layout
+    KSQL_LOG4J_OPTS="-Dlog4j.configuration=file:/etc/ksqldb/log4j.properties"
   fi
 fi
 

--- a/ksqldb-docker/Dockerfile
+++ b/ksqldb-docker/Dockerfile
@@ -11,7 +11,7 @@ ARG ARTIFACT_ID
 ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/ksqldb-rest-app/
 ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/bin/* /usr/bin/
 ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/bin/docker/* /usr/bin/docker/
-ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/etc/* /etc/ksql/
+ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/etc/* /etc/ksqldb/
 ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/
 
 RUN echo "===> Installing confluent-hub..." \


### PR DESCRIPTION
### Description 

Undoes the second change in https://github.com/confluentinc/ksql/pull/4785 in favor of fixing forward since we'd like the config directory to be named `ksqldb` rather than `ksql`. @agavra will take care of making the analogous update for CP docker images and updating docs to reference the new directory.

### Testing done 

Built local image and verified server logging works as expected.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

