### PR TITLE
feat: CORS support for Vert.x based ksqlDB

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ApiServerConfig.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ApiServerConfig.java
@@ -109,6 +109,18 @@ public class ApiServerConfig extends AbstractConfig {
   public static final String MAX_PUSH_QUERIES_DOC =
       "The maximum number of push queries allowed on the server at any one time";
 
+  public static final String CORS_ALLOWED_ORIGINS = propertyName("cors.allowed.origins");
+  public static final String CORS_ALLOWED_ORIGINS_DOC =
+      "CORS support: Comma separated list of allowed origins, can contain wildcards";
+
+  public static final String CORS_ALLOWED_HEADERS = propertyName("cors.allowed.headers");
+  public static final String CORS_ALLOWED_HEADERS_DOC =
+      "CORS support: Comma separated list of allowed headers";
+
+  public static final String CORS_ALLOWED_METHODS = propertyName("cors.allowed.methods");
+  public static final String CORS_ALLOWED_METHODS_DOC =
+      "CORS support: Comma separated list of allowed methods";
+
   private static String propertyName(final String name) {
     return KsqlConfig.KSQL_CONFIG_PROPERTY_PREFIX + PROPERTY_PREFIX + name;
   }
@@ -196,7 +208,28 @@ public class ApiServerConfig extends AbstractConfig {
           DEFAULT_MAX_PUSH_QUERIES,
           zeroOrPositive(),
           Importance.MEDIUM,
-          MAX_PUSH_QUERIES_DOC);
+          MAX_PUSH_QUERIES_DOC)
+      .define(
+          CORS_ALLOWED_ORIGINS,
+          Type.STRING,
+          "",
+          Importance.MEDIUM,
+          CORS_ALLOWED_ORIGINS_DOC
+      )
+      .define(
+          CORS_ALLOWED_HEADERS,
+          Type.LIST,
+          "",
+          Importance.MEDIUM,
+          CORS_ALLOWED_HEADERS_DOC
+      )
+      .define(
+          CORS_ALLOWED_METHODS,
+          Type.LIST,
+          "",
+          Importance.MEDIUM,
+          CORS_ALLOWED_METHODS_DOC
+      );
 
   public ApiServerConfig(final Map<?, ?> map) {
     super(CONFIG_DEF, map);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/KSqlCorsHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/KSqlCorsHandler.java
@@ -20,8 +20,8 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.CorsHandler;
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -31,11 +31,7 @@ public class KSqlCorsHandler implements Handler<RoutingContext> {
   private static final List<String> DEFAULT_ALLOWED_METHODS = Arrays.asList("GET", "POST", "HEAD");
   private static final List<String> DEFAULT_ALLOWED_HEADERS = Arrays
       .asList("X-Requested-With", "Content-Type", "Accept", "Origin");
-  public static final List<String> EXCLUDED_PATH_PREFIXES = new ArrayList<>();
-
-  static {
-    EXCLUDED_PATH_PREFIXES.add("/ws/");
-  }
+  private static final List<String> EXCLUDED_PATH_PREFIXES = Collections.singletonList("/ws/");
 
   static void setupCorsHandler(final Server server, final Router router) {
     final ApiServerConfig apiServerConfig = server.getConfig();

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/KSqlCorsHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/KSqlCorsHandler.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.server;
+
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.CorsHandler;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+public class KSqlCorsHandler implements Handler<RoutingContext> {
+
+  private static final List<String> DEFAULT_ALLOWED_METHODS = Arrays.asList("GET", "POST", "HEAD");
+  private static final List<String> DEFAULT_ALLOWED_HEADERS = Arrays
+      .asList("X-Requested-With", "Content-Type", "Accept", "Origin");
+  public static final List<String> EXCLUDED_PATH_PREFIXES = new ArrayList<>();
+
+  static {
+    EXCLUDED_PATH_PREFIXES.add("/ws/");
+  }
+
+  static void setupCorsHandler(final Server server, final Router router) {
+    final ApiServerConfig apiServerConfig = server.getConfig();
+    final String allowedOrigins = apiServerConfig
+        .getString(ApiServerConfig.CORS_ALLOWED_ORIGINS);
+    if (allowedOrigins.trim().isEmpty()) {
+      return;
+    }
+    final String convertedPattern = convertAllowedOrigin(allowedOrigins);
+    final CorsHandler corsHandler = CorsHandler.create(convertedPattern);
+    final List<String> allowedMethods = apiServerConfig
+        .getList(ApiServerConfig.CORS_ALLOWED_METHODS);
+    final Set<String> allowedMethodsSet = new LinkedHashSet<>(allowedMethods);
+    allowedMethodsSet.addAll(DEFAULT_ALLOWED_METHODS);
+    for (String allowedMethod : allowedMethodsSet) {
+      corsHandler.allowedMethod(HttpMethod.valueOf(allowedMethod.toUpperCase()));
+    }
+
+    final List<String> allowedHeaders = apiServerConfig
+        .getList(ApiServerConfig.CORS_ALLOWED_HEADERS);
+    final Set<String> allowedHeadersSet = new LinkedHashSet<>(allowedHeaders);
+    allowedHeadersSet.addAll(DEFAULT_ALLOWED_HEADERS);
+    for (String allowedHeader : allowedHeadersSet) {
+      corsHandler.allowedHeader(allowedHeader);
+    }
+    corsHandler.allowCredentials(true);
+
+    router.route().handler(new KSqlCorsHandler(corsHandler));
+  }
+
+  private final CorsHandler corsHandler;
+
+  public KSqlCorsHandler(final CorsHandler corsHandler) {
+    this.corsHandler = corsHandler;
+  }
+
+  @Override
+  public void handle(final RoutingContext routingContext) {
+    final String path = routingContext.normalisedPath();
+    for (String excludedPrefix : EXCLUDED_PATH_PREFIXES) {
+      if (path.startsWith(excludedPrefix)) {
+        routingContext.next();
+        return;
+      }
+    }
+    corsHandler.handle(routingContext);
+  }
+
+  // Convert to regex
+  private static String convertAllowedOrigin(final String allowedOrigins) {
+    final String[] parts = allowedOrigins.split(",");
+    final StringBuilder out = new StringBuilder();
+    for (int i = 0; i < parts.length; i++) {
+      String part = parts[i].trim();
+      part = part.replace(".", "\\.")
+          .replace("+", "\\+")
+          .replace("?", "\\?")
+          .replace("*", ".*");
+      out.append(part);
+      if (i != parts.length - 1) {
+        out.append('|');
+      }
+    }
+    return out.toString();
+  }
+
+}

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -116,7 +116,7 @@ public class ServerVerticle extends AbstractVerticle {
       PortedEndpoints.setupFailureHandler(router);
     }
 
-    KSqlCorsHandler.setupCorsHandler(server, router);
+    KsqlCorsHandler.setupCorsHandler(server, router);
 
     setUpFailureHandler(router);
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -116,6 +116,8 @@ public class ServerVerticle extends AbstractVerticle {
       PortedEndpoints.setupFailureHandler(router);
     }
 
+    KSqlCorsHandler.setupCorsHandler(server, router);
+
     setUpFailureHandler(router);
 
     setupAuthHandlers(router);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -262,6 +262,16 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
       origs.put(ApiServerConfig.AUTHENTICATION_SKIP_PATHS_CONFIG, unauthedPaths);
     }
 
+    final String corsAllowedOrigin = config
+        .getString(RestConfig.ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG);
+    origs.put(ApiServerConfig.CORS_ALLOWED_ORIGINS, corsAllowedOrigin);
+    final String corsAllowedHeaders = config
+        .getString(RestConfig.ACCESS_CONTROL_ALLOW_HEADERS);
+    origs.put(ApiServerConfig.CORS_ALLOWED_HEADERS, corsAllowedHeaders);
+    final String corsAllowedMethods = config
+        .getString(RestConfig.ACCESS_CONTROL_ALLOW_METHODS);
+    origs.put(ApiServerConfig.CORS_ALLOWED_METHODS, corsAllowedMethods);
+
     return new KsqlRestConfig(origs);
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/BaseApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/BaseApiTest.java
@@ -211,7 +211,7 @@ public class BaseApiTest {
   }
 
   @SuppressWarnings("unchecked")
-  private void setDefaultRowGenerator() {
+  protected void setDefaultRowGenerator() {
     List<GenericRow> rows = new ArrayList<>();
     for (JsonArray ja : DEFAULT_ROWS) {
       rows.add(GenericRow.fromList(ja.getList()));

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/CorsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/CorsTest.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import io.confluent.ksql.api.server.ApiServerConfig;
+import io.confluent.ksql.api.server.KSqlCorsHandler;
+import io.confluent.ksql.util.VertxCompletableFuture;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpResponse;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CorsTest extends BaseApiTest {
+
+  private Map<String, Object> config = new HashMap<>();
+
+  private static final String ACCESS_CONTROL_ALLOW_ORIGIN_HEADER = "Access-Control-Allow-Origin";
+  private static final String ACCESS_CONTROL_ALLOW_METHODS_HEADER = "Access-Control-Allow-Methods";
+  private static final String ACCESS_CONTROL_ALLOW_HEADERS_HEADER = "Access-Control-Allow-Headers";
+  private static final String ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER = "Access-Control-Allow-Credentials";
+
+  private static final String ACCESS_CONTROL_REQUEST_METHOD_HEADER = "Access-Control-Request-Method";
+
+  private static final String DEFAULT_ACCESS_CONTROL_ALLOW_HEADERS = "X-Requested-With,Content-Type,Accept,Origin";
+  private static final String DEFAULT_ACCESS_CONTROL_ALLOW_METHODS = "GET,POST,HEAD";
+
+  @Before
+  public void setUp() {
+
+    vertx = Vertx.vertx();
+    vertx.exceptionHandler(t -> log.error("Unhandled exception in Vert.x", t));
+
+    testEndpoints = new TestEndpoints();
+    setDefaultRowGenerator();
+  }
+
+  @After
+  public void tearDown() {
+    stopClient();
+    stopServer();
+    if (vertx != null) {
+      vertx.close();
+    }
+  }
+
+  @Test
+  public void shouldNotBeCorsResponseIfNoCorsConfigured() throws Exception {
+
+    // Given:
+    init();
+
+    // When
+    HttpResponse<Buffer> response = sendCorsRequest(HttpMethod.POST, "wibble.com");
+
+    // Then:
+    assertThat(response.statusCode(), is(200));
+    assertThat(response.getHeader(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER), is(nullValue()));
+    assertThat(response.getHeader(ACCESS_CONTROL_ALLOW_METHODS_HEADER), is(nullValue()));
+    assertThat(response.getHeader(ACCESS_CONTROL_ALLOW_HEADERS_HEADER), is(nullValue()));
+  }
+
+  @Test
+  public void shouldExcludePath() throws Exception {
+
+    // Given:
+    init();
+    config.put(ApiServerConfig.CORS_ALLOWED_ORIGINS, "wibble.com");
+    KSqlCorsHandler.EXCLUDED_PATH_PREFIXES.add("/query-stream");
+
+    // When
+    HttpResponse<Buffer> response = sendCorsRequest(HttpMethod.POST, "wibble.com");
+
+    // Then:
+    assertThat(response.statusCode(), is(200));
+    assertThat(response.getHeader(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER), is(nullValue()));
+    assertThat(response.getHeader(ACCESS_CONTROL_ALLOW_METHODS_HEADER), is(nullValue()));
+    assertThat(response.getHeader(ACCESS_CONTROL_ALLOW_HEADERS_HEADER), is(nullValue()));
+
+    KSqlCorsHandler.EXCLUDED_PATH_PREFIXES
+        .remove(KSqlCorsHandler.EXCLUDED_PATH_PREFIXES.size() - 1);
+  }
+
+  @Test
+  public void shouldNotBeCorsResponseIfNotCorsRequest() throws Exception {
+
+    // Given:
+    init();
+    config.put(ApiServerConfig.CORS_ALLOWED_ORIGINS, "wibble.com");
+
+    // When
+    VertxCompletableFuture<HttpResponse<Buffer>> requestFuture = new VertxCompletableFuture<>();
+    client
+        .request(HttpMethod.POST, "/query-stream")
+        .sendJsonObject(new JsonObject().put("sql", DEFAULT_PULL_QUERY), requestFuture);
+    HttpResponse<Buffer> response = requestFuture.get();
+
+    // Then:
+    assertThat(response.statusCode(), is(200));
+    assertThat(response.getHeader(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER), is(nullValue()));
+    assertThat(response.getHeader(ACCESS_CONTROL_ALLOW_METHODS_HEADER), is(nullValue()));
+    assertThat(response.getHeader(ACCESS_CONTROL_ALLOW_HEADERS_HEADER), is(nullValue()));
+  }
+
+  @Test
+  public void shouldAcceptCorsRequestOriginExactMatch() throws Exception {
+    shouldAcceptCorsRequest("wibble.com", "wibble.com");
+  }
+
+  @Test
+  public void shouldRejectCorsRequestOriginExactMatch() throws Exception {
+    shouldRejectCorsRequest("foo.com", "wibble.com");
+  }
+
+  @Test
+  public void shouldAcceptCorsRequestOriginExactMatchOneOfList() throws Exception {
+    shouldAcceptCorsRequest("wibble.com", "foo.com,wibble.com");
+  }
+
+  @Test
+  public void shouldRejectCorsRequestOriginExactMatchOenOfList() throws Exception {
+    shouldRejectCorsRequest("foo.com", "wibble.com,blah.com");
+  }
+
+  @Test
+  public void shouldAcceptCorsRequestAcceptAll() throws Exception {
+    shouldAcceptCorsRequest("wibble.com", "*");
+  }
+
+  @Test
+  public void shouldAcceptCorsRequestWildcardMatch() throws Exception {
+    shouldAcceptCorsRequest("foo.wibble.com", "*.wibble.com");
+  }
+
+  @Test
+  public void shouldRejectCorsRequestWildcardMatch() throws Exception {
+    shouldRejectCorsRequest("foo.wibble.com", "*.blibble.com");
+  }
+
+  @Test
+  public void shouldAcceptCorsRequestWilcardMatchList() throws Exception {
+    shouldAcceptCorsRequest("foo.wibble.com", "blah.com,*.wibble.com,foo.com");
+  }
+
+  @Test
+  public void shouldRejectCorsRequestWilcardMatchList() throws Exception {
+    shouldRejectCorsRequest("foo.wibble.com", "blah.com,*.blibble.com,foo.com");
+  }
+
+  @Test
+  public void shouldAcceptPreflightRequestOriginExactMatchDefaultHeaders() throws Exception {
+    shouldAcceptPreflightRequest("wibble.com", "wibble.com", DEFAULT_ACCESS_CONTROL_ALLOW_HEADERS,
+        DEFAULT_ACCESS_CONTROL_ALLOW_METHODS);
+  }
+
+  @Test
+  public void shouldRejectPreflightRequestOriginExactMatchDefaultHeaders() throws Exception {
+    shouldRejectPreflightRequest("wibble.com", "flibble.com");
+  }
+
+  @Test
+  public void shouldAcceptPreflightRequestOriginExactMatchSpecifiedHeaders() throws Exception {
+    config.put(ApiServerConfig.CORS_ALLOWED_HEADERS, "foo-header,bar-header");
+    shouldAcceptPreflightRequest("wibble.com", "wibble.com",
+        "foo-header,bar-header,X-Requested-With,Content-Type,Accept,Origin",
+        DEFAULT_ACCESS_CONTROL_ALLOW_METHODS);
+  }
+
+  @Test
+  public void shouldAcceptPreflightRequestOriginExactMatchSpecifiedMethods() throws Exception {
+    config.put(ApiServerConfig.CORS_ALLOWED_METHODS, "DELETE,PATCH");
+    shouldAcceptPreflightRequest("wibble.com", "wibble.com",
+        DEFAULT_ACCESS_CONTROL_ALLOW_HEADERS,
+        "DELETE,PATCH,GET,POST,HEAD");
+  }
+
+  private void shouldAcceptCorsRequest(final String origin, final String allowedOrigins)
+      throws Exception {
+
+    // Given:
+    config.put(ApiServerConfig.CORS_ALLOWED_ORIGINS, allowedOrigins);
+    init();
+
+    // When
+    HttpResponse<Buffer> response = sendCorsRequest(HttpMethod.POST, origin);
+
+    // Then:
+    assertThat(response.statusCode(), is(200));
+    assertThat(response.getHeader(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER),
+        is(origin));
+    assertThat(response.getHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER), is("true"));
+  }
+
+  private void shouldRejectCorsRequest(final String origin, final String allowedOrigins)
+      throws Exception {
+
+    // Given:
+    config.put(ApiServerConfig.CORS_ALLOWED_ORIGINS, allowedOrigins);
+    init();
+
+    // When
+    HttpResponse<Buffer> response = sendCorsRequest(HttpMethod.POST, origin);
+
+    // Then:
+    assertThat(response.statusCode(), is(403));
+  }
+
+  private void shouldRejectPreflightRequest(final String origin, final String allowedOrigins)
+      throws Exception {
+
+    // Given:
+    config.put(ApiServerConfig.CORS_ALLOWED_ORIGINS, allowedOrigins);
+    init();
+
+    // When:
+    HttpResponse<Buffer> response = sendCorsRequest(HttpMethod.OPTIONS,
+        MultiMap.caseInsensitiveMultiMap().add("origin", origin)
+            .add(ACCESS_CONTROL_REQUEST_METHOD_HEADER, "POST"));
+
+    // Then:
+    assertThat(response.statusCode(), is(403));
+  }
+
+  private void shouldAcceptPreflightRequest(final String origin, final String allowedOrigins,
+      final String accessControlAllowHeaders, final String accessControlAllowMethods)
+      throws Exception {
+
+    config.put(ApiServerConfig.CORS_ALLOWED_ORIGINS, allowedOrigins);
+    init();
+
+    // Given
+    HttpResponse<Buffer> response = sendCorsRequest(HttpMethod.OPTIONS,
+        MultiMap.caseInsensitiveMultiMap().add("origin", origin)
+            .add(ACCESS_CONTROL_REQUEST_METHOD_HEADER, "POST"));
+
+    assertThat(response.getHeader(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER),
+        is(origin));
+    assertThat(response.getHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER), is("true"));
+    assertThat(response.getHeader(ACCESS_CONTROL_ALLOW_HEADERS_HEADER),
+        is(accessControlAllowHeaders));
+    assertThat(response.getHeader(ACCESS_CONTROL_ALLOW_METHODS_HEADER),
+        is(accessControlAllowMethods));
+  }
+
+  private void init() {
+    ApiServerConfig serverConfig = new ApiServerConfig(config);
+    createServer(serverConfig);
+    this.client = createClient();
+  }
+
+  private HttpResponse<Buffer> sendCorsRequest(final HttpMethod httpMethod, final MultiMap headers)
+      throws Exception {
+    VertxCompletableFuture<HttpResponse<Buffer>> requestFuture = new VertxCompletableFuture<>();
+    client
+        .request(httpMethod, "/query-stream")
+        .putHeaders(headers)
+        .sendJsonObject(new JsonObject().put("sql", DEFAULT_PULL_QUERY), requestFuture);
+    return requestFuture.get();
+  }
+
+  private HttpResponse<Buffer> sendCorsRequest(final HttpMethod httpMethod,
+      final String origin)
+      throws Exception {
+    return sendCorsRequest(httpMethod, MultiMap.caseInsensitiveMultiMap().add("origin", origin));
+  }
+}


### PR DESCRIPTION
### Description 

This PR adds CORS support for ksqlDB in the absence of Jetty.

In KsqlRestApplication I've tried to maintain compatibility with the existing way CORS is configured.

This is a stacked PR, please only review the top commit(s)

### Testing done 

Added new test class

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

