### PR TITLE
build: ST-3227: Cleanup up all docker images after building

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -330,27 +330,10 @@ def job = {
 
 def post = {
     withDockerServer([uri: dockerHost()]) {
-        repos = config.dockerArtifacts + config.dockerRepos
-        repos.reverse().each { dockerRepo ->
-            if (params.PROMOTE_TO_PRODUCTION) {
-                sh """#!/usr/bin/env bash \n
-                images=\$(docker images -q ${dockerRepo})
-                if [[ ! -z \$images ]]; then
-                    docker rmi -f \$images || true
-                    else
-                        echo 'No images for ${dockerRepo} need cleanup'
-                    fi
-                """
-            }
-            sh """#!/usr/bin/env bash \n
-            images=\$(docker images -q ${config.dockerRegistry}${dockerRepo})
-            if [[ ! -z \$images ]]; then
-                docker rmi -f \$images || true
-                else
-                    echo 'No images for ${config.dockerRegistry}${dockerRepo} need cleanup'
-                fi
-            """
-        }
+        sh """#!/usr/bin/env bash \n
+            # Delete all images
+            docker rmi -f \$(docker images -a -q) || true
+        """
     }
     commonPost(finalConfig)
 }


### PR DESCRIPTION
### Description 
This will delete all of the docker images on the jenkins node after building. If we don't do this and only cleanup the CP images then we never pull down the latest version of the base os image. This issue may never really affect this builds, but better to be safe and just delete everything. Also, leaving images on the machine after this builds could affect other builds.

### Testing done 
This has been tested with building the CP images.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

