### PR TITLE
added dot dymbol to valid source names pattern

### DIFF
--- a/ksqldb-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
@@ -48,7 +48,7 @@ public final class ParserUtil {
    *
    * @see org.apache.kafka.streams.state.StoreBuilder#name
    */
-  private static final Pattern VALID_SOURCE_NAMES = Pattern.compile("[a-zA-Z0-9_-]*");
+  private static final Pattern VALID_SOURCE_NAMES = Pattern.compile("[a-zA-Z0-9_\.-]*");
 
   private ParserUtil() {
   }


### PR DESCRIPTION
### Description 
Added dot symbol to valid source names pattern in ParserUtil class.
Fixes #<4955>

### Testing done 
Currently we can create table with names that including dot symbol