### PR TITLE
fix: throw error when column does not exist during INSERT INTO

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
@@ -265,6 +265,12 @@ public class InsertValuesExecutor {
 
     final LogicalSchema schema = dataSource.getSchema();
 
+    for (ColumnName col : columns) {
+      if (!schema.findColumn(col).isPresent()) {
+        throw new KsqlException("Column name " + col + " does not exist.");
+      }
+    }
+
     final Map<ColumnName, Object> values = resolveValues(
         insertValues, columns, schema, functionRegistry, config);
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
@@ -727,6 +727,28 @@ public class InsertValuesExecutorTest {
   }
 
   @Test
+  public void shouldThrowIfColumnDoesNotExistInSchema() {
+    // Given:
+    givenSourceStreamWithSchema(SINGLE_VALUE_COLUMN_SCHEMA, SerdeOption.none(), Optional.empty());
+
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of(
+            K0,
+            ColumnName.of("NONEXISTENT")),
+        ImmutableList.of(
+            new StringLiteral("foo"),
+            new StringLiteral("bar"))
+    );
+
+    // Expect:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectCause(hasMessage(containsString("Column name `NONEXISTENT` does not exist.")));
+
+    // When:
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
+  }
+
+  @Test
   public void shouldFailOnDowncast() {
     // Given:
     givenSourceStreamWithSchema(BIG_SCHEMA, SerdeOption.none(), Optional.of(COL0));


### PR DESCRIPTION
### Description
When using `INSERT INTO` with a nonexistent column, return a helpful error message instead of `null`.

```
ksql> CREATE STREAM test_stream (x VARCHAR, y INTEGER) WITH (kafka_topic='test_topic', key='x', value_format='json', partitions=1);
ksql> INSERT INTO test_stream (x, nonexistent) VALUES ('x', 0);
Failed to insert values into 'TEST_STREAM'. Column name `NONEXISTENT` does not exist.
```

Fixes #3838
Fixes #4253

### Testing done 
Wrote new unit test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

