### PR TITLE
chore: add syntax for multi-way joins

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analysis.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analysis.java
@@ -59,7 +59,7 @@ public class Analysis implements ImmutableAnalysis {
   private final Function<Map<SourceName, LogicalSchema>, SourceSchemas> sourceSchemasFactory;
   private Optional<Into> into = Optional.empty();
   private final List<AliasedDataSource> fromDataSources = new ArrayList<>();
-  private Optional<JoinInfo> joinInfo = Optional.empty();
+  private final List<JoinInfo> joinInfo = new ArrayList<>();
   private Optional<Expression> whereExpression = Optional.empty();
   private final List<SelectItem> selectItems = new ArrayList<>();
   private final Set<ColumnName> selectColumnNames = new HashSet<>();
@@ -169,20 +169,20 @@ public class Analysis implements ImmutableAnalysis {
     this.limitClause = OptionalInt.of(limitClause);
   }
 
-  void setJoin(final JoinInfo joinInfo) {
+  void addJoin(final JoinInfo joinInfo) {
     if (fromDataSources.size() <= 1) {
       throw new IllegalStateException("Join info can only be supplied for joins");
     }
 
-    this.joinInfo = Optional.of(joinInfo);
+    this.joinInfo.add(joinInfo);
   }
 
-  public Optional<JoinInfo> getJoin() {
+  public List<JoinInfo> getJoin() {
     return joinInfo;
   }
 
   public boolean isJoin() {
-    return joinInfo.isPresent();
+    return !joinInfo.isEmpty();
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analysis.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analysis.java
@@ -170,7 +170,8 @@ public class Analysis implements ImmutableAnalysis {
   }
 
   void addJoin(final JoinInfo joinInfo) {
-    if (fromDataSources.size() <= 1) {
+    // we cannot add more joins than we have data sources
+    if (fromDataSources.size() < this.joinInfo.size()) {
       throw new IllegalStateException("Join info can only be supplied for joins");
     }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -282,14 +282,14 @@ class Analyzer {
       isJoin = true;
 
       process(node.getLeft(), context);
-      node.getSources().forEach(right -> process(right.getRelation(), context));
+      node.getRights().forEach(right -> process(right.getRelation(), context));
 
       final JoinNode.JoinType joinType = getJoinType(node);
 
       final AliasedDataSource left = analysis.getFromDataSources().get(0);
       final AliasedDataSource right = analysis.getFromDataSources().get(1);
 
-      final JoinedSource source = Iterables.getOnlyElement(node.getSources());
+      final JoinedSource source = Iterables.getOnlyElement(node.getRights());
       final JoinOn joinOn = (JoinOn) source.getCriteria();
       final ComparisonExpression comparisonExpression = (ComparisonExpression) joinOn
           .getExpression();
@@ -434,7 +434,7 @@ class Analyzer {
 
     private JoinNode.JoinType getJoinType(final Join node) {
       final JoinNode.JoinType joinType;
-      final JoinedSource source = Iterables.getOnlyElement(node.getSources());
+      final JoinedSource source = Iterables.getOnlyElement(node.getRights());
       switch (source.getType()) {
         case INNER:
           joinType = JoinNode.JoinType.INNER;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/ImmutableAnalysis.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/ImmutableAnalysis.java
@@ -56,7 +56,9 @@ public interface ImmutableAnalysis {
 
   OptionalInt getLimitClause();
 
-  Optional<JoinInfo> getJoin();
+  boolean isJoin();
+
+  List<JoinInfo> getJoin();
 
   List<AliasedDataSource> getFromDataSources();
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/RewrittenAnalysis.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/RewrittenAnalysis.java
@@ -135,15 +135,20 @@ public class RewrittenAnalysis implements ImmutableAnalysis {
   }
 
   @Override
-  public Optional<JoinInfo> getJoin() {
-    return original.getJoin().map(
+  public List<JoinInfo> getJoin() {
+    return original.getJoin().stream().map(
         j -> new JoinInfo(
             rewrite(j.getLeftJoinExpression()),
             rewrite(j.getRightJoinExpression()),
             j.getType(),
             j.getWithinExpression()
         )
-    );
+    ).collect(Collectors.toList());
+  }
+
+  @Override
+  public boolean isJoin() {
+    return original.isJoin();
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/DataSourceExtractor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/DataSourceExtractor.java
@@ -152,7 +152,7 @@ class DataSourceExtractor {
       }
       addFieldNames(leftDataSource.getSchema(), leftColumnNames);
       final AliasedRelation right =
-          (AliasedRelation) Iterables.getOnlyElement(join.getSources()).getRelation();
+          (AliasedRelation) Iterables.getOnlyElement(join.getRights()).getRelation();
       rightAlias = right.getAlias();
       rightName = ((Table) right.getRelation()).getName();
       final DataSource

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/DataSourceExtractor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/DataSourceExtractor.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.engine.rewrite;
 
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
@@ -150,7 +151,8 @@ class DataSourceExtractor {
             + "exist.");
       }
       addFieldNames(leftDataSource.getSchema(), leftColumnNames);
-      final AliasedRelation right = (AliasedRelation) join.getRight();
+      final AliasedRelation right =
+          (AliasedRelation) Iterables.getOnlyElement(join.getSources()).getRelation();
       rightAlias = right.getAlias();
       rightName = ((Table) right.getRelation()).getName();
       final DataSource

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/StatementRewriter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/StatementRewriter.java
@@ -297,7 +297,7 @@ public final class StatementRewriter<C> {
       }
 
       final Relation rewrittenLeft = (Relation) rewriter.apply(node.getLeft(), context);
-      final JoinedSource rightSource = Iterables.getOnlyElement(node.getSources());
+      final JoinedSource rightSource = Iterables.getOnlyElement(node.getRights());
       final Relation rewrittenRight = (Relation) rewriter.apply(rightSource.getRelation(), context);
       final Optional<WithinExpression> rewrittenWithin = rightSource.getWithinExpression()
           .map(within -> (WithinExpression) rewriter.apply(within, context));

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -421,36 +421,37 @@ public class LogicalPlanner {
 
     final List<AliasedDataSource> sources = analysis.getFromDataSources();
 
-    final Optional<JoinInfo> joinInfo = analysis.getOriginal().getJoin();
-    if (!joinInfo.isPresent()) {
+    if (!analysis.isJoin()) {
       return buildNonJoinNode(sources);
     }
 
-    if (sources.size() != 2) {
-      throw new IllegalStateException("Expected 2 sources. Got " + sources.size());
+    if (sources.size() == 1) {
+      throw new IllegalStateException("Expected more than one source. Got " + sources.size());
     }
 
     final AliasedDataSource left = sources.get(0);
     final AliasedDataSource right = sources.get(1);
 
+    final List<JoinInfo> joinInfo = analysis.getOriginal().getJoin();
+
     final PlanNode leftSourceNode = buildSourceForJoin(
         left,
         "Left",
-        joinInfo.get().getLeftJoinExpression()
+        joinInfo.get(0).getLeftJoinExpression()
     );
 
     final PlanNode rightSourceNode = buildSourceForJoin(
         right,
         "Right",
-        joinInfo.get().getRightJoinExpression()
+        joinInfo.get(0).getRightJoinExpression()
     );
 
     return new JoinNode(
         new PlanNodeId("Join"),
-        joinInfo.get().getType(),
+        joinInfo.get(0).getType(),
         leftSourceNode,
         rightSourceNode,
-        joinInfo.get().getWithinExpression()
+        joinInfo.get(0).getWithinExpression()
     );
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/topic/SourceTopicsExtractor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/topic/SourceTopicsExtractor.java
@@ -51,7 +51,7 @@ public class SourceTopicsExtractor extends DefaultTraversalVisitor<AstNode, Void
   @Override
   protected AstNode visitJoin(final Join node, final Void context) {
     process(node.getLeft(), context);
-    process(node.getRight(), context);
+    node.getSources().forEach(source -> process(source.getRelation(), context));
     return null;
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/topic/SourceTopicsExtractor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/topic/SourceTopicsExtractor.java
@@ -51,7 +51,7 @@ public class SourceTopicsExtractor extends DefaultTraversalVisitor<AstNode, Void
   @Override
   protected AstNode visitJoin(final Join node, final Void context) {
     process(node.getLeft(), context);
-    node.getSources().forEach(source -> process(source.getRelation(), context));
+    node.getRights().forEach(source -> process(source.getRelation(), context));
     return null;
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/StatementRewriterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/StatementRewriterTest.java
@@ -45,7 +45,8 @@ import io.confluent.ksql.parser.tree.GroupBy;
 import io.confluent.ksql.parser.tree.GroupingElement;
 import io.confluent.ksql.parser.tree.InsertInto;
 import io.confluent.ksql.parser.tree.Join;
-import io.confluent.ksql.parser.tree.Join.Type;
+import io.confluent.ksql.parser.tree.JoinedSource;
+import io.confluent.ksql.parser.tree.JoinedSource.Type;
 import io.confluent.ksql.parser.tree.JoinCriteria;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Relation;
@@ -417,7 +418,7 @@ public class StatementRewriterTest {
   private Join givenJoin(final Optional<WithinExpression> within) {
     when(mockRewriter.apply(relation, context)).thenReturn(rewrittenRelation);
     when(mockRewriter.apply(rightRelation, context)).thenReturn(rewrittenRightRelation);
-    return new Join(location, Type.LEFT, relation, rightRelation, joinCriteria, within);
+    return new Join(location, relation, ImmutableList.of(new JoinedSource(Optional.empty(), rightRelation, Type.LEFT, joinCriteria, within)));
   }
 
   @Test
@@ -434,11 +435,13 @@ public class StatementRewriterTest {
         equalTo(
             new Join(
                 location,
-                Type.LEFT,
                 rewrittenRelation,
-                rewrittenRightRelation,
-                joinCriteria,
-                Optional.empty()))
+                ImmutableList.of(new JoinedSource(
+                    Optional.empty(),
+                    rewrittenRightRelation,
+                    Type.LEFT,
+                    joinCriteria,
+                    Optional.empty()))))
     );
   }
 
@@ -459,11 +462,13 @@ public class StatementRewriterTest {
         equalTo(
             new Join(
                 location,
-                Type.LEFT,
                 rewrittenRelation,
-                rewrittenRightRelation,
-                joinCriteria,
-                Optional.of(rewrittenWithinExpression)))
+                ImmutableList.of(new JoinedSource(
+                    Optional.empty(),
+                    rewrittenRightRelation,
+                    Type.LEFT,
+                    joinCriteria,
+                    Optional.of(rewrittenWithinExpression)))))
     );
   }
 

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/joins.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/joins.json
@@ -4020,6 +4020,19 @@
         "type": "io.confluent.ksql.util.KsqlStatementException",
         "message": "Implicit repartitioning of windowed sources is not supported. See https://github.com/confluentinc/ksql/issues/4385."
       }
+    },
+    {
+      "name": "join with multiple sources",
+      "statements": [
+        "CREATE STREAM S1 (ROWKEY INT KEY, ID bigint) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE TABLE T2 (ROWKEY INT KEY, ID bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE TABLE T3 (ROWKEY INT KEY, ID bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT * FROM S1 JOIN T2 ON S1.ID = T2.ID JOIN T3 ON S1.ID = T3.ID;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Invalid join criteria specified; KSQL does not support multi-way joins."
+      }
     }
   ]
 }

--- a/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -180,8 +180,12 @@ selectItem
     ;
 
 relation
-    : left=aliasedRelation joinType JOIN right=aliasedRelation joinWindow? joinCriteria #joinRelation
-    | aliasedRelation                                                                   #relationDefault
+    : left=aliasedRelation joinedSource+  #joinRelation
+    | aliasedRelation                     #relationDefault
+    ;
+
+joinedSource
+    : joinType JOIN aliasedRelation joinWindow? joinCriteria
     ;
 
 joinType

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/DefaultTraversalVisitor.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/DefaultTraversalVisitor.java
@@ -73,7 +73,7 @@ public abstract class DefaultTraversalVisitor<R, C> extends AstVisitor<R, C> {
   @Override
   protected R visitJoin(final Join node, final C context) {
     process(node.getLeft(), context);
-    process(node.getRight(), context);
+    node.getSources().forEach(join -> process(join, context));
 
     return null;
   }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/DefaultTraversalVisitor.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/DefaultTraversalVisitor.java
@@ -73,7 +73,7 @@ public abstract class DefaultTraversalVisitor<R, C> extends AstVisitor<R, C> {
   @Override
   protected R visitJoin(final Join node, final C context) {
     process(node.getLeft(), context);
-    node.getSources().forEach(join -> process(join, context));
+    node.getRights().forEach(join -> process(join, context));
 
     return null;
   }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
@@ -206,7 +206,7 @@ public final class SqlFormatter {
 
     @Override
     protected Void visitJoin(final Join join, final Integer indent) {
-      final JoinedSource node = Iterables.getOnlyElement(join.getSources());
+      final JoinedSource node = Iterables.getOnlyElement(join.getRights());
 
       final String type = node.getType().getFormatted();
       process(join.getLeft(), indent);

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.parser;
 import static com.google.common.collect.Iterables.getOnlyElement;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.Iterables;
 import io.confluent.ksql.execution.expression.formatter.ExpressionFormatter;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.name.Name;
@@ -40,6 +41,7 @@ import io.confluent.ksql.parser.tree.InsertValues;
 import io.confluent.ksql.parser.tree.Join;
 import io.confluent.ksql.parser.tree.JoinCriteria;
 import io.confluent.ksql.parser.tree.JoinOn;
+import io.confluent.ksql.parser.tree.JoinedSource;
 import io.confluent.ksql.parser.tree.ListFunctions;
 import io.confluent.ksql.parser.tree.ListStreams;
 import io.confluent.ksql.parser.tree.ListTables;
@@ -203,14 +205,16 @@ public final class SqlFormatter {
     }
 
     @Override
-    protected Void visitJoin(final Join node, final Integer indent) {
+    protected Void visitJoin(final Join join, final Integer indent) {
+      final JoinedSource node = Iterables.getOnlyElement(join.getSources());
+
       final String type = node.getType().getFormatted();
-      process(node.getLeft(), indent);
+      process(join.getLeft(), indent);
 
       builder.append('\n');
       append(indent, type).append(" JOIN ");
 
-      process(node.getRight(), indent);
+      process(node.getRelation(), indent);
 
       final JoinCriteria criteria = node.getCriteria();
 

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/Join.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/Join.java
@@ -18,78 +18,42 @@ package io.confluent.ksql.parser.tree;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
 @Immutable
 public class Join extends Relation {
 
-  private final Type type;
   private final Relation left;
-  private final Relation right;
-  private final JoinCriteria criteria;
-  private final Optional<WithinExpression> withinExpression;
-
-  public enum Type {
-    INNER("INNER"), LEFT("LEFT OUTER"), OUTER("FULL OUTER");
-
-    private final String formattedText;
-
-    Type(final String formattedText) {
-      this.formattedText = Objects.requireNonNull(formattedText, "formattedText");
-    }
-
-    public String getFormatted() {
-      return formattedText;
-    }
-  }
+  private final ImmutableList<JoinedSource> sources;
 
   public Join(
-      final Type type,
       final Relation left,
-      final Relation right,
-      final JoinCriteria criteria,
-      final Optional<WithinExpression> withinExpression
+      final List<JoinedSource> sources
   ) {
-    this(Optional.empty(), type, left, right, criteria, withinExpression);
+    this(Optional.empty(), left, sources);
   }
 
   public Join(
       final Optional<NodeLocation> location,
-      final Type type,
       final Relation left,
-      final Relation right,
-      final JoinCriteria criteria,
-      final Optional<WithinExpression> withinExpression
+      final List<JoinedSource> sources
   ) {
     super(location);
-    this.type = requireNonNull(type, "type");
     this.left = requireNonNull(left, "left");
-    this.right = requireNonNull(right, "right");
-    this.criteria = requireNonNull(criteria, "criteria");
-    this.withinExpression = requireNonNull(withinExpression, "withinExpression");
-  }
-
-  public Type getType() {
-    return type;
+    this.sources = ImmutableList.copyOf(Objects.requireNonNull(sources, "sources"));
   }
 
   public Relation getLeft() {
     return left;
   }
 
-  public Relation getRight() {
-    return right;
-  }
-
-  public JoinCriteria getCriteria() {
-    return criteria;
-  }
-
-  public Optional<WithinExpression> getWithinExpression() {
-    return withinExpression;
+  public ImmutableList<JoinedSource> getSources() {
+    return sources;
   }
 
   @Override
@@ -100,10 +64,8 @@ public class Join extends Relation {
   @Override
   public String toString() {
     return toStringHelper(this)
-        .add("type", type)
         .add("left", left)
-        .add("right", right)
-        .add("criteria", criteria)
+        .add("sources", sources)
         .omitNullValues()
         .toString();
   }
@@ -116,16 +78,13 @@ public class Join extends Relation {
     if ((o == null) || (getClass() != o.getClass())) {
       return false;
     }
-    final Join join = (Join) o;
-    return (type == join.type)
-           && Objects.equals(left, join.left)
-           && Objects.equals(right, join.right)
-           && Objects.equals(criteria, join.criteria)
-           && Objects.equals(withinExpression, join.withinExpression);
+    final Join that = (Join) o;
+    return Objects.equals(left, that.left)
+           && Objects.equals(sources, that.sources);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(type, left, right, criteria, withinExpression);
+    return Objects.hash(left, sources);
   }
 }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/Join.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/Join.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.parser.tree;
 
-import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.base.Preconditions;

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/Join.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/Join.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.parser.tree;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
@@ -29,31 +30,32 @@ import java.util.Optional;
 public class Join extends Relation {
 
   private final Relation left;
-  private final ImmutableList<JoinedSource> sources;
+  private final ImmutableList<JoinedSource> rights;
 
   public Join(
       final Relation left,
-      final List<JoinedSource> sources
+      final List<JoinedSource> rights
   ) {
-    this(Optional.empty(), left, sources);
+    this(Optional.empty(), left, rights);
   }
 
   public Join(
       final Optional<NodeLocation> location,
       final Relation left,
-      final List<JoinedSource> sources
+      final List<JoinedSource> rights
   ) {
     super(location);
     this.left = requireNonNull(left, "left");
-    this.sources = ImmutableList.copyOf(Objects.requireNonNull(sources, "sources"));
+    this.rights = ImmutableList.copyOf(Objects.requireNonNull(rights, "sources"));
+    Preconditions.checkArgument(!rights.isEmpty(), "Cannot join without any right sources!");
   }
 
   public Relation getLeft() {
     return left;
   }
 
-  public ImmutableList<JoinedSource> getSources() {
-    return sources;
+  public ImmutableList<JoinedSource> getRights() {
+    return rights;
   }
 
   @Override
@@ -63,11 +65,10 @@ public class Join extends Relation {
 
   @Override
   public String toString() {
-    return toStringHelper(this)
-        .add("left", left)
-        .add("sources", sources)
-        .omitNullValues()
-        .toString();
+    return "Join{"
+        + "left=" + left
+        + ", rights=" + rights
+        + '}';
   }
 
   @Override
@@ -80,11 +81,11 @@ public class Join extends Relation {
     }
     final Join that = (Join) o;
     return Objects.equals(left, that.left)
-           && Objects.equals(sources, that.sources);
+           && Objects.equals(rights, that.rights);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(left, sources);
+    return Objects.hash(left, rights);
   }
 }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/JoinedSource.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/JoinedSource.java
@@ -36,10 +36,10 @@ public class JoinedSource extends Relation {
       final Optional<WithinExpression> withinExpression
   ) {
     super(location);
-    this.relation = relation;
-    this.type = type;
-    this.criteria = criteria;
-    this.withinExpression = withinExpression;
+    this.relation = Objects.requireNonNull(relation, "relation");
+    this.type = Objects.requireNonNull(type, "type");
+    this.criteria = Objects.requireNonNull(criteria, "criteria");
+    this.withinExpression = Objects.requireNonNull(withinExpression, "withinExpression");
   }
 
   public Relation getRelation() {

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/JoinedSource.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/JoinedSource.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser.tree;
+
+import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.parser.NodeLocation;
+import java.util.Objects;
+import java.util.Optional;
+
+@Immutable
+public class JoinedSource extends Relation {
+
+  private final Relation relation;
+  private final Type type;
+  private final JoinCriteria criteria;
+  private final Optional<WithinExpression> withinExpression;
+
+  public JoinedSource(
+      final Optional<NodeLocation> location,
+      final Relation relation,
+      final Type type,
+      final JoinCriteria criteria,
+      final Optional<WithinExpression> withinExpression
+  ) {
+    super(location);
+    this.relation = relation;
+    this.type = type;
+    this.criteria = criteria;
+    this.withinExpression = withinExpression;
+  }
+
+  public Relation getRelation() {
+    return relation;
+  }
+
+  public Type getType() {
+    return type;
+  }
+
+  public JoinCriteria getCriteria() {
+    return criteria;
+  }
+
+  public Optional<WithinExpression> getWithinExpression() {
+    return withinExpression;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final JoinedSource that = (JoinedSource) o;
+    return Objects.equals(relation, that.relation)
+        && Objects.equals(type, that.type)
+        && Objects.equals(criteria, that.criteria)
+        && Objects.equals(withinExpression, that.withinExpression);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(relation, type, criteria, withinExpression);
+  }
+
+  @Override
+  public String toString() {
+    return "JoinedSource{"
+        + "relation=" + relation
+        + ", type=" + type
+        + ", criteria=" + criteria
+        + ", withinExpression=" + withinExpression
+        + '}';
+  }
+
+  public enum Type {
+    INNER("INNER"), LEFT("LEFT OUTER"), OUTER("FULL OUTER");
+
+    private final String formattedText;
+
+    Type(final String formattedText) {
+      this.formattedText = Objects.requireNonNull(formattedText, "formattedText");
+    }
+
+    public String getFormatted() {
+      return formattedText;
+    }
+  }
+}

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
@@ -18,9 +18,11 @@ package io.confluent.ksql.parser;
 import static io.confluent.ksql.parser.tree.JoinMatchers.hasLeft;
 import static io.confluent.ksql.parser.tree.JoinMatchers.hasRight;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.ImmutableList;
@@ -104,6 +106,18 @@ public class AstBuilderTest {
 
     // Then:
     assertThat(result.getFrom(), is(new AliasedRelation(TEST1, SourceName.of("T"))));
+  }
+
+  @Test
+  public void shouldFailOnMultiWayJoin() {
+    // Given:
+    final SingleStatementContext stmt = givenQuery("SELECT * FROM TEST1 JOIN TEST2 ON test1.col1 = test2.col2 JOIN TEST3 ON test1.col1 = test3.col0;");
+
+    // When:
+    final KsqlException e= assertThrows(KsqlException.class, () -> builder.buildStatement(stmt));
+
+    // Then:
+    assertThat(e.getMessage(), containsString("KSQL does not support multi-way joins."));
   }
 
   @Test

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -396,9 +396,9 @@ public class KsqlParserTest {
     final Query query = (Query) statement;
     assertThat(query.getFrom(), is(instanceOf(Join.class)));
     final Join join = (Join) query.getFrom();
-    assertThat(Iterables.getOnlyElement(join.getSources()).getType().toString(), is("LEFT"));
+    assertThat(Iterables.getOnlyElement(join.getRights()).getType().toString(), is("LEFT"));
     assertThat(((AliasedRelation)join.getLeft()).getAlias(), is(SourceName.of("T1")));
-    assertThat(((AliasedRelation) Iterables.getOnlyElement(join.getSources()).getRelation()).getAlias(), is(SourceName.of("T2")));
+    assertThat(((AliasedRelation) Iterables.getOnlyElement(join.getRights()).getRelation()).getAlias(), is(SourceName.of("T2")));
   }
 
   @Test
@@ -412,9 +412,9 @@ public class KsqlParserTest {
     final Query query = (Query) statement;
     assertThat(query.getFrom(), is(instanceOf(Join.class)));
     final Join join = (Join) query.getFrom();
-    assertThat(Iterables.getOnlyElement(join.getSources()).getType().toString(), is("LEFT"));
+    assertThat(Iterables.getOnlyElement(join.getRights()).getType().toString(), is("LEFT"));
     assertThat(((AliasedRelation)join.getLeft()).getAlias(), is(SourceName.of("T1")));
-    assertThat(((AliasedRelation) Iterables.getOnlyElement(join.getSources()).getRelation()).getAlias(), is(SourceName.of("T2")));
+    assertThat(((AliasedRelation) Iterables.getOnlyElement(join.getRights()).getRelation()).getAlias(), is(SourceName.of("T2")));
     assertThat(query.getWhere().get().toString(), is("(T2.COL2 = 'test')"));
   }
 
@@ -480,7 +480,7 @@ public class KsqlParserTest {
 
     final Join join = (Join) query.getFrom();
     assertThat(((AliasedRelation) join.getLeft()).getAlias(), is(SourceName.of("T1")));
-    assertThat(((AliasedRelation) Iterables.getOnlyElement(join.getSources()).getRelation()).getAlias(), is(SourceName.of("T2")));
+    assertThat(((AliasedRelation) Iterables.getOnlyElement(join.getRights()).getRelation()).getAlias(), is(SourceName.of("T2")));
   }
 
   @Test
@@ -864,7 +864,7 @@ public class KsqlParserTest {
 
     assertThat(query.getFrom(), instanceOf(Join.class));
 
-    final JoinedSource join = Iterables.getOnlyElement(((Join) query.getFrom()).getSources());
+    final JoinedSource join = Iterables.getOnlyElement(((Join) query.getFrom()).getRights());
 
     assertTrue(join.getWithinExpression().isPresent());
 
@@ -894,7 +894,7 @@ public class KsqlParserTest {
 
     assertThat(query.getFrom(), instanceOf(Join.class));
 
-    final JoinedSource join = Iterables.getOnlyElement(((Join) query.getFrom()).getSources());
+    final JoinedSource join = Iterables.getOnlyElement(((Join) query.getFrom()).getRights());
 
     assertTrue(join.getWithinExpression().isPresent());
 
@@ -923,7 +923,7 @@ public class KsqlParserTest {
 
     assertThat(query.getFrom(), instanceOf(Join.class));
 
-    final JoinedSource join = Iterables.getOnlyElement(((Join) query.getFrom()).getSources());
+    final JoinedSource join = Iterables.getOnlyElement(((Join) query.getFrom()).getRights());
 
     assertThat(join.getType(), is(JoinedSource.Type.INNER));
   }
@@ -944,7 +944,7 @@ public class KsqlParserTest {
 
     assertThat(query.getFrom(), instanceOf(Join.class));
 
-    final JoinedSource join = Iterables.getOnlyElement(((Join) query.getFrom()).getSources());
+    final JoinedSource join = Iterables.getOnlyElement(((Join) query.getFrom()).getRights());
 
     assertThat(join.getType(), is(JoinedSource.Type.LEFT));
   }
@@ -965,7 +965,7 @@ public class KsqlParserTest {
 
     assertThat(query.getFrom(), instanceOf(Join.class));
 
-    final JoinedSource join = Iterables.getOnlyElement(((Join) query.getFrom()).getSources());
+    final JoinedSource join = Iterables.getOnlyElement(((Join) query.getFrom()).getRights());
 
     assertThat(join.getType(), is(JoinedSource.Type.LEFT));
   }
@@ -986,7 +986,7 @@ public class KsqlParserTest {
 
     assertThat(query.getFrom(), instanceOf(Join.class));
 
-    final JoinedSource join = Iterables.getOnlyElement(((Join) query.getFrom()).getSources());
+    final JoinedSource join = Iterables.getOnlyElement(((Join) query.getFrom()).getRights());
 
     assertThat(join.getType(), is(JoinedSource.Type.OUTER));
   }
@@ -1007,7 +1007,7 @@ public class KsqlParserTest {
 
     assertThat(query.getFrom(), instanceOf(Join.class));
 
-    final JoinedSource join = Iterables.getOnlyElement(((Join) query.getFrom()).getSources());
+    final JoinedSource join = Iterables.getOnlyElement(((Join) query.getFrom()).getRights());
 
     assertThat(join.getType(), is(JoinedSource.Type.OUTER));
   }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -63,6 +63,7 @@ import io.confluent.ksql.parser.tree.DropStream;
 import io.confluent.ksql.parser.tree.DropTable;
 import io.confluent.ksql.parser.tree.InsertInto;
 import io.confluent.ksql.parser.tree.Join;
+import io.confluent.ksql.parser.tree.JoinedSource;
 import io.confluent.ksql.parser.tree.ListProperties;
 import io.confluent.ksql.parser.tree.ListQueries;
 import io.confluent.ksql.parser.tree.ListStreams;
@@ -395,9 +396,9 @@ public class KsqlParserTest {
     final Query query = (Query) statement;
     assertThat(query.getFrom(), is(instanceOf(Join.class)));
     final Join join = (Join) query.getFrom();
-    assertThat(join.getType().toString(), is("LEFT"));
+    assertThat(Iterables.getOnlyElement(join.getSources()).getType().toString(), is("LEFT"));
     assertThat(((AliasedRelation)join.getLeft()).getAlias(), is(SourceName.of("T1")));
-    assertThat(((AliasedRelation)join.getRight()).getAlias(), is(SourceName.of("T2")));
+    assertThat(((AliasedRelation) Iterables.getOnlyElement(join.getSources()).getRelation()).getAlias(), is(SourceName.of("T2")));
   }
 
   @Test
@@ -411,9 +412,9 @@ public class KsqlParserTest {
     final Query query = (Query) statement;
     assertThat(query.getFrom(), is(instanceOf(Join.class)));
     final Join join = (Join) query.getFrom();
-    assertThat(join.getType().toString(), is("LEFT"));
+    assertThat(Iterables.getOnlyElement(join.getSources()).getType().toString(), is("LEFT"));
     assertThat(((AliasedRelation)join.getLeft()).getAlias(), is(SourceName.of("T1")));
-    assertThat(((AliasedRelation)join.getRight()).getAlias(), is(SourceName.of("T2")));
+    assertThat(((AliasedRelation) Iterables.getOnlyElement(join.getSources()).getRelation()).getAlias(), is(SourceName.of("T2")));
     assertThat(query.getWhere().get().toString(), is("(T2.COL2 = 'test')"));
   }
 
@@ -479,7 +480,7 @@ public class KsqlParserTest {
 
     final Join join = (Join) query.getFrom();
     assertThat(((AliasedRelation) join.getLeft()).getAlias(), is(SourceName.of("T1")));
-    assertThat(((AliasedRelation) join.getRight()).getAlias(), is(SourceName.of("T2")));
+    assertThat(((AliasedRelation) Iterables.getOnlyElement(join.getSources()).getRelation()).getAlias(), is(SourceName.of("T2")));
   }
 
   @Test
@@ -863,7 +864,7 @@ public class KsqlParserTest {
 
     assertThat(query.getFrom(), instanceOf(Join.class));
 
-    final Join join = (Join) query.getFrom();
+    final JoinedSource join = Iterables.getOnlyElement(((Join) query.getFrom()).getSources());
 
     assertTrue(join.getWithinExpression().isPresent());
 
@@ -872,7 +873,7 @@ public class KsqlParserTest {
     assertThat(withinExpression.getBefore(), is(10L));
     assertThat(withinExpression.getAfter(), is(10L));
     assertThat(withinExpression.getBeforeTimeUnit(), is(TimeUnit.SECONDS));
-    assertThat(join.getType(), is(Join.Type.INNER));
+    assertThat(join.getType(), is(JoinedSource.Type.INNER));
   }
 
 
@@ -893,7 +894,7 @@ public class KsqlParserTest {
 
     assertThat(query.getFrom(), instanceOf(Join.class));
 
-    final Join join = (Join) query.getFrom();
+    final JoinedSource join = Iterables.getOnlyElement(((Join) query.getFrom()).getSources());
 
     assertTrue(join.getWithinExpression().isPresent());
 
@@ -903,7 +904,7 @@ public class KsqlParserTest {
     assertThat(withinExpression.getAfter(), is(20L));
     assertThat(withinExpression.getBeforeTimeUnit(), is(TimeUnit.SECONDS));
     assertThat(withinExpression.getAfterTimeUnit(), is(TimeUnit.MINUTES));
-    assertThat(join.getType(), is(Join.Type.INNER));
+    assertThat(join.getType(), is(JoinedSource.Type.INNER));
   }
 
   @Test
@@ -922,9 +923,9 @@ public class KsqlParserTest {
 
     assertThat(query.getFrom(), instanceOf(Join.class));
 
-    final Join join = (Join) query.getFrom();
+    final JoinedSource join = Iterables.getOnlyElement(((Join) query.getFrom()).getSources());
 
-    assertThat(join.getType(), is(Join.Type.INNER));
+    assertThat(join.getType(), is(JoinedSource.Type.INNER));
   }
 
   @Test
@@ -943,9 +944,9 @@ public class KsqlParserTest {
 
     assertThat(query.getFrom(), instanceOf(Join.class));
 
-    final Join join = (Join) query.getFrom();
+    final JoinedSource join = Iterables.getOnlyElement(((Join) query.getFrom()).getSources());
 
-    assertThat(join.getType(), is(Join.Type.LEFT));
+    assertThat(join.getType(), is(JoinedSource.Type.LEFT));
   }
 
   @Test
@@ -964,9 +965,9 @@ public class KsqlParserTest {
 
     assertThat(query.getFrom(), instanceOf(Join.class));
 
-    final Join join = (Join) query.getFrom();
+    final JoinedSource join = Iterables.getOnlyElement(((Join) query.getFrom()).getSources());
 
-    assertThat(join.getType(), is(Join.Type.LEFT));
+    assertThat(join.getType(), is(JoinedSource.Type.LEFT));
   }
 
   @Test
@@ -985,9 +986,9 @@ public class KsqlParserTest {
 
     assertThat(query.getFrom(), instanceOf(Join.class));
 
-    final Join join = (Join) query.getFrom();
+    final JoinedSource join = Iterables.getOnlyElement(((Join) query.getFrom()).getSources());
 
-    assertThat(join.getType(), is(Join.Type.OUTER));
+    assertThat(join.getType(), is(JoinedSource.Type.OUTER));
   }
 
   @Test
@@ -1006,9 +1007,9 @@ public class KsqlParserTest {
 
     assertThat(query.getFrom(), instanceOf(Join.class));
 
-    final Join join = (Join) query.getFrom();
+    final JoinedSource join = Iterables.getOnlyElement(((Join) query.getFrom()).getSources());
 
-    assertThat(join.getType(), is(Join.Type.OUTER));
+    assertThat(join.getType(), is(JoinedSource.Type.OUTER));
   }
 
   @Test

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
@@ -45,6 +46,7 @@ import io.confluent.ksql.parser.tree.DropTable;
 import io.confluent.ksql.parser.tree.Join;
 import io.confluent.ksql.parser.tree.JoinCriteria;
 import io.confluent.ksql.parser.tree.JoinOn;
+import io.confluent.ksql.parser.tree.JoinedSource;
 import io.confluent.ksql.parser.tree.ListStreams;
 import io.confluent.ksql.parser.tree.ListTables;
 import io.confluent.ksql.parser.tree.Statement;
@@ -333,9 +335,12 @@ public class SqlFormatterTest {
 
   @Test
   public void shouldFormatLeftJoinWithWithin() {
-    final Join join = new Join(Join.Type.LEFT, leftAlias, rightAlias,
-                         criteria,
-                         Optional.of(new WithinExpression(10, TimeUnit.SECONDS)));
+    final Join join = new Join(leftAlias, ImmutableList.of(new JoinedSource(
+        Optional.empty(),
+        rightAlias,
+        JoinedSource.Type.LEFT,
+        criteria,
+        Optional.of(new WithinExpression(10, TimeUnit.SECONDS)))));
 
     final String expected = "`left` L\nLEFT OUTER JOIN `right` R WITHIN 10 SECONDS ON "
                             + "(('left.col0' = 'right.col0'))";
@@ -344,8 +349,12 @@ public class SqlFormatterTest {
 
   @Test
   public void shouldFormatLeftJoinWithoutJoinWindow() {
-    final Join join = new Join(Join.Type.LEFT, leftAlias, rightAlias,
-                               criteria, Optional.empty());
+    final Join join = new Join(leftAlias, ImmutableList.of(new JoinedSource(
+        Optional.empty(),
+        rightAlias,
+        JoinedSource.Type.LEFT,
+        criteria,
+        Optional.empty())));
 
     final String result = SqlFormatter.formatSql(join);
     final String expected = "`left` L\nLEFT OUTER JOIN `right` R ON (('left.col0' = 'right.col0'))";
@@ -354,9 +363,12 @@ public class SqlFormatterTest {
 
   @Test
   public void shouldFormatInnerJoin() {
-    final Join join = new Join(Join.Type.INNER, leftAlias, rightAlias,
-                               criteria,
-                               Optional.of(new WithinExpression(10, TimeUnit.SECONDS)));
+    final Join join = new Join(leftAlias, ImmutableList.of(new JoinedSource(
+        Optional.empty(),
+        rightAlias,
+        JoinedSource.Type.INNER,
+        criteria,
+        Optional.of(new WithinExpression(10, TimeUnit.SECONDS)))));
 
     final String expected = "`left` L\nINNER JOIN `right` R WITHIN 10 SECONDS ON "
                             + "(('left.col0' = 'right.col0'))";
@@ -365,9 +377,12 @@ public class SqlFormatterTest {
 
   @Test
   public void shouldFormatInnerJoinWithoutJoinWindow() {
-    final Join join = new Join(Join.Type.INNER, leftAlias, rightAlias,
-                               criteria,
-                               Optional.empty());
+    final Join join = new Join(leftAlias, ImmutableList.of(new JoinedSource(
+        Optional.empty(),
+        rightAlias,
+        JoinedSource.Type.INNER,
+        criteria,
+        Optional.empty())));
 
     final String expected = "`left` L\nINNER JOIN `right` R ON (('left.col0' = 'right.col0'))";
     assertEquals(expected, SqlFormatter.formatSql(join));
@@ -376,9 +391,12 @@ public class SqlFormatterTest {
 
   @Test
   public void shouldFormatOuterJoin() {
-    final Join join = new Join(Join.Type.OUTER, leftAlias, rightAlias,
-                               criteria,
-                               Optional.of(new WithinExpression(10, TimeUnit.SECONDS)));
+    final Join join = new Join(leftAlias, ImmutableList.of(new JoinedSource(
+        Optional.empty(),
+        rightAlias,
+        JoinedSource.Type.OUTER,
+        criteria,
+        Optional.of(new WithinExpression(10, TimeUnit.SECONDS)))));
 
     final String expected = "`left` L\nFULL OUTER JOIN `right` R WITHIN 10 SECONDS ON"
                             + " (('left.col0' = 'right.col0'))";
@@ -388,9 +406,12 @@ public class SqlFormatterTest {
 
   @Test
   public void shouldFormatOuterJoinWithoutJoinWindow() {
-    final Join join = new Join(Join.Type.OUTER, leftAlias, rightAlias,
-                               criteria,
-                               Optional.empty());
+    final Join join = new Join(leftAlias, ImmutableList.of(new JoinedSource(
+        Optional.empty(),
+        rightAlias,
+        JoinedSource.Type.OUTER,
+        criteria,
+        Optional.empty())));
 
     final String expected = "`left` L\nFULL OUTER JOIN `right` R ON (('left.col0' = 'right.col0'))";
     assertEquals(expected, SqlFormatter.formatSql(join));

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/JoinMatchers.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/JoinMatchers.java
@@ -49,7 +49,7 @@ public final class JoinMatchers {
         (relationship, "right relationship", "right") {
       @Override
       protected Relation featureValueOf(final Join actual) {
-        return Iterables.getOnlyElement(actual.getSources()).getRelation();
+        return Iterables.getOnlyElement(actual.getRights()).getRelation();
       }
     };
   }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/JoinMatchers.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/JoinMatchers.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.parser.tree;
 
 import static org.hamcrest.Matchers.is;
 
+import com.google.common.collect.Iterables;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 
@@ -48,7 +49,7 @@ public final class JoinMatchers {
         (relationship, "right relationship", "right") {
       @Override
       protected Relation featureValueOf(final Join actual) {
-        return actual.getRight();
+        return Iterables.getOnlyElement(actual.getSources()).getRelation();
       }
     };
   }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/JoinTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/JoinTest.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2019 Confluent Inc.
+ * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Confluent Community License (the "License"); you may not use
- * this file except in compliance with the License.  You may obtain a copy of the
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
  * License at
  *
  * http://www.confluent.io/confluent-community-license
@@ -15,55 +15,44 @@
 
 package io.confluent.ksql.parser.tree;
 
-import static io.confluent.ksql.parser.tree.Join.Type.INNER;
-import static io.confluent.ksql.parser.tree.Join.Type.OUTER;
-
+import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
-import io.confluent.ksql.execution.expression.tree.StringLiteral;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.NodeLocation;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class JoinTest {
 
   public static final NodeLocation SOME_LOCATION = new NodeLocation(0, 0);
   public static final NodeLocation OTHER_LOCATION = new NodeLocation(1, 0);
   private static final Relation RELATION_0 = new Table(SourceName.of("bob"));
   private static final Relation RELATION_1 = new Table(SourceName.of("pete"));
-  private static final JoinCriteria SOME_CRITERIA = new JoinOn(new StringLiteral("j"));
-  private static final JoinCriteria OTHER_CRITERIA = new JoinOn(new StringLiteral("p"));
-  private static final Optional<WithinExpression> SOME_WITHIN =
-      Optional.of(new WithinExpression(1, TimeUnit.SECONDS));
+
+  @Mock
+  private JoinedSource someSource;
+  @Mock
+  private JoinedSource otherSource;
 
   @Test
-  public void shouldImplementHashCodeAndEqualsProperty() {
+  public void shouldImplementHashCodeAndEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            // Note: At the moment location does not take part in equality testing
-            new Join(INNER, RELATION_0, RELATION_1, SOME_CRITERIA, SOME_WITHIN),
-            new Join(INNER, RELATION_0, RELATION_1, SOME_CRITERIA, SOME_WITHIN),
-            new Join(Optional.of(SOME_LOCATION), INNER, RELATION_0, RELATION_1, SOME_CRITERIA,
-                SOME_WITHIN),
-            new Join(Optional.of(OTHER_LOCATION), INNER, RELATION_0, RELATION_1, SOME_CRITERIA,
-                SOME_WITHIN)
+            new Join(Optional.empty(), RELATION_0, ImmutableList.of(someSource)),
+            new Join(Optional.of(new NodeLocation(0, 0)), RELATION_0, ImmutableList.of(someSource)),
+            new Join(Optional.of(new NodeLocation(1, 1)), RELATION_0, ImmutableList.of(someSource))
         )
         .addEqualityGroup(
-            new Join(OUTER, RELATION_0, RELATION_1, SOME_CRITERIA, SOME_WITHIN)
+            new Join(Optional.empty(), RELATION_1, ImmutableList.of(someSource))
         )
         .addEqualityGroup(
-            new Join(INNER, RELATION_1, RELATION_1, SOME_CRITERIA, SOME_WITHIN)
-        )
-        .addEqualityGroup(
-            new Join(INNER, RELATION_0, RELATION_0, SOME_CRITERIA, SOME_WITHIN)
-        )
-        .addEqualityGroup(
-            new Join(INNER, RELATION_0, RELATION_1, OTHER_CRITERIA, SOME_WITHIN)
-        )
-        .addEqualityGroup(
-            new Join(INNER, RELATION_0, RELATION_1, SOME_CRITERIA, Optional.empty())
+            new Join(Optional.empty(), RELATION_1, ImmutableList.of(otherSource))
         )
         .testEquals();
   }
+
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/JoinedSourceTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/JoinedSourceTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser.tree;
+
+import com.google.common.testing.EqualsTester;
+import io.confluent.ksql.execution.expression.tree.StringLiteral;
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.parser.NodeLocation;
+import io.confluent.ksql.parser.tree.JoinedSource.Type;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+
+public class JoinedSourceTest {
+
+  public static final NodeLocation SOME_LOCATION = new NodeLocation(0, 0);
+  public static final NodeLocation OTHER_LOCATION = new NodeLocation(1, 0);
+  private static final Relation RELATION_0 = new Table(SourceName.of("bob"));
+  private static final Relation RELATION_1 = new Table(SourceName.of("pete"));
+  private static final JoinCriteria SOME_CRITERIA = new JoinOn(new StringLiteral("j"));
+  private static final JoinCriteria OTHER_CRITERIA = new JoinOn(new StringLiteral("p"));
+  private static final Optional<WithinExpression> SOME_WITHIN =
+      Optional.of(new WithinExpression(1, TimeUnit.SECONDS));
+
+  @Test
+  public void shouldImplementHashCodeAndEqualsProperty() {
+    new EqualsTester()
+        .addEqualityGroup(
+            // Note: At the moment location does not take part in equality testing
+            new JoinedSource(Optional.empty(), RELATION_0, Type.INNER, SOME_CRITERIA, SOME_WITHIN),
+            new JoinedSource(Optional.of(SOME_LOCATION), RELATION_0, Type.INNER, SOME_CRITERIA, SOME_WITHIN),
+            new JoinedSource(Optional.of(OTHER_LOCATION), RELATION_0, Type.INNER, SOME_CRITERIA, SOME_WITHIN)
+        )
+        .addEqualityGroup(
+            new JoinedSource(Optional.of(OTHER_LOCATION), RELATION_0, Type.OUTER, SOME_CRITERIA, SOME_WITHIN)
+        )
+        .addEqualityGroup(
+            new JoinedSource(Optional.of(OTHER_LOCATION), RELATION_1, Type.OUTER, SOME_CRITERIA, SOME_WITHIN)
+        )
+        .addEqualityGroup(
+            new JoinedSource(Optional.of(OTHER_LOCATION), RELATION_1, Type.OUTER, OTHER_CRITERIA, SOME_WITHIN)
+        )
+        .addEqualityGroup(
+            new JoinedSource(Optional.of(OTHER_LOCATION), RELATION_1, Type.OUTER, OTHER_CRITERIA, Optional.empty())
+        )
+        .testEquals();
+  }
+}


### PR DESCRIPTION
fixes #1612

### Description 
Simply adds the syntax for multi-way joins, but still fails if users try to use it. The message, however, is now clearer:
```
Invalid join criteria specified; KSQL does not support multi-way joins.
```

### Testing done 

All existing tests pass, and I added a unit and QTT test to make sure that the new message is returned in the case of a multi-way join.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

