### PR TITLE
feat: add COALESCE function

### DIFF
--- a/docs-md/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs-md/developer-guide/ksqldb-reference/scalar-functions.md
@@ -21,7 +21,6 @@ keywords: ksqlDB, function, scalar
   - [SIGN](#sign)
   - [SQRT](#sqrt)
 - [Collections](#collections)
-  - [ARRAY_LENGTH](#array_length)
   - [ARRAYCONTAINS](#arraycontains)
   - [ARRAY](#array)
   - [MAP](#map)
@@ -188,15 +187,6 @@ The square root of a value.
 
 Collections
 ===========
-
-ARRAY_LENGTH
-------------
-
-`ARRAY_LENGTH(ARRAY[1, 2, 3])`
-
-Given an array, return the number of elements in the array.
-
-If the supplied parameter is null the method returns 0.
 
 ARRAYCONTAINS
 -------------

--- a/docs-md/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs-md/developer-guide/ksqldb-reference/scalar-functions.md
@@ -444,10 +444,11 @@ COALESCE
 
 Returns the first non-null parameter. All parameters must be of the same type.
 
+Where the parameter type is a complex type, for example `ARRAY` or `STRUCT`, the contents of the
+complex type are not inspected. The behaviour is the same: the first non-null element is returned.
+
 IFNULL
 ------
-
-Deprecated: Please use [COALESCE](#coalesce)
 
 `IFNULL(col1, retval)`
 

--- a/docs-md/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs-md/developer-guide/ksqldb-reference/scalar-functions.md
@@ -21,6 +21,7 @@ keywords: ksqlDB, function, scalar
   - [SIGN](#sign)
   - [SQRT](#sqrt)
 - [Collections](#collections)
+  - [ARRAY_LENGTH](#array_length)
   - [ARRAYCONTAINS](#arraycontains)
   - [ARRAY](#array)
   - [MAP](#map)
@@ -31,7 +32,6 @@ keywords: ksqlDB, function, scalar
 - [Strings](#strings)
   - [CONCAT](#concat)
   - [EXTRACTJSONFIELD](#extractjsonfield)
-  - [IFNULL](#ifnull)
   - [INITCAP](#initcap)
   - [LCASE](#lcase)
   - [LEN](#len)
@@ -46,6 +46,9 @@ keywords: ksqlDB, function, scalar
   - [SUBSTRING](#substring)
   - [TRIM](#trim)
   - [UCASE](#ucase)
+- [Nulls](#nulls)
+  - [COALESCE](#coalesce)
+  - [IFNULL](#ifnull)
 - [Date and Time](#date-and-time)
   - [UNIX_DAT](#unixdat)
   - [UNIX_TIMESTAMP](#unixtimestamp)
@@ -90,7 +93,7 @@ Constructs an array of structs from the entries in a map. Each struct has
 a field named `K` containing the key, which is a string, and a field named
 `V`, which holds the value.
 
-If `sorted` is true, the entries are sorted by key.                                          
+If `sorted` is true, the entries are sorted by key.
 
 EXP
 ---
@@ -111,7 +114,7 @@ GENERATE_SERIES
 
 `GENERATE_SERIES(start, end)`
 
-Constructs an array of values between `start` and `end` (inclusive).       
+Constructs an array of values between `start` and `end` (inclusive).
 Parameters can be `INT` or `BIGINT`.
 
 GENERATE_SERIES
@@ -120,7 +123,7 @@ GENERATE_SERIES
 `GENERATE_SERIES(start, end, step)`
 
 Constructs an array of values between `start` and `end` (inclusive)
-with a specified step size. The step can be positive or negative.      
+with a specified step size. The step can be positive or negative.
 Parameters `start` and `end` can be `INT` or `BIGINT`. Parameter `step`
 must be an `INT`.
 
@@ -146,7 +149,7 @@ RANDOM
 
 `RANDOM()`
 
-Return a random DOUBLE value between 0.0 and 1.0.  
+Return a random DOUBLE value between 0.0 and 1.0.
 
 ROUND
 -----
@@ -185,6 +188,15 @@ The square root of a value.
 
 Collections
 ===========
+
+ARRAY_LENGTH
+------------
+
+`ARRAY_LENGTH(ARRAY[1, 2, 3])`
+
+Given an array, return the number of elements in the array.
+
+If the supplied parameter is null the method returns 0.
 
 ARRAYCONTAINS
 -------------
@@ -272,15 +284,6 @@ you can use the `STRUCT` type, which is easier to work with. For example,
 {"foo": {"bar": "quux"}}.
 ```
 
-IFNULL
-------
-
-`IFNULL(col1, retval)`
-
-If the provided VARCHAR is NULL, return `retval`, otherwise, return the
-value. Only VARCHAR values are supported for the input. The return value
-must be a VARCHAR.
-
 INITCAP
 -------
 
@@ -324,7 +327,7 @@ all default masks. `MASK("My Test $123", '*', NULL, '1', NULL)` will yield
 MASK_KEEP_LEFT
 --------------
 
-`MASK_KEEP_LEFT(col1, numChars, 'X', 'x', 'n', '-')` 
+`MASK_KEEP_LEFT(col1, numChars, 'X', 'x', 'n', '-')`
 
 Similar to the `MASK` function above, except
 that the first or left-most `numChars`
@@ -357,7 +360,7 @@ will return `Xx-Xest $123`.
 MASK_RIGHT
 ----------
 
-`MASK_RIGHT(col1, numChars, 'X', 'x', 'n', '-')`  
+`MASK_RIGHT(col1, numChars, 'X', 'x', 'n', '-')`
 
 Similar to the `MASK` function above, except
 that only the last or right-most `numChars`
@@ -398,7 +401,7 @@ element in the array. If the delimiter is empty,
 then all characters in the string are split.
 If either, string or delimiter, are NULL, then a
 NULL value is returned.
-                                                  
+
 If the delimiter is found at the beginning or end
 of the string, or there are contiguous delimiters,
 then an empty space is added to the array.
@@ -430,6 +433,26 @@ UCASE
 `UCASE(col1)`
 
 Convert a string to uppercase.
+
+Nulls
+=====
+
+COALESCE
+--------
+
+`COALESCE(a, b, c, d)`
+
+Returns the first non-null parameter. All parameters must be of the same type.
+
+IFNULL
+------
+
+Deprecated: Please use [COALESCE](#coalesce)
+
+`IFNULL(col1, retval)`
+
+If the provided VARCHAR is NULL, return `retval`, otherwise, return `col1`.
+Only VARCHAR values are supported for the input. The return value must be a VARCHAR.
 
 Date and Time
 =============

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/nulls/Coalesce.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/nulls/Coalesce.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.nulls;
+
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Returns first non-null element
+ */
+@SuppressWarnings("MethodMayBeStatic") // UDF methods can not be static.
+@UdfDescription(name = "COALESCE", description = "Returns first non-null element")
+public class Coalesce {
+
+  @SuppressWarnings("varargs")
+  @SafeVarargs
+  @Udf
+  public final <T> T coalesce(final T first, final T... others) {
+    if (first != null) {
+      return first;
+    }
+
+    if (others == null) {
+      return null;
+    }
+
+    return Arrays.stream(others)
+        .filter(Objects::nonNull)
+        .findFirst()
+        .orElse(null);
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/IfNullKudf.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/IfNullKudf.java
@@ -17,22 +17,11 @@ package io.confluent.ksql.function.udf.string;
 
 import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Kudf;
-import java.util.concurrent.atomic.AtomicBoolean;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class IfNullKudf implements Kudf {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(IfNullKudf.class);
-  private static final AtomicBoolean FIRST_CALL = new AtomicBoolean(true);
-
   @Override
   public Object evaluate(final Object... args) {
-    if (FIRST_CALL.getAndSet(false)) {
-      LOGGER.warn("Use of IFNULL is deprecated and will be removed in a future release. "
-          + "Please change your queries to use COALESCE.");
-    }
-
     if (args.length != 2) {
       throw new KsqlFunctionException("IfNull udf should have two input argument.");
     }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/IfNullKudf.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/IfNullKudf.java
@@ -17,11 +17,22 @@ package io.confluent.ksql.function.udf.string;
 
 import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Kudf;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class IfNullKudf implements Kudf {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(IfNullKudf.class);
+  private static final AtomicBoolean FIRST_CALL = new AtomicBoolean(true);
+
   @Override
   public Object evaluate(final Object... args) {
+    if (FIRST_CALL.getAndSet(false)) {
+      LOGGER.warn("Use of IFNULL is deprecated and will be removed in a future release. "
+          + "Please change your queries to use COALESCE.");
+    }
+
     if (args.length != 2) {
       throw new KsqlFunctionException("IfNull udf should have two input argument.");
     }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/nulls/CoalesceTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/nulls/CoalesceTest.java
@@ -1,0 +1,42 @@
+package io.confluent.ksql.function.udf.nulls;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CoalesceTest {
+
+  private Coalesce udf;
+
+  @Before
+  public void setUp() {
+    udf = new Coalesce();
+  }
+
+  @Test
+  public void shouldReturnNullForNullOnly() {
+    assertThat(udf.coalesce(null), is(nullValue()));
+  }
+
+  @Test
+  public void shouldReturnNullForNullOthers() {
+    assertThat(udf.coalesce(null, (String[]) null), is(nullValue()));
+  }
+
+  @Test
+  public void shouldReturnNullForEmptyOthers() {
+    assertThat(udf.coalesce(null, new Double[]{}), is(nullValue()));
+  }
+
+  @Test
+  public void shouldReturnFirstNonNullEntity() {
+    assertThat(udf.coalesce(1, 2, 3), is(1));
+    assertThat(udf.coalesce(null, "a", "b", "c", "d"), is("a"));
+    assertThat(udf.coalesce(null, ImmutableList.of(), null), is(ImmutableList.of()));
+    assertThat(udf.coalesce(null, null, 1.0), is(1.0));
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/null.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/null.json
@@ -76,6 +76,42 @@
         "type": "io.confluent.ksql.util.KsqlStatementException",
         "message": "Comparison with NULL not supported: NULL <> NULL"
       }
+    },
+    {
+      "name": "coalesce",
+      "statements": [
+        "CREATE STREAM INPUT (COL0 INT KEY, COL1 STRING, COL2 ARRAY<INT>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT COALESCE(COL0, 10, 20) AS A, COALESCE(COL1, 'x') AS B, COALESCE(COL2, ARRAY[10, 20]) AS C FROM INPUT;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": {"COL1": "not null", "COL2": [1, 2, 3]}},
+        {"topic": "test_topic", "key": null, "value": {}},
+        {"topic": "test_topic", "key": null, "value": null},
+        {"topic": "test_topic", "key": 2, "value": {"COL1": "not null", "COL2": [4, 5, 6]}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"A": 1, "B": "not null", "C": [1, 2, 3]}},
+        {"topic": "OUTPUT", "key": null, "value": {"A": 10, "B": "x", "C": [10, 20]}},
+        {"topic": "OUTPUT", "key": null, "value": null},
+        {"topic": "OUTPUT", "key": 2, "value": {"A": 2, "B": "not null", "C": [4, 5, 6]}}
+      ]
+    },
+    {
+      "name": "coalesce - no params",
+      "statements": [
+        "CREATE STREAM INPUT (COL0 INT KEY, COL1 STRING, COL2 ARRAY<INT>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT COALESCE() FROM INPUT;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Function 'COALESCE' does not accept parameters ()"
+      }
     }
   ]
 }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/null.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/null.json
@@ -80,23 +80,23 @@
     {
       "name": "coalesce",
       "statements": [
-        "CREATE STREAM INPUT (COL0 INT KEY, COL1 STRING, COL2 ARRAY<INT>) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT COALESCE(COL0, 10, 20) AS A, COALESCE(COL1, 'x') AS B, COALESCE(COL2, ARRAY[10, 20]) AS C FROM INPUT;"
+        "CREATE STREAM INPUT (COL0 INT KEY, COL1 INT, COL2 STRING, COL3 ARRAY<INT>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT COALESCE(COL0, COL1, COL0, COL1) AS A, COALESCE(COL2, 'x') AS B, COALESCE(COL3, ARRAY[10, 20]) AS C FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
       },
       "inputs": [
-        {"topic": "test_topic", "key": 1, "value": {"COL1": "not null", "COL2": [1, 2, 3]}},
+        {"topic": "test_topic", "key": 1, "value": {"COL1": 2, "COL2": "not null", "COL3": [1, 2, 3]}},
         {"topic": "test_topic", "key": null, "value": {}},
         {"topic": "test_topic", "key": null, "value": null},
-        {"topic": "test_topic", "key": 2, "value": {"COL1": "not null", "COL2": [4, 5, 6]}}
+        {"topic": "test_topic", "key": null, "value": {"COL1": 2, "COL2": "not null", "COL3": [4, 5, 6]}}
       ],
       "outputs": [
         {"topic": "OUTPUT", "key": 1, "value": {"A": 1, "B": "not null", "C": [1, 2, 3]}},
-        {"topic": "OUTPUT", "key": null, "value": {"A": 10, "B": "x", "C": [10, 20]}},
+        {"topic": "OUTPUT", "key": null, "value": {"A": null, "B": "x", "C": [10, 20]}},
         {"topic": "OUTPUT", "key": null, "value": null},
-        {"topic": "OUTPUT", "key": 2, "value": {"A": 2, "B": "not null", "C": [4, 5, 6]}}
+        {"topic": "OUTPUT", "key": null, "value": {"A": 2, "B": "not null", "C": [4, 5, 6]}}
       ]
     },
     {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/partition-by.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/partition-by.json
@@ -387,6 +387,26 @@
           }
         ]
       }
+    },
+    {
+      "name": "nulls using coalesce",
+      "statements": [
+        "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar) with (kafka_topic='test_topic', value_format = 'json');",
+        "CREATE STREAM REPARTITIONED AS select id from TEST partition by COALESCE(name, 'default');"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "fred"}},
+        {"topic": "test_topic", "key": 1, "value": {"NAME": null}},
+        {"topic": "test_topic", "key": 2, "value": {}}
+      ],
+      "outputs": [
+        {"topic": "REPARTITIONED", "key": "fred", "value": {"ID": 0}},
+        {"topic": "REPARTITIONED", "key": "default", "value": {"ID": 1}},
+        {"topic": "REPARTITIONED", "key": "default", "value": {"ID": 2}}
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Description 

The `COALESCE` function takes one or more parameters and returns the first that is non-null.

All parameters must be of the same type.

This function supersedes the existing `IFNULL` function, which only worked for strings and one accepted two parameters.

Note: also added docs for the `ARRAY_LENGH` I added recently, as I seemed to of missed adding docs!

### Testing done 

QTT + unit tests added.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

