### PR TITLE
fix: output valid multiline queries when running SHOW QUERIES

### DIFF
--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/table/builder/QueriesTableBuilderTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/table/builder/QueriesTableBuilderTest.java
@@ -1,0 +1,66 @@
+package io.confluent.ksql.cli.console.table.builder;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+
+import com.google.common.collect.ImmutableSet;
+import io.confluent.ksql.cli.console.table.Table;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.rest.entity.Queries;
+import io.confluent.ksql.rest.entity.RunningQuery;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.Test;
+
+public class QueriesTableBuilderTest {
+  @Test
+  public void shouldBuildQueriesTable() {
+    // Given:
+    final RunningQuery query = new RunningQuery(
+        "EXAMPLE QUERY;",
+        ImmutableSet.of("SINK"),
+        ImmutableSet.of("SINK"),
+        new QueryId("0"),
+        Optional.of("RUNNING"));
+
+    // When:
+    final Table table = buildTableWithSingleQuery(query);
+
+    // Then:
+    assertThat(table.headers(), contains("Query ID", "Status", "Sink Name", "Sink Kafka Topic", "Query String"));
+    assertThat(table.rows(), hasSize(1));
+    assertThat(table.rows().get(0), contains("0", "RUNNING", "SINK", "SINK", "EXAMPLE QUERY;"));
+  }
+
+  @Test
+  public void shouldBuildQueriesTableWithNewlines() {
+    // Given:
+    final RunningQuery query = new RunningQuery(
+        "CREATE STREAM S2 AS SELECT *\nFROM S1\nEMIT CHANGES;",
+        ImmutableSet.of("S2"),
+        ImmutableSet.of("S2"),
+        new QueryId("CSAS_S2_0"),
+        Optional.of("RUNNING"));
+
+
+    // When:
+    final Table table = buildTableWithSingleQuery(query);
+
+    // Then:
+    assertThat(table.headers(), contains("Query ID", "Status", "Sink Name", "Sink Kafka Topic", "Query String"));
+    assertThat(table.rows(), hasSize(1));
+    assertThat(table.rows().get(0), contains("CSAS_S2_0", "RUNNING", "S2", "S2", "CREATE STREAM S2 AS SELECT * FROM S1 EMIT CHANGES;"));
+  }
+
+  private Table buildTableWithSingleQuery(RunningQuery query) {
+    List<RunningQuery> queries = new ArrayList<>();
+    queries.add(query);
+
+    final Queries entity = new Queries(null, queries);
+
+    QueriesTableBuilder builder = new QueriesTableBuilder();
+    return builder.buildTable(entity);
+  }
+}

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/RunningQuery.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/RunningQuery.java
@@ -54,7 +54,7 @@ public class RunningQuery {
 
   @JsonIgnore
   public String getQuerySingleLine() {
-    return queryString.replaceAll(System.lineSeparator(), "");
+    return queryString.replaceAll(System.lineSeparator(), " ");
   }
 
   public Set<String> getSinks() {


### PR DESCRIPTION
### Description
Format multiline queries correctly when running `SHOW QUERIES`.

```
ksql> CREATE STREAM S3 AS
SELECT * FROM S1
EMIT CHANGES;

ksql> SHOW QUERIES;
Query ID   | Status  | Sink Name | Sink Kafka Topic | Query String
CSAS_S2_73 | RUNNING | S2        | S2               | CREATE STREAM S2 WITH (KAFKA_TOPIC='S2', PARTITIONS=2, REPLICAS=1) AS SELECT * FROM S1 S1 EMIT CHANGES;
```

Fixes #4900

### Testing done 
Wrote new unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

