### PR TITLE
fix: fix NPE in latest_by_offset if first element being processed has null…

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/latest/LatestByOffset.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/latest/LatestByOffset.java
@@ -126,7 +126,7 @@ public final class LatestByOffset {
 
       @Override
       public Struct initialize() {
-        return null;
+        return createStruct(structSchema, null);
       }
 
       @Override
@@ -156,6 +156,5 @@ public final class LatestByOffset {
       }
     };
   }
-
 
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/latest/LatestByOffsetUdafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/latest/LatestByOffsetUdafTest.java
@@ -17,7 +17,7 @@ package io.confluent.ksql.function.udaf.latest;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.notNullValue;
 
 import io.confluent.ksql.function.udaf.Udaf;
 import org.apache.kafka.connect.data.Struct;
@@ -26,7 +26,7 @@ import org.junit.Test;
 public class LatestByOffsetUdafTest {
 
   @Test
-  public void shouldInitializeToNull() {
+  public void shouldInitialize() {
     // Given:
     final Udaf<Integer, Struct, Integer> udaf = LatestByOffset
         .latest(LatestByOffset.STRUCT_LONG);
@@ -35,7 +35,7 @@ public class LatestByOffsetUdafTest {
     Struct init = udaf.initialize();
 
     // Then:
-    assertThat(init, is(nullValue()));
+    assertThat(init, is(notNullValue()));
   }
 
   @Test

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_latest_by_offset_with_all_nulls/6.0.0_1586169741905/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_latest_by_offset_with_all_nulls/6.0.0_1586169741905/plan.json
@@ -1,0 +1,164 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ROWKEY BIGINT KEY, ID BIGINT, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F0` INTEGER",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  LATEST_BY_OFFSET(INPUT.F0) L0\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `L0` INTEGER",
+      "keyField" : "ID",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F0` INTEGER"
+                },
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "LATEST_BY_OFFSET(F0)" ]
+          },
+          "selectExpressions" : [ "ID AS ID", "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_latest_by_offset_with_all_nulls/6.0.0_1586169741905/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_latest_by_offset_with_all_nulls/6.0.0_1586169741905/spec.json
@@ -1,0 +1,40 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1586169741905,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<ID BIGINT, F0 INT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : "STRUCT<ID BIGINT, F0 INT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : "STRUCT<ID BIGINT, F0 INT, KSQL_AGG_VARIABLE_0 STRUCT<SEQ BIGINT, VAL INT>> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<ID BIGINT, L0 INT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F0" : null
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F0" : null
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "L0" : null
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "L0" : null
+    }
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_latest_by_offset_with_all_nulls/6.0.0_1586169741905/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_latest_by_offset_with_all_nulls/6.0.0_1586169741905/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/latest-offset-udaf.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/latest-offset-udaf.json
@@ -36,6 +36,21 @@
         {"topic": "OUTPUT", "key": 0, "value": {"ID": 0, "L0": 12}},
         {"topic": "OUTPUT", "key": 0, "value": {"ID": 0, "L0": 12}}
       ]
+    },
+    {
+      "name": "latest by offset with all nulls",
+      "statements": [
+        "CREATE STREAM INPUT (ROWKEY BIGINT KEY, ID BIGINT, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0) AS L0 FROM INPUT GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "F0": null}},
+        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "F0": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"ID": 0, "L0": null}},
+        {"topic": "OUTPUT", "key": 0, "value": {"ID": 0, "L0": null}}
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Description 

This PR fixes a NPE which occurs in the latest_by_offset UDAF when the first time a value is seen it is null, then it is null again.

We already had a test for null values but it did not exercise this specific case.

### Testing done 

Added new QTT test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

