### PR TITLE
fix: Pass correct request configs when making pull query request

### DIFF
--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
@@ -149,12 +149,12 @@ public final class KsqlTarget {
 
   public RestResponse<List<StreamedRow>> postQueryRequest(
       final String ksql,
-      final Map<String, ?> serverProperties,
+      final Map<String, ?> requestProperties,
       final Optional<Long> previousCommandSeqNum
   ) {
     return post(
         QUERY_PATH,
-        createKsqlRequest(ksql, Collections.emptyMap(), previousCommandSeqNum),
+        createKsqlRequest(ksql, requestProperties, previousCommandSeqNum),
         KsqlTarget::toRows
     );
   }
@@ -176,13 +176,13 @@ public final class KsqlTarget {
 
   private KsqlRequest createKsqlRequest(
       final String ksql,
-      final Map<String, ?> serverProperties,
+      final Map<String, ?> requestProperties,
       final Optional<Long> previousCommandSeqNum
   ) {
     return new KsqlRequest(
         ksql,
         localProperties.toMap(),
-        serverProperties,
+        requestProperties,
         previousCommandSeqNum.orElse(null)
     );
   }


### PR DESCRIPTION
### Description 
A bug was introduced during fixing the API change introduced by #4597 whereby instead of the actual `requestProperties` a `Collections.emptyMap` was being passed.  

### Testing done 
Verified it works locally
