### PR TITLE
test: fix issue with unresolvable host test

### DIFF
--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestConfigTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestConfigTest.java
@@ -310,7 +310,7 @@ public class KsqlRestConfigTest {
   @Test
   public void shouldThrowIfOnGetInterNodeListenerIfFirstListenerSetToUnresolvableHost() {
     // Given:
-    final URL expected = url("https://unresolvable.host:12345");
+    final URL expected = url("https://unresolvable_host:12345");
 
     final KsqlRestConfig config = new KsqlRestConfig(ImmutableMap.<String, Object>builder()
         .put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
@@ -321,7 +321,7 @@ public class KsqlRestConfigTest {
     // Expect:
     expectedException.expect(ConfigException.class);
     expectedException.expectMessage("Invalid value "
-        + "[https://unresolvable.host:12345, http://localhost:2589] for configuration "
+        + "[https://unresolvable_host:12345, http://localhost:2589] for configuration "
         + LISTENERS_CONFIG
         + ": Could not resolve first host"
     );


### PR DESCRIPTION
### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

unresolvable.host, r.host, and some *.host URLs are valid hosts in some machines. The `KsqlRestConfigTest#shouldThrowIfOnGetInterNodeListenerIfFirstListenerSetToUnresolvableHost` was failing in my machine because an expected exception was not thrown for the unresolvable host.

This fix replaces .host for _host to make it invalid

See *.host issues:
```
$ ping local.host
PING local.host (23.202.231.169) 56(84) bytes of data.
64 bytes from a23-202-231-169.deploy.static.akamaitechnologies.com (23.202.231.169): icmp_seq=1 ttl=53 time=45.1 ms

$ ping r.host
PING r.host (23.217.138.110) 56(84) bytes of data.
64 bytes from a23-217-138-110.deploy.static.akamaitechnologies.com (23.217.138.110): icmp_seq=1 ttl=55 time=51.2 ms

$ ping unresolvable.host
PING unresolvable.host (23.217.138.110) 56(84) bytes of data.
64 bytes from a23-217-138-110.deploy.static.akamaitechnologies.com (23.217.138.110): icmp_seq=1 ttl=55 time=51.5 ms
```


### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

