### PR TITLE
refactor: avoid returning null

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -135,13 +135,12 @@ public abstract class QueryMetadata {
   }
 
   public Map<String, Map<Integer, LagInfo>> getAllLocalStorePartitionLags() {
-    Map<String, Map<Integer, LagInfo>> getLagMap = null;
     try {
-      getLagMap = kafkaStreams.allLocalStorePartitionLags();
+      return kafkaStreams.allLocalStorePartitionLags();
     } catch (IllegalStateException | StreamsException e) {
       LOG.error(e.getMessage());
+      return ImmutableMap.of();
     }
-    return getLagMap;
   }
 
   public Collection<StreamsMetadata> getAllMetadata() {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/LagReportingAgent.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/LagReportingAgent.java
@@ -212,7 +212,6 @@ public final class LagReportingAgent implements HostStatusListener {
       final Map<QueryStateStoreId, Map<Integer, LagInfo>> localLagMap
           = currentQueries.stream()
           .map(qm -> Pair.of(qm, qm.getAllLocalStorePartitionLags()))
-          .filter(pair -> pair.getRight() != null)
           .map(pair -> pair.getRight().entrySet().stream()
               .collect(Collectors.toMap(
                   e -> QueryStateStoreId.of(pair.getLeft().getQueryApplicationId(), e.getKey()),


### PR DESCRIPTION
### Description 

Quick refactor to avoid returning null from `getAllLocalStorePartitionLags`.  In general the KSQL code does not return nulls. These means, as someone working on the code, you don't need to constantly check if the method you're calling can return null, and you don't need to litter the code with null checks. Things are also much less likely to fail with NullPointerExceptions.

In this case, the method can simply return an empty map, and the result is the same. Where a distinction is needed between a result and no result, then return `Optional<>`.

### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

