### PR TITLE
feat: Support wildcards for unauthed paths

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/AuthenticationPluginHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/AuthenticationPluginHandler.java
@@ -59,16 +59,8 @@ public class AuthenticationPluginHandler implements Handler<RoutingContext> {
     final List<String> unauthed = server.getConfig()
         .getList(ApiServerConfig.AUTHENTICATION_SKIP_PATHS_CONFIG);
     unauthenticatedPaths.addAll(unauthed);
-    final StringBuilder pathBuilder = new StringBuilder();
-    int i = 0;
-    for (String path : unauthenticatedPaths) {
-      pathBuilder.append(path);
-      if (i != unauthenticatedPaths.size() - 1) {
-        pathBuilder.append(',');
-      }
-      i++;
-    }
-    final String converted = convertCommaSeparatedWilcardsToRegex(pathBuilder.toString());
+    final String paths = String.join(",", unauthenticatedPaths);
+    final String converted = convertCommaSeparatedWilcardsToRegex(paths);
     unauthedPathsPattern = Pattern.compile(converted);
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ApiServerConfig.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ApiServerConfig.java
@@ -95,7 +95,7 @@ public class ApiServerConfig extends AbstractConfig {
   public static final String AUTHENTICATION_SKIP_PATHS_CONFIG = propertyName(
       "authentication.skip.paths");
   public static final String AUTHENTICATION_SKIP_PATHS_DOC =
-      "List of paths where authentication is not required.";
+      "Comma separated of paths where authentication is not required. Wildcards are supported.";
   public static final List<String> AUTHENTICATION_SKIP_PATHS_DEFAULT =
       Collections.unmodifiableList(Collections.emptyList());
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ApiServerConfig.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ApiServerConfig.java
@@ -95,7 +95,8 @@ public class ApiServerConfig extends AbstractConfig {
   public static final String AUTHENTICATION_SKIP_PATHS_CONFIG = propertyName(
       "authentication.skip.paths");
   public static final String AUTHENTICATION_SKIP_PATHS_DOC =
-      "Comma separated of paths where authentication is not required. Wildcards are supported.";
+      "Comma separated list of paths where authentication is not required. "
+          + "Wildcards are supported.";
   public static final List<String> AUTHENTICATION_SKIP_PATHS_DEFAULT =
       Collections.unmodifiableList(Collections.emptyList());
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/KsqlCorsHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/KsqlCorsHandler.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.api.server;
 
+import static io.confluent.ksql.api.server.ServerUtils.convertCommaSeparatedWilcardsToRegex;
+
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.Router;
@@ -41,7 +43,7 @@ public class KsqlCorsHandler implements Handler<RoutingContext> {
     if (allowedOrigins.trim().isEmpty()) {
       return;
     }
-    final String convertedPattern = convertAllowedOrigin(allowedOrigins);
+    final String convertedPattern = convertCommaSeparatedWilcardsToRegex(allowedOrigins);
     final CorsHandler corsHandler = CorsHandler.create(convertedPattern);
     final Set<String> allowedMethodsSet = new HashSet<>(apiServerConfig
         .getList(ApiServerConfig.CORS_ALLOWED_METHODS));
@@ -80,24 +82,6 @@ public class KsqlCorsHandler implements Handler<RoutingContext> {
       }
     }
     corsHandler.handle(routingContext);
-  }
-
-  // Convert to regex
-  private static String convertAllowedOrigin(final String allowedOrigins) {
-    final String[] parts = allowedOrigins.split(",");
-    final StringBuilder out = new StringBuilder();
-    for (int i = 0; i < parts.length; i++) {
-      String part = parts[i].trim();
-      part = part.replace(".", "\\.")
-          .replace("+", "\\+")
-          .replace("?", "\\?")
-          .replace("*", ".*");
-      out.append(part);
-      if (i != parts.length - 1) {
-        out.append('|');
-      }
-    }
-    return out.toString();
   }
 
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerUtils.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerUtils.java
@@ -45,6 +45,28 @@ public final class ServerUtils {
     return PojoCodec.deserialiseObject(buffer, new HttpResponseErrorHandler(routingContext), clazz);
   }
 
+  /*
+  Converts a list of patterns that can include asterisk (E.g. "/ws/*,/foo,/bar/wibble")
+  wildcard to a regex pattern
+  */
+  public static String convertCommaSeparatedWilcardsToRegex(final String csv) {
+    final String[] parts = csv.split(",");
+    final StringBuilder out = new StringBuilder();
+    for (int i = 0; i < parts.length; i++) {
+      String part = parts[i].trim();
+      part = part.replace(".", "\\.")
+          .replace("+", "\\+")
+          .replace("?", "\\?")
+          .replace("-", "\\-")
+          .replace("*", ".*");
+      out.append(part);
+      if (i != parts.length - 1) {
+        out.append('|');
+      }
+    }
+    return out.toString();
+  }
+
   private static class HttpResponseErrorHandler implements PojoDeserializerErrorHandler {
 
     private final RoutingContext routingContext;

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/AuthTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/AuthTest.java
@@ -296,14 +296,14 @@ public class AuthTest extends ApiTest {
   }
 
   @Test
-  public void shouldAllowQueryWithSecurityPluginRejectingIfInAuthedPaths() throws Exception {
+  public void shouldAllowQueryWithSecurityPluginRejectingIfInUnAuthedPaths() throws Exception {
     unauthedPaths = "/query-stream";
     shouldAuthenticateWithSecurityPlugin(USER_WITHOUT_ACCESS,
         super::shouldExecutePullQuery, false, false);
   }
 
   @Test
-  public void shouldAllowQueryWithSecurityPluginRejectingIfInAuthedPathsWithWildcard()
+  public void shouldAllowQueryWithSecurityPluginRejectingIfInUnAuthedPathsWithWildcard()
       throws Exception {
     unauthedPaths = "/query*";
     shouldAuthenticateWithSecurityPlugin(USER_WITHOUT_ACCESS,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/AuthTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/AuthTest.java
@@ -302,6 +302,14 @@ public class AuthTest extends ApiTest {
         super::shouldExecutePullQuery, false, false);
   }
 
+  @Test
+  public void shouldAllowQueryWithSecurityPluginRejectingIfInAuthedPathsWithWildcard()
+      throws Exception {
+    unauthedPaths = "/query*";
+    shouldAuthenticateWithSecurityPlugin(USER_WITHOUT_ACCESS,
+        super::shouldExecutePullQuery, false, false);
+  }
+
   private void shouldFailQuery(final String username, final String password,
       final int expectedStatus, final String expectedMessage, final int expectedErrorCode)
       throws Exception {


### PR DESCRIPTION
### Description 

This PR extends the unauthed paths for AuthenticationPluginHandler to support wildcards. This make it compatible with authentication.skip.paths in rest-utils config.

This is a stacked PR, please just review the top commit.

### Testing done 

Added new test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

