### PR TITLE
fix: Infer TLS based on scheme of server string

### DIFF
--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslClientAuthFunctionalTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslClientAuthFunctionalTest.java
@@ -178,7 +178,6 @@ public class SslClientAuthFunctionalTest {
     clientProps.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, clientCertPassword);
 
     clientProps.put(KsqlClient.DISABLE_HOSTNAME_VERIFICATION_PROP_NAME, "true");
-    clientProps.put(KsqlClient.TLS_ENABLED_PROP_NAME, "true");
 
     // WS:
     sslContextFactory.setTrustStorePath(ClientTrustStore.trustStorePath());
@@ -195,7 +194,6 @@ public class SslClientAuthFunctionalTest {
     clientProps.putAll(ClientTrustStore.trustStoreProps());
 
     clientProps.put(KsqlClient.DISABLE_HOSTNAME_VERIFICATION_PROP_NAME, "true");
-    clientProps.put(KsqlClient.TLS_ENABLED_PROP_NAME, "true");
 
     // WS:
     sslContextFactory.setTrustStorePath(ClientTrustStore.trustStorePath());

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslFunctionalTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslFunctionalTest.java
@@ -176,7 +176,6 @@ public class SslFunctionalTest {
     clientProps = new HashMap<>();
     clientProps.putAll(ClientTrustStore.trustStoreProps());
     clientProps.put(KsqlClient.DISABLE_HOSTNAME_VERIFICATION_PROP_NAME, "true");
-    clientProps.put(KsqlClient.TLS_ENABLED_PROP_NAME, "true");
 
     // WS:
     sslContextFactory.setTrustStorePath(ClientTrustStore.trustStorePath());
@@ -187,7 +186,6 @@ public class SslFunctionalTest {
   private void givenClientConfguredWithoutTruststore() {
     clientProps = new HashMap<>();
     clientProps.put(KsqlClient.DISABLE_HOSTNAME_VERIFICATION_PROP_NAME, "true");
-    clientProps.put(KsqlClient.TLS_ENABLED_PROP_NAME, "true");
   }
 
   private Code canMakeCliRequest() {

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -63,6 +63,9 @@ public class KsqlRestClient implements Closeable {
       final Optional<BasicCredentials> creds
   ) {
     final LocalProperties localProperties = new LocalProperties(localProps);
+    if (serverAddress.startsWith("https:")) {
+      clientProps.put(KsqlClient.TLS_ENABLED_PROP_NAME, "true");
+    }
     final KsqlClient client = new KsqlClient(clientProps, creds, localProperties,
         new HttpClientOptions());
     return new KsqlRestClient(client, serverAddress, localProperties);

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -63,7 +63,7 @@ public class KsqlRestClient implements Closeable {
       final Optional<BasicCredentials> creds
   ) {
     final LocalProperties localProperties = new LocalProperties(localProps);
-    if (serverAddress.startsWith("https:")) {
+    if (serverAddress.toLowerCase().startsWith("https:")) {
       clientProps.put(KsqlClient.TLS_ENABLED_PROP_NAME, "true");
     }
     final KsqlClient client = new KsqlClient(clientProps, creds, localProperties,


### PR DESCRIPTION
### Description 

Fixes: https://github.com/confluentinc/ksql/issues/4885

Now we infer whether tls is enabled for the KsqlRestClient based on the server connect string.

### Testing done 

Updated tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

