### PR TITLE
chore: decouple CLI from ROWKEY

### DIFF
--- a/docs-md/developer-guide/create-a-stream.md
+++ b/docs-md/developer-guide/create-a-stream.md
@@ -92,7 +92,7 @@ Name                 : PAGEVIEWS
  Field    | Type
 --------------------------------------
  ROWTIME  | BIGINT           (system)
- ROWKEY   | VARCHAR(STRING)  (system)
+ ROWKEY   | VARCHAR(STRING)  (key)
  VIEWTIME | BIGINT
  USERID   | VARCHAR(STRING)
  PAGEID   | VARCHAR(STRING)

--- a/docs-md/developer-guide/create-a-table.md
+++ b/docs-md/developer-guide/create-a-table.md
@@ -98,7 +98,7 @@ Name                 : USERS
  Field        | Type
 ------------------------------------------
  ROWTIME      | BIGINT           (system)
- ROWKEY       | VARCHAR(STRING)  (system)
+ ROWKEY       | VARCHAR(STRING)  (key)
  REGISTERTIME | BIGINT
  USERID       | VARCHAR(STRING)
  GENDER       | VARCHAR(STRING)

--- a/docs-md/developer-guide/ksqldb-reference/describe.md
+++ b/docs-md/developer-guide/ksqldb-reference/describe.md
@@ -56,7 +56,7 @@ Your output should resemble:
  Field   | Type
 -------------------------------------
  ROWTIME | BIGINT           (system)
- ROWKEY  | VARCHAR(STRING)  (system)
+ ROWKEY  | VARCHAR(STRING)  (key)
  IP      | VARCHAR(STRING)  (key)
  KBYTES  | BIGINT
 -------------------------------------
@@ -83,7 +83,7 @@ Kafka output topic   : IP_SUM (partitions: 4, replication: 1)
  Field   | Type
 -------------------------------------
  ROWTIME | BIGINT           (system)
- ROWKEY  | VARCHAR(STRING)  (system)
+ ROWKEY  | VARCHAR(STRING)  (key)
  IP      | VARCHAR(STRING)  (key)
  KBYTES  | BIGINT
 -------------------------------------

--- a/docs-md/developer-guide/query-with-structured-data.md
+++ b/docs-md/developer-guide/query-with-structured-data.md
@@ -276,7 +276,7 @@ Name                 : TYPE_1
  Field         | Type
 -------------------------------------------
  ROWTIME       | BIGINT           (system)
- ROWKEY        | VARCHAR(STRING)  (system)
+ ROWKEY        | VARCHAR(STRING)  (key)
  DATA__field-a | INTEGER
  DATA__field-b | VARCHAR(STRING)
 -------------------------------------------
@@ -296,7 +296,7 @@ Name                 : TYPE_2
  Field         | Type
 -------------------------------------------
  ROWTIME       | BIGINT           (system)
- ROWKEY        | VARCHAR(STRING)  (system)
+ ROWKEY        | VARCHAR(STRING)  (key)
  DATA__field-a | INTEGER
  DATA__field-c | INTEGER
  DATA__field-d | VARCHAR(STRING)

--- a/docs-md/developer-guide/test-and-debug/generate-custom-test-data.md
+++ b/docs-md/developer-guide/test-and-debug/generate-custom-test-data.md
@@ -131,7 +131,7 @@ Name                 : ORDERS_RAW
  Field     | Type                                                                 
 ----------------------------------------------------------------------------------
  ROWTIME   | BIGINT           (system)                                            
- ROWKEY    | VARCHAR(STRING)  (system)                                            
+ ROWKEY    | VARCHAR(STRING)  (key)
  ITEMID    | VARCHAR(STRING)                                                      
  PRICE     | DOUBLE                                                               
  LOCATION  | STRUCT<CITY VARCHAR(STRING), STATE VARCHAR(STRING), ZIPCODE INTEGER> 
@@ -187,7 +187,7 @@ Name                 : USERS_ORIGINAL
  Field        | Type                      
 ------------------------------------------
  ROWTIME      | BIGINT           (system) 
- ROWKEY       | VARCHAR(STRING)  (system) 
+ ROWKEY       | VARCHAR(STRING)  (key)
  REGISTERTIME | BIGINT                    
  GENDER       | VARCHAR(STRING)           
  REGIONID     | VARCHAR(STRING)           
@@ -243,7 +243,7 @@ Name                 : USERS_EXTENDED
  Field        | Type                         
 ---------------------------------------------
  ROWTIME      | BIGINT           (system)    
- ROWKEY       | VARCHAR(STRING)  (system)    
+ ROWKEY       | VARCHAR(STRING)  (key)
  REGISTERTIME | BIGINT                       
  GENDER       | VARCHAR(STRING)              
  REGIONID     | VARCHAR(STRING)              
@@ -297,7 +297,7 @@ Name                 : PAGEVIEWS_ORIGINAL
  Field    | Type                      
 --------------------------------------
  ROWTIME  | BIGINT           (system) 
- ROWKEY   | VARCHAR(STRING)  (system) 
+ ROWKEY   | VARCHAR(STRING)  (key)
  VIEWTIME | BIGINT                    
  USERID   | VARCHAR(STRING)           
  PAGEID   | VARCHAR(STRING)           

--- a/docs-md/developer-guide/test-and-debug/processing-log.md
+++ b/docs-md/developer-guide/test-and-debug/processing-log.md
@@ -243,7 +243,7 @@ Name                 : PROCESSING_LOG
 Field   | Type
 ---------------------------------------------------------------------------------------------------------------------------
  ROWTIME | BIGINT           (system)
- ROWKEY  | VARCHAR(STRING)  (system)
+ ROWKEY  | VARCHAR(STRING)  (key)
  LOGGER  | VARCHAR(STRING)
  LEVEL   | VARCHAR(STRING)
  TIME    | BIGINT

--- a/docs-md/tutorials/basics-docker.md
+++ b/docs-md/tutorials/basics-docker.md
@@ -725,7 +725,7 @@ EMIT CHANGES;
  Field    | Type                                              
 --------------------------------------------------------------
  ROWTIME  | BIGINT           (system)                         
- ROWKEY   | VARCHAR(STRING)  (system) (Window type: TUMBLING) 
+ ROWKEY   | VARCHAR(STRING)  (key) (Window type: TUMBLING)
  GENDER   | VARCHAR(STRING)                                   
  REGIONID | VARCHAR(STRING)                                   
  NUMUSERS | BIGINT                                            

--- a/docs/developer-guide/create-a-stream.rst
+++ b/docs/developer-guide/create-a-stream.rst
@@ -86,7 +86,7 @@ Your output should resemble:
      Field    | Type
     --------------------------------------
      ROWTIME  | BIGINT           (system)
-     ROWKEY   | VARCHAR(STRING)  (system)
+     ROWKEY   | VARCHAR(STRING)  (key)
      VIEWTIME | BIGINT
      USERID   | VARCHAR(STRING)
      PAGEID   | VARCHAR(STRING)

--- a/docs/developer-guide/create-a-table.rst
+++ b/docs/developer-guide/create-a-table.rst
@@ -93,7 +93,7 @@ Your output should resemble:
      Field        | Type
     ------------------------------------------
      ROWTIME      | BIGINT           (system)
-     ROWKEY       | VARCHAR(STRING)  (system)
+     ROWKEY       | VARCHAR(STRING)  (key)
      REGISTERTIME | BIGINT
      USERID       | VARCHAR(STRING)
      GENDER       | VARCHAR(STRING)

--- a/docs/developer-guide/processing-log.rst
+++ b/docs/developer-guide/processing-log.rst
@@ -206,7 +206,7 @@ When you start KSQL, you should see the stream in your list of streams:
     Field   | Type
     ---------------------------------------------------------------------------------------------------------------------------
      ROWTIME | BIGINT           (system)
-     ROWKEY  | VARCHAR(STRING)  (system)
+     ROWKEY  | VARCHAR(STRING)  (key)
      LOGGER  | VARCHAR(STRING)
      LEVEL   | VARCHAR(STRING)
      TIME    | BIGINT

--- a/docs/developer-guide/query-with-structured-data.rst
+++ b/docs/developer-guide/query-with-structured-data.rst
@@ -269,7 +269,7 @@ Your output should resemble:
      Field         | Type
     -------------------------------------------
      ROWTIME       | BIGINT           (system)
