### PR TITLE
fix: do not allow GROUP BY and PARTITION BY on boolean expressions

### DIFF
--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
@@ -267,6 +267,20 @@
       }
     },
     {
+      "name": "complex expressions",
+      "statements": [
+        "CREATE STREAM TEST (ID INT KEY, data STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT COUNT(*) FROM TEST GROUP BY DATA AND ID;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.parser.exception.ParseFailedException",
+        "message": "mismatched input 'AND' expecting ';'"
+      }
+    },
+    {
       "name": "multiple expressions with nulls",
       "comment": "bad_udf return every other invocation - tables need a PRIMARY key so null keys are dropped",
       "statements": [

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/partition-by.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/partition-by.json
@@ -188,6 +188,20 @@
       ]
     },
     {
+      "name": "complex expressions",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT KEY, NAME STRING, AGE INT) with (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS select * from INPUT partition by NAME AND AGE;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.parser.exception.ParseFailedException",
+        "message": "mismatched input 'AND' expecting ';'"
+      }
+    },
+    {
       "name": "partition by with projection select some",
       "statements": [
         "CREATE STREAM TEST (ID bigint, NAME varchar, VALUE bigint) with (kafka_topic='test_topic', value_format = 'delimited');",

--- a/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -76,7 +76,7 @@ query
       (WINDOW  windowExpression)?
       (WHERE where=booleanExpression)?
       (GROUP BY groupBy)?
-      (PARTITION BY partitionBy=booleanExpression)?
+      (PARTITION BY partitionBy=valueExpression)?
       (HAVING having=booleanExpression)?
       (EMIT resultMaterialization)?
       limitClause?
@@ -161,8 +161,8 @@ groupingElement
     ;
 
 groupingExpressions
-    : '(' (expression (',' expression)*)? ')'
-    | expression
+    : '(' (valueExpression (',' valueExpression)*)? ')'
+    | valueExpression
     ;
 
 values

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -571,7 +571,7 @@ public class AstBuilder {
     public Node visitSingleGroupingSet(final SqlBaseParser.SingleGroupingSetContext context) {
       return new SimpleGroupBy(
           getLocation(context),
-          visit(context.groupingExpressions().expression(), Expression.class)
+          visit(context.groupingExpressions().valueExpression(), Expression.class)
       );
     }
 


### PR DESCRIPTION
### Description 

fixes: https://github.com/confluentinc/ksql/issues/4939

Change to SQL syntax to not allow GROUP BY and PARTITION BY on boolean expressions. Only value expressions will be allowed.

### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

