### PR TITLE
chore: remove unecessary acls for starting up server

### DIFF
--- a/docs-md/operate-and-deploy/installation/server-config/security.md
+++ b/docs-md/operate-and-deploy/installation/server-config/security.md
@@ -449,9 +449,6 @@ ksqlDB always requires the following ACLs for its internal operations and
 data management:
 
 -   The `DESCRIBE_CONFIGS` operation on the `CLUSTER` resource type.
--   The `DESCRIBE` operation on the `TOPIC` with `LITERAL` name`__consumer_offsets`.
--   The `DESCRIBE` operation on the `TOPIC` with `LITERAL` name `__transaction_state`.
--   The `DESCRIBE` and `WRITE` operations on the `TRANSACTIONAL_ID` with `LITERAL` name `<ksql.service.id>`.
 -   The `ALL` operation on all internal `TOPICS` that are `PREFIXED`
     with `_confluent-ksql-<ksql.service.id>`.
 -   The `ALL` operation on all internal `GROUPS` that are `PREFIXED`
@@ -585,8 +582,6 @@ bin/kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --
 bin/kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --allow-principal User:KSQL1 --allow-host 198.51.100.0 --allow-host 198.51.100.1 --allow-host 198.51.100.2 --operation All --topic fraud_ksql_processing_log
 
 # Allow ksqlDB to produce to the command topic:
-bin/kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --allow-principal User:KSQL1 --allow-host 198.51.100.0 --allow-host 198.51.100.1 --allow-host 198.51.100.2 --operation Describe  --topic __transaction_state
-bin/kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --allow-principal User:KSQL1 --allow-host 198.51.100.0 --allow-host 198.51.100.1 --allow-host 198.51.100.2 --operation Describe --topic __consumer_offsets
 bin/kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --allow-principal User:KSQL1 --allow-host 198.51.100.0 --allow-host 198.51.100.1 --allow-host 198.51.100.2 --producer --transactional-id ksql-fraud_ --topic _confluent-ksql-fraud__command_topic
 ```
 

--- a/docs/installation/server-config/security.rst
+++ b/docs/installation/server-config/security.rst
@@ -404,7 +404,6 @@ The ACLs required are the same for both :ref:`Interactive and non-interactive (h
 KSQL always requires the following ACLs for its internal operations and data management:
 
 - The ``DESCRIBE_CONFIGS`` operation on the ``CLUSTER`` resource type.
-- The ``DESCRIBE`` and ``WRITE`` operations on the ``TRANSACTIONAL_ID`` with ``LITERAL`` name ``<ksql.service.id>``.
 - The ``ALL`` operation on all internal ``TOPICS`` that are ``PREFIXED`` with ``_confluent-ksql-<ksql.service.id>``.
 - The ``ALL`` operation on all internal ``GROUPS`` that are ``PREFIXED`` with ``_confluent-ksql-<ksql.service.id>``.
 

--- a/docs/installation/server-config/security.rst
+++ b/docs/installation/server-config/security.rst
@@ -404,8 +404,6 @@ The ACLs required are the same for both :ref:`Interactive and non-interactive (h
 KSQL always requires the following ACLs for its internal operations and data management:
 
 - The ``DESCRIBE_CONFIGS`` operation on the ``CLUSTER`` resource type.
-- The ``DESCRIBE`` operation on the ``TOPIC`` with ``LITERAL`` name ``__consumer_offsets``.
-- The ``DESCRIBE`` operation on the ``TOPIC`` with ``LITERAL`` name ``__transaction_state``.
 - The ``DESCRIBE`` and ``WRITE`` operations on the ``TRANSACTIONAL_ID`` with ``LITERAL`` name ``<ksql.service.id>``.
 - The ``ALL`` operation on all internal ``TOPICS`` that are ``PREFIXED`` with ``_confluent-ksql-<ksql.service.id>``.
 - The ``ALL`` operation on all internal ``GROUPS`` that are ``PREFIXED`` with ``_confluent-ksql-<ksql.service.id>``.
@@ -514,8 +512,6 @@ Then the following commands would create the necessary ACLs in the Kafka cluster
     bin/kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --allow-principal User:KSQL1 --allow-host 198.51.100.0 --allow-host 198.51.100.1 --allow-host 198.51.100.2 --operation All --topic fraud_ksql_processing_log
 
     # Allow KSQL to produce to the command topic:
-    bin/kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --allow-principal User:KSQL1 --allow-host 198.51.100.0 --allow-host 198.51.100.1 --allow-host 198.51.100.2 --operation Describe  --topic __transaction_state
-    bin/kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --allow-principal User:KSQL1 --allow-host 198.51.100.0 --allow-host 198.51.100.1 --allow-host 198.51.100.2 --operation Describe --topic __consumer_offsets
     bin/kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --allow-principal User:KSQL1 --allow-host 198.51.100.0 --allow-host 198.51.100.1 --allow-host 198.51.100.2 --producer --transactional-id ksql-fraud_ --topic _confluent-ksql-fraud__command_topic
 
 The following table shows the necessary ACLs in the Kafka cluster to allow

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -145,14 +145,6 @@ public class RestApiTest {
                   NORMAL_USER,
                   resource(TRANSACTIONAL_ID, "default_"),
                   ops(DESCRIBE)
-              ).withAcl(
-                  NORMAL_USER,
-                  resource(TOPIC, "__consumer_offsets"),
-                  ops(DESCRIBE)
-              ).withAcl(
-                  NORMAL_USER,
-                  resource(TOPIC, "__transaction_state"),
-                  ops(DESCRIBE)
               )
       )
       .build();


### PR DESCRIPTION
### Description 
Removed unnecessary ACLs from an integration test
Removed ACL commands from docs

Experimented more with what ACLs are necessary to get the server running, and realized that permissions for `__consumer_offsets` and `__transaction_state` were unnecessary.

### Testing done 
test still passes

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

