### PR TITLE
fix: Removes unnecessary error logging for heartbeat since this is ex…

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/DefaultKsqlClient.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/DefaultKsqlClient.java
@@ -111,7 +111,7 @@ final class DefaultKsqlClient implements SimpleKsqlClient {
         .exceptionally(t -> {
           // We send heartbeat requests quite frequently and to nodes that might be down.  We don't
           // want to fill the logs with spam, so we debug log exceptions.
-          LOG.debug("Exception in async request", t);
+          LOG.debug("Exception in async heartbeat request", t);
           return null;
         });
   }
@@ -134,7 +134,7 @@ final class DefaultKsqlClient implements SimpleKsqlClient {
 
     getTarget(target, authHeader).postAsyncLagReportingRequest(lagReportingMessage)
         .exceptionally(t -> {
-          LOG.error("Unexpected exception in async request", t);
+          LOG.debug("Exception in async lag reporting request", t);
           return null;
         });
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/HighAvailabilityTestUtil.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/HighAvailabilityTestUtil.java
@@ -28,8 +28,12 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class HighAvailabilityTestUtil {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HighAvailabilityTestUtil.class);
 
   static ClusterStatusResponse sendClusterStatusRequest(final TestKsqlRestApp restApp) {
     try (final KsqlRestClient restClient = restApp.buildKsqlClient()) {
@@ -159,7 +163,11 @@ class HighAvailabilityTestUtil {
   ) {
 
     try (final KsqlRestClient restClient = restApp.buildKsqlClient()) {
-      restClient.makeAsyncHeartbeatRequest(hostInfoEntity, timestamp);
+      restClient.makeAsyncHeartbeatRequest(hostInfoEntity, timestamp)
+          .exceptionally(t -> {
+            LOG.error("Unexpected exception in async request", t);
+            return null;
+          });
     }
   }
 
@@ -169,7 +177,11 @@ class HighAvailabilityTestUtil {
   ) {
 
     try (final KsqlRestClient restClient = restApp.buildKsqlClient()) {
-      restClient.makeAsyncLagReportingRequest(lagReportingMessage);
+      restClient.makeAsyncLagReportingRequest(lagReportingMessage)
+          .exceptionally(t -> {
+            LOG.error("Unexpected exception in async request", t);
+            return null;
+          });
     }
   }
 }

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -24,9 +24,11 @@ import io.confluent.ksql.rest.entity.ClusterStatusResponse;
 import io.confluent.ksql.rest.entity.CommandStatus;
 import io.confluent.ksql.rest.entity.CommandStatuses;
 import io.confluent.ksql.rest.entity.HealthCheckResponse;
+import io.confluent.ksql.rest.entity.HeartbeatResponse;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlHostInfoEntity;
 import io.confluent.ksql.rest.entity.LagReportingMessage;
+import io.confluent.ksql.rest.entity.LagReportingResponse;
 import io.confluent.ksql.rest.entity.ServerInfo;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import io.vertx.core.http.HttpClientOptions;
@@ -38,6 +40,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 public class KsqlRestClient implements Closeable {
@@ -92,21 +95,21 @@ public class KsqlRestClient implements Closeable {
     return target().getServerHealth();
   }
 
-  public void makeAsyncHeartbeatRequest(
+  public CompletableFuture<RestResponse<HeartbeatResponse>> makeAsyncHeartbeatRequest(
       final KsqlHostInfoEntity host,
       final long timestamp
   ) {
-    target().postAsyncHeartbeatRequest(host, timestamp);
+    return target().postAsyncHeartbeatRequest(host, timestamp);
   }
 
   public RestResponse<ClusterStatusResponse> makeClusterStatusRequest() {
     return target().getClusterStatus();
   }
 
-  public void makeAsyncLagReportingRequest(
+  public CompletableFuture<RestResponse<LagReportingResponse>> makeAsyncLagReportingRequest(
       final LagReportingMessage lagReportingMessage
   ) {
-    target().postAsyncLagReportingRequest(lagReportingMessage);
+    return target().postAsyncLagReportingRequest(lagReportingMessage);
   }
 
   public RestResponse<KsqlEntityList> makeKsqlRequest(final String ksql) {

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
@@ -25,10 +25,12 @@ import io.confluent.ksql.rest.entity.CommandStatus;
 import io.confluent.ksql.rest.entity.CommandStatuses;
 import io.confluent.ksql.rest.entity.HealthCheckResponse;
 import io.confluent.ksql.rest.entity.HeartbeatMessage;
+import io.confluent.ksql.rest.entity.HeartbeatResponse;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlHostInfoEntity;
 import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.entity.LagReportingMessage;
+import io.confluent.ksql.rest.entity.LagReportingResponse;
 import io.confluent.ksql.rest.entity.ServerInfo;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.util.VertxCompletableFuture;
@@ -99,16 +101,15 @@ public final class KsqlTarget {
     return get("/healthcheck", HealthCheckResponse.class);
   }
 
-  public void postAsyncHeartbeatRequest(
+  public CompletableFuture<RestResponse<HeartbeatResponse>> postAsyncHeartbeatRequest(
       final KsqlHostInfoEntity host,
       final long timestamp
   ) {
-    executeRequestAsync(
+    return executeRequestAsync(
+        HttpMethod.POST,
         HEARTBEAT_PATH,
         new HeartbeatMessage(host, timestamp),
-        // We send heartbeat requests quite frequently and to nodes that might be down.  We don't
-        // want to fill the logs with spam, so we set expectFailures to true.
-        true /* expectFailures */
+        r -> deserialize(r.getBody(), HeartbeatResponse.class)
     );
   }
 
@@ -116,13 +117,14 @@ public final class KsqlTarget {
     return get(CLUSTERSTATUS_PATH, ClusterStatusResponse.class);
   }
 
-  public void postAsyncLagReportingRequest(
+  public CompletableFuture<RestResponse<LagReportingResponse>> postAsyncLagReportingRequest(
       final LagReportingMessage lagReportingMessage
   ) {
-    executeRequestAsync(
+    return executeRequestAsync(
+        HttpMethod.POST,
         LAG_REPORT_PATH,
         lagReportingMessage,
-        false /* expectFailures */
+        r -> deserialize(r.getBody(), LagReportingResponse.class)
     );
   }
 
@@ -197,19 +199,14 @@ public final class KsqlTarget {
     return executeRequestSync(HttpMethod.POST, path, jsonEntity, mapper);
   }
 
-  private void executeRequestAsync(
+  private <T> CompletableFuture<RestResponse<T>> executeRequestAsync(
+      final HttpMethod httpMethod,
       final String path,
       final Object jsonEntity,
-      final boolean expectFailures
+      final Function<ResponseWithBody, T> mapper
   ) {
-    execute(HttpMethod.POST, path, jsonEntity, (resp, vcf) -> {
-    }).exceptionally(t -> {
-      if (expectFailures) {
-        log.debug("Expected exception in async request", t);
-      } else {
-        log.error("Unexpected exception in async request", t);
-      }
-      return null;
+    return executeAsync(httpMethod, path, jsonEntity, mapper, (resp, vcf) -> {
+      resp.bodyHandler(buff -> vcf.complete(new ResponseWithBody(resp, buff)));
     });
   }
 
@@ -262,6 +259,18 @@ public final class KsqlTarget {
           "Error issuing " + httpMethod + " to KSQL server. path:" + path, e);
     }
     return KsqlClientUtil.toRestResponse(response, path, mapper);
+  }
+
+  private <T> CompletableFuture<RestResponse<T>> executeAsync(
+      final HttpMethod httpMethod,
+      final String path,
+      final Object requestBody,
+      final Function<ResponseWithBody, T> mapper,
+      final BiConsumer<HttpClientResponse, CompletableFuture<ResponseWithBody>> responseHandler
+  ) {
+    final CompletableFuture<ResponseWithBody> vcf =
+        execute(httpMethod, path, requestBody, responseHandler);
+    return vcf.thenApply(response -> KsqlClientUtil.toRestResponse(response, path, mapper));
   }
 
   private CompletableFuture<ResponseWithBody> execute(


### PR DESCRIPTION
…pected

### Description 
Disables error logging for heartbeat requests since these happen quite often and deliberately are done with nodes that might be down.  During startup especially (and possibly other situations as well) this leads to tons of log spam.  Since we have other mechanisms like the hearbeatAgent which log periodically when hosts are considered down, this isn't necessary.

Fixes #4807 

### Testing done 
Ran tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

