### PR TITLE
docs: remove extraneous ACLs from ksqlDB security topic (DOCS-3787)

### DIFF
--- a/docs-md/operate-and-deploy/installation/server-config/security.md
+++ b/docs-md/operate-and-deploy/installation/server-config/security.md
@@ -449,8 +449,6 @@ ksqlDB always requires the following ACLs for its internal operations and
 data management:
 
 -   The `DESCRIBE_CONFIGS` operation on the `CLUSTER` resource type.
--   The `DESCRIBE` operation on the `TOPIC` with `LITERAL` name`__consumer_offsets`.
--   The `DESCRIBE` operation on the `TOPIC` with `LITERAL` name `__transaction_state`.
 -   The `DESCRIBE` and `WRITE` operations on the `TRANSACTIONAL_ID` with `LITERAL` name `<ksql.service.id>`.
 -   The `ALL` operation on all internal `TOPICS` that are `PREFIXED`
     with `_confluent-ksql-<ksql.service.id>`.
@@ -585,8 +583,6 @@ bin/kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --
 bin/kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --allow-principal User:KSQL1 --allow-host 198.51.100.0 --allow-host 198.51.100.1 --allow-host 198.51.100.2 --operation All --topic fraud_ksql_processing_log
 
 # Allow ksqlDB to produce to the command topic:
-bin/kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --allow-principal User:KSQL1 --allow-host 198.51.100.0 --allow-host 198.51.100.1 --allow-host 198.51.100.2 --operation Describe  --topic __transaction_state
-bin/kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --allow-principal User:KSQL1 --allow-host 198.51.100.0 --allow-host 198.51.100.1 --allow-host 198.51.100.2 --operation Describe --topic __consumer_offsets
 bin/kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --allow-principal User:KSQL1 --allow-host 198.51.100.0 --allow-host 198.51.100.1 --allow-host 198.51.100.2 --producer --transactional-id ksql-fraud_ --topic _confluent-ksql-fraud__command_topic
 ```
 


### PR DESCRIPTION
### Description 
Same change as https://github.com/confluentinc/ksql/pull/4906, for the new markdown docs. 