-     ROWKEY        | VARCHAR(STRING)  (system)
+     ROWKEY        | VARCHAR(STRING)  (key)
      DATA__field-a | INTEGER
      DATA__field-b | VARCHAR(STRING)
     -------------------------------------------
@@ -289,7 +289,7 @@ Your output should resemble:
      Field         | Type
     -------------------------------------------
      ROWTIME       | BIGINT           (system)
-     ROWKEY        | VARCHAR(STRING)  (system)
+     ROWKEY        | VARCHAR(STRING)  (key)
      DATA__field-a | INTEGER
      DATA__field-c | INTEGER
      DATA__field-d | VARCHAR(STRING)

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -1064,7 +1064,7 @@ Your output should resemble:
      Field   | Type
     -------------------------------------
      ROWTIME | BIGINT           (system)
-     ROWKEY  | VARCHAR(STRING)  (system)
+     ROWKEY  | VARCHAR(STRING)  (key)
      IP      | VARCHAR(STRING)  (key)
      KBYTES  | BIGINT
     -------------------------------------
@@ -1090,7 +1090,7 @@ Your output should resemble:
      Field   | Type
     -------------------------------------
      ROWTIME | BIGINT           (system)
-     ROWKEY  | VARCHAR(STRING)  (system)
+     ROWKEY  | VARCHAR(STRING)  (key)
      IP      | VARCHAR(STRING)  (key)
      KBYTES  | BIGINT
     -------------------------------------

--- a/docs/includes/ksql-includes.rst
+++ b/docs/includes/ksql-includes.rst
@@ -436,7 +436,7 @@ the latest offset.
         Field    | Type
         --------------------------------------
         ROWTIME  | BIGINT           (system)
-        ROWKEY   | VARCHAR(STRING)  (system)
+        ROWKEY   | VARCHAR(STRING)  (key)
         GENDER   | VARCHAR(STRING)
         REGIONID | VARCHAR(STRING)
         NUMUSERS | BIGINT
@@ -563,7 +563,7 @@ Your output should resemble:
      Field      | Type
     ----------------------------------------------------------------------------------
      ROWTIME    | BIGINT           (system)
-     ROWKEY     | VARCHAR(STRING)  (system)
+     ROWKEY     | VARCHAR(STRING)  (key)
      ORDERTIME  | BIGINT
      ORDERID    | INTEGER
      ITEMID     | VARCHAR(STRING)
@@ -869,7 +869,7 @@ Your output should resemble:
      Field      | Type
     ----------------------------------------------------------------------------------
      ROWTIME    | BIGINT           (system)
-     ROWKEY     | VARCHAR(STRING)  (system)
+     ROWKEY     | VARCHAR(STRING)  (key)
      SRC        | VARCHAR(STRING)
      ORDERTIME  | BIGINT
      ORDERID    | INTEGER

--- a/docs/tutorials/generate-custom-test-data.rst
+++ b/docs/tutorials/generate-custom-test-data.rst
@@ -133,7 +133,7 @@ Your output should resemble:
     Field     | Type                                                                 
    ----------------------------------------------------------------------------------
     ROWTIME   | BIGINT           (system)                                            
-    ROWKEY    | VARCHAR(STRING)  (system)                                            
+    ROWKEY    | VARCHAR(STRING)  (key)
     ITEMID    | VARCHAR(STRING)                                                      
     PRICE     | DOUBLE                                                               
     LOCATION  | STRUCT<CITY VARCHAR(STRING), STATE VARCHAR(STRING), ZIPCODE INTEGER> 
@@ -188,7 +188,7 @@ Your output should resemble:
     Field        | Type                      
    ------------------------------------------
     ROWTIME      | BIGINT           (system) 
-    ROWKEY       | VARCHAR(STRING)  (system) 
+    ROWKEY       | VARCHAR(STRING)  (key)
     REGISTERTIME | BIGINT                    
     GENDER       | VARCHAR(STRING)           
     REGIONID     | VARCHAR(STRING)           
@@ -243,7 +243,7 @@ Your output should resemble:
     Field        | Type                         
    ---------------------------------------------
     ROWTIME      | BIGINT           (system)    
