### PR TITLE
chore: unify PARTITION BY validation & improve error msg

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -261,19 +261,22 @@ class Analyzer {
           new ColumnReferenceValidator(analysis.getFromSourceSchemas(true));
 
       analysis.getWhereExpression()
-          .ifPresent(columnValidator::analyzeExpression);
+          .ifPresent(expression -> columnValidator.analyzeExpression(expression, "WHERE"));
 
       analysis.getGroupByExpressions()
-          .forEach(columnValidator::analyzeExpression);
+          .forEach(expression -> columnValidator.analyzeExpression(expression, "GROUP BY"));
+
+      analysis.getPartitionBy()
+          .ifPresent(expression -> columnValidator.analyzeExpression(expression, "PARTITION BY"));
 
       analysis.getHavingExpression()
-          .ifPresent(columnValidator::analyzeExpression);
+          .ifPresent(expression -> columnValidator.analyzeExpression(expression, "HAVING"));
 
       analysis.getSelectItems().stream()
           .filter(si -> si instanceof SingleColumn)
           .map(SingleColumn.class::cast)
           .map(SingleColumn::getExpression)
-          .forEach(columnValidator::analyzeExpression);
+          .forEach(expression -> columnValidator.analyzeExpression(expression, "SELECT"));
     }
 
     @Override
