### PR TITLE
fix: Don't wait for streams thread to be in running state

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -198,12 +198,6 @@ public class KsqlConfig extends AbstractConfig {
           + "or set in the CLI. It's only enabled when lag.reporting.enable is true. "
           + "By default, any amount of lag is is allowed.";
 
-  public static final String KSQL_QUERY_PULL_STREAMSTORE_REBALANCING_TIMEOUT_MS_CONFIG =
-      "ksql.query.pull.streamsstore.rebalancing.timeout.ms";
-  public static final Long KSQL_QUERY_PULL_STREAMSTORE_REBALANCING_TIMEOUT_MS_DEFAULT = 10000L;
-  public static final String KSQL_QUERY_PULL_STREAMSTORE_REBALANCING_TIMEOUT_MS_DOC = "Timeout in "
-      + "milliseconds when waiting for rebalancing of the stream store during a pull query";
-
   public static final String KSQL_QUERY_PULL_METRICS_ENABLED =
       "ksql.query.pull.metrics.enabled";
   public static final String KSQL_QUERY_PULL_METRICS_ENABLED_DOC =
@@ -572,12 +566,6 @@ public class KsqlConfig extends AbstractConfig {
             zeroOrPositive(),
             Importance.MEDIUM,
             KSQL_QUERY_PULL_MAX_ALLOWED_OFFSET_LAG_DOC
-        ).define(
-            KSQL_QUERY_PULL_STREAMSTORE_REBALANCING_TIMEOUT_MS_CONFIG,
-            ConfigDef.Type.LONG,
-            KSQL_QUERY_PULL_STREAMSTORE_REBALANCING_TIMEOUT_MS_DEFAULT,
-            Importance.LOW,
-            KSQL_QUERY_PULL_STREAMSTORE_REBALANCING_TIMEOUT_MS_DOC
         ).define(
             KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG,
             Type.STRING,

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsStateStore.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsStateStore.java
@@ -28,6 +28,8 @@ import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.state.QueryableStoreType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Wrapper around Kafka Streams state store.
@@ -39,6 +41,7 @@ class KsStateStore {
   private final LogicalSchema schema;
   private final KsqlConfig ksqlConfig;
   private final Supplier<Long> clock;
+  private static final Logger LOG = LoggerFactory.getLogger(KsStateStore.class);
 
   KsStateStore(
       final String stateStoreName,
@@ -69,8 +72,6 @@ class KsStateStore {
   }
 
   <T> T store(final QueryableStoreType<T> queryableStoreType) {
-    awaitRunning();
-
     try {
       if (ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PULL_ENABLE_STANDBY_READS)) {
         // True flag allows queries on standby and replica state stores
@@ -78,6 +79,7 @@ class KsStateStore {
             StoreQueryParameters.fromNameAndType(stateStoreName, queryableStoreType)
                 .enableStaleStores());
       } else {
+        awaitRunning();
         // False flag allows queries only on active state store
         return kafkaStreams.store(
             StoreQueryParameters.fromNameAndType(stateStoreName, queryableStoreType));
@@ -93,6 +95,7 @@ class KsStateStore {
   }
 
   private void awaitRunning() {
+    LOG.debug("Waiting for streams thread to be in RUNNING state");
     final long timeoutMs =
         ksqlConfig.getLong(KsqlConfig.KSQL_QUERY_PULL_STREAMSTORE_REBALANCING_TIMEOUT_MS_CONFIG);
     final long threshold = clock.get() + timeoutMs;

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsStateStoreTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsStateStoreTest.java
@@ -87,7 +87,7 @@ public class KsStateStoreTest {
   }
 
   @Test
-  public void shouldAwaitRunning() {
+  public void shouldNotAwaitRunning() {
     // Given:
     final QueryableStoreType<ReadOnlySessionStore<String, Long>> storeType =
         QueryableStoreTypes.sessionStore();

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsStateStoreTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsStateStoreTest.java
@@ -19,8 +19,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -28,13 +28,10 @@ import com.google.common.testing.NullPointerTester;
 import com.google.common.testing.NullPointerTester.Visibility;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.execution.streams.materialization.MaterializationException;
-import io.confluent.ksql.execution.streams.materialization.MaterializationTimeOutException;
-import io.confluent.ksql.execution.streams.materialization.NotRunningException;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlConfig;
-import java.util.function.Supplier;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.StoreQueryParameters;
@@ -47,7 +44,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
@@ -59,14 +55,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class KsStateStoreTest {
 
   private static final String STORE_NAME = "someStore";
-  private static final Long TIMEOUT_MS = 10L;
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
       .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
       .keyColumn(ColumnName.of("v0"), SqlTypes.BIGINT)
       .build();
-
-  @Rule
-  public final Timeout timeout = Timeout.seconds(10);
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
@@ -74,20 +66,14 @@ public class KsStateStoreTest {
   @Mock
   private KafkaStreams kafkaStreams;
   @Mock
-  private Supplier<Long> clock;
-  @Mock
   private KsqlConfig ksqlConfig;
 
   private KsStateStore store;
 
   @Before
   public void setUp() {
-    store = new KsStateStore(STORE_NAME, kafkaStreams, SCHEMA, ksqlConfig, clock);
-
-    when(clock.get()).thenReturn(0L);
+    store = new KsStateStore(STORE_NAME, kafkaStreams, SCHEMA, ksqlConfig);
     when(kafkaStreams.state()).thenReturn(State.RUNNING);
-    when(ksqlConfig.getLong(KsqlConfig.KSQL_QUERY_PULL_STREAMSTORE_REBALANCING_TIMEOUT_MS_CONFIG))
-        .thenReturn(TIMEOUT_MS);
   }
 
   @SuppressWarnings("UnstableApiUsage")
@@ -96,7 +82,6 @@ public class KsStateStoreTest {
     new NullPointerTester()
         .setDefault(KafkaStreams.class, kafkaStreams)
         .setDefault(LogicalSchema.class, SCHEMA)
-        .setDefault(Supplier.class, clock)
         .setDefault(KsqlConfig.class, ksqlConfig)
         .testConstructors(KsStateStore.class, Visibility.PACKAGE);
   }
@@ -104,35 +89,14 @@ public class KsStateStoreTest {
   @Test
   public void shouldAwaitRunning() {
     // Given:
-    when(kafkaStreams.state())
-        .thenReturn(State.REBALANCING)
-        .thenReturn(State.REBALANCING)
-        .thenReturn(State.RUNNING);
-
     final QueryableStoreType<ReadOnlySessionStore<String, Long>> storeType =
         QueryableStoreTypes.sessionStore();
 
     // When:
-
     store.store(storeType);
 
     // Then:
-    verify(kafkaStreams, atLeast(3)).state();
-  }
-
-  @Test
-  public void shouldThrowIfDoesNotFinishRebalanceBeforeTimeout() {
-    // Given:
-    when(kafkaStreams.state()).thenReturn(State.REBALANCING);
-    when(clock.get()).thenReturn(0L, 5L, TIMEOUT_MS + 1);
-
-    // When:
-    expectedException.expect(MaterializationTimeOutException.class);
-    expectedException.expectMessage(
-        "Store failed to rebalance within the configured timeout. timeout: 10ms");
-
-    // When:
-    store.store(QueryableStoreTypes.sessionStore());
+    verify(kafkaStreams, never()).state();
   }
 
   @Test
@@ -144,8 +108,8 @@ public class KsStateStoreTest {
     when(kafkaStreams.store(any())).thenThrow(new IllegalStateException());
 
     // When:
-    expectedException.expect(NotRunningException.class);
-    expectedException.expectMessage("The query was not in a running state. state: NOT_RUNNING");
+    expectedException.expect(MaterializationException.class);
+    expectedException.expectMessage("State store currently unavailable: someStore");
 
     // When:
     store.store(QueryableStoreTypes.sessionStore());
@@ -153,15 +117,11 @@ public class KsStateStoreTest {
 
   @Test
   public void shouldGetStoreOnceRunning() {
-    // Given:
-    when(kafkaStreams.state()).thenReturn(State.RUNNING);
-
     // When:
     store.store(QueryableStoreTypes.<String, Long>sessionStore());
 
     // Then:
     final InOrder inOrder = Mockito.inOrder(kafkaStreams);
-    inOrder.verify(kafkaStreams, atLeast(1)).state();
     inOrder.verify(kafkaStreams).store(any());
   }
 


### PR DESCRIPTION
### Description 
When forwarding to standby is enabled as part of HA, we were still waiting for streams thread to reach running state. I moved the waiting to happen only when forwarding to standby is not enabled.

### Testing done 
Confirmed it works as expected via experiments on EC2 cluster

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

