### PR TITLE
fix: remove immutable properties from headless mode

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/properties/LocalPropertyValidator.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/properties/LocalPropertyValidator.java
@@ -19,30 +19,18 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.config.ImmutableProperties;
 import io.confluent.ksql.config.PropertyValidator;
-import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.KsqlConstants;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.streams.StreamsConfig;
 
 /**
  * This class adds additional validation of properties on top of that provided by the
  * {@code ConfigDef} instances.
  */
 public class LocalPropertyValidator implements PropertyValidator {
-
-  // Only these config properties can be configured using SET/UNSET commands.
-  public static final Set<String> CONFIG_PROPERTY_WHITELIST = ImmutableSet.<String>builder()
-      .add(KsqlConfig.SINK_WINDOW_CHANGE_LOG_ADDITIONAL_RETENTION_MS_PROPERTY)
-      .add(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG)
-      .add(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)
-      .add(KsqlConstants.LEGACY_RUN_SCRIPT_STATEMENTS_CONTENT)
-      .add(ConsumerConfig.GROUP_ID_CONFIG)
-      .build();
 
   private final Set<String> immutableProps;
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/properties/PropertyOverrider.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/properties/PropertyOverrider.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.properties;
 
 import com.google.common.collect.ImmutableMap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.confluent.ksql.config.KsqlConfigResolver;
 import io.confluent.ksql.parser.tree.SetProperty;
 import io.confluent.ksql.parser.tree.UnsetProperty;
 import io.confluent.ksql.statement.ConfiguredStatement;
@@ -32,6 +33,7 @@ public final class PropertyOverrider {
       final Map<String, Object> mutableProperties
   ) {
     final SetProperty setProperty = statement.getStatement();
+    throwIfInvalidProperty(setProperty.getPropertyName(), statement.getStatementText());
     throwIfInvalidPropertyValues(setProperty, statement);
     mutableProperties.put(setProperty.getPropertyName(), setProperty.getPropertyValue());
   }
@@ -41,6 +43,7 @@ public final class PropertyOverrider {
       final Map<String, Object> mutableProperties
   ) {
     final UnsetProperty unsetProperty = statement.getStatement();
+    throwIfInvalidProperty(unsetProperty.getPropertyName(), statement.getStatementText());
     mutableProperties.remove(unsetProperty.getPropertyName());
   }
 
@@ -57,6 +60,12 @@ public final class PropertyOverrider {
       throw new KsqlStatementException(
           e.getMessage(), statement.getStatementText(), e.getCause());
     }
+  }
+
+  private static void throwIfInvalidProperty(final String propertyName, final String text) {
+    new KsqlConfigResolver()
+        .resolve(propertyName, true)
+        .orElseThrow(() -> new KsqlStatementException("Unknown property: " + propertyName, text));
   }
 
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/properties/PropertyOverrider.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/properties/PropertyOverrider.java
@@ -32,7 +32,6 @@ public final class PropertyOverrider {
       final Map<String, Object> mutableProperties
   ) {
     final SetProperty setProperty = statement.getStatement();
-    throwIfInvalidProperty(setProperty.getPropertyName(), statement.getStatementText());
     throwIfInvalidPropertyValues(setProperty, statement);
     mutableProperties.put(setProperty.getPropertyName(), setProperty.getPropertyValue());
   }
@@ -42,7 +41,6 @@ public final class PropertyOverrider {
       final Map<String, Object> mutableProperties
   ) {
     final UnsetProperty unsetProperty = statement.getStatement();
-    throwIfInvalidProperty(unsetProperty.getPropertyName(), statement.getStatementText());
     mutableProperties.remove(unsetProperty.getPropertyName());
   }
 
@@ -58,12 +56,6 @@ public final class PropertyOverrider {
     } catch (final Exception e) {
       throw new KsqlStatementException(
           e.getMessage(), statement.getStatementText(), e.getCause());
-    }
-  }
-
-  private static void throwIfInvalidProperty(final String propertyName, final String text) {
-    if (!LocalPropertyValidator.CONFIG_PROPERTY_WHITELIST.contains(propertyName)) {
-      throw new KsqlStatementException("Unknown property: " + propertyName, text);
     }
   }
 


### PR DESCRIPTION
fixes #4930 

### Description 

Reverts #2618 from headless and `RUN SCRIPT` execution path to be consistent with interactive mode (local property settings).

### Testing done 

End-to-end local testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