@@ -301,10 +304,10 @@ class Analyzer {
           new ColumnReferenceValidator(analysis.getFromSourceSchemas(false));
 
       final Set<SourceName> srcsUsedInLeft = columnValidator
-          .analyzeExpression(comparisonExpression.getLeft());
+          .analyzeExpression(comparisonExpression.getLeft(), "JOIN ON");
 
       final Set<SourceName> srcsUsedInRight = columnValidator
-          .analyzeExpression(comparisonExpression.getRight());
+          .analyzeExpression(comparisonExpression.getRight(), "JOIN ON");
 
       final SourceName leftSourceName = getOnlySourceForJoin(
           comparisonExpression.getLeft(), comparisonExpression, srcsUsedInLeft);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -58,7 +58,6 @@ import io.confluent.ksql.planner.plan.ProjectNode;
 import io.confluent.ksql.planner.plan.RepartitionNode;
 import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.Column.Namespace;
-import io.confluent.ksql.schema.ksql.FormatOptions;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.LogicalSchema.Builder;
 import io.confluent.ksql.schema.ksql.types.SqlType;
@@ -67,7 +66,6 @@ import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.SerdeOptions;
 import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.SchemaUtil;
 import java.util.List;
 import java.util.Objects;
@@ -341,9 +339,7 @@ public class LogicalPlanner {
 
       final Column proposedKey = sourceSchema
           .findColumn(columnName)
-          .orElseThrow(() -> new KsqlException("Invalid identifier for PARTITION BY clause: '"
-              + columnName.toString(FormatOptions.noEscape()) + "' Only columns from the "
-              + "source schema can be referenced in the PARTITION BY clause."));
+          .orElseThrow(IllegalStateException::new);
 
       switch (proposedKey.namespace()) {
         case KEY:

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -44,7 +44,6 @@ import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.Column;
-import io.confluent.ksql.schema.ksql.FormatOptions;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.KeyFormat;
@@ -370,10 +369,7 @@ public class SchemaKStream<K> {
 
     final Column proposedKey = getSchema()
         .findValueColumn(columnName)
-        .orElseThrow(() -> new KsqlException("Invalid identifier for PARTITION BY clause: '"
-            + columnName.toString(FormatOptions.noEscape()) + "' Only columns from the "
-            + "source schema can be referenced in the PARTITION BY clause."));
-
+        .orElseThrow(IllegalStateException::new);
 
     final boolean namesMatch = existingKey
         .map(kf -> kf.name().equals(proposedKey.name()))

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
@@ -539,17 +539,6 @@ public class SchemaKStreamTest {
     );
   }
 
-  @Test(expected = KsqlException.class)
-  public void shouldThrowOnSelectKeyIfKeyNotInSchema() {
-    givenInitialKStreamOf("SELECT col0, col2, col3 FROM test1 WHERE col0 > 100 EMIT CHANGES;");
-
-    final SchemaKStream<?> rekeyedSchemaKStream = initialSchemaKStream.selectKey(
-        new UnqualifiedColumnReferenceExp(ColumnName.of("won't find me")),
-        childContextStacker);
-
-    assertThat(rekeyedSchemaKStream.getKeyField(), is(validJoinKeyField));
-  }
-
   @Test
   public void testGroupByKey() {
     // Given:

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/elements.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/elements.json
@@ -811,7 +811,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlException",
-        "message": "Column 'INPUT.UNKNOWN' cannot be resolved."
+        "message": "Line: 1, Col: 32: SELECT column 'INPUT.UNKNOWN' cannot be resolved."
       }
     },
     {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/joins.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/joins.json
@@ -1413,7 +1413,7 @@
       },
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Column 'T.IID' cannot be resolved."
+        "message": "Line: 3, Col: 31: JOIN ON column 'T.IID' cannot be resolved."
       }
     },
     {
@@ -1428,7 +1428,7 @@
       },
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Column 'TT.IID' cannot be resolved."
+        "message": "Line: 3, Col: 38: JOIN ON column 'TT.IID' cannot be resolved."
       }
     },
     {
@@ -3728,7 +3728,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Column 'T.IID' cannot be resolved."
+        "message": "Line: 3, Col: 31: JOIN ON column 'T.IID' cannot be resolved."
       }
     },
     {
@@ -3740,7 +3740,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Column 'TT.IID' cannot be resolved."
+        "message": "Line: 3, Col: 38: JOIN ON column 'TT.IID' cannot be resolved."
       }
     },
     {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/key-field.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/key-field.json
@@ -92,7 +92,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid identifier for PARTITION BY clause: 'ALIASED'"
+        "message": "Line: 5, Col: 14: PARTITION BY column 'INPUT.ALIASED' cannot be resolved."
       }
     },
     {
@@ -282,7 +282,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid identifier for PARTITION BY clause: 'ALIASED'"
+        "message": "Line: 5, Col: 14: PARTITION BY column 'INPUT.ALIASED' cannot be resolved"
       }
     },
     {
@@ -334,7 +334,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid identifier for PARTITION BY clause: 'ALIASED'"
+        "message": "Line: 5, Col: 14: PARTITION BY column 'INPUT.ALIASED' cannot be resolved."
       }
     },
     {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/partition-by.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/partition-by.json
@@ -342,7 +342,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlException",
-        "message": "Invalid identifier for PARTITION BY clause: 'ID_NEW'"
+        "message": "Line: 5, Col: 14: PARTITION BY column 'TEST.ID_NEW' cannot be resolved."
       }
     },
     {

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
@@ -932,7 +932,7 @@
       ],
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "Column 'AGGREGATE.WINDOWSTART' cannot be resolved",
+        "message": "WHERE column 'AGGREGATE.WINDOWSTART' cannot be resolved",
         "status": 400
       }
     },


### PR DESCRIPTION
### Description 

This commit moves the checking for unknown column references in PARTITION BY clauses into the `Analyzer`, alongside the same checks done for other clause types.

It also improves the error message thrown from the `ColumnReferenceValidator` to include:
 - the type of clause the bad reference was found in, e.g. PARTITION BY, SELECT, etc.
 - the location, e.g `Line: 3, Col: 24`
These two bits of information should help users more quickly identify where their error is.

Note: the QTT tests that throw such errors have misaligned locations. This is because QTT reformats the tests to ensure `SqlFormatter` has coverage.  This does not happen for the normal flow.  This was tested manually:

```
ksql> CREATE STREAM REPARTITIONED AS select ID + '_new' AS ID_new, NAME from TEST partition by ID_NEW;
Line: 1, Col: 90: PARTITION BY column 'TEST.ID_NEW' cannot be resolved.
```

### Testing done 

Usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