-    ROWKEY       | VARCHAR(STRING)  (system)    
+    ROWKEY       | VARCHAR(STRING)  (key)
     REGISTERTIME | BIGINT                       
     GENDER       | VARCHAR(STRING)              
     REGIONID     | VARCHAR(STRING)              
@@ -295,7 +295,7 @@ Your output should resemble:
     Field    | Type                      
    --------------------------------------
     ROWTIME  | BIGINT           (system) 
-    ROWKEY   | VARCHAR(STRING)  (system) 
+    ROWKEY   | VARCHAR(STRING)  (key)
     VIEWTIME | BIGINT                    
     USERID   | VARCHAR(STRING)           
     PAGEID   | VARCHAR(STRING)           

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -54,6 +54,7 @@ import io.confluent.ksql.rest.entity.DropConnectorEntity;
 import io.confluent.ksql.rest.entity.ErrorEntity;
 import io.confluent.ksql.rest.entity.ExecutionPlan;
 import io.confluent.ksql.rest.entity.FieldInfo;
+import io.confluent.ksql.rest.entity.FieldInfo.FieldType;
 import io.confluent.ksql.rest.entity.FunctionDescriptionList;
 import io.confluent.ksql.rest.entity.FunctionInfo;
 import io.confluent.ksql.rest.entity.FunctionNameList;
@@ -85,7 +86,6 @@ import io.confluent.ksql.util.HandlerMaps;
 import io.confluent.ksql.util.HandlerMaps.ClassHandlerMap1;
 import io.confluent.ksql.util.HandlerMaps.Handler1;
 import io.confluent.ksql.util.KsqlException;
-import io.confluent.ksql.util.SchemaUtil;
 import io.confluent.ksql.util.TabularRow;
 import java.io.Closeable;
 import java.io.File;
