### PR TITLE
chore: remove ROWKEY from datagen

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
@@ -51,9 +51,6 @@ public final class LogicalSchema {
   private static final Column IMPLICIT_TIME_COLUMN = Column
       .of(SchemaUtil.ROWTIME_NAME, SqlTypes.BIGINT, Column.Namespace.META, 0);
 
-  private static final Column IMPLICIT_KEY_COLUMN = Column
-      .of(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING, Column.Namespace.KEY, 0);
-
   private final ImmutableList<Column> columns;
 
   public static Builder builder() {

--- a/ksqldb-examples/src/test/java/io/confluent/ksql/datagen/RowGeneratorTest.java
+++ b/ksqldb-examples/src/test/java/io/confluent/ksql/datagen/RowGeneratorTest.java
@@ -44,7 +44,7 @@ public class RowGeneratorTest {
 
     final Struct key = rowPair.getLeft();
     assertThat(key, is(notNullValue()));
-    assertThat(key.get("ROWKEY"), is(instanceOf(Integer.class)));
+    assertThat(key.get("Key"), is(instanceOf(Integer.class)));
 
     assertThat(rowPair.getRight().values(), hasSize(5));
     assertThat(rowPair.getRight().get(4), instanceOf(Struct.class));
@@ -67,8 +67,8 @@ public class RowGeneratorTest {
     final Struct key = rowPair.getLeft();
     final GenericRow value = rowPair.getRight();
     assertThat(key, is(notNullValue()));
-    assertThat(key.get("ROWKEY"), is(instanceOf(Long.class)));
+    assertThat(key.get("Key"), is(instanceOf(Long.class)));
 
-    assertThat("must match copy of key in value", key.get("ROWKEY"), is(value.get(0)));
+    assertThat("must match copy of key in value", key.get("Key"), is(value.get(0)));
   }
 }


### PR DESCRIPTION
### Description 

This commit removes any use of `ROWKEY` from the DataGen app. This is being done as part of the work to allow any key column names, (https://github.com/confluentinc/ksql/issues/3536).

This is a compatible change as the key column name is not persisted in the data sent to Kafka. Hence the output doesn't change.

### Testing done 

Usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

