### PR TITLE
fix: Filter out hosts with no lag info by default

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/MaximumLagFilter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/MaximumLagFilter.java
@@ -66,7 +66,10 @@ public final class MaximumLagFilter implements RoutingFilter {
           final long offsetLag = Math.max(endOffset - hostLag.getCurrentOffsetPosition(), 0);
           return offsetLag <= allowedOffsetLag;
         })
-        // If we don't have lag info, we'll be conservative and not include the host
+        // If we don't have lag info, we'll be conservative and not include the host.  We have a
+        // dual purpose, in both having HA and also having lag guarantees.  This ensures that we are
+        // honoring the lag guarantees, and we'll try to minimize the window where lag isn't
+        // available to promote HA.
         .orElse(false);
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/MaximumLagFilter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/MaximumLagFilter.java
@@ -66,8 +66,8 @@ public final class MaximumLagFilter implements RoutingFilter {
           final long offsetLag = Math.max(endOffset - hostLag.getCurrentOffsetPosition(), 0);
           return offsetLag <= allowedOffsetLag;
         })
-        // If we don't have lag info, we'll be conservative and include the host
-        .orElse(true);
+        // If we don't have lag info, we'll be conservative and not include the host
+        .orElse(false);
   }
 
   /**

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/HighAvailabilityTestUtil.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/HighAvailabilityTestUtil.java
@@ -175,7 +175,7 @@ class HighAvailabilityTestUtil {
   public static void sendLagReportingRequest(
       final TestKsqlRestApp restApp,
       final LagReportingMessage lagReportingMessage
-  ) {
+  ) throws ExecutionException, InterruptedException {
 
     try (final KsqlRestClient restClient = restApp.buildKsqlClient()) {
       restClient.makeAsyncLagReportingRequest(lagReportingMessage)
@@ -183,9 +183,7 @@ class HighAvailabilityTestUtil {
             LOG.error("Unexpected exception in async request", t);
             return null;
           })
-      .get();
-    } catch (Exception e) {
-      LOG.error("Error waiting on lag report", e);
+          .get();
     }
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/HighAvailabilityTestUtil.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/HighAvailabilityTestUtil.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -181,7 +182,10 @@ class HighAvailabilityTestUtil {
           .exceptionally(t -> {
             LOG.error("Unexpected exception in async request", t);
             return null;
-          });
+          })
+      .get();
+    } catch (Exception e) {
+      LOG.error("Error waiting on lag report", e);
     }
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
@@ -244,7 +244,7 @@ public class PullQueryRoutingFunctionalTest {
   }
 
   @Test
-  public void shouldQueryActiveWhenActiveAliveQueryIssuedToStandby() {
+  public void shouldQueryActiveWhenActiveAliveQueryIssuedToStandby() throws Exception {
     // Given:
     ClusterFormation clusterFormation = findClusterFormation(REST_APP_0, REST_APP_1, REST_APP_2);
     waitForClusterToBeDiscovered(clusterFormation.standBy.right, 3);
@@ -265,7 +265,7 @@ public class PullQueryRoutingFunctionalTest {
 
 
   @Test
-  public void shouldQueryActiveWhenActiveAliveStandbyDeadQueryIssuedToRouter() {
+  public void shouldQueryActiveWhenActiveAliveStandbyDeadQueryIssuedToRouter() throws Exception {
     // Given:
     ClusterFormation clusterFormation = findClusterFormation(REST_APP_0, REST_APP_1, REST_APP_2);
     waitForClusterToBeDiscovered(clusterFormation.router.right, 3);
@@ -291,7 +291,7 @@ public class PullQueryRoutingFunctionalTest {
   }
 
   @Test
-  public void shouldQueryStandbyWhenActiveDeadStandbyAliveQueryIssuedToRouter() {
+  public void shouldQueryStandbyWhenActiveDeadStandbyAliveQueryIssuedToRouter() throws Exception {
     // Given:
     ClusterFormation clusterFormation = findClusterFormation(REST_APP_0, REST_APP_1, REST_APP_2);
     waitForClusterToBeDiscovered(clusterFormation.router.right, 3);
@@ -313,7 +313,7 @@ public class PullQueryRoutingFunctionalTest {
   }
 
   @Test
-  public void shouldFilterLaggyServers() {
+  public void shouldFilterLaggyServers() throws Exception {
     // Given:
     ClusterFormation clusterFormation = findClusterFormation(REST_APP_0, REST_APP_1, REST_APP_2);
     waitForClusterToBeDiscovered(clusterFormation.router.right, 3);
@@ -336,11 +336,12 @@ public class PullQueryRoutingFunctionalTest {
     KsqlErrorMessage errorMessage = makePullQueryRequestWithError(clusterFormation.router.right,
         sql, LAG_FILTER_25);
     Assert.assertEquals(40001, errorMessage.getErrorCode());
+    Assert.assertEquals("All nodes are dead or exceed max allowed lag.", errorMessage.getMessage());
   }
 
   private void sendLagReportingMessages(
       final Pair<KsqlHostInfoEntity, TestKsqlRestApp> to,
-      final Pair<KsqlHostInfoEntity, TestKsqlRestApp> from) {
+      final Pair<KsqlHostInfoEntity, TestKsqlRestApp> from) throws Exception {
     LagReportingMessage lagReportingMessage =
         new LagReportingMessage(from.left,
             new HostStoreLags(createLagMap(HOST_CURRENT_OFFSET, HOST_END_OFFSET, HOST_LAG), 100));

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
@@ -336,8 +336,6 @@ public class PullQueryRoutingFunctionalTest {
     KsqlErrorMessage errorMessage = makePullQueryRequestWithError(clusterFormation.router.right,
         sql, LAG_FILTER_25);
     Assert.assertEquals(40001, errorMessage.getErrorCode());
-    Assert.assertTrue(errorMessage.getMessage()
-        .contains("All nodes are dead or exceed max allowed lag"));
   }
 
   private void sendLagReportingMessages(

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/MaximumLagFilterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/MaximumLagFilterTest.java
@@ -94,7 +94,7 @@ public class MaximumLagFilterTest {
         PARTITION).get();
 
     // Then:
-    assertTrue(filter.filter(HOST1));
+    assertFalse(filter.filter(HOST1));
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/MaximumLagFilterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/MaximumLagFilterTest.java
@@ -81,7 +81,7 @@ public class MaximumLagFilterTest {
   }
 
   @Test
-  public void filter_hostNoLag() {
+  public void filter_shouldRemoveWhenNoLag() {
     // Given:
     when(lagReportingAgent.getLagInfoForHost(eq(HOST1),
         eq(QueryStateStoreId.of(APPLICATION_ID, STATE_STORE)), eq(PARTITION)))


### PR DESCRIPTION


### Description 
Previously, this would include hosts with no lag information.  This reverses that.  This means that there will be a couple seconds of downtime for a host when it starts up.  We're taking other efforst to fix this.

Also, makes PullQueryRoutingFunctionalTest more reliable by waiting on the lag report request to finish.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

