### PR TITLE
fix: Infer TLS based on scheme of server string

### DIFF
--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslClientAuthFunctionalTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslClientAuthFunctionalTest.java
@@ -178,7 +178,6 @@ public class SslClientAuthFunctionalTest {
     clientProps.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, clientCertPassword);
 
     clientProps.put(KsqlClient.DISABLE_HOSTNAME_VERIFICATION_PROP_NAME, "true");
-    clientProps.put(KsqlClient.TLS_ENABLED_PROP_NAME, "true");
 
     // WS:
     sslContextFactory.setTrustStorePath(ClientTrustStore.trustStorePath());
@@ -195,7 +194,6 @@ public class SslClientAuthFunctionalTest {
     clientProps.putAll(ClientTrustStore.trustStoreProps());
 
     clientProps.put(KsqlClient.DISABLE_HOSTNAME_VERIFICATION_PROP_NAME, "true");
-    clientProps.put(KsqlClient.TLS_ENABLED_PROP_NAME, "true");
 
     // WS:
     sslContextFactory.setTrustStorePath(ClientTrustStore.trustStorePath());

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslClientAuthFunctionalTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslClientAuthFunctionalTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.internal.matchers.ThrowableCauseMatcher.hasCause;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.net.UrlEscapers;
 import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.integration.IntegrationTestHarness;
@@ -108,8 +109,7 @@ public class SslClientAuthFunctionalTest {
 
   @Before
   public void setUp() {
-    clientProps = new HashMap<>();
-    clientProps.put(KsqlClient.DISABLE_HOSTNAME_VERIFICATION_PROP_NAME, "true");
+    clientProps = ImmutableMap.of(KsqlClient.DISABLE_HOSTNAME_VERIFICATION_PROP_NAME, "true");
     sslContextFactory = new Server();
   }
 
@@ -171,13 +171,12 @@ public class SslClientAuthFunctionalTest {
         .get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG);
 
     // HTTP:
-    clientProps = new HashMap<>();
-    clientProps.putAll(ClientTrustStore.trustStoreProps());
-
-    clientProps.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, clientCertPath);
-    clientProps.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, clientCertPassword);
-
-    clientProps.put(KsqlClient.DISABLE_HOSTNAME_VERIFICATION_PROP_NAME, "true");
+    clientProps = ImmutableMap.<String, String>builder()
+        .putAll(ClientTrustStore.trustStoreProps())
+        .put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, clientCertPath)
+        .put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, clientCertPassword)
+        .put(KsqlClient.DISABLE_HOSTNAME_VERIFICATION_PROP_NAME, "true")
+        .build();
 
     // WS:
     sslContextFactory.setTrustStorePath(ClientTrustStore.trustStorePath());
