### PR TITLE
chore: remove remaining refs to FETCH_FIELD_FROM_STRUCT (Minor)

### DIFF
--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/simple-struct.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/simple-struct.json
@@ -1823,17 +1823,6 @@
       ]
     },
     {
-      "name": "direct use of FETCH_FIELD_FROM_STRUCT",
-      "statements": [
-        "CREATE STREAM input (s STRUCT<f0 BIGINT>) WITH (kafka_topic='input_topic', value_format='JSON');",
-        "CREATE STREAM output AS SELECT FETCH_FIELD_FROM_STRUCT(s, 'f0') FROM input;"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Can't find any functions with the name 'FETCH_FIELD_FROM_STRUCT'"
-      }
-    },
-    {
       "name": "generated name",
       "statements": [
         "CREATE STREAM INPUT (A STRUCT<B MAP<STRING, STRUCT<C ARRAY<STRUCT<D INT>>>>>) WITH (kafka_topic='test_topic', value_format='json');",

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListFunctionsExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListFunctionsExecutorTest.java
@@ -15,10 +15,8 @@
 
 package io.confluent.ksql.rest.server.execution;
 
-import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.mock;
 
 import io.confluent.ksql.rest.SessionProperties;
@@ -57,11 +55,5 @@ public class ListFunctionsExecutorTest {
         new SimpleFunctionInfo("TEST_UDTF1", FunctionType.TABLE),
         new SimpleFunctionInfo("TEST_UDTF2", FunctionType.TABLE)
     ));
-
-    assertThat("shouldn't contain internal functions", functionList.getFunctions(),
-        not(hasItem(new SimpleFunctionInfo("FETCH_FIELD_FROM_STRUCT", FunctionType.SCALAR)))
-    );
   }
-
-
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -457,10 +457,6 @@ public class KsqlResourceTest {
         new SimpleFunctionInfo("TOPK", FunctionType.AGGREGATE),
         new SimpleFunctionInfo("MAX", FunctionType.AGGREGATE)
     ));
-
-    assertThat("shouldn't contain internal functions", functionList.getFunctions(),
-        not(hasItem(new SimpleFunctionInfo("FETCH_FIELD_FROM_STRUCT", FunctionType.SCALAR)))
-    );
   }
 
   @Test


### PR DESCRIPTION
### Description 

FETCH_FIELD_FROM_STRUCT was removed releases ago. This commit removes the latest references.

### Testing done 

non-functional change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

