### PR TITLE
chore: correct key column names in GROUP BY key struct

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/logging/processing/NoopProcessingLogContext.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/logging/processing/NoopProcessingLogContext.java
@@ -26,7 +26,7 @@ public final class NoopProcessingLogContext implements ProcessingLogContext {
 
   private static final ProcessingLogConfig NOOP_CONFIG = new ProcessingLogConfig(ImmutableMap.of());
 
-  private static final ProcessingLogger NOOP_LOGGER = msgFactory -> { };
+  public static final ProcessingLogger NOOP_LOGGER = msgFactory -> { };
 
   private static final ProcessingLoggerFactory NOOP_FACTORY = new ProcessingLoggerFactory() {
     @Override

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/GroupByParamsFactoryTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/GroupByParamsFactoryTest.java
@@ -33,7 +33,6 @@ import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
 import io.confluent.ksql.execution.expression.tree.LongLiteral;
 import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
 import io.confluent.ksql.execution.util.StructKeyUtil;
-import io.confluent.ksql.execution.util.StructKeyUtil.KeyBuilder;
 import io.confluent.ksql.logging.processing.ProcessingLogConfig;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.logging.processing.RecordProcessingError;
@@ -44,6 +43,7 @@ import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.SchemaUtil;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -53,20 +53,18 @@ import java.util.stream.Collectors;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.Struct;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(Parameterized.class)
 public class GroupByParamsFactoryTest {
-
-  private static final KeyBuilder INT_KEY_BUILDER = StructKeyUtil
-      .keyBuilder(SchemaUtil.ROWKEY_NAME, SqlTypes.INTEGER);
-  private static final KeyBuilder STRING_KEY_BUILDER = StructKeyUtil
-      .keyBuilder(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING);
 
   private static final ColumnName COL3 = ColumnName.of("COL3");
   private static final SqlStruct COL3_TYPE = SqlTypes.struct()
@@ -78,6 +76,9 @@ public class GroupByParamsFactoryTest {
       .valueColumn(ColumnName.of("KSQL_COL_0"), SqlTypes.DOUBLE)
       .valueColumn(COL3, COL3_TYPE)
       .build();
+
+  @Rule
+  public final MockitoRule initMockito = MockitoJUnit.rule();
 
   @Mock
   private ExpressionMetadata groupBy0;
@@ -92,11 +93,26 @@ public class GroupByParamsFactoryTest {
   @Captor
   private ArgumentCaptor<Function<ProcessingLogConfig, SchemaAndValue>> msgCaptor;
 
+  private final boolean anyKeyName;
   private GroupByParams singleParams;
   private GroupByParams multiParams;
 
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<Object[]> data() {
+    return ImmutableList.of(
+        new Object[]{"old skool", false},
+        new Object[]{"new skool", true}
+    );
+  }
+
+  public GroupByParamsFactoryTest(final String name, final boolean anyKeyName) {
+    this.anyKeyName = anyKeyName;
+  }
+
   @Before
   public void setUp() {
+    when(ksqlConfig.getBoolean(KsqlConfig.KSQL_ANY_KEY_NAME_ENABLED)).thenReturn(anyKeyName);
+
     when(groupBy0.getExpression()).thenReturn(new LongLiteral(0));
     when(groupBy0.getExpressionType()).thenReturn(SqlTypes.INTEGER);
 
@@ -171,7 +187,11 @@ public class GroupByParamsFactoryTest {
     final Struct result = singleParams.getMapper().apply(value);
 
     // Then:
-    assertThat(result, is(INT_KEY_BUILDER.build(10)));
+    final ColumnName expectedKeyColName = anyKeyName
+        ? ColumnName.of("KSQL_COL_1")
+        : SchemaUtil.ROWKEY_NAME;
+
+    assertThat(result, is(structKey(expectedKeyColName, 10)));
   }
 
   @Test
@@ -184,7 +204,11 @@ public class GroupByParamsFactoryTest {
     final Struct result = multiParams.getMapper().apply(value);
 
     // Then:
-    assertThat(result, is(STRING_KEY_BUILDER.build("99|+|-100")));
+    final ColumnName expectedKeyColName = anyKeyName
+        ? ColumnName.of("KSQL_COL_1")
+        : SchemaUtil.ROWKEY_NAME;
+
+    assertThat(result, is(structKey(expectedKeyColName, "99|+|-100")));
   }
 
   @Test
@@ -262,7 +286,6 @@ public class GroupByParamsFactoryTest {
   @Test
   public void shouldSetKeyNameFromSingleGroupByColumnName() {
     // When:
-    when(ksqlConfig.getBoolean(KsqlConfig.KSQL_ANY_KEY_NAME_ENABLED)).thenReturn(true);
     when(groupBy0.getExpression())
         .thenReturn(new UnqualifiedColumnReferenceExp(ColumnName.of("Bob")));
 
@@ -271,9 +294,13 @@ public class GroupByParamsFactoryTest {
         .buildSchema(SOURCE_SCHEMA, ImmutableList.of(groupBy0), ksqlConfig);
 
     // Then:
+    final ColumnName expectedKeyColName = anyKeyName
+        ? ColumnName.of("Bob")
+        : SchemaUtil.ROWKEY_NAME;
+
     assertThat(schema, is(LogicalSchema.builder()
         .withRowTime()
-        .keyColumn(ColumnName.of("Bob"), SqlTypes.INTEGER)
+        .keyColumn(expectedKeyColName, SqlTypes.INTEGER)
         .valueColumns(SOURCE_SCHEMA.value())
         .build()));
   }
@@ -281,7 +308,6 @@ public class GroupByParamsFactoryTest {
   @Test
   public void shouldSetKeyNameFromSingleGroupByFieldName() {
     // When:
-    when(ksqlConfig.getBoolean(KsqlConfig.KSQL_ANY_KEY_NAME_ENABLED)).thenReturn(true);
     when(groupBy0.getExpression()).thenReturn(new DereferenceExpression(
         Optional.empty(),
         new UnqualifiedColumnReferenceExp(COL3),
@@ -293,9 +319,13 @@ public class GroupByParamsFactoryTest {
         .buildSchema(SOURCE_SCHEMA, ImmutableList.of(groupBy0), ksqlConfig);
 
     // Then:
+    final ColumnName expectedKeyColName = anyKeyName
+        ? ColumnName.of("COL3__someField")
+        : SchemaUtil.ROWKEY_NAME;
+
     assertThat(schema, is(LogicalSchema.builder()
         .withRowTime()
-        .keyColumn(ColumnName.of("COL3__someField"), SqlTypes.INTEGER)
+        .keyColumn(expectedKeyColName, SqlTypes.INTEGER)
         .valueColumns(SOURCE_SCHEMA.value())
         .build()));
   }
@@ -303,7 +333,6 @@ public class GroupByParamsFactoryTest {
   @Test
   public void shouldGenerateKeyNameFromSingleGroupByOtherExpressionType() {
     // When:
-    when(ksqlConfig.getBoolean(KsqlConfig.KSQL_ANY_KEY_NAME_ENABLED)).thenReturn(true);
     when(groupBy0.getExpression())
         .thenReturn(new LongLiteral(1));
 
@@ -312,9 +341,13 @@ public class GroupByParamsFactoryTest {
         .buildSchema(SOURCE_SCHEMA, ImmutableList.of(groupBy0), ksqlConfig);
 
     // Then:
+    final ColumnName expectedKeyColName = anyKeyName
+        ? ColumnName.of("KSQL_COL_1")
+        : SchemaUtil.ROWKEY_NAME;
+
     assertThat(schema, is(LogicalSchema.builder()
         .withRowTime()
-        .keyColumn(ColumnName.of("KSQL_COL_1"), SqlTypes.INTEGER)
+        .keyColumn(expectedKeyColName, SqlTypes.INTEGER)
         .valueColumns(SOURCE_SCHEMA.value())
         .build()));
   }
@@ -322,17 +355,30 @@ public class GroupByParamsFactoryTest {
   @Test
   public void shouldGenerateKeyNameForMultiGroupBys() {
     // When:
-    when(ksqlConfig.getBoolean(KsqlConfig.KSQL_ANY_KEY_NAME_ENABLED)).thenReturn(true);
-
-    // When:
     final LogicalSchema schema = GroupByParamsFactory
         .buildSchema(SOURCE_SCHEMA, ImmutableList.of(groupBy0, groupBy1), ksqlConfig);
 
     // Then:
+    final ColumnName expectedKeyColName = anyKeyName
+        ? ColumnName.of("KSQL_COL_1")
+        : SchemaUtil.ROWKEY_NAME;
+
     assertThat(schema, is(LogicalSchema.builder()
         .withRowTime()
-        .keyColumn(ColumnName.of("KSQL_COL_1"), SqlTypes.STRING)
+        .keyColumn(expectedKeyColName, SqlTypes.STRING)
         .valueColumns(SOURCE_SCHEMA.value())
         .build()));
+  }
+
+  private static Struct structKey(final ColumnName keyColName, final String keyValue) {
+    return StructKeyUtil
+        .keyBuilder(keyColName, SqlTypes.STRING)
+        .build(keyValue);
+  }
+
+  private static Struct structKey(final ColumnName keyColName, final int keyValue) {
+    return StructKeyUtil
+        .keyBuilder(keyColName, SqlTypes.INTEGER)
+        .build(keyValue);
   }
 }


### PR DESCRIPTION
### Description 

quick refactor of `GroupByParamsFactory` while correcting the name of the key column. The two inner classes were incorrectly using `ROWKEY` as the key column name, not the name of the key in the schema, which can now be things other than `ROWKEY`. This wasn't causing any issues (yet) as the key column name is not persisted (yet).  But good to clean it up.

### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

