### PR TITLE
fix: don't cleanup topics on engine close (#4658)

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
@@ -533,6 +533,9 @@ public class KsqlEngine implements Closeable {
   @Override
   public void close() {
     for (final QueryMetadata queryMetadata : allLiveQueries) {
+      if (queryMetadata instanceof PersistentQueryMetadata) {
+        queryMetadata.stop();
+      }
       queryMetadata.close();
     }
     adminClient.close();

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -95,4 +95,8 @@ public class PersistentQueryMetadata extends QueryMetadata {
   public int hashCode() {
     return Objects.hash(id, super.hashCode());
   }
+
+  public void stop() {
+    doClose(false);
+  }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/QueuedQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/QueuedQueryMetadata.java
@@ -76,6 +76,11 @@ public class QueuedQueryMetadata extends QueryMetadata {
   }
 
   @Override
+  public void stop() {
+    close();
+  }
+
+  @Override
   public void close() {
     super.close();
     isRunning.set(false);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/StatementExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/StatementExecutor.java
@@ -350,9 +350,7 @@ public class StatementExecutor {
       final TerminateQuery terminateQuery,
       final Mode mode) throws Exception {
     final QueryId queryId = terminateQuery.getQueryId();
-    if (!ksqlEngine.terminateQuery(queryId, mode == Mode.EXECUTE)) {
-      throw new Exception(String.format("No running query with id %s was found", queryId));
-    }
+    ksqlEngine.terminateQuery(queryId, mode == Mode.EXECUTE);
   }
 
   private void maybeTerminateQueryForLegacyDropCommand(

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StreamedQueryResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StreamedQueryResourceTest.java
@@ -168,9 +168,9 @@ public class StreamedQueryResourceTest {
     expectLastCall();
     mockKafkaStreams.setUncaughtExceptionHandler(anyObject(Thread.UncaughtExceptionHandler.class));
     expectLastCall();
-    expect(mockKafkaStreams.state()).andReturn(State.RUNNING).once();
-    expect(mockKafkaStreams.state()).andReturn(KafkaStreams.State.NOT_RUNNING).once();
     mockKafkaStreams.close();
+    expectLastCall();
+    mockKafkaStreams.cleanUp();
     expectLastCall();
 
 


### PR DESCRIPTION
### Description 
Like https://github.com/confluentinc/ksql/pull/4819/files but for 5.1
Backports these fixes
https://github.com/confluentinc/ksql/pull/4643
https://github.com/confluentinc/ksql/pull/4658

I don't think it's possible to backport the KsqlEngineTest since 5.1.x is when it was still using EasyMock, so there's no `Spy` option for the `topicClient`.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

