### PR TITLE
build: change the build template not to use iteritems (MINOR)

### DIFF
--- a/config/connect.properties.template
+++ b/config/connect.properties.template
@@ -14,6 +14,6 @@
 #
 
 {% set kr_props = env_to_props('KSQL_CONNECT_', '') -%}
-{% for name, value in kr_props.iteritems() -%}
+{% for name, value in kr_props.items() -%}
 {{name}}={{value}}
 {% endfor -%}

--- a/config/ksqldb-server.properties.template
+++ b/config/ksqldb-server.properties.template
@@ -14,6 +14,6 @@
 #
 
 {% set kr_props = env_to_props('KSQL_', '') -%}
-{% for name, value in kr_props.iteritems() -%}
+{% for name, value in kr_props.items() -%}
 {{name}}={{value}}
 {% endfor -%}


### PR DESCRIPTION
### Description 

In some distributions of python, dict doesn't have `iteritems` (I saw this when building the docker image for ubi8). This changes it to just use `items()`

### Testing done 

This is the same change that was applied to ksql-images, and is being ported here. I will later have ksql-images depend on this file.

Also built the images in ksql-images and made sure both ubi8 and deb9 worked

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

