### PR TITLE
feat: use describeTopics() for Kafka healtcheck probe

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgent.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgent.java
@@ -16,14 +16,20 @@
 package io.confluent.ksql.rest.healthcheck;
 
 import com.google.common.collect.ImmutableList;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.confluent.ksql.exception.KsqlTopicAuthorizationException;
 import io.confluent.ksql.rest.client.RestResponse;
 import io.confluent.ksql.rest.entity.HealthCheckResponse;
 import io.confluent.ksql.rest.entity.HealthCheckResponseDetail;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.ServerUtil;
+import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.SimpleKsqlClient;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.ReservedInternalTopics;
 import java.net.URI;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -36,25 +42,31 @@ public class HealthCheckAgent {
 
   private static final List<Check> DEFAULT_CHECKS = ImmutableList.of(
       new ExecuteStatementCheck(METASTORE_CHECK_NAME, "list streams; list tables; list queries;"),
-      new ExecuteStatementCheck(KAFKA_CHECK_NAME, "list topics;")
+      new KafkaBrokerCheck(KAFKA_CHECK_NAME)
   );
 
   private final SimpleKsqlClient ksqlClient;
   private final URI serverEndpoint;
+  private final ServiceContext serviceContext;
+  private final KsqlConfig ksqlConfig;
 
   public HealthCheckAgent(
       final SimpleKsqlClient ksqlClient,
-      final KsqlRestConfig restConfig
+      final KsqlRestConfig restConfig,
+      final ServiceContext serviceContext,
+      final KsqlConfig ksqlConfig
   ) {
     this.ksqlClient = Objects.requireNonNull(ksqlClient, "ksqlClient");
     this.serverEndpoint = ServerUtil.getServerAddress(restConfig);
+    this.serviceContext = Objects.requireNonNull(serviceContext, "serviceContext");
+    this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig");
   }
 
   public HealthCheckResponse checkHealth() {
     final Map<String, HealthCheckResponseDetail> results = DEFAULT_CHECKS.stream()
         .collect(Collectors.toMap(
             Check::getName,
-            check -> check.check(ksqlClient, serverEndpoint)
+            check -> check.check(this)
         ));
     final boolean allHealthy = results.values().stream()
         .allMatch(HealthCheckResponseDetail::getIsHealthy);
@@ -64,7 +76,7 @@ public class HealthCheckAgent {
   private interface Check {
     String getName();
 
-    HealthCheckResponseDetail check(SimpleKsqlClient ksqlClient, URI serverEndpoint);
+    HealthCheckResponseDetail check(HealthCheckAgent healthCheckAgent);
   }
 
   private static class ExecuteStatementCheck implements Check {
@@ -82,13 +94,47 @@ public class HealthCheckAgent {
     }
 
     @Override
-    public HealthCheckResponseDetail check(
-        final SimpleKsqlClient ksqlClient,
-        final URI serverEndpoint
-    ) {
+    public HealthCheckResponseDetail check(final HealthCheckAgent healthCheckAgent) {
       final RestResponse<KsqlEntityList> response =
-          ksqlClient.makeKsqlRequest(serverEndpoint, ksqlStatement);
+          healthCheckAgent.ksqlClient
+              .makeKsqlRequest(healthCheckAgent.serverEndpoint, ksqlStatement);
       return new HealthCheckResponseDetail(response.isSuccessful());
+    }
+  }
+
+  private static class KafkaBrokerCheck implements Check {
+    private final String name;
+
+    KafkaBrokerCheck(final String name) {
+      this.name = Objects.requireNonNull(name, "name");
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
+    @Override
+    public HealthCheckResponseDetail check(final HealthCheckAgent healthCheckAgent) {
+      final String commandTopic = ReservedInternalTopics.commandTopic(healthCheckAgent.ksqlConfig);
+      boolean isHealthy;
+
+      try {
+        healthCheckAgent.serviceContext
+            .getAdminClient()
+            .describeTopics(Collections.singletonList(commandTopic))
+            .all()
+            .get();
+
+        isHealthy = true;
+      } catch (final KsqlTopicAuthorizationException e) {
+        isHealthy = true;
+      } catch (final Exception e) {
+        isHealthy = false;
+      }
+
+      return new HealthCheckResponseDetail(isHealthy);
     }
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgent.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgent.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import org.apache.kafka.clients.admin.DescribeTopicsOptions;
 
 public class HealthCheckAgent {
 
@@ -103,6 +104,8 @@ public class HealthCheckAgent {
   }
 
   private static class KafkaBrokerCheck implements Check {
+    private static final int DESCRIBE_TOPICS_TIMEOUT_MS = 30000;
+
     private final String name;
 
     KafkaBrokerCheck(final String name) {
@@ -123,7 +126,8 @@ public class HealthCheckAgent {
       try {
         healthCheckAgent.serviceContext
             .getAdminClient()
-            .describeTopics(Collections.singletonList(commandTopic))
+            .describeTopics(Collections.singletonList(commandTopic),
+                new DescribeTopicsOptions().timeoutMs(DESCRIBE_TOPICS_TIMEOUT_MS))
             .all()
             .get();
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -318,7 +318,13 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
     config.register(statusResource);
     config.register(ksqlResource);
     config.register(streamedQueryResource);
-    config.register(HealthCheckResource.create(ksqlResource, serviceContext, this.config));
+    config.register(HealthCheckResource.create(
+        ksqlResource,
+        serviceContext,
+        this.config,
+        this.ksqlConfigNoPort)
+    );
+
     if (heartbeatAgent.isPresent()) {
       config.register(new HeartbeatResource(heartbeatAgent.get()));
       config.register(new ClusterStatusResource(

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/HealthCheckResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/HealthCheckResource.java
@@ -26,6 +26,8 @@ import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.services.ServerInternalKsqlClient;
 import io.confluent.ksql.security.KsqlSecurityContext;
 import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.util.KsqlConfig;
+
 import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
@@ -68,13 +70,14 @@ public class HealthCheckResource {
   public static HealthCheckResource create(
       final KsqlResource ksqlResource,
       final ServiceContext serviceContext,
-      final KsqlRestConfig restConfig
+      final KsqlRestConfig restConfig,
+      final KsqlConfig ksqlConfig
   ) {
     return new HealthCheckResource(
         new HealthCheckAgent(
             new ServerInternalKsqlClient(ksqlResource,
                 new KsqlSecurityContext(Optional.empty(), serviceContext)),
-            restConfig),
+            restConfig, serviceContext, ksqlConfig),
         Duration.ofMillis(restConfig.getLong(KsqlRestConfig.KSQL_HEALTHCHECK_INTERVAL_MS_CONFIG))
     );
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgentTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgentTest.java
@@ -90,7 +90,7 @@ public class HealthCheckAgentTest {
     when(serviceContext.getAdminClient()).thenReturn(adminClient);
 
     final DescribeTopicsResult topicsResult = mock(DescribeTopicsResult.class);
-    when(adminClient.describeTopics(any())).thenReturn(topicsResult);
+    when(adminClient.describeTopics(any(), any())).thenReturn(topicsResult);
     when(topicsResult.all()).thenReturn(KafkaFuture.completedFuture(Collections.emptyMap()));
 
     final KsqlConfig ksqlConfig = new KsqlConfig(ImmutableMap.of(
@@ -130,7 +130,7 @@ public class HealthCheckAgentTest {
   @Test
   public void shouldReturnUnhealthyIfKafkaCheckFails() {
     // Given:
-    doThrow(KafkaResponseGetFailedException.class).when(adminClient).describeTopics(any());
+    doThrow(KafkaResponseGetFailedException.class).when(adminClient).describeTopics(any(), any());
 
     // When:
     final HealthCheckResponse response = healthCheckAgent.checkHealth();
@@ -143,7 +143,7 @@ public class HealthCheckAgentTest {
   @Test
   public void shouldReturnHealthyIfKafkaCheckFailsWithAuthorizationException() {
     // Given:
-    doThrow(KsqlTopicAuthorizationException.class).when(adminClient).describeTopics(any());
+    doThrow(KsqlTopicAuthorizationException.class).when(adminClient).describeTopics(any(), any());
 
     // When:
     final HealthCheckResponse response = healthCheckAgent.checkHealth();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgentTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgentTest.java
@@ -23,18 +23,30 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.exception.KafkaResponseGetFailedException;
+import io.confluent.ksql.exception.KsqlTopicAuthorizationException;
 import io.confluent.ksql.rest.client.RestResponse;
 import io.confluent.ksql.rest.entity.HealthCheckResponse;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
+import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.SimpleKsqlClient;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.rest.RestConfig;
 import java.net.URI;
 import java.net.URL;
+import java.util.Collections;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.DescribeTopicsResult;
+import org.apache.kafka.common.KafkaFuture;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -59,6 +71,10 @@ public class HealthCheckAgentTest {
   @Mock
   private KsqlRestConfig restConfig;
   @Mock
+  private ServiceContext serviceContext;
+  @Mock
+  private Admin adminClient;
+  @Mock
   private RestResponse<KsqlEntityList> successfulResponse;
   @Mock
   private RestResponse<KsqlEntityList> unSuccessfulResponse;
@@ -71,8 +87,18 @@ public class HealthCheckAgentTest {
         .thenReturn(ImmutableList.of(SERVER_ADDRESS));
     when(successfulResponse.isSuccessful()).thenReturn(true);
     when(unSuccessfulResponse.isSuccessful()).thenReturn(false);
+    when(serviceContext.getAdminClient()).thenReturn(adminClient);
 
-    healthCheckAgent = new HealthCheckAgent(ksqlClient, restConfig);
+    final DescribeTopicsResult topicsResult = mock(DescribeTopicsResult.class);
+    when(adminClient.describeTopics(any())).thenReturn(topicsResult);
+    when(topicsResult.all()).thenReturn(KafkaFuture.completedFuture(Collections.emptyMap()));
+
+    final KsqlConfig ksqlConfig = new KsqlConfig(ImmutableMap.of(
+        KsqlConfig.KSQL_SERVICE_ID_CONFIG,
+        "default_"
+    ));
+
+    healthCheckAgent = new HealthCheckAgent(ksqlClient, restConfig, serviceContext, ksqlConfig);
   }
 
   @Test
@@ -104,8 +130,7 @@ public class HealthCheckAgentTest {
   @Test
   public void shouldReturnUnhealthyIfKafkaCheckFails() {
     // Given:
-    when(ksqlClient.makeKsqlRequest(SERVER_URI, "list topics;"))
-        .thenReturn(unSuccessfulResponse);
+    doThrow(KafkaResponseGetFailedException.class).when(adminClient).describeTopics(any());
 
     // When:
     final HealthCheckResponse response = healthCheckAgent.checkHealth();
@@ -113,5 +138,18 @@ public class HealthCheckAgentTest {
     // Then:
     assertThat(response.getDetails().get(KAFKA_CHECK_NAME).getIsHealthy(), is(false));
     assertThat(response.getIsHealthy(), is(false));
+  }
+
+  @Test
+  public void shouldReturnHealthyIfKafkaCheckFailsWithAuthorizationException() {
+    // Given:
+    doThrow(KsqlTopicAuthorizationException.class).when(adminClient).describeTopics(any());
+
+    // When:
+    final HealthCheckResponse response = healthCheckAgent.checkHealth();
+
+    // Then:
+    assertThat(response.getDetails().get(KAFKA_CHECK_NAME).getIsHealthy(), is(true));
+    assertThat(response.getIsHealthy(), is(true));
   }
 }


### PR DESCRIPTION
### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_
Use a faster connectivity check for Kafka health check. The new approach uses the describeTopics() call to get metadata information from the KSQL command topic. If the describe does not fail, then Kafka is considered healthy.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._
Unit tests
Manual test

Healthy
```
sergio@pop-os:~/Development/ksql$ curl -X "GET" "http://localhost:8088/healthcheck" -H "Content-Type: application/vnd.ksql.v1+json; charset=utf-8" | jq .
{
  "isHealthy": true,
  "details": {
    "metastore": {
      "isHealthy": true
    },
    "kafka": {
      "isHealthy": true
    }
  }
}
```

Kafka not healthy
```
$ curl -X "GET" "http://localhost:8088/healthcheck" -H "Content-Type: application/vnd.ksql.v1+json; charset=utf-8" | jq .
{
  "isHealthy": false,
  "details": {
    "metastore": {
      "isHealthy": true
    },
    "kafka": {
      "isHealthy": false
    }
  }
}
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

