### PR TITLE
build: Fix for config object not being referenced correctly in the job method.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-def config = {
+def baseConfig = {
     owner = 'ksql'
     slackChannel = '#ksql-alerts'
     ksql_db_version = "0.8.0-SNAPSHOT"
@@ -36,7 +36,7 @@ def updateConfig = { c ->
     c.properties = [parameters(defaultParams)]
 }
 
-def finalConfig = jobConfig(config, [:], updateConfig)
+def config = jobConfig(baseConfig, [:], updateConfig)
 
 def job = {
     if (config.isPrJob && params.PROMOTE_TO_PRODUCTION) {
@@ -268,7 +268,7 @@ def job = {
             }
         }
 
-    if(config.dockerScan){
+    if(config.dockerScan && !config.isPrJob){
         stage('Twistloc scan') {
             withDockerServer([uri: dockerHost()]) {
                 config.dockerRepos.each { dockerRepo ->
@@ -291,7 +291,7 @@ def job = {
         }
     }
 
-    if(config.dockerScan){
+    if(config.dockerScan && !config.isPrJob){
         stage('Twistloc publish') {
             withDockerServer([uri: dockerHost()]) {
                 config.dockerRepos.each { dockerRepo ->
@@ -352,7 +352,7 @@ def post = {
             """
         }
     }
-    commonPost(finalConfig)
+    commonPost(config)
 }
 
-runJob finalConfig, job, post
+runJob config, job, post


### PR DESCRIPTION
### Description 
This fixes an issue discovered by @vcrfxia in which she found that the config.isPrJob variable was not being set or available in the job method so all of the logic based on that config variable being present was not working as expected. It turns out that none of the config variables that get set during jobConfig were available.

Due to my misunderstanding of the variable scope the final config object was not available in the job method. The config object does not get passed to the job method via runJob. It is actually referencing it directly from the Jenkinsfile. So all of the calls in the job method to config were actually referencing the original declaration of that object and not what was returned after jobConfig processed all the configs. This is because the variable name used for the results of jobConfig was finalConfig. Instead of renaming each reference in the job method to the config object to finalConfig I renamed the original config object to baseConfig and renamed the finalConfig object to config.

### Testing done 
I tested this in another PR where I replayed it several times after doing this rename and printed out the value of the config object from the job method to ensure the values were present. Prior to this fix the config object was null.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

