### PR TITLE
fix: only create processing log stream if it doesn't exist

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -55,6 +55,8 @@ import io.confluent.ksql.rest.Errors;
 import io.confluent.ksql.rest.client.RestResponse;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlErrorMessage;
+import io.confluent.ksql.rest.entity.SourceInfo;
+import io.confluent.ksql.rest.entity.StreamsList;
 import io.confluent.ksql.rest.server.HeartbeatAgent.Builder;
 import io.confluent.ksql.rest.server.computation.CommandRunner;
 import io.confluent.ksql.rest.server.computation.CommandStore;
@@ -959,22 +961,48 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
           new ServerInternalKsqlClient(ksqlResource, new KsqlSecurityContext(
               Optional.empty(), serviceContext));
       final URI serverEndpoint = ServerUtil.getServerAddress(restConfig);
-
-      final RestResponse<KsqlEntityList> response = internalClient.makeKsqlRequest(
+      
+      final String processingLogStreamName =
+          processingLogConfig.getString(ProcessingLogConfig.STREAM_NAME);
+      if (!processingLogStreamExists(
+          internalClient,
           serverEndpoint,
-          ProcessingLogServerUtils.processingLogStreamCreateStatement(
-              processingLogConfig,
-              ksqlConfig
-          )
-      );
+          processingLogStreamName
+      )) {
+        final RestResponse<KsqlEntityList> response = internalClient.makeKsqlRequest(
+            serverEndpoint,
+            ProcessingLogServerUtils.processingLogStreamCreateStatement(
+                processingLogConfig,
+                ksqlConfig
+            )
+        );
 
-      if (response.isSuccessful()) {
-        log.info("Successfully created processing log stream.");
+        if (response.isSuccessful()) {
+          log.info("Successfully created processing log stream.");
+        }
       }
     } catch (final Exception e) {
       log.error(
           "Error while sending processing log CreateStream request to KsqlResource: ", e);
     }
+  }
+
+  private static boolean processingLogStreamExists(
+      final SimpleKsqlClient internalClient,
+      final URI serverEndpoint,
+      final String processingLogStreamName
+  ) {
+    final RestResponse<KsqlEntityList> listStreamsResponse = internalClient.makeKsqlRequest(
+        serverEndpoint,
+        "list streams;"
+    );
+
+    final List<SourceInfo.Stream> streams =
+        ((StreamsList) listStreamsResponse.getResponse().get(0)).getStreams();
+
+    return streams
+        .stream()
+        .anyMatch(stream -> stream.getName().equals(processingLogStreamName));
   }
 
   /**

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -37,8 +37,11 @@ import io.confluent.ksql.logging.processing.ProcessingLogConfig;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
+import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlErrorMessage;
 import io.confluent.ksql.rest.entity.KsqlRequest;
+import io.confluent.ksql.rest.entity.SourceInfo;
+import io.confluent.ksql.rest.entity.StreamsList;
 import io.confluent.ksql.rest.server.computation.CommandRunner;
 import io.confluent.ksql.rest.server.computation.CommandStore;
 import io.confluent.ksql.rest.server.context.KsqlSecurityContextBinder;
@@ -65,6 +68,8 @@ import java.util.Queue;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import javax.ws.rs.core.Configurable;
+import javax.ws.rs.core.Response;
+
 import org.apache.kafka.streams.StreamsConfig;
 import org.junit.Before;
 import org.junit.Rule;
@@ -82,6 +87,7 @@ public class KsqlRestApplicationTest {
   private static final String LOG_STREAM_NAME = "log_stream";
   private static final String LOG_TOPIC_NAME = "log_topic";
   private static final String CMD_TOPIC_NAME = "command_topic";
+  private static final String LIST_STREAMS_SQL = "list streams;";
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
@@ -130,6 +136,8 @@ public class KsqlRestApplicationTest {
   private HeartbeatAgent heartbeatAgent;
   @Mock
   private LagReportingAgent lagReportingAgent;
+  @Mock
+  private Response response;
 
   @Mock
   private SchemaRegistryClient schemaRegistryClient;
@@ -166,6 +174,17 @@ public class KsqlRestApplicationTest {
     when(precondition1.checkPrecondition(any(), any())).thenReturn(Optional.empty());
     when(precondition2.checkPrecondition(any(), any())).thenReturn(Optional.empty());
 
+    when(response.getStatus()).thenReturn(200);
+    when(response.getEntity()).thenReturn(new KsqlEntityList(
+        Collections.singletonList(new StreamsList(
+            LIST_STREAMS_SQL,
+            Collections.emptyList()))));
+
+    when(ksqlResource.handleKsqlStatements(
+        any(),
+        any())
+    ).thenReturn(response);
+    
     securityContext = new KsqlSecurityContext(Optional.empty(), serviceContext);
 
     logCreateStatement = ProcessingLogServerUtils.processingLogStreamCreateStatement(
@@ -250,6 +269,31 @@ public class KsqlRestApplicationTest {
     );
   }
 
+  @Test
+  public void shouldNotCreateLogStreamIfAlreadyExists() {
+    // Given:
+
+    final StreamsList streamsList =
+        new StreamsList(
+            LIST_STREAMS_SQL,
+            Collections.singletonList(new SourceInfo.Stream(LOG_STREAM_NAME, "", "")));
+    when(response.getEntity()).thenReturn(new KsqlEntityList(Collections.singletonList(streamsList)));
+    
+    when(ksqlResource.handleKsqlStatements(
+        any(),
+        any())
+    ).thenReturn(response);
+
+    // When:
+    app.startKsql(ksqlConfig);
+
+    // Then:
+    verify(ksqlResource, never()).handleKsqlStatements(
+        securityContextArgumentCaptor.capture(),
+        eq(new KsqlRequest(logCreateStatement, Collections.emptyMap(), Collections.emptyMap(), null))
+    );
+  }
+  
   @Test
   public void shouldStartCommandStoreAndCommandRunnerBeforeCreatingLogStream() {
     // When:


### PR DESCRIPTION
### Description 
https://github.com/confluentinc/ksql/issues/4788
Issue a `list streams;` request to the server first in order to see if the processing log stream is already present or not

### Testing done 
Unit test
Started up server back to back and the exception doesn't show up anymore

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

