### PR TITLE
docs: stop recommending headless mode

### DIFF
--- a/docs-md/concepts/ksqldb-and-kafka-streams.md
+++ b/docs-md/concepts/ksqldb-and-kafka-streams.md
@@ -81,10 +81,7 @@ There are different workflows for ksqlDB and {{ site.kstreams }} when you
 develop streaming applications.
 
 - ksqlDB: You write SQL queries interactively and view the results in
-real-time, either in the ksqlDB CLI or in {{ site.c3 }}. You can save
-a .sql file and deploy it to production as a "headless"
-application, which runs without a GUI, CLI, or REST interface on
-ksqlDB servers.
+real-time, either in the ksqlDB CLI or in {{ site.c3 }}.
 - {{ site.kstreams }}: You write code in Java or Scala, recompile, and run
 and test the application in an IDE, like IntelliJ. You deploy the
 application to production as a jar file that runs in a {{ site.ak }} cluster.

--- a/docs-md/concepts/ksqldb-architecture.md
+++ b/docs-md/concepts/ksqldb-architecture.md
@@ -124,10 +124,7 @@ For more information, see
 ksqlDB Deployment Modes
 -----------------------
 
-You can use these modes to deploy your ksqlDB streaming applications:
-
-- **Interactive:** data exploration and pipeline development
-- **Headless:** long-running production environments
+You can use deploy your ksqlDB streaming applications using either **Interactive** or **Headless** mode. We recommend using interactive mode when possible.
 
 In both deployment modes, ksqlDB enables distributing the processing load
 for your ksqlDB applications across all ksqlDB Server instances, and you can
@@ -138,16 +135,16 @@ add more ksqlDB Server instances without restarting your applications.
 
 ### Interactive Deployment
 
-Use the interactive mode to develop your ksqlDB applications. When you
-deploy a ksqlDB server in interactive mode, the REST interface is
-available for the ksqlDB CLI and {{ site.c3 }} to connect to.
+When you deploy a ksqlDB server in interactive mode, the REST interface is
+available for the ksqlDB CLI and {{ site.c3 }} to connect to. This allows you
+to add and remove persistent queries without restarting the servers.
 
 ![Diagram showing interactive ksqlDB deployment](../img/ksqldb-client-server-interactive-mode.png)
 
 In interactive mode, you can:
 
 -   Write statements and queries on the fly
--   Start any number of server nodes:
+-   Start any number of server nodes dynamically:
     `<path-to-confluent>/bin/ksql-server-start`
 -   Start one or more CLIs or REST Clients and point them to a server:
     `<path-to-confluent>/bin/ksql https://<ksql-server-ip-address>:8090`
@@ -167,12 +164,12 @@ this makes the topic name easier to read.
 
 ### Headless Deployment
 
-Use headless mode to deploy your ksqlDB application to a production
-environment. When you deploy a ksqlDB Server in headless mode, the REST
+When you deploy a ksqlDB Server in headless mode, the REST
 interface isn't available, so you assign workloads to ksqlDB clusters by
-using a SQL file. The SQL file contains the SQL statements and queries
-that define your application. Headless mode is ideal for streaming ETL
-application deployments.
+using a SQL file. This can be useful if you want to completely lock down
+the set of persistent queries that ksqlDB will run.
+The SQL file contains the SQL statements and queries
+that define your application.
 
 ![Diagram showing headless ksqlDB deployment](../img/ksqldb-standalone-headless.png)
 
@@ -181,7 +178,6 @@ In headless mode you can:
 -   Start any number of server nodes
 -   Pass a SQL file with SQL statements to execute:
     `<path-to-confluent>bin/ksql-node query-file=path/to/myquery.sql`
--   Version-control your queries and transformations as code
 -   Ensure resource isolation
 -   Leave resource management to dedicated systems, like Kubernetes
 

--- a/docs-md/operate-and-deploy/capacity-planning.md
+++ b/docs-md/operate-and-deploy/capacity-planning.md
@@ -333,7 +333,7 @@ By default, ksqlDB Servers is configured for interactive use, which means
 you can use the ksqlDB CLI to interact with a ksqlDB cluster in order to,
 for example, execute new queries. Interactive ksqlDB usage allows for easy
 and quick iterative development and testing of your SQL queries via the
-ksqlDB CLI.
+ksqlDB CLI. This mode is recommended for production.
 
 You can also
 [configure the servers for headless, non-interactive operation](installation/server-config/index.md#non-interactive-headless-ksqldb-usage),
@@ -343,24 +343,12 @@ processing application that communicates to the outside world by reading
 from and writing to {{ site.ak }} topics. Sizing, deploying, and managing in
 this scenario is similar to a
 [Kafka Streams application](https://docs.confluent.io/current/streams/index.html).
-You should integrate ksqlDB deployments with your own CI/CD pipeline, for
-example, to version-control the .sql file.
+You can integrate ksqlDB deployments with your own CI/CD pipeline, for
+example, to version-control the .sql file. This can be desirable if you
+want to lock down the set of persistent queries that ksqlDB's servers can run.
 
-Here are some guidelines for choosing between the configuration types:
-
--   For production deployments, headless, non-interactive ksqlDB clusters
-    are recommended. This configuration provides the best isolation and,
-    unlike interactive ksqlDB clusters, minimizes the likelihood of
-    operator error and human mistakes.
--   For exploring and experimenting with your data, interactive ksqlDB
-    clusters are recommended. With this method you can quickly create
-    queries for your use case that will function as a streaming
-    "application" to produce meaningful results. You can then run this
-    "application" with headless, non-interactive ksqlDB clusters in
-    production.
--   For interactive ksqlDB usage, you should deploy an interactive ksqlDB
-    cluster per project or per team instead of a single, large ksqlDB
-    cluster for your organization.
+We recommend deploying a ksqlDB cluster per project, use case, or team instead
+of a single, large ksqlDB cluster to share across your organization.
 
 ### Scaling ksqlDB
 

--- a/docs-md/operate-and-deploy/installation/install-ksqldb-with-docker.md
+++ b/docs-md/operate-and-deploy/installation/install-ksqldb-with-docker.md
@@ -71,7 +71,6 @@ docker run -d \
   -e KSQL_KSQL_QUERIES_FILE=/path/in/container/queries.sql \
   confluentinc/ksqldb-server:{{ site.release }}
 ```
-TODO: Figure out how to style these
 
 `KSQL_BOOTSTRAP_SERVERS`
 


### PR DESCRIPTION
### Description 

We're trying to consolidate headless and interactive mode. For a while, we've started to recommend switching to interactive mode to take advantage of pull queries. We should make this our official recommendation to stop contradicting ourselves in the docs.
