### PR TITLE
fix: avoid long possible format lists on PRINT TOPIC for nulls

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/RecordFormatter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/RecordFormatter.java
@@ -19,6 +19,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
 import com.google.protobuf.Message;
 import com.google.protobuf.TextFormat;
@@ -203,6 +204,7 @@ public final class RecordFormatter {
 
     private final String topicName;
     private final List<NamedDeserializer> deserializers;
+    private boolean seenData = false;
 
     @SuppressWarnings("UnstableApiUsage")
     Deserializers(
@@ -232,6 +234,10 @@ public final class RecordFormatter {
     }
 
     List<String> getPossibleFormats() {
+      if (!seenData) {
+        return ImmutableList.of("¯\\_(ツ)_/¯ - no data processed");
+      }
+
       return deserializers.stream()
           .map(NamedDeserializer::toString)
           .filter(name -> !name.equals(Format.UNRECOGNISED_BYTES.toString()))
@@ -242,6 +248,8 @@ public final class RecordFormatter {
       if (bytes == null || bytes.get() == null) {
         return "<null>";
       }
+
+      seenData = true;
 
       String firstResult = null;
       final Iterator<NamedDeserializer> it = deserializers.iterator();


### PR DESCRIPTION
### Description 

fixes: https://github.com/confluentinc/ksql/issues/4852

If processing data with NULL key or values, (generally keys), then PRINT TOPIC would output a long list of possible formats for the key, i.e. ALL the possible formats for the key.  This isn't really very useful.

The cause was that no data had been processed, so no formats had been rejected.

This commit changes the behaviour in the situation where no data has been processed to output a shorter message, for example:

```
ksql> print Topic_with_null_keys from beginning;
Key format: ¯\_(ツ)_/¯ - no data processed
Value format: JSON or KAFKA_STRING
rowtime: 23/03/20 12:45:33 GMT, key: <null>, value: {"NAME": "bob"}
```

### Testing done 

Unit tests updated + manual testing.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

