### PR TITLE
fix: Don't set chunked transfer encoding for HTTP2 proxy

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/VertxUtils.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/VertxUtils.java
@@ -16,8 +16,6 @@
 package io.confluent.ksql.util;
 
 import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 
 /**
@@ -27,24 +25,6 @@ import io.vertx.core.Vertx;
 public final class VertxUtils {
 
   private VertxUtils() {
-  }
-
-  /**
-   * Connects promise to the future. I.e. when the future completes it causes the promise to
-   * complete.
-   *
-   * @param future  The future
-   * @param promise The promise
-   * @param <T>     The type of the result
-   */
-  public static <T> void connectPromise(final Future<T> future, final Promise<T> promise) {
-    future.setHandler(ar -> {
-      if (ar.succeeded()) {
-        promise.complete(ar.result());
-      } else {
-        promise.fail(ar.cause());
-      }
-    });
   }
 
   public static void checkIsWorker() {

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/services/DisabledKsqlClient.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/services/DisabledKsqlClient.java
@@ -36,7 +36,7 @@ public final class DisabledKsqlClient implements SimpleKsqlClient {
 
   private DisabledKsqlClient() {
   }
-
+  
   @Override
   public RestResponse<KsqlEntityList> makeKsqlRequest(
       final URI serverEndPoint,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/PortedEndpoints.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/PortedEndpoints.java
@@ -117,7 +117,7 @@ class PortedEndpoints {
         routingContext.fail(HttpStatus.SC_INTERNAL_SERVER_ERROR, e);
         return;
       }
-
+      
       response.setStatusCode(endpointResponse.getStatusCode())
           .setStatusMessage(endpointResponse.getStatusMessage())
           .end(responseBody);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -63,24 +63,26 @@ public class ServerVerticle extends AbstractVerticle {
   private final Endpoints endpoints;
   private final HttpServerOptions httpServerOptions;
   private final Server server;
-  private final ProxyHandler proxyHandler;
+  private final boolean proxyEnabled;
+  private ProxyHandler proxyHandler;
   private ConnectionQueryManager connectionQueryManager;
-  private volatile HttpServer httpServer;
+  private HttpServer httpServer;
 
   public ServerVerticle(final Endpoints endpoints, final HttpServerOptions httpServerOptions,
       final Server server, final boolean proxyEnabled) {
     this.endpoints = Objects.requireNonNull(endpoints);
     this.httpServerOptions = Objects.requireNonNull(httpServerOptions);
     this.server = Objects.requireNonNull(server);
-    if (proxyEnabled) {
-      this.proxyHandler = new ProxyHandler(server);
-    } else {
-      this.proxyHandler = null;
-    }
+    this.proxyEnabled = proxyEnabled;
   }
 
   @Override
   public void start(final Promise<Void> startPromise) {
+    if (proxyEnabled) {
+      this.proxyHandler = new ProxyHandler(server, context);
+    } else {
+      this.proxyHandler = null;
+    }
     this.connectionQueryManager = new ConnectionQueryManager(context, server);
     httpServer = vertx.createHttpServer(httpServerOptions).requestHandler(setupRouter())
         .exceptionHandler(ServerVerticle::unhandledExceptionHandler);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -54,7 +54,7 @@ public class ServerVerticle extends AbstractVerticle {
   // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
   private static final Logger log = LoggerFactory.getLogger(ServerVerticle.class);
 
-  private static final Set<String> NON_PROXIED_ENDPOINTS = ImmutableSet
+  public static final Set<String> NON_PROXIED_ENDPOINTS = ImmutableSet
       .of("/query-stream", "/inserts-stream", "/close-query", "/ksql");
 
   // Quick switch so we can easily revert to not serving ported endpoints directly

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -68,7 +68,7 @@ public final class KsqlRestClient implements Closeable {
         localProps,
         clientProps,
         creds,
-        (cProps, credz, lProps) -> new KsqlClient(cProps, credz, lProps, new HttpClientOptions())
+        (cprops, credz, lprops) -> new KsqlClient(cprops, credz, lprops, new HttpClientOptions())
     );
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <wiremock.version>2.24.0</wiremock.version>
         <clearspring-analytics.version>2.9.5</clearspring-analytics.version>
         <icu.version>65.1</icu.version>
-        <vertx.version>3.8.5</vertx.version>
+        <vertx.version>3.9.0</vertx.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <skip.docker.build>true</skip.docker.build>
         <skip.docker.test>true</skip.docker.test>


### PR DESCRIPTION
### Description 

This is a stacked PR, please review only the top commit.

This fixes a bug where we were setting transfer-encoding: chunked in the ProxyHandler for HTTP2 request which have a connection:close header. This is illegal.

### Testing done 

Added new test.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