@@ -455,16 +455,18 @@ public class Console implements Closeable {
       final Optional<WindowType> windowType,
       final String keyField
   ) {
-    if (field.getName().equals(SchemaUtil.ROWTIME_NAME.text())) {
+    final FieldType possibleFieldType = field.getType().orElse(null);
+
+    if (possibleFieldType == FieldType.SYSTEM) {
       return String.format("%-16s %s", field.getSchema().toTypeString(), "(system)");
     }
 
-    if (field.getName().equals(SchemaUtil.ROWKEY_NAME.text())) {
+    if (possibleFieldType == FieldType.KEY) {
       final String wt = windowType
           .map(v -> " (Window type: " + v + ")")
           .orElse("");
 
-      return String.format("%-16s %s%s", field.getSchema().toTypeString(), "(system)", wt);
+      return String.format("%-16s %s%s", field.getSchema().toTypeString(), "(key)", wt);
     }
 
     if (keyField != null && keyField.contains("." + field.getName())) {

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -489,7 +489,7 @@ public class CliTest {
         "describe " + ORDER_DATA_PROVIDER.kstreamName() + ";",
         containsRows(
             row("ROWTIME", "BIGINT           (system)"),
-            row("ROWKEY", "BIGINT           (system)"),
+            row("ROWKEY", "BIGINT           (key)"),
             row("ORDERTIME", "BIGINT"),
             row("ORDERID", "VARCHAR(STRING)"),
             row("ITEMID", "VARCHAR(STRING)"),

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -404,14 +404,16 @@ public class ConsoleTest {
           + "        \"type\" : \"BIGINT\"," + NEWLINE
           + "        \"fields\" : null," + NEWLINE
           + "        \"memberSchema\" : null" + NEWLINE
-          + "      }" + NEWLINE
+          + "      }," + NEWLINE
+          + "      \"type\" : \"SYSTEM\"" + NEWLINE
           + "    }, {" + NEWLINE
           + "      \"name\" : \"ROWKEY\"," + NEWLINE
           + "      \"schema\" : {" + NEWLINE
           + "        \"type\" : \"STRING\"," + NEWLINE
           + "        \"fields\" : null," + NEWLINE
           + "        \"memberSchema\" : null" + NEWLINE
-          + "      }" + NEWLINE
+          + "      }," + NEWLINE
+          + "      \"type\" : \"KEY\"" + NEWLINE
           + "    }, {" + NEWLINE
           + "      \"name\" : \"f_0\"," + NEWLINE
           + "      \"schema\" : {" + NEWLINE
@@ -505,7 +507,7 @@ public class ConsoleTest {
           + " Field   | Type                      " + NEWLINE
           + "-------------------------------------" + NEWLINE
           + " ROWTIME | BIGINT           (system) " + NEWLINE
-          + " ROWKEY  | VARCHAR(STRING)  (system) " + NEWLINE
+          + " ROWKEY  | VARCHAR(STRING)  (key)    " + NEWLINE
           + " f_0     | BOOLEAN                   " + NEWLINE
           + " f_1     | INTEGER                   " + NEWLINE
           + " f_2     | BIGINT                    " + NEWLINE
@@ -607,14 +609,16 @@ public class ConsoleTest {
           + "        \"type\" : \"BIGINT\"," + NEWLINE
           + "        \"fields\" : null," + NEWLINE
           + "        \"memberSchema\" : null" + NEWLINE
-          + "      }" + NEWLINE
+          + "      }," + NEWLINE
+          + "      \"type\" : \"SYSTEM\"" + NEWLINE
           + "    }, {" + NEWLINE
           + "      \"name\" : \"ROWKEY\"," + NEWLINE
           + "      \"schema\" : {" + NEWLINE
           + "        \"type\" : \"STRING\"," + NEWLINE
           + "        \"fields\" : null," + NEWLINE
           + "        \"memberSchema\" : null" + NEWLINE
-          + "      }" + NEWLINE
+          + "      }," + NEWLINE
+          + "      \"type\" : \"KEY\"" + NEWLINE
           + "    }, {" + NEWLINE
           + "      \"name\" : \"f_0\"," + NEWLINE
           + "      \"schema\" : {" + NEWLINE
@@ -915,7 +919,7 @@ public class ConsoleTest {
             "typeA", new SchemaInfo(
                 SqlBaseType.STRUCT,
                 ImmutableList.of(
-                    new FieldInfo("f1", new SchemaInfo(SqlBaseType.STRING, null, null))),
+                    new FieldInfo("f1", new SchemaInfo(SqlBaseType.STRING, null, null), Optional.empty())),
                 null)
         ))
     ));
@@ -1059,14 +1063,16 @@ public class ConsoleTest {
           + "        \"type\" : \"BIGINT\"," + NEWLINE
           + "        \"fields\" : null," + NEWLINE
           + "        \"memberSchema\" : null" + NEWLINE
-          + "      }" + NEWLINE
+          + "      }," + NEWLINE
+          + "      \"type\" : \"SYSTEM\"" + NEWLINE
           + "    }, {" + NEWLINE
           + "      \"name\" : \"ROWKEY\"," + NEWLINE
           + "      \"schema\" : {" + NEWLINE
           + "        \"type\" : \"STRING\"," + NEWLINE
           + "        \"fields\" : null," + NEWLINE
           + "        \"memberSchema\" : null" + NEWLINE
-          + "      }" + NEWLINE
+          + "      }," + NEWLINE
+          + "      \"type\" : \"KEY\"" + NEWLINE
           + "    }, {" + NEWLINE
           + "      \"name\" : \"f_0\"," + NEWLINE
           + "      \"schema\" : {" + NEWLINE
@@ -1104,7 +1110,7 @@ public class ConsoleTest {
           + " Field   | Type                      " + NEWLINE
           + "-------------------------------------" + NEWLINE
           + " ROWTIME | BIGINT           (system) " + NEWLINE
-          + " ROWKEY  | VARCHAR(STRING)  (system) " + NEWLINE
+          + " ROWKEY  | VARCHAR(STRING)  (key)    " + NEWLINE
           + " f_0     | VARCHAR(STRING)           " + NEWLINE
           + "-------------------------------------" + NEWLINE
           + "" + NEWLINE

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.BlockingRowQueue;
 import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.rest.entity.FieldInfo.FieldType;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.SqlBaseType;
@@ -184,17 +185,17 @@ public class QueryDescriptionFactoryTest {
   @Test
   public void shouldExposeValueFieldsForTransientQueries() {
     assertThat(transientQueryDescription.getFields(), contains(
-        new FieldInfo("field1", new SchemaInfo(SqlBaseType.INTEGER, null, null)),
-        new FieldInfo("field2", new SchemaInfo(SqlBaseType.STRING, null, null))));
+        new FieldInfo("field1", new SchemaInfo(SqlBaseType.INTEGER, null, null), Optional.empty()),
+        new FieldInfo("field2", new SchemaInfo(SqlBaseType.STRING, null, null), Optional.empty())));
   }
 
   @Test
   public void shouldExposeAllFieldsForPersistentQueries() {
     assertThat(persistentQueryDescription.getFields(), contains(
-        new FieldInfo("ROWTIME", new SchemaInfo(SqlBaseType.BIGINT, null, null)),
-        new FieldInfo("k0", new SchemaInfo(SqlBaseType.STRING, null, null)),
-        new FieldInfo("field1", new SchemaInfo(SqlBaseType.INTEGER, null, null)),
-        new FieldInfo("field2", new SchemaInfo(SqlBaseType.STRING, null, null))));
+        new FieldInfo("ROWTIME", new SchemaInfo(SqlBaseType.BIGINT, null, null), Optional.of(FieldType.SYSTEM)),
+        new FieldInfo("k0", new SchemaInfo(SqlBaseType.STRING, null, null), Optional.of(FieldType.KEY)),
+        new FieldInfo("field1", new SchemaInfo(SqlBaseType.INTEGER, null, null), Optional.empty()),
+        new FieldInfo("field2", new SchemaInfo(SqlBaseType.STRING, null, null), Optional.empty())));
   }
 
   @Test
@@ -235,9 +236,9 @@ public class QueryDescriptionFactoryTest {
 
     // Then:
     assertThat(transientQueryDescription.getFields(), contains(
-        new FieldInfo("field1", new SchemaInfo(SqlBaseType.INTEGER, null, null)),
-        new FieldInfo("ROWTIME", new SchemaInfo(SqlBaseType.BIGINT, null, null)),
-        new FieldInfo("field2", new SchemaInfo(SqlBaseType.STRING, null, null))));
+        new FieldInfo("field1", new SchemaInfo(SqlBaseType.INTEGER, null, null), Optional.empty()),
+        new FieldInfo("ROWTIME", new SchemaInfo(SqlBaseType.BIGINT, null, null), Optional.empty()),
+        new FieldInfo("field2", new SchemaInfo(SqlBaseType.STRING, null, null), Optional.empty())));
   }
 
   @Test
@@ -268,8 +269,8 @@ public class QueryDescriptionFactoryTest {
 
     // Then:
     assertThat(transientQueryDescription.getFields(), contains(
-        new FieldInfo("field1", new SchemaInfo(SqlBaseType.INTEGER, null, null)),
-        new FieldInfo("ROWKEY", new SchemaInfo(SqlBaseType.STRING, null, null)),
-        new FieldInfo("field2", new SchemaInfo(SqlBaseType.STRING, null, null))));
+        new FieldInfo("field1", new SchemaInfo(SqlBaseType.INTEGER, null, null), Optional.empty()),
+        new FieldInfo("ROWKEY", new SchemaInfo(SqlBaseType.STRING, null, null), Optional.empty()),
+        new FieldInfo("field2", new SchemaInfo(SqlBaseType.STRING, null, null), Optional.empty())));
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -265,7 +265,7 @@ public class RestApiTest {
     assertValidJsonMessages(messages);
     assertThat(messages.get(0),
         is("["
-            + "{\"name\":\"ROWKEY\",\"schema\":{\"type\":\"STRING\",\"fields\":null,\"memberSchema\":null}},"
+            + "{\"name\":\"ROWKEY\",\"schema\":{\"type\":\"STRING\",\"fields\":null,\"memberSchema\":null},\"type\":\"KEY\"},"
             + "{\"name\":\"ROWTIME\",\"schema\":{\"type\":\"BIGINT\",\"fields\":null,\"memberSchema\":null}},"
             + "{\"name\":\"COUNT\",\"schema\":{\"type\":\"BIGINT\",\"fields\":null,\"memberSchema\":null}}"
             + "]"));
@@ -290,7 +290,7 @@ public class RestApiTest {
     assertThat(messages.get(0),
         is("["
             + "{\"name\":\"COUNT\",\"schema\":{\"type\":\"BIGINT\",\"fields\":null,\"memberSchema\":null}},"
-            + "{\"name\":\"ROWKEY\",\"schema\":{\"type\":\"STRING\",\"fields\":null,\"memberSchema\":null}}"
+            + "{\"name\":\"ROWKEY\",\"schema\":{\"type\":\"STRING\",\"fields\":null,\"memberSchema\":null},\"type\":\"KEY\"}"
             + "]"));
     assertThat(messages.get(1),
         is("{\"row\":{\"columns\":[1,\"USER_1\"]}}"));
@@ -310,7 +310,7 @@ public class RestApiTest {
     assertValidJsonMessages(messages);
     assertThat(messages.get(0),
         is("["
-            + "{\"name\":\"ROWKEY\",\"schema\":{\"type\":\"STRING\",\"fields\":null,\"memberSchema\":null}}"
+            + "{\"name\":\"ROWKEY\",\"schema\":{\"type\":\"STRING\",\"fields\":null,\"memberSchema\":null},\"type\":\"KEY\"}"
             + "]"));
     assertThat(messages.get(1),
         is("{\"row\":{\"columns\":[\"USER_1\"]}}"));

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriberTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriberTest.java
@@ -133,8 +133,8 @@ public class WebSocketSubscriberTest {
     assertThat(
         schema.getValue(),
         is("["
-            + "{\"name\":\"ROWTIME\",\"schema\":{\"type\":\"BIGINT\",\"fields\":null,\"memberSchema\":null}},"
-            + "{\"name\":\"ROWKEY\",\"schema\":{\"type\":\"STRING\",\"fields\":null,\"memberSchema\":null}},"
+            + "{\"name\":\"ROWTIME\",\"schema\":{\"type\":\"BIGINT\",\"fields\":null,\"memberSchema\":null},\"type\":\"SYSTEM\"},"
+            + "{\"name\":\"ROWKEY\",\"schema\":{\"type\":\"STRING\",\"fields\":null,\"memberSchema\":null},\"type\":\"KEY\"},"
             + "{\"name\":\"currency\",\"schema\":{\"type\":\"STRING\",\"fields\":null,\"memberSchema\":null}},"
             + "{\"name\":\"amount\",\"schema\":{\"type\":\"DOUBLE\",\"fields\":null,\"memberSchema\":null}}"
             + "]"

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/EntityUtilTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/EntityUtilTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertThat;
 
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.rest.entity.FieldInfo;
+import io.confluent.ksql.rest.entity.FieldInfo.FieldType;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
@@ -113,6 +114,7 @@ public class EntityUtilTest {
     assertThat(fields.get(0).getSchema().getFields().get().size(), equalTo(1));
     final FieldInfo inner = fields.get(0).getSchema().getFields().get().get(0);
     assertThat(inner.getSchema().getTypeName(), equalTo("STRING"));
+    assertThat(inner.getType(), equalTo(Optional.empty()));
     assertThat(fields.get(0).getSchema().getMemberSchema(), equalTo(Optional.empty()));
   }
 
@@ -150,7 +152,9 @@ public class EntityUtilTest {
     // Then:
     assertThat(fields, hasSize(3));
     assertThat(fields.get(0).getName(), equalTo("ROWKEY"));
+    assertThat(fields.get(0).getType(), equalTo(Optional.empty()));
     assertThat(fields.get(1).getName(), equalTo("ROWTIME"));
+    assertThat(fields.get(1).getType(), equalTo(Optional.empty()));
   }
 
   @Test
@@ -167,6 +171,7 @@ public class EntityUtilTest {
     assertThat(fields, hasSize(1));
     assertThat(fields.get(0).getName(), equalTo("ROWTIME"));
     assertThat(fields.get(0).getSchema().getTypeName(), equalTo("BIGINT"));
+    assertThat(fields.get(0).getType(), equalTo(Optional.of(FieldType.SYSTEM)));
   }
 
   @Test
@@ -183,6 +188,7 @@ public class EntityUtilTest {
     assertThat(fields, hasSize(1));
     assertThat(fields.get(0).getName(), equalTo("field1"));
     assertThat(fields.get(0).getSchema().getTypeName(), equalTo("INTEGER"));
+    assertThat(fields.get(0).getType(), equalTo(Optional.of(FieldType.KEY)));
   }
 
   @Test
@@ -221,6 +227,7 @@ public class EntityUtilTest {
     assertThat(fields.get(0).getSchema().getTypeName(), equalTo(schemaName));
     assertThat(fields.get(0).getSchema().getFields(), equalTo(Optional.empty()));
     assertThat(fields.get(0).getSchema().getMemberSchema(), equalTo(Optional.empty()));
+    assertThat(fields.get(0).getType(), equalTo(Optional.empty()));
   }
 }
 

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/FieldInfo.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/FieldInfo.java
@@ -17,26 +17,36 @@ package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import java.util.Objects;
+import java.util.Optional;
 
 @Immutable
+@JsonInclude(Include.NON_ABSENT)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class FieldInfo {
+
+  public enum FieldType {
+    SYSTEM, KEY
+  }
+
   private final String name;
   private final SchemaInfo schema;
+  private final Optional<FieldType> type;
 
   @JsonCreator
   public FieldInfo(
-      @JsonProperty("name") final String name,
-      @JsonProperty("schema") final SchemaInfo schema) {
-    Objects.requireNonNull(name);
-    Objects.requireNonNull(schema);
-    this.name = name;
-    this.schema = schema;
+      @JsonProperty(value = "name", required = true) final String name,
+      @JsonProperty(value = "schema", required = true) final SchemaInfo schema,
+      @JsonProperty("fieldType") final Optional<FieldType> type
+  ) {
+    this.name = Objects.requireNonNull(name, "name");
+    this.schema = Objects.requireNonNull(schema, "schema");
+    this.type = Objects.requireNonNull(type, "type");
   }
-
 
   public String getName() {
     return this.name;
@@ -46,16 +56,21 @@ public class FieldInfo {
     return schema;
   }
 
+  public Optional<FieldType> getType() {
+    return type;
+  }
+
   @Override
   public boolean equals(final Object other) {
     return other instanceof FieldInfo
-        && Objects.equals(name, ((FieldInfo)other).name)
-        && Objects.equals(schema, ((FieldInfo)other).schema);
+        && Objects.equals(name, ((FieldInfo) other).name)
+        && Objects.equals(schema, ((FieldInfo) other).schema)
+        && Objects.equals(type, ((FieldInfo) other).type);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, schema);
+    return Objects.hash(name, schema, type);
   }
 
   @Override
@@ -63,6 +78,7 @@ public class FieldInfo {
     return "FieldInfo{"
         + "name='" + name + '\''
         + ", schema=" + schema
+        + ", type=" + type
         + '}';
   }
 }


### PR DESCRIPTION
### Description 

fixes: https://github.com/confluentinc/ksql/issues/4928

The server response when describing a source schema now includes `fieldType='SYSTEM'` or `fieldType='KEY'` to differentiate system columns, i.e. ROWTIME, and key columns from value column.

Old output:

```
 Field   | Type
-------------------------------------
 ROWTIME | BIGINT           (system)
 ROWKEY  | VARCHAR(STRING)  (system)
 IP      | VARCHAR(STRING)  (key)
 KBYTES  | BIGINT
-------------------------------------
```

New output:

```
 Field   | Type
-------------------------------------
 ROWTIME | BIGINT           (system)
 ROWKEY  | VARCHAR(STRING)  (key)
 IP      | VARCHAR(STRING)  (key)
 KBYTES  | BIGINT
-------------------------------------
```

The default is no field type. This design decision was taken as the `FieldInfo` pojo is used not just to describe the columns in the schema, but also fields in structs and a fieldType of `VALUE` wouldn't make much sense for a struct field. Where as no field type kind of works.

Note, if a column in the value has also been identified as a 'key' column using the `WITH(KEY)` syntax, then both `ROWKEY` and that column will be flagged with `(key)`.  However, the `WITH(KEY)` syntax is going v. soon, so this isn't really an issue. (https://github.com/confluentinc/ksql/issues/3537)

### Testing done 

usual + manual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

