### PR TITLE
fix: rename ksqldb in normal logging path (MINOR)

### DIFF
--- a/bin/ksql
+++ b/bin/ksql
@@ -18,7 +18,7 @@ if [ -z "$KSQL_LOG4J_OPTS" ]; then
   elif [ -e "$base_dir/etc/ksqldb/log4j.properties" ]; then # Simple zip file layout
     KSQL_CONFIG_DIR="$base_dir/etc/ksqldb"
   elif [ -e "/etc/ksqldb/log4j.properties" ]; then # Normal install layout
-    KSQL_CONFIG_DIR="/etc/ksql"
+    KSQL_CONFIG_DIR="/etc/ksqldb"
   fi
 fi
 


### PR DESCRIPTION
### Description 

Starting up ksql in the 5.5.x packages causes the following if the base dir isn't properly set:

```
log4j:ERROR Could not read configuration file from URL [file:/etc/ksql/log4j-file.properties].
java.io.FileNotFoundException: /etc/ksql/log4j-file.properties (No such file or directory)
	at java.io.FileInputStream.open0(Native Method)
	at java.io.FileInputStream.open(FileInputStream.java:195)
	at java.io.FileInputStream.<init>(FileInputStream.java:138)
	at java.io.FileInputStream.<init>(FileInputStream.java:93)
	at sun.net.www.protocol.file.FileURLConnection.connect(FileURLConnection.java:90)
	at sun.net.www.protocol.file.FileURLConnection.getInputStream(FileURLConnection.java:188)
	at org.apache.log4j.PropertyConfigurator.doConfigure(PropertyConfigurator.java:557)
	at org.apache.log4j.helpers.OptionConverter.selectAndConfigure(OptionConverter.java:526)
	at org.apache.log4j.LogManager.<clinit>(LogManager.java:127)
	at org.slf4j.impl.Log4jLoggerFactory.<init>(Log4jLoggerFactory.java:66)
	at org.slf4j.impl.StaticLoggerBinder.<init>(StaticLoggerBinder.java:72)
	at org.slf4j.impl.StaticLoggerBinder.<clinit>(StaticLoggerBinder.java:45)
	at org.slf4j.LoggerFactory.bind(LoggerFactory.java:150)
	at org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:124)
	at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:412)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:357)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:383)
	at io.confluent.ksql.Ksql.<clinit>(Ksql.java:41)
log4j:ERROR Ignoring configuration file [file:/etc/ksql/log4j-file.properties].
```

### Testing done 

N/A

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

