### PR TITLE
fix: Catch server startup exceptions

### DIFF
--- a/ksqldb-execution/src/main/java/io/confluent/ksql/services/DisabledKsqlClient.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/services/DisabledKsqlClient.java
@@ -34,6 +34,9 @@ public final class DisabledKsqlClient implements SimpleKsqlClient {
     return new DisabledKsqlClient();
   }
 
+  private DisabledKsqlClient() {
+  }
+
   @Override
   public RestResponse<KsqlEntityList> makeKsqlRequest(
       final URI serverEndPoint,

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/services/DisabledKsqlClient.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/services/DisabledKsqlClient.java
@@ -34,12 +34,6 @@ public final class DisabledKsqlClient implements SimpleKsqlClient {
     return new DisabledKsqlClient();
   }
 
-  private final Exception createStack;
-
-  private DisabledKsqlClient() {
-    this.createStack = new Exception();
-  }
-
   @Override
   public RestResponse<KsqlEntityList> makeKsqlRequest(
       final URI serverEndPoint,
@@ -55,8 +49,6 @@ public final class DisabledKsqlClient implements SimpleKsqlClient {
       final Map<String, ?> configOverrides,
       final Map<String, ?> requestProperties
   ) {
-    System.out.println("Created in");
-    createStack.printStackTrace();
     throw new UnsupportedOperationException("KSQL client is disabled");
   }
 

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/services/DisabledKsqlClient.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/services/DisabledKsqlClient.java
@@ -34,7 +34,10 @@ public final class DisabledKsqlClient implements SimpleKsqlClient {
     return new DisabledKsqlClient();
   }
 
+  private final Exception createStack;
+
   private DisabledKsqlClient() {
+    this.createStack = new Exception();
   }
 
   @Override
@@ -52,6 +55,8 @@ public final class DisabledKsqlClient implements SimpleKsqlClient {
       final Map<String, ?> configOverrides,
       final Map<String, ?> requestProperties
   ) {
+    System.out.println("Created in");
+    createStack.printStackTrace();
     throw new UnsupportedOperationException("KSQL client is disabled");
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerMain.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerMain.java
@@ -77,6 +77,7 @@ public class KsqlServerMain {
       executable.awaitTerminated();
     } catch (Throwable t) {
       log.error("Unhandled exception in server startup", t);
+      throw t;
     } finally {
       log.info("Server shutting down");
       executable.triggerShutdown();

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerMain.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerMain.java
@@ -75,6 +75,8 @@ public class KsqlServerMain {
       executable.startAsync();
       log.info("Server up and running");
       executable.awaitTerminated();
+    } catch (Throwable t) {
+      log.error("Unhandled exception in server startup", t);
     } finally {
       log.info("Server shutting down");
       executable.triggerShutdown();

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -177,7 +177,9 @@ public class StreamedQueryResource implements KsqlConfigurable {
   }
 
   public void closeMetrics() {
-    pullQueryMetrics.ifPresent(PullQueryExecutorMetrics::close);
+    if (pullQueryMetrics != null) {
+      pullQueryMetrics.ifPresent(PullQueryExecutorMetrics::close);
+    }
   }
 
   private void throwIfNotConfigured() {


### PR DESCRIPTION
### Description 

fixes #4873 

This is a stacked PR, please just review the top commit(s).

This PR fixes a couple of issues that make it hard to diagnose ksqlDB server startup issues.

1. Exceptions thrown from startup currently aren't logged, making it hard to diagnose startup issues
2. NPE thrown from StreamQueryResource.closeMetrics

### Testing done 

N/A

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

