### PR TITLE
docs: migration instructions for KSQL 5.4 to ksqlDB 5.5 (DOCS-3744)

### DIFF
--- a/docs/installation/upgrading.rst
+++ b/docs/installation/upgrading.rst
@@ -103,13 +103,26 @@ Upgrading to ksqlDB 5.5 from KSQL 5.4
    :ref:`role-based access control (RBAC) <ksql-rbac>`,
    :ref:`ACLs <config-security-ksql-acl>`, and no authorization.
 
-   Create three new role bindings or assign ACLs for the ``ksql`` service
+   Create new role bindings or assign ACLs for the ``ksql`` service
    principal:
 
    - Topic: ``__consumer_offsets``
    - Topic: ``__transaction_state``
    - TransactionalId: ``ksqldb_``. Use the value that you set in the
      configuration file.
+
+     If you're using ACLs for security, these ACLs are required:
+
+     - ``DESCRIBE`` operation on the ``TOPIC`` with ``LITERAL`` name ``__consumer_offsets``.
+     - ``DESCRIBE`` operation on the ``TOPIC`` with ``LITERAL`` name ``__transaction_state``.
+     - ``DESCRIBE`` and ``WRITE`` operations on the ``TRANSACTIONAL_ID`` with ``LITERAL`` name ``<ksql.service.id>``.
+
+     If you're using RBAC for security, these role assignments are required:
+
+     - ``DeveloperRead`` role on the ``__consumer_offsets`` topic.
+     - ``DeveloperRead`` role on ``__transaction_state`` topic.
+     - ``DeveloperWrite`` role on the ``<ksql.service.id>`` TransactionalId.
+
 
 #. Start the ``ksqldb`` service.
 

--- a/docs/installation/upgrading.rst
+++ b/docs/installation/upgrading.rst
@@ -26,19 +26,21 @@ Upgrading to ksqlDB 5.5 from KSQL 5.4
    ./bin/kafka-console-consumer --bootstrap-server localhost:9092 --topic _confluent-ksql-default__command_topic --from-beginning | jq ".statement" 
    ```
 
-#. List your application's streams, tables, and types. Don't use the EXTENDED
-   option. Go through each list, and find the the last CREATE statement for each
-   stream/table/type name. Order the CREATE statements so they show the correct
-   dependencies.
+#. Use the DESCRIBE statement to list your application's streams, tables, and
+   types. Don't use the EXTENDED option. Go through each list and re-create the
+   corresponding CREATE statements based on the displayed schemas.
    
 #. Make other compatibility-related changes, as shown in the
    `upgrade guide <https://docs.ksqldb.io/en/latest/operate-and-deploy/installation/upgrading/#how-to-upgrade>`__.
 
+#. Save your statements as an SQL file. 
+
 #. Stop the ``ksql`` service.
 
-#. Uninstall the ksql 5.4 DEB or RPM package.
+#. Uninstall the ksql 5.4 DEB or RPM package. For RPM, you can use the
+   ``yum swap`` command.
 
-#. Install the ksqldb 5.5 DEB or RPM package.
+#. Install the ksqldb 5.5 DEB or RPM package. 
 
 #. Copy the version 5.4 configuration file to the ksqldb 5.5 configuration
    folder, which is located at ``${CONFLUENT_HOME}/etc/ksqldb``:
@@ -54,7 +56,7 @@ Upgrading to ksqlDB 5.5 from KSQL 5.4
    :ref:`role-based access control (RBAC) <ksql-rbac>`,
    :ref:`ACLs <config-security-ksql-acl>`, and no authorization.
 
-#. Create three new role bindings or assign ACLs for the ``ksql`` service
+   Create three new role bindings or assign ACLs for the ``ksql`` service
    principal:
 
    - Topic: ``__consumer_offsets``
@@ -64,7 +66,7 @@ Upgrading to ksqlDB 5.5 from KSQL 5.4
 
 #. Start the ``ksqldb`` service.
 
-#. Run the file that you prepared previously.
+#. Run the SQL file that you prepared previously.
 
 .. note::
 

--- a/docs/installation/upgrading.rst
+++ b/docs/installation/upgrading.rst
@@ -1,13 +1,23 @@
 .. _upgrading-ksql:
 
-Upgrading KSQL
-==============
+Upgrading ksqlDB
+================
 
-Upgrade one KSQL server at a time (i.e. rolling restart). The remaining KSQL servers should have sufficient spare
-capacity to take over temporarily for unavailable, restarting servers.
+Upgrade one server at a time in a "rolling restart". The remaining servers
+should have sufficient spare capacity to take over temporarily for unavailable,
+restarting servers.
+
+For general guidance on upgrading, see
+[Upgrade ksqlDB](https://docs.ksqldb.io/en/latest/operate-and-deploy/installation/upgrading/).
 
 Upgrading to ksqlDB 5.5 from KSQL 5.4
 -------------------------------------
+
+.. important::
+
+   The upgrade from KSQL 5.4 to ksqlDB 5.5 is not a rolling restart. You must
+   shut down all KSQL instances and then start up all ksqlDB instances, so there
+   will be downtime.
 
 #. Prepare a list of SQL statements for migration. One way is to dump the command
    topic.
@@ -26,11 +36,11 @@ Upgrading to ksqlDB 5.5 from KSQL 5.4
 
 #. Stop the ``ksql`` service.
 
-#. Uninstall the v5.4 ksql rpm package.
+#. Uninstall the ksql 5.4 DEB or RPM package.
 
-#. Install the v5.5 ksqldb rpm package.
+#. Install the ksqldb 5.5 DEB or RPM package.
 
-#. Copy the v5.4 configuration file to the v5.5 ksqldb configuration
+#. Copy the version 5.4 configuration file to the ksqldb 5.5 configuration
    folder, which is located at ``${CONFLUENT_HOME}/etc/ksqldb``:
 
    ```bash
@@ -40,10 +50,12 @@ Upgrading to ksqlDB 5.5 from KSQL 5.4
 #. Change the ``ksql.service.id`` in the property file, for example, from
    ``default_`` to ``ksqldb_``.
 
-#. Create role bindings for the ``ksql`` service principal. For more information,
-   see :ref:`ksql-rbac`.
+#. Set up security for your ksqlDB app. ksqlDB supports using
+   :ref:`role-based access control (RBAC) <ksql-rbac>`,
+   :ref:`ACLs <config-security-ksql-acl>`, and no authorization.
 
-#. Create three new role bindings:
+#. Create three new role bindings or assign ACLs for the ``ksql`` service
+   principal:
 
    - Topic: ``__consumer_offsets``
    - Topic: ``__transaction_state``


### PR DESCRIPTION
### Description 
Working draft for migration instructions.

Also fixes some indentation issues.