@@ -190,10 +189,10 @@ public class SslClientAuthFunctionalTest {
   private void givenClientConfiguredWithoutCertificate() {
 
     // HTTP:
-    clientProps = new HashMap<>();
-    clientProps.putAll(ClientTrustStore.trustStoreProps());
-
-    clientProps.put(KsqlClient.DISABLE_HOSTNAME_VERIFICATION_PROP_NAME, "true");
+    clientProps = ImmutableMap.<String, String>builder()
+        .putAll(ClientTrustStore.trustStoreProps())
+        .put(KsqlClient.DISABLE_HOSTNAME_VERIFICATION_PROP_NAME, "true")
+        .build();
 
     // WS:
     sslContextFactory.setTrustStorePath(ClientTrustStore.trustStorePath());

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslFunctionalTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslFunctionalTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.internal.matchers.ThrowableCauseMatcher.hasCause;
 import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.net.UrlEscapers;
 import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.integration.IntegrationTestHarness;
@@ -110,8 +111,7 @@ public class SslFunctionalTest {
 
   @Before
   public void setUp() {
-    clientProps = new HashMap<>();
-    clientProps.put(KsqlClient.DISABLE_HOSTNAME_VERIFICATION_PROP_NAME, "true");
+    clientProps = ImmutableMap.of(KsqlClient.DISABLE_HOSTNAME_VERIFICATION_PROP_NAME, "true");
     sslContextFactory = new Server();
   }
 
@@ -173,9 +173,10 @@ public class SslFunctionalTest {
 
   private void givenTrustStoreConfigured() {
     // HTTP:
-    clientProps = new HashMap<>();
-    clientProps.putAll(ClientTrustStore.trustStoreProps());
-    clientProps.put(KsqlClient.DISABLE_HOSTNAME_VERIFICATION_PROP_NAME, "true");
+    clientProps = ImmutableMap.<String, String>builder()
+        .putAll(ClientTrustStore.trustStoreProps())
+        .put(KsqlClient.DISABLE_HOSTNAME_VERIFICATION_PROP_NAME, "true")
+        .build();
 
     // WS:
     sslContextFactory.setTrustStorePath(ClientTrustStore.trustStorePath());
@@ -184,8 +185,7 @@ public class SslFunctionalTest {
   }
 
   private void givenClientConfguredWithoutTruststore() {
-    clientProps = new HashMap<>();
-    clientProps.put(KsqlClient.DISABLE_HOSTNAME_VERIFICATION_PROP_NAME, "true");
+    clientProps = ImmutableMap.of(KsqlClient.DISABLE_HOSTNAME_VERIFICATION_PROP_NAME, "true");
   }
 
   private Code canMakeCliRequest() {

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslFunctionalTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslFunctionalTest.java
@@ -176,7 +176,6 @@ public class SslFunctionalTest {
     clientProps = new HashMap<>();
     clientProps.putAll(ClientTrustStore.trustStoreProps());
     clientProps.put(KsqlClient.DISABLE_HOSTNAME_VERIFICATION_PROP_NAME, "true");
-    clientProps.put(KsqlClient.TLS_ENABLED_PROP_NAME, "true");
 
     // WS:
     sslContextFactory.setTrustStorePath(ClientTrustStore.trustStorePath());
@@ -187,7 +186,6 @@ public class SslFunctionalTest {
   private void givenClientConfguredWithoutTruststore() {
     clientProps = new HashMap<>();
     clientProps.put(KsqlClient.DISABLE_HOSTNAME_VERIFICATION_PROP_NAME, "true");
-    clientProps.put(KsqlClient.TLS_ENABLED_PROP_NAME, "true");
   }
 
   private Code canMakeCliRequest() {

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -44,7 +44,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
-public class KsqlRestClient implements Closeable {
+public final class KsqlRestClient implements Closeable {
 
   private final KsqlClient client;
   private final LocalProperties localProperties;

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -63,6 +63,9 @@ public class KsqlRestClient implements Closeable {
       final Optional<BasicCredentials> creds
   ) {
     final LocalProperties localProperties = new LocalProperties(localProps);
+    if (serverAddress.startsWith("https:")) {
+      clientProps.put(KsqlClient.TLS_ENABLED_PROP_NAME, "true");
+    }
     final KsqlClient client = new KsqlClient(clientProps, creds, localProperties,
         new HttpClientOptions());
     return new KsqlRestClient(client, serverAddress, localProperties);

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -63,7 +63,7 @@ public class KsqlRestClient implements Closeable {
       final Optional<BasicCredentials> creds
   ) {
     final LocalProperties localProperties = new LocalProperties(localProps);
-    if (serverAddress.startsWith("https:")) {
+    if (serverAddress.toLowerCase().startsWith("https:")) {
       clientProps.put(KsqlClient.TLS_ENABLED_PROP_NAME, "true");
     }
     final KsqlClient client = new KsqlClient(clientProps, creds, localProperties,


### PR DESCRIPTION
### Description 

This PR builds on top of https://github.com/confluentinc/ksql/pull/4891, which attempts to fix https://github.com/confluentinc/ksql/issues/4885.

The changes in https://github.com/confluentinc/ksql/pull/4891 reveal another bug:
The client props passed by the CLI to the rest client come from: https://github.com/confluentinc/ksql/blob/b0669a044b53407fba3ceb11bddee73e69c0006f/ksqldb-cli/src/main/java/io/confluent/ksql/Ksql.java#L124 and are immutable: https://github.com/confluentinc/ksql/blob/b0669a044b53407fba3ceb11bddee73e69c0006f/ksqldb-common/src/main/java/io/confluent/ksql/properties/PropertiesUtil.java#L95 which means a `java.lang.UnsupportedOperationException` is thrown when the code tries to execute
```
clientProps.put(KsqlClient.TLS_ENABLED_PROP_NAME, "true");
```
as in https://github.com/confluentinc/ksql/pull/4891.

This PR works around that by copying the immutable map, and also updates unit and integration tests so similar issues don't reappear in the future.

### Testing done 

Manually verification that this fixes https://github.com/confluentinc/ksql/issues/4885

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

