### PR TITLE
Primary keys

### DIFF
--- a/docs-md/developer-guide/create-a-stream.md
+++ b/docs-md/developer-guide/create-a-stream.md
@@ -21,10 +21,10 @@ query results from other streams.
 Create a Stream from an existing Kafka topic
 --------------------------------------------
 
-Use the CREATE STREAM statement to create a stream from an existing underlying
-Kafka topic. The Kafka topic must exist already in your Kafka cluster.
+Use the [CREATE STREAM](./create-stream) statement to create a stream from an existing underlying
+Kafka topic.
 
-The following examples show how to create streams from a Kafka topic,
+The following examples show how to create streams from an existing Kafka topic,
 named `pageviews`. To see these examples in action, create the
 `pageviews` topic by following the procedure in
 [Write Streaming Queries Against {{ site.aktm }} Using ksqlDB](../tutorials/basics-docker.md).

--- a/docs-md/developer-guide/create-a-table.md
+++ b/docs-md/developer-guide/create-a-table.md
@@ -21,10 +21,10 @@ query results from other tables or streams.
 Create a Table from an existing Kafka Topic
 -------------------------------------------
 
-Use the CREATE TABLE statement to create a table from an existing
-underlying Kafka topic. The Kafka topic must exist already in your Kafka cluster.
+Use the [CREATE TABLE](./create-table) statement to create a table from an existing
+underlying Kafka topic.
 
-The following examples show how to create tables from a Kafka topic,
+The following examples show how to create tables from an existing Kafka topic,
 named `users`. To see these examples in action, create the `users` topic
 by following the procedure in
 [Write Streaming Queries Against {{ site.aktm }} Using ksqlDB](../tutorials/basics-docker.md).

--- a/docs-md/developer-guide/joins/join-streams-and-tables.md
+++ b/docs-md/developer-guide/joins/join-streams-and-tables.md
@@ -96,8 +96,7 @@ both of the following conditions are true:
 -   For every record, the contents of the message key of the {{
     site.aktm }} message itself must be the same as the contents of
     the column set in KEY.
--   The KEY property must be set to a column of type VARCHAR or
-    STRING.
+-   The KEY property must be set to a value column with the same SQL data type as the key column.
 
 For more information, see [Key Requirements](../syntax-reference.md#key-requirements).
 

--- a/docs-md/developer-guide/joins/partition-data.md
+++ b/docs-md/developer-guide/joins/partition-data.md
@@ -72,7 +72,7 @@ column (`userId`) and assign the key before performing the join.
     -- the primary key of table users is a BIGINT. 
     -- The userId column in the value matches the key, so can be used as an alias for ROWKEY in queries to make them more readable.
     -- the schema of table users is: ROWTIME BIGINT | ROWKEY BIGINT | USERID BIGINT | FULLNAME STRING
-    CREATE TABLE  users  (ROWKEY BIGINT KEY, userId BIGINT, fullName STRING) WITH(kafka_topic='users', value_format='json', key='userId');
+    CREATE TABLE  users (ROWKEY BIGINT PRIMARY KEY, userId BIGINT, fullName STRING) WITH(kafka_topic='users', value_format='json', key='userId');
 
     -- join of users table with clicks stream, joining on the table's primary key alias and the stream's userId column: 
     -- join will automatically repartition clicks stream:
@@ -119,7 +119,7 @@ the `INT` side to a `LONG`:
     CREATE STREAM clicks (userId INT, url STRING) WITH(kafka_topic='clickstream', value_format='json');
 
     -- table with BIGINT userId stored in they key:
-    CREATE TABLE  users  (ROWKEY BIGINT KEY, fullName STRING) WITH(kafka_topic='users', value_format='json');
+    CREATE TABLE  users (ROWKEY BIGINT PRIMARY KEY, fullName STRING) WITH(kafka_topic='users', value_format='json');
     
    -- Join utilising a CAST to convert the left sides join column to match the rights type.
    SELECT clicks.url, users.fullName FROM clicks JOIN users ON CAST(clicks.userId AS BIGINT) = users.ROWKEY;

--- a/docs-md/developer-guide/ksqldb-reference/create-stream.md
+++ b/docs-md/developer-guide/ksqldb-reference/create-stream.md
@@ -13,16 +13,42 @@ Synopsis
 --------
 
 ```sql
-CREATE STREAM stream_name ( { column_name data_type } [, ...] )
+CREATE STREAM stream_name ( { column_name data_type (KEY) } [, ...] )
   WITH ( property_name = expression [, ...] );
 ```
 
 Description
 -----------
 
-Create a new stream with the specified columns and properties. Columns
-can be any of the [data types](../syntax-reference.md#ksqldb-data-types) supported by
-ksqlDB.
+Create a new stream with the specified columns and properties.
+
+A ksqlDB STREAM is a stream of _facts_. Each _fact_ is immutable and is unique.
+A stream can store its data in either `KEY` or `VALUE` columns.
+Both `KEY` and `VALUE` columns can be NULL. No special processing is done if two rows have the same
+key. The table below contrasts this to a [ksqlDB TABLE](./create-table):
+
+|                          |  STREAM                                                       | TABLE                                                             |
+| ------------------------ | --------------------------------------------------------------| ----------------------------------------------------------------- |
+| Key column type          | `KEY`                                                         | `PRIMARY KEY`                                                     |
+| NON NULL key constraint  | No                                                            | Yes                                                               |
+:                          :                                                               : Messages in the Kafka topic with a NULL `PRIMARY KEY` are ignored :
+| Unique key constraint    | No                                                            | Yes                                                               |
+:                          : Messages with the same key as another have no special meaning : Later messages with the same key _replace_ earlier                :
+| Tombstones               | No                                                            | Yes                                                               |
+:                          : Messages with NULL values are ignored                         : NULL message values are treated as a _tombstone_                  :
+:                          :                                                               : Any existing row with a matching key is deleted                   :
+| ------------------------ | --------------------------------------------------------------| ----------------------------------------------------------------- |
+
+Each column is defined by:
+ * `column_name`: the name of the column. If unquoted the name must be a valid
+   [SQL identifier](../../concepts/schemas#valid-identifiers) and will be converted to uppercase.
+   The name can be quoted if case needs to be preserved or if the name is not a valid SQL
+   identifier, for example ``` `mixedCaseId` ``` or ``` `$with@invalid!chars`.
+ * `data_type`: the SQL type of the column. Columns can be any of the
+   [data types](../syntax-reference.md#ksqldb-data-types) supported by ksqlDB.
+ * `KEY`: columns that are stored in the Kafka message's key should be marked as `KEY` columns.
+   If a column is not marked as a `KEY` column ksqlDB will load it from the Kafka message's value.
+   Unlike a table's `PRIMARY KEY`, a stream's keys can be NULL.
 
 ksqlDB adds the implicit columns `ROWTIME` and `ROWKEY` to every stream
 and table, which represent the corresponding Kafka message timestamp and
@@ -37,7 +63,7 @@ The WITH clause supports the following properties:
 | PARTITIONS              | The number of partitions in the backing topic. This property must be set if creating a STREAM without an existing topic (the command will fail if the topic does not exist). |
 | REPLICAS                | The number of replicas in the backing topic. If this property is not set but PARTITIONS is set, then the default Kafka cluster configuration for replicas will be used for creating a new topic. |
 | VALUE_DELIMITER         | Used when VALUE_FORMAT='DELIMITED'. Supports single character to be a delimiter, defaults to ','. For space and tab delimited values you must use the special values 'SPACE' or 'TAB', not an actual space or tab character. |
-| KEY                     | Optimization hint: If the Kafka message key is also present as a field/column in the Kafka message value, you may set this property to associate the corresponding field/column with the implicit `ROWKEY` column (message key). If set, ksqlDB uses it as an optimization hint to determine if repartitioning can be avoided when performing aggregations and joins. You can only use this if the key format in Kafka is `VARCHAR` or `STRING`. Do not use this hint if the message key format in Kafka is `AVRO` or `JSON`. See [Key Requirements](../syntax-reference.md#key-requirements) for more information. |
+| KEY                     | Optimization hint: If the Kafka message key is also present as a field/column in the Kafka message value, you may set this property to associate the corresponding field/column with the implicit `ROWKEY` column (message key). If set, ksqlDB uses it as an optimization hint to determine if repartitioning can be avoided when performing aggregations and joins. Do not use this hint if the message key format in Kafka is `AVRO` or `JSON`. See [Key Requirements](../syntax-reference.md#key-requirements) for more information. |
 | TIMESTAMP               | By default, the implicit `ROWTIME` column is the timestamp of the message in the Kafka topic. The TIMESTAMP property can be used to override `ROWTIME` with the contents of the specified field/column within the Kafka message value (similar to timestamp extractors in Kafka's Streams API). Timestamps have a millisecond accuracy. Time-based operations, such as windowing, will process a record according to the timestamp in `ROWTIME`. |
 | TIMESTAMP_FORMAT        | Used in conjunction with TIMESTAMP. If not set will assume that the timestamp field is a `bigint`. If it is set, then the TIMESTAMP field must be of type `varchar` and have a format that can be parsed with the java `DateTimeFormatter`. If your timestamp format has characters requiring single quotes, you can escape them with successive single quotes, `''`, for example: `'yyyy-MM-dd''T''HH:mm:ssX'`. For more information on timestamp formats, see [DateTimeFormatter](https://cnfl.io/java-dtf).                                       |
 | WRAP_SINGLE_VALUE       | Controls how values are deserialized where the value schema contains only a single field. The setting controls how ksqlDB will deserialize the value of the records in the supplied `KAFKA_TOPIC` that contain only a single field.<br>If set to `true`, ksqlDB expects the field to have been serialized as a named field within a record.<br>If set to `false`, ksqlDB expects the field to have been serialized as an anonymous value.<br>If not supplied, the system default, defined by [ksql.persistence.wrap.single.values](../../operate-and-deploy/installation/server-config/config-reference.md#ksqlpersistencewrapsinglevalues) and defaulting to `true`, is used.<br>**Note:** `null` values have special meaning in ksqlDB. Care should be taken when dealing with single-field schemas where the value can be `null`. For more information, see [Single field (un)wrapping](../serialization.md#single-field-unwrapping).<br>**Note:** Supplying this property for formats that do not support wrapping, for example `DELIMITED`, or when the value schema has multiple fields, will result in an error. |
@@ -58,8 +84,13 @@ Example
 -------
 
 ```sql
-CREATE STREAM pageviews (viewtime BIGINT, user_id VARCHAR, page_id VARCHAR)
-  WITH (VALUE_FORMAT = 'JSON',
-        KAFKA_TOPIC = 'my-pageviews-topic');
+CREATE STREAM pageviews
+  (
+    rowkey BIGINT KEY,
+    viewtime BIGINT,
+    user_id VARCHAR,
+    page_id VARCHAR
+  )
+  WITH (VALUE_FORMAT = 'JSON', KAFKA_TOPIC = 'my-pageviews-topic');
 ```
 

--- a/docs-md/developer-guide/ksqldb-reference/create-stream.md
+++ b/docs-md/developer-guide/ksqldb-reference/create-stream.md
@@ -30,14 +30,9 @@ key. The table below contrasts this to a [ksqlDB TABLE](./create-table):
 |                          |  STREAM                                                       | TABLE                                                             |
 | ------------------------ | --------------------------------------------------------------| ----------------------------------------------------------------- |
 | Key column type          | `KEY`                                                         | `PRIMARY KEY`                                                     |
-| NON NULL key constraint  | No                                                            | Yes                                                               |
-:                          :                                                               : Messages in the Kafka topic with a NULL `PRIMARY KEY` are ignored :
-| Unique key constraint    | No                                                            | Yes                                                               |
-:                          : Messages with the same key as another have no special meaning : Later messages with the same key _replace_ earlier                :
-| Tombstones               | No                                                            | Yes                                                               |
-:                          : Messages with NULL values are ignored                         : NULL message values are treated as a _tombstone_                  :
-:                          :                                                               : Any existing row with a matching key is deleted                   :
-| ------------------------ | --------------------------------------------------------------| ----------------------------------------------------------------- |
+| NON NULL key constraint  | No                                                            | Yes <br> Messages in the Kafka topic with a NULL `PRIMARY KEY` are ignored |
+| Unique key constraint    | No <br> Messages with the same key as another have no special meaning | Yes <br> Later messages with the same key _replace_ earlier |
+| Tombstones               | No <br> Messages with NULL values are ignored                 | Yes <br> NULL message values are treated as a _tombstone_ <br> Any existing row with a matching key is deleted |
 
 Each column is defined by:
  * `column_name`: the name of the column. If unquoted the name must be a valid

--- a/docs-md/developer-guide/ksqldb-reference/create-stream.md
+++ b/docs-md/developer-guide/ksqldb-reference/create-stream.md
@@ -22,27 +22,27 @@ Description
 
 Create a new stream with the specified columns and properties.
 
-A ksqlDB STREAM is a stream of _facts_. Each _fact_ is immutable and is unique.
+A ksqlDB STREAM is a stream of _facts_. Each fact is immutable and unique.
 A stream can store its data in either `KEY` or `VALUE` columns.
 Both `KEY` and `VALUE` columns can be NULL. No special processing is done if two rows have the same
-key. The table below contrasts this to a [ksqlDB TABLE](./create-table):
+key. This situation is handled differently by [ksqlDB TABLE](./create-table), as shown in the following table.
 
 |                          |  STREAM                                                       | TABLE                                                             |
 | ------------------------ | --------------------------------------------------------------| ----------------------------------------------------------------- |
 | Key column type          | `KEY`                                                         | `PRIMARY KEY`                                                     |
-| NON NULL key constraint  | No                                                            | Yes <br> Messages in the Kafka topic with a NULL `PRIMARY KEY` are ignored |
-| Unique key constraint    | No <br> Messages with the same key as another have no special meaning | Yes <br> Later messages with the same key _replace_ earlier |
-| Tombstones               | No <br> Messages with NULL values are ignored                 | Yes <br> NULL message values are treated as a _tombstone_ <br> Any existing row with a matching key is deleted |
+| NON NULL key constraint  | No                                                            | Yes <br> Messages in the Kafka topic with a NULL `PRIMARY KEY` are ignored. |
+| Unique key constraint    | No <br> Messages with the same key as another have no special meaning. | Yes <br> Later messages with the same key _replace_ earlier. |
+| Tombstones               | No <br> Messages with NULL values are ignored.                | Yes <br> NULL message values are treated as a _tombstone_ <br> Any existing row with a matching key is deleted. |
 
 Each column is defined by:
- * `column_name`: the name of the column. If unquoted the name must be a valid
-   [SQL identifier](../../concepts/schemas#valid-identifiers) and will be converted to uppercase.
+ * `column_name`: the name of the column. If unquoted, the name must be a valid
+   [SQL identifier](../../concepts/schemas#valid-identifiers) and ksqlDB converts it to uppercase.
    The name can be quoted if case needs to be preserved or if the name is not a valid SQL
-   identifier, for example ``` `mixedCaseId` ``` or ``` `$with@invalid!chars`.
+   identifier, for example ``` `mixedCaseId` ``` or ``` `$with@invalid!chars` ```.
  * `data_type`: the SQL type of the column. Columns can be any of the
    [data types](../syntax-reference.md#ksqldb-data-types) supported by ksqlDB.
  * `KEY`: columns that are stored in the Kafka message's key should be marked as `KEY` columns.
-   If a column is not marked as a `KEY` column ksqlDB will load it from the Kafka message's value.
+   If a column is not marked as a `KEY` column, ksqlDB loads it from the Kafka message's value.
    Unlike a table's `PRIMARY KEY`, a stream's keys can be NULL.
 
 ksqlDB adds the implicit columns `ROWTIME` and `ROWKEY` to every stream

--- a/docs-md/developer-guide/ksqldb-reference/create-table.md
+++ b/docs-md/developer-guide/ksqldb-reference/create-table.md
@@ -10,24 +10,48 @@ Synopsis
 --------
 
 ```sql
-CREATE TABLE table_name ( { column_name data_type } [, ...] )
+CREATE TABLE table_name ( { column_name data_type (PRIMARY KEY) } [, ...] )
   WITH ( property_name = expression [, ...] );
 ```
 
 Description
 -----------
 
-Create a new table with the specified columns and properties. Columns
-can be any of the [data types](../syntax-reference.md#ksqldb-data-types) supported by
-ksqlDB.
+Create a new table with the specified columns and properties.
+
+A ksqlDB TABLE works much like tables in other SQL systems. A table has zero or more rows. Each
+row is identified by its `PRIMARY KEY`. `PRIMARY KEY` values can not be NULL. A message in the
+underlying Kafka topic with the same key as an existing row will _replace_ the earlier row in the
+table, or _delete_ the row if the message's value is NULL, as long as the earlier row does not have
+a later timestamp / `ROWTIME`. The table below contrasts this to a [ksqlDB STREAM](./create-stream):
+
+|                          |  STREAM                                                       | TABLE                                                             |
+| ------------------------ | --------------------------------------------------------------| ----------------------------------------------------------------- |
+| Key column type          | `KEY`                                                         | `PRIMARY KEY`                                                     |
+| NON NULL key constraint  | No                                                            | Yes                                                               |
+:                          :                                                               : Messages in the Kafka topic with a NULL `PRIMARY KEY` are ignored :
+| Unique key constraint    | No                                                            | Yes                                                               |
+:                          : Messages with the same key as another have no special meaning : Later messages with the same key _replace_ earlier                :
+| Tombstones               | No                                                            | Yes                                                               |
+:                          : Messages with NULL values are ignored                         : NULL message values are treated as a _tombstone_                  :
+:                          :                                                               : Any existing row with a matching key is deleted                   :
+| ------------------------ | --------------------------------------------------------------| ----------------------------------------------------------------- |
+
+Each column is defined by:
+ * `column_name`: the name of the column. If unquoted the name must be a valid
+   [SQL identifier](../../concepts/schemas#valid-identifiers) and will be converted to uppercase.
+   The name can be quoted if case needs to be preserved or if the name is not a valid SQL
+   identifier, for example ``` `mixedCaseId` ``` or ``` `$with@invalid!chars`.
+ * `data_type`: the SQL type of the column. Columns can be any of the
+   [data types](../syntax-reference.md#ksqldb-data-types) supported by ksqlDB.
+ * `PRIMARY KEY`: columns that are stored in the Kafka message's key should be marked as
+   `PRIMARY KEY` columns. If a column is not marked as a `PRIMARY KEY` column ksqlDB will load it
+   from the Kafka message's value. Unlike a stream's `KEY` column, a table's `PRIMARY KEY` column
+   are NON NULL. Any records in the Kafka topic with NULL key columns will be dropped.
 
 ksqlDB adds the implicit columns `ROWTIME` and `ROWKEY` to every stream
 and table, which represent the corresponding Kafka message timestamp and
 message key, respectively. The timestamp has milliseconds accuracy.
-
-When creating a table from a Kafka topic, ksqlDB requries the message key
-to be a `VARCHAR` aka `STRING`. If the message key is not of this type
-follow the instructions in [Key Requirements](../syntax-reference.md#key-requirements).
 
 The WITH clause supports the following properties:
 
@@ -38,7 +62,7 @@ The WITH clause supports the following properties:
 | PARTITIONS              | The number of partitions in the backing topic. This property must be set if creating a TABLE without an existing topic (the command will fail if the topic does not exist). |
 | REPLICAS                | The number of replicas in the backing topic. If this property is not set but PARTITIONS is set, then the default Kafka cluster configuration for replicas will be used for creating a new topic. |
 | VALUE_DELIMITER         | Used when VALUE_FORMAT='DELIMITED'. Supports single character to be a delimiter, defaults to ','. For space and tab delimited values you must use the special values 'SPACE' or 'TAB', not an actual space or tab character. |
-| KEY                     | **Optimization hint:** If the Kafka message key is also present as a field/column in the Kafka message value, you may set this property to associate the corresponding field/column with the implicit `ROWKEY` column (message key). If set, ksqlDB uses it as an optimization hint to determine if repartitioning can be avoided when performing aggregations and joins. You can only use this if the key format in kafka is `VARCHAR` or `STRING`. Do not use this hint if the message key format in kafka is `AVRO` or `JSON`. For more information, see [Key Requirements](../syntax-reference.md#key-requirements).  |
+| KEY                     | **Optimization hint:** If the Kafka message key is also present as a field/column in the Kafka message value, you may set this property to associate the corresponding field/column with the implicit `ROWKEY` column (message key). If set, ksqlDB uses it as an optimization hint to determine if repartitioning can be avoided when performing aggregations and joins. Do not use this hint if the message key format in kafka is `AVRO` or `JSON`. For more information, see [Key Requirements](../syntax-reference.md#key-requirements).  |
 | TIMESTAMP               | By default, the implicit `ROWTIME` column is the timestamp of the message in the Kafka topic. The TIMESTAMP property can be used to override `ROWTIME` with the contents of the specified field/column within the Kafka message value (similar to timestamp extractors in the Kafka Streams API). Timestamps have a millisecond accuracy. Time-based operations, such as windowing, will process a record according to the timestamp in `ROWTIME`.  |
 | TIMESTAMP_FORMAT        | Used in conjunction with TIMESTAMP. If not set will assume that the timestamp field is a `bigint`. If it is set, then the TIMESTAMP field must be of type varchar and have a format that can be parsed with the Java `DateTimeFormatter`. If your timestamp format has characters requiring single quotes, you can escape them with two successive single quotes, `''`, for example: `'yyyy-MM-dd''T''HH:mm:ssX'`. For more information on timestamp formats, see [DateTimeFormatter](https://cnfl.io/java-dtf). |
 | WRAP_SINGLE_VALUE       | Controls how values are deserialized where the values schema contains only a single field. The setting controls how ksqlDB will deserialize the value of the records in the supplied `KAFKA_TOPIC` that contain only a single field.<br>If set to `true`, ksqlDB expects the field to have been serialized as named field within a record.<br>If set to `false`, ksqlDB expects the field to have been serialized as an anonymous value.<br>If not supplied, the system default, defined by [ksql.persistence.wrap.single.values](../../operate-and-deploy/installation/server-config/config-reference.md#ksqlpersistencewrapsinglevalues) and defaulting to `true`, is used.<br>**Note:** `null` values have special meaning in ksqlDB. Care should be taken when dealing with single-field schemas where the value can be `null`. For more information, see [Single field (un)wrapping](../serialization.md#single-field-unwrapping).<br>**Note:** Supplying this property for formats that do not support wrapping, for example `DELIMITED`, or when the value schema has multiple fields, will result in an error. |
@@ -55,7 +79,13 @@ Example
 -------
 
 ```sql
-CREATE TABLE users (usertimestamp BIGINT, user_id VARCHAR, gender VARCHAR, region_id VARCHAR) WITH (
-    KAFKA_TOPIC = 'my-users-topic',
-    KEY = 'user_id');
+CREATE TABLE users
+   (
+     rowkey BIGINT PRIMARY KEY,
+     usertimestamp BIGINT,
+     user_id VARCHAR,
+     gender VARCHAR,
+     region_id VARCHAR
+   )
+   WITH (KAFKA_TOPIC = 'my-users-topic', VALUE_FORMAT='JSON');
 ```

--- a/docs-md/developer-guide/ksqldb-reference/create-table.md
+++ b/docs-md/developer-guide/ksqldb-reference/create-table.md
@@ -21,28 +21,29 @@ Create a new table with the specified columns and properties.
 
 A ksqlDB TABLE works much like tables in other SQL systems. A table has zero or more rows. Each
 row is identified by its `PRIMARY KEY`. `PRIMARY KEY` values can not be NULL. A message in the
-underlying Kafka topic with the same key as an existing row will _replace_ the earlier row in the
+underlying Kafka topic that has the same key as an existing row will _replace_ the earlier row in the
 table, or _delete_ the row if the message's value is NULL, as long as the earlier row does not have
-a later timestamp / `ROWTIME`. The table below contrasts this to a [ksqlDB STREAM](./create-stream):
+a later timestamp / `ROWTIME`. This situation is handled differently by
+[ksqlDB STREAM](./create-stream), as shown in the following table.
 
 |                          |  STREAM                                                       | TABLE                                                             |
 | ------------------------ | --------------------------------------------------------------| ----------------------------------------------------------------- |
 | Key column type          | `KEY`                                                         | `PRIMARY KEY`                                                     |
-| NON NULL key constraint  | No                                                            | Yes <br> Messages in the Kafka topic with a NULL `PRIMARY KEY` are ignored |
-| Unique key constraint    | No <br> Messages with the same key as another have no special meaning | Yes <br> Later messages with the same key _replace_ earlier |
-| Tombstones               | No <br> Messages with NULL values are ignored                 | Yes <br> NULL message values are treated as a _tombstone_ <br> Any existing row with a matching key is deleted |
+| NON NULL key constraint  | No                                                            | Yes <br> Messages in the Kafka topic with a NULL `PRIMARY KEY` are ignored. |
+| Unique key constraint    | No <br> Messages with the same key as another have no special meaning. | Yes <br> Later messages with the same key _replace_ earlier. |
+| Tombstones               | No <br> Messages with NULL values are ignored.                | Yes <br> NULL message values are treated as a _tombstone_ <br> Any existing row with a matching key is deleted. |
 
 Each column is defined by:
- * `column_name`: the name of the column. If unquoted the name must be a valid
-   [SQL identifier](../../concepts/schemas#valid-identifiers) and will be converted to uppercase.
+ * `column_name`: the name of the column. If unquoted, the name must be a valid
+   [SQL identifier](../../concepts/schemas#valid-identifiers) and ksqlDB converts it to uppercase.
    The name can be quoted if case needs to be preserved or if the name is not a valid SQL
-   identifier, for example ``` `mixedCaseId` ``` or ``` `$with@invalid!chars`.
+   identifier, for example ``` `mixedCaseId` ``` or ``` `$with@invalid!chars` ```.
  * `data_type`: the SQL type of the column. Columns can be any of the
    [data types](../syntax-reference.md#ksqldb-data-types) supported by ksqlDB.
  * `PRIMARY KEY`: columns that are stored in the Kafka message's key should be marked as
-   `PRIMARY KEY` columns. If a column is not marked as a `PRIMARY KEY` column ksqlDB will load it
-   from the Kafka message's value. Unlike a stream's `KEY` column, a table's `PRIMARY KEY` column
-   are NON NULL. Any records in the Kafka topic with NULL key columns will be dropped.
+   `PRIMARY KEY` columns. If a column is not marked as a `PRIMARY KEY` column ksqlDB loads it
+   from the Kafka message's value. Unlike a stream's `KEY` column, a table's `PRIMARY KEY` column(s)
+   are NON NULL. Any records in the Kafka topic with NULL key columns are dropped.
 
 ksqlDB adds the implicit columns `ROWTIME` and `ROWKEY` to every stream
 and table, which represent the corresponding Kafka message timestamp and

--- a/docs-md/developer-guide/ksqldb-reference/create-table.md
+++ b/docs-md/developer-guide/ksqldb-reference/create-table.md
@@ -28,14 +28,9 @@ a later timestamp / `ROWTIME`. The table below contrasts this to a [ksqlDB STREA
 |                          |  STREAM                                                       | TABLE                                                             |
 | ------------------------ | --------------------------------------------------------------| ----------------------------------------------------------------- |
 | Key column type          | `KEY`                                                         | `PRIMARY KEY`                                                     |
-| NON NULL key constraint  | No                                                            | Yes                                                               |
-:                          :                                                               : Messages in the Kafka topic with a NULL `PRIMARY KEY` are ignored :
-| Unique key constraint    | No                                                            | Yes                                                               |
-:                          : Messages with the same key as another have no special meaning : Later messages with the same key _replace_ earlier                :
-| Tombstones               | No                                                            | Yes                                                               |
-:                          : Messages with NULL values are ignored                         : NULL message values are treated as a _tombstone_                  :
-:                          :                                                               : Any existing row with a matching key is deleted                   :
-| ------------------------ | --------------------------------------------------------------| ----------------------------------------------------------------- |
+| NON NULL key constraint  | No                                                            | Yes <br> Messages in the Kafka topic with a NULL `PRIMARY KEY` are ignored |
+| Unique key constraint    | No <br> Messages with the same key as another have no special meaning | Yes <br> Later messages with the same key _replace_ earlier |
+| Tombstones               | No <br> Messages with NULL values are ignored                 | Yes <br> NULL message values are treated as a _tombstone_ <br> Any existing row with a matching key is deleted |
 
 Each column is defined by:
  * `column_name`: the name of the column. If unquoted the name must be a valid

--- a/docs-md/developer-guide/syntax-reference.md
+++ b/docs-md/developer-guide/syntax-reference.md
@@ -433,7 +433,7 @@ message key by setting the `KEY` property of the `WITH` clause.
 Example:
 
 ```sql
-CREATE TABLE users (rowkey INT KEY, registertime BIGINT, gender VARCHAR, regionid VARCHAR, userid INT)
+CREATE TABLE users (rowkey INT PRIMARY KEY, registertime BIGINT, gender VARCHAR, regionid VARCHAR, userid INT)
   WITH (KAFKA_TOPIC='users', VALUE_FORMAT='JSON', KEY = 'userid');
 ```
 
@@ -457,7 +457,7 @@ following conditions are true:
 1.  For every record, the contents of the Kafka message key must be the
     same as the contents of the column set in `KEY` (which is derived
     from a field in the Kafka message value).
-2.  `KEY` must be set to a column of type `VARCHAR` aka `STRING`.
+2.  `KEY` must be set to a value column with the same SQL type as the key column.
 
 If these conditions aren't met, then the results of aggregations and
 joins may be incorrect. However, if your data doesn't meet these
@@ -518,7 +518,7 @@ CREATE STREAM users_with_proper_key
   EMIT CHANGES;
 
 -- Now you can create the table on the properly keyed stream.
-CREATE TABLE users_table (ROWKEY INT KEY, username VARCHAR, email VARCHAR)
+CREATE TABLE users_table (ROWKEY INT PRIMARY KEY, username VARCHAR, email VARCHAR)
   WITH (KAFKA_TOPIC='users-with-proper-key',
         VALUE_FORMAT='JSON');
 
@@ -533,7 +533,7 @@ CREATE STREAM users_with_proper_key_and_user_id
 
 -- Now you can create the table on the properly keyed stream.
 -- queries against the table can use ROWKEY and userid interchangeably
-CREATE TABLE users_table_2 (ROWKEY INT KEY, userid KEY, username VARCHAR, email VARCHAR)
+CREATE TABLE users_table_2 (ROWKEY INT PRIMARY KEY, userid KEY, username VARCHAR, email VARCHAR)
   WITH (KAFKA_TOPIC='users_with_proper_key_and_user_id',
         VALUE_FORMAT='JSON',
         KEY='userid');

--- a/docs-md/operate-and-deploy/installation/server-config/avro-schema.md
+++ b/docs-md/operate-and-deploy/installation/server-config/avro-schema.md
@@ -123,7 +123,7 @@ creates the `users` table with a 64-bit integer key and infers the value
 columns from the Avro schema.
 
 ```sql
-CREATE TABLE users (ROWKEY BIGINT KEY)
+CREATE TABLE users (ROWKEY BIGINT PRIMARY KEY)
   WITH (KAFKA_TOPIC='users-avro-topic',
         VALUE_FORMAT='AVRO',
         KEY='userid');

--- a/docs-md/tutorials/basics-docker.md
+++ b/docs-md/tutorials/basics-docker.md
@@ -285,7 +285,7 @@ Your output should resemble:
       default, it is assumed the key schema is a single `KAFKA` formatted `STRING`
       column and is called `ROWKEY`. It is also possible to supply just the key
       column in the statement, allowing you to specify the key column type. For example:
-      `CREATE TABLE users_original (ROWKEY INT KEY) WITH (...);`
+      `CREATE TABLE users_original (ROWKEY INT PRIMARY KEY) WITH (...);`
 
 !!! note
       The data generated has the same value in the {{ site.ak }} record's key
@@ -1025,14 +1025,14 @@ in the value:
 
 ```sql
 CREATE TABLE WAREHOUSE_LOCATION 
-   (ROWKEY INT KEY, WAREHOUSE_ID INT, CITY VARCHAR, COUNTRY VARCHAR)
+   (ROWKEY INT PRIMARY KEY, WAREHOUSE_ID INT, CITY VARCHAR, COUNTRY VARCHAR)
    WITH (KAFKA_TOPIC='warehouse_location',
       VALUE_FORMAT='JSON',
       KEY='WAREHOUSE_ID',
       PARTITIONS=2);
 
 CREATE TABLE WAREHOUSE_SIZE 
-   (ROWKEY INT KEY, WAREHOUSE_ID INT, SQUARE_FOOTAGE DOUBLE)
+   (ROWKEY INT PRIMARY KEY, WAREHOUSE_ID INT, SQUARE_FOOTAGE DOUBLE)
    WITH (KAFKA_TOPIC='warehouse_size',
       VALUE_FORMAT='JSON',
       KEY='WAREHOUSE_ID',

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -453,7 +453,8 @@ public class Console implements Closeable {
   private static String formatFieldType(
       final FieldInfo field,
       final Optional<WindowType> windowType,
-      final String keyField
+      final String keyField,
+      final boolean isTable
   ) {
     final FieldType possibleFieldType = field.getType().orElse(null);
 
@@ -466,7 +467,8 @@ public class Console implements Closeable {
           .map(v -> " (Window type: " + v + ")")
           .orElse("");
 
-      return String.format("%-16s %s%s", field.getSchema().toTypeString(), "(key)", wt);
+      final String keyType = isTable ? "(primary key)" : "(key)";
+      return String.format("%-16s %s%s", field.getSchema().toTypeString(), keyType, wt);
     }
 
     if (keyField != null && keyField.contains("." + field.getName())) {
@@ -479,13 +481,16 @@ public class Console implements Closeable {
   private void printSchema(
       final Optional<WindowType> windowType,
       final List<FieldInfo> fields,
-      final String keyField
+      final String keyField,
+      final boolean isTable
   ) {
     final Table.Builder tableBuilder = new Table.Builder();
     if (!fields.isEmpty()) {
       tableBuilder.withColumnHeaders("Field", "Type");
-      fields.forEach(
-          f -> tableBuilder.withRow(f.getName(), formatFieldType(f, windowType, keyField)));
+      fields.forEach(f -> tableBuilder.withRow(
+          f.getName(),
+          formatFieldType(f, windowType, keyField, isTable)
+      ));
       tableBuilder.build().print(this);
     }
   }
@@ -584,9 +589,11 @@ public class Console implements Closeable {
   }
 
   private void printSourceDescription(final SourceDescription source) {
+    final boolean isTable = source.getType().equalsIgnoreCase("TABLE");
+
     writer().println(String.format("%-20s : %s", "Name", source.getName()));
     if (!source.isExtended()) {
-      printSchema(source.getWindowType(), source.getFields(), source.getKey());
+      printSchema(source.getWindowType(), source.getFields(), source.getKey(), isTable);
       writer().println(
           "For runtime statistics and query details run: DESCRIBE EXTENDED <Stream,Table>;");
       return;
@@ -597,7 +604,7 @@ public class Console implements Closeable {
     writer().println(String.format("%-20s : %s", "Statement", source.getStatement()));
     writer().println("");
 
-    printSchema(source.getWindowType(), source.getFields(), source.getKey());
+    printSchema(source.getWindowType(), source.getFields(), source.getKey(), isTable);
 
     printQueries(source.getReadQueries(), source.getType(), "read");
 
@@ -662,7 +669,7 @@ public class Console implements Closeable {
       writer().println(String.format("%-20s : %s", "Status", query.getState().get()));
     }
     writer().println();
-    printSchema(query.getWindowType(), query.getFields(), "");
+    printSchema(query.getWindowType(), query.getFields(), "", false);
     printQuerySources(query);
     printQuerySinks(query);
     printExecutionPlan(query);

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -241,7 +241,7 @@ public class CliTest {
 
   private static void createKStream(final TestDataProvider<?> dataProvider, final Cli cli) {
     run("CREATE STREAM " + dataProvider.kstreamName()
-            + " (" + dataProvider.ksqlSchemaString() + ")"
+            + " (" + dataProvider.ksqlSchemaString(false) + ")"
             + " WITH (value_format = 'json', kafka_topic = '" + dataProvider.topicName() + "');",
         cli);
   }

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -504,19 +504,19 @@ public class ConsoleTest {
     } else {
       assertThat(output, is("" + NEWLINE
           + "Name                 : TestSource" + NEWLINE
-          + " Field   | Type                      " + NEWLINE
-          + "-------------------------------------" + NEWLINE
-          + " ROWTIME | BIGINT           (system) " + NEWLINE
-          + " ROWKEY  | VARCHAR(STRING)  (key)    " + NEWLINE
-          + " f_0     | BOOLEAN                   " + NEWLINE
-          + " f_1     | INTEGER                   " + NEWLINE
-          + " f_2     | BIGINT                    " + NEWLINE
-          + " f_3     | DOUBLE                    " + NEWLINE
-          + " f_4     | VARCHAR(STRING)           " + NEWLINE
-          + " f_5     | ARRAY<VARCHAR(STRING)>    " + NEWLINE
-          + " f_6     | MAP<STRING, BIGINT>       " + NEWLINE
-          + " f_7     | STRUCT<a DOUBLE>          " + NEWLINE
-          + "-------------------------------------" + NEWLINE
+          + " Field   | Type                           " + NEWLINE
+          + "------------------------------------------" + NEWLINE
+          + " ROWTIME | BIGINT           (system)      " + NEWLINE
+          + " ROWKEY  | VARCHAR(STRING)  (primary key) " + NEWLINE
+          + " f_0     | BOOLEAN                        " + NEWLINE
+          + " f_1     | INTEGER                        " + NEWLINE
+          + " f_2     | BIGINT                         " + NEWLINE
+          + " f_3     | DOUBLE                         " + NEWLINE
+          + " f_4     | VARCHAR(STRING)                " + NEWLINE
+          + " f_5     | ARRAY<VARCHAR(STRING)>         " + NEWLINE
+          + " f_6     | MAP<STRING, BIGINT>            " + NEWLINE
+          + " f_7     | STRUCT<a DOUBLE>               " + NEWLINE
+          + "------------------------------------------" + NEWLINE
           + "For runtime statistics and query details run: DESCRIBE EXTENDED <Stream,Table>;"
           + NEWLINE));
     }
@@ -1107,12 +1107,12 @@ public class ConsoleTest {
           + "Kafka topic          : kadka-topic (partitions: 2, replication: 1)" + NEWLINE
           + "Statement            : sql statement text" + NEWLINE
           + "" + NEWLINE
-          + " Field   | Type                      " + NEWLINE
-          + "-------------------------------------" + NEWLINE
-          + " ROWTIME | BIGINT           (system) " + NEWLINE
-          + " ROWKEY  | VARCHAR(STRING)  (key)    " + NEWLINE
-          + " f_0     | VARCHAR(STRING)           " + NEWLINE
-          + "-------------------------------------" + NEWLINE
+          + " Field   | Type                           " + NEWLINE
+          + "------------------------------------------" + NEWLINE
+          + " ROWTIME | BIGINT           (system)      " + NEWLINE
+          + " ROWKEY  | VARCHAR(STRING)  (primary key) " + NEWLINE
+          + " f_0     | VARCHAR(STRING)                " + NEWLINE
+          + "------------------------------------------" + NEWLINE
           + "" + NEWLINE
           + "Queries that read from this TABLE" + NEWLINE
           + "-----------------------------------" + NEWLINE

--- a/ksqldb-common/src/main/java/io/confluent/ksql/parser/NodeLocation.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/parser/NodeLocation.java
@@ -36,6 +36,10 @@ public final class NodeLocation {
     return charPositionInLine + 1;
   }
 
+  public String asPrefix() {
+    return toString() + ": ";
+  }
+
   @Override
   public String toString() {
     return String.format("Line: %d, Col: %d", line, charPositionInLine + 1);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
@@ -29,7 +29,6 @@ import io.confluent.ksql.parser.properties.with.CreateSourceProperties;
 import io.confluent.ksql.parser.tree.CreateSource;
 import io.confluent.ksql.parser.tree.CreateStream;
 import io.confluent.ksql.parser.tree.CreateTable;
-import io.confluent.ksql.parser.tree.TableElement.Namespace;
 import io.confluent.ksql.parser.tree.TableElements;
 import io.confluent.ksql.schema.ksql.FormatOptions;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
@@ -180,7 +179,7 @@ public final class CreateSourceFactory {
 
       if (!ksqlConfig.getBoolean(KsqlConfig.KSQL_ANY_KEY_NAME_ENABLED)) {
         final boolean isRowKey = e.getName().equals(SchemaUtil.ROWKEY_NAME);
-        if (e.getNamespace() == Namespace.KEY) {
+        if (e.getNamespace().isKey()) {
           if (!isRowKey) {
             throw new KsqlException("'" + e.getName().text() + "' is an invalid KEY column name. "
                 + "KSQL currently only supports KEY columns named ROWKEY.");

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
@@ -163,7 +163,7 @@ public class DefaultSchemaInjector implements Injector {
       final ConfiguredStatement<CreateSource> preparedStatement
   ) {
     return preparedStatement.getStatement().getElements().stream()
-        .filter(e -> e.getNamespace() == Namespace.KEY);
+        .filter(e -> e.getNamespace().isKey());
   }
 
   private static PreparedStatement<CreateSource> buildPreparedStatement(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceFactoryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceFactoryTest.java
@@ -94,8 +94,11 @@ public class CreateSourceFactoryTest {
 
   private static final SourceName SOME_NAME = SourceName.of("bob");
 
-  private static final TableElement EXPLICIT_ROWKEY =
+  private static final TableElement EXPLICIT_KEY =
       tableElement(Namespace.KEY, ROWKEY_NAME.text(), new Type(SqlTypes.INTEGER));
+
+  private static final TableElement EXPLICIT_PRIMARY_KEY =
+      tableElement(Namespace.PRIMARY_KEY, ROWKEY_NAME.text(), new Type(SqlTypes.INTEGER));
 
   private static final TableElement ELEMENT1 =
       tableElement(VALUE, "bob", new Type(SqlTypes.STRING));
@@ -106,7 +109,10 @@ public class CreateSourceFactoryTest {
   private static final TableElements ONE_ELEMENTS = TableElements.of(ELEMENT1);
 
   private static final TableElements TABLE_ELEMENTS =
-      TableElements.of(EXPLICIT_ROWKEY, ELEMENT1, ELEMENT2);
+      TableElements.of(EXPLICIT_PRIMARY_KEY, ELEMENT1, ELEMENT2);
+
+  private static final TableElements STREAM_ELEMENTS =
+      TableElements.of(EXPLICIT_KEY, ELEMENT1, ELEMENT2);
 
   private static final LogicalSchema EXPECTED_SCHEMA = LogicalSchema.builder()
       .withRowTime()
@@ -175,7 +181,7 @@ public class CreateSourceFactoryTest {
   public void shouldCreateCommandForCreateStream() {
     // Given:
     final CreateStream ddlStatement =
-        new CreateStream(SOME_NAME, TABLE_ELEMENTS, true, withProperties);
+        new CreateStream(SOME_NAME, STREAM_ELEMENTS, true, withProperties);
 
     // When:
     final CreateStreamCommand result = createSourceFactory
@@ -476,7 +482,7 @@ public class CreateSourceFactoryTest {
         new StringLiteral(quote(ELEMENT2.getName().text()))
     );
     final CreateStream statement =
-        new CreateStream(SOME_NAME, TABLE_ELEMENTS, true, withProperties);
+        new CreateStream(SOME_NAME, STREAM_ELEMENTS, true, withProperties);
 
     // When:
     final CreateStreamCommand cmd = createSourceFactory.createStreamCommand(
@@ -528,7 +534,7 @@ public class CreateSourceFactoryTest {
         new StringLiteral("%s")
     ));
     final CreateStream statement =
-        new CreateStream(SOME_NAME, TABLE_ELEMENTS, true, withProperties);
+        new CreateStream(SOME_NAME, STREAM_ELEMENTS, true, withProperties);
 
     // When:
     final CreateStreamCommand cmd = createSourceFactory.createStreamCommand(
@@ -548,7 +554,7 @@ public class CreateSourceFactoryTest {
   @Test
   public void shouldBuildSchemaWithImplicitKeyFieldForStream() {
     // Given:
-    final CreateStream statement = new CreateStream(SOME_NAME, TABLE_ELEMENTS, true,
+    final CreateStream statement = new CreateStream(SOME_NAME, STREAM_ELEMENTS, true,
         withProperties);
 
     // When:
@@ -595,7 +601,7 @@ public class CreateSourceFactoryTest {
   public void shouldValidateKeyFormatCanHandleKeySchema() {
     // Given:
     givenCommandFactoriesWithMocks();
-    final CreateStream statement = new CreateStream(SOME_NAME, TABLE_ELEMENTS, true,
+    final CreateStream statement = new CreateStream(SOME_NAME, STREAM_ELEMENTS, true,
         withProperties);
 
     when(keySerdeFactory.create(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -33,7 +33,6 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
@@ -826,7 +825,7 @@ public class KsqlEngineTest {
         + "CREATE STREAM S0 (a INT, b VARCHAR) "
         + "      WITH (kafka_topic='s0_topic', value_format='DELIMITED');\n"
         + "\n"
-        + "CREATE TABLE T1 (ROWKEY BIGINT KEY, f0 BIGINT, f1 DOUBLE) "
+        + "CREATE TABLE T1 (ROWKEY BIGINT PRIMARY KEY, f0 BIGINT, f1 DOUBLE) "
         + "     WITH (kafka_topic='t1_topic', value_format='JSON', key = 'f0');\n"
         + "\n"
         + "CREATE STREAM S1 AS SELECT * FROM S0;\n"

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/StatementRewriterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/StatementRewriterTest.java
@@ -55,6 +55,7 @@ import io.confluent.ksql.parser.tree.SingleColumn;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.Statements;
 import io.confluent.ksql.parser.tree.TableElement;
+import io.confluent.ksql.parser.tree.TableElement.Namespace;
 import io.confluent.ksql.parser.tree.TableElements;
 import io.confluent.ksql.parser.tree.WindowExpression;
 import io.confluent.ksql.parser.tree.WithinExpression;
@@ -512,6 +513,7 @@ public class StatementRewriterTest {
   private static TableElement givenTableElement(final String name) {
     final TableElement element = mock(TableElement.class);
     when(element.getName()).thenReturn(ColumnName.of(name));
+    when(element.getNamespace()).thenReturn(Namespace.VALUE);
     return element;
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/StreamsSelectAndProjectIntTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/StreamsSelectAndProjectIntTest.java
@@ -422,7 +422,7 @@ public class StreamsSelectAndProjectIntTest {
   }
 
   private void createOrdersStream() {
-    final String columns = DATA_PROVIDER.ksqlSchemaString();
+    final String columns = DATA_PROVIDER.ksqlSchemaString(false);
 
     ksqlContext.sql("CREATE STREAM " + JSON_STREAM_NAME + " (" + columns + ") WITH "
         + "(kafka_topic='" + jsonTopicName + "', value_format='JSON');");

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
@@ -737,7 +737,7 @@ public class KsMaterializationFunctionalTest {
     ksqlContext.ensureStarted();
 
     ksqlContext.sql("CREATE TABLE " + USER_TABLE
-        + " (" + USER_DATA_PROVIDER.ksqlSchemaString() + ")"
+        + " (" + USER_DATA_PROVIDER.ksqlSchemaString(true) + ")"
         + " WITH ("
         + "    kafka_topic='" + USERS_TOPIC + "', "
         + "    value_format='" + VALUE_FORMAT.name() + "', "
@@ -746,7 +746,7 @@ public class KsMaterializationFunctionalTest {
     );
 
     ksqlContext.sql("CREATE STREAM " + USER_STREAM + " "
-        + " (" + USER_DATA_PROVIDER.ksqlSchemaString() + ")"
+        + " (" + USER_DATA_PROVIDER.ksqlSchemaString(false) + ")"
         + " WITH ("
         + "    kafka_topic='" + USERS_TOPIC + "', "
         + "    value_format='" + VALUE_FORMAT.name() + "', "
@@ -755,7 +755,7 @@ public class KsMaterializationFunctionalTest {
     );
 
     ksqlContext.sql("CREATE STREAM " + PAGE_VIEWS_STREAM + " "
-        + " (" + PAGE_VIEW_DATA_PROVIDER.ksqlSchemaString() + ")"
+        + " (" + PAGE_VIEW_DATA_PROVIDER.ksqlSchemaString(false) + ")"
         + " WITH ("
         + "    kafka_topic='" + PAGE_VIEWS_TOPIC + "', "
         + "    value_format='" + VALUE_FORMAT.name() + "', "

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -77,11 +77,11 @@ public class PhysicalPlanBuilderTest {
       + " WITH (KAFKA_TOPIC = 'test3', VALUE_FORMAT = 'JSON', KEY='ID3');";
 
   private static final String CREATE_TABLE_TEST4 = "CREATE TABLE TEST4 "
-      + "(ROWKEY BIGINT KEY, ID BIGINT, COL0 BIGINT, COL1 DOUBLE) "
+      + "(ROWKEY BIGINT PRIMARY KEY, ID BIGINT, COL0 BIGINT, COL1 DOUBLE) "
       + " WITH (KAFKA_TOPIC = 'test4', VALUE_FORMAT = 'JSON', KEY='ID');";
 
   private static final String CREATE_TABLE_TEST5 = "CREATE TABLE TEST5 "
-      + "(ROWKEY BIGINT KEY, ID BIGINT, COL0 BIGINT, COL1 DOUBLE) "
+      + "(ROWKEY BIGINT PRIMARY KEY, ID BIGINT, COL0 BIGINT, COL1 DOUBLE) "
       + " WITH (KAFKA_TOPIC = 'test5', VALUE_FORMAT = 'JSON', KEY='ID');";
 
   private static final String CREATE_STREAM_TEST6 = "CREATE STREAM TEST6 "

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/TestDataProvider.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/TestDataProvider.java
@@ -16,9 +16,11 @@
 package io.confluent.ksql.util;
 
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.schema.ksql.Column.Namespace;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 public abstract class TestDataProvider<K> {
 
@@ -45,8 +47,11 @@ public abstract class TestDataProvider<K> {
     return topicName;
   }
 
-  public String ksqlSchemaString() {
-    return schema.logicalSchema().toString();
+  public String ksqlSchemaString(final boolean asTable) {
+    return schema.logicalSchema().columns().stream()
+        .filter(col -> col.namespace() != Namespace.META)
+        .map(col -> col.name() + " " + col.type() + namespace(col.namespace(), asTable))
+        .collect(Collectors.joining(", "));
   }
 
   public String key() {
@@ -63,5 +68,15 @@ public abstract class TestDataProvider<K> {
 
   public String kstreamName() {
     return kstreamName;
+  }
+
+  private static String namespace(final Namespace namespace, final boolean asTable) {
+    if (namespace != Namespace.KEY) {
+      return "";
+    }
+
+    return asTable
+        ? " PRIMARY KEY"
+        : " KEY";
   }
 }

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_bool_map_table_-_JSON/6.0.0_1585912758234/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_bool_map_table_-_JSON/6.0.0_1585912758234/plan.json
@@ -1,0 +1,165 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, NAME STRING, VALUE MAP<STRING, BOOLEAN>) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` MAP<STRING, BOOLEAN>",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_LIST(TEST.VALUE['key1']) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `COLLECTED` ARRAY<BOOLEAN>",
+      "keyField" : "ID",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` MAP<STRING, BOOLEAN>"
+                },
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE", "VALUE['key1'] AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              },
+              "groupByExpressions" : [ "ID" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_LIST(KSQL_INTERNAL_COL_2)" ]
+          },
+          "selectExpressions" : [ "ID AS ID", "KSQL_AGG_VARIABLE_0 AS COLLECTED" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_bool_map_table_-_JSON/6.0.0_1585912758234/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_bool_map_table_-_JSON/6.0.0_1585912758234/spec.json
@@ -1,0 +1,80 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912758234,
+  "schemas" : {
+    "CTAS_S2_0.KsqlTopic.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE MAP<VARCHAR, BOOLEAN>> NOT NULL",
+    "CTAS_S2_0.Aggregate.GroupBy" : "STRUCT<ID BIGINT, VALUE MAP<VARCHAR, BOOLEAN>, KSQL_INTERNAL_COL_2 BOOLEAN> NOT NULL",
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : "STRUCT<ID BIGINT, VALUE MAP<VARCHAR, BOOLEAN>, KSQL_AGG_VARIABLE_0 ARRAY<BOOLEAN>> NOT NULL",
+    "CTAS_S2_0.S2" : "STRUCT<ID BIGINT, COLLECTED ARRAY<BOOLEAN>> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "id" : 0,
+      "name" : "zero",
+      "value" : {
+        "key1" : true,
+        "key2" : false
+      }
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "id" : 0,
+      "name" : "zero",
+      "value" : {
+        "key1" : false,
+        "key2" : true
+      }
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "id" : 0,
+      "name" : "zero",
+      "value" : {
+        "key1" : true,
+        "key2" : true
+      }
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ true ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ false ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ true ]
+    }
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_bool_map_table_-_JSON/6.0.0_1585912758234/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_bool_map_table_-_JSON/6.0.0_1585912758234/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_bool_map_table_-_PROTOBUF/6.0.0_1585912758276/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_bool_map_table_-_PROTOBUF/6.0.0_1585912758276/plan.json
@@ -1,0 +1,165 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, NAME STRING, VALUE MAP<STRING, BOOLEAN>) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` MAP<STRING, BOOLEAN>",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_LIST(TEST.VALUE['key1']) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `COLLECTED` ARRAY<BOOLEAN>",
+      "keyField" : "ID",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "PROTOBUF"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` MAP<STRING, BOOLEAN>"
+                },
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE", "VALUE['key1'] AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "PROTOBUF"
+                }
+              },
+              "groupByExpressions" : [ "ID" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_LIST(KSQL_INTERNAL_COL_2)" ]
+          },
+          "selectExpressions" : [ "ID AS ID", "KSQL_AGG_VARIABLE_0 AS COLLECTED" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_bool_map_table_-_PROTOBUF/6.0.0_1585912758276/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_bool_map_table_-_PROTOBUF/6.0.0_1585912758276/spec.json
@@ -1,0 +1,80 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912758276,
+  "schemas" : {
+    "CTAS_S2_0.KsqlTopic.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE MAP<VARCHAR, BOOLEAN>> NOT NULL",
+    "CTAS_S2_0.Aggregate.GroupBy" : "STRUCT<ID BIGINT, VALUE MAP<VARCHAR, BOOLEAN>, KSQL_INTERNAL_COL_2 BOOLEAN> NOT NULL",
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : "STRUCT<ID BIGINT, VALUE MAP<VARCHAR, BOOLEAN>, KSQL_AGG_VARIABLE_0 ARRAY<BOOLEAN>> NOT NULL",
+    "CTAS_S2_0.S2" : "STRUCT<ID BIGINT, COLLECTED ARRAY<BOOLEAN>> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "id" : 0,
+      "name" : "zero",
+      "value" : {
+        "key1" : true,
+        "key2" : false
+      }
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "id" : 0,
+      "name" : "zero",
+      "value" : {
+        "key1" : false,
+        "key2" : true
+      }
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "id" : 0,
+      "name" : "zero",
+      "value" : {
+        "key1" : true,
+        "key2" : true
+      }
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ true ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ false ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ true ]
+    }
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_bool_map_table_-_PROTOBUF/6.0.0_1585912758276/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_bool_map_table_-_PROTOBUF/6.0.0_1585912758276/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_double_table_-_AVRO/6.0.0_1585912757981/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_double_table_-_AVRO/6.0.0_1585912757981/plan.json
@@ -1,0 +1,165 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, VALUE DOUBLE) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `VALUE` DOUBLE",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_LIST(TEST.VALUE) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `COLLECTED` ARRAY<DOUBLE>",
+      "keyField" : "ID",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "AVRO"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `VALUE` DOUBLE"
+                },
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "AVRO"
+                }
+              },
+              "groupByExpressions" : [ "ID" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "AVRO"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_LIST(VALUE)" ]
+          },
+          "selectExpressions" : [ "ID AS ID", "KSQL_AGG_VARIABLE_0 AS COLLECTED" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_double_table_-_AVRO/6.0.0_1585912757981/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_double_table_-_AVRO/6.0.0_1585912757981/spec.json
@@ -1,0 +1,82 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912757981,
+  "schemas" : {
+    "CTAS_S2_0.KsqlTopic.Source" : "STRUCT<ID BIGINT, VALUE DOUBLE> NOT NULL",
+    "CTAS_S2_0.Aggregate.GroupBy" : "STRUCT<ID BIGINT, VALUE DOUBLE> NOT NULL",
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : "STRUCT<ID BIGINT, VALUE DOUBLE, KSQL_AGG_VARIABLE_0 ARRAY<DOUBLE>> NOT NULL",
+    "CTAS_S2_0.S2" : "STRUCT<ID BIGINT, COLLECTED ARRAY<DOUBLE>> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "VALUE" : 5.4
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "VALUE" : 100.1
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "VALUE" : 500.9
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "VALUE" : 300.8
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ 5.4 ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ 100.1 ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ 500.9 ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ 300.8 ]
+    }
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_double_table_-_AVRO/6.0.0_1585912757981/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_double_table_-_AVRO/6.0.0_1585912757981/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_double_table_-_JSON/6.0.0_1585912758021/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_double_table_-_JSON/6.0.0_1585912758021/plan.json
@@ -1,0 +1,165 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, VALUE DOUBLE) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `VALUE` DOUBLE",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_LIST(TEST.VALUE) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `COLLECTED` ARRAY<DOUBLE>",
+      "keyField" : "ID",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `VALUE` DOUBLE"
+                },
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              },
+              "groupByExpressions" : [ "ID" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_LIST(VALUE)" ]
+          },
+          "selectExpressions" : [ "ID AS ID", "KSQL_AGG_VARIABLE_0 AS COLLECTED" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_double_table_-_JSON/6.0.0_1585912758021/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_double_table_-_JSON/6.0.0_1585912758021/spec.json
@@ -1,0 +1,82 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912758021,
+  "schemas" : {
+    "CTAS_S2_0.KsqlTopic.Source" : "STRUCT<ID BIGINT, VALUE DOUBLE> NOT NULL",
+    "CTAS_S2_0.Aggregate.GroupBy" : "STRUCT<ID BIGINT, VALUE DOUBLE> NOT NULL",
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : "STRUCT<ID BIGINT, VALUE DOUBLE, KSQL_AGG_VARIABLE_0 ARRAY<DOUBLE>> NOT NULL",
+    "CTAS_S2_0.S2" : "STRUCT<ID BIGINT, COLLECTED ARRAY<DOUBLE>> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "VALUE" : 5.4
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "VALUE" : 100.1
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "VALUE" : 500.9
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "VALUE" : 300.8
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ 5.4 ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ 100.1 ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ 500.9 ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ 300.8 ]
+    }
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_double_table_-_JSON/6.0.0_1585912758021/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_double_table_-_JSON/6.0.0_1585912758021/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_double_table_-_PROTOBUF/6.0.0_1585912758064/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_double_table_-_PROTOBUF/6.0.0_1585912758064/plan.json
@@ -1,0 +1,165 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, VALUE DOUBLE) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `VALUE` DOUBLE",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_LIST(TEST.VALUE) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `COLLECTED` ARRAY<DOUBLE>",
+      "keyField" : "ID",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "PROTOBUF"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `VALUE` DOUBLE"
+                },
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "PROTOBUF"
+                }
+              },
+              "groupByExpressions" : [ "ID" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_LIST(VALUE)" ]
+          },
+          "selectExpressions" : [ "ID AS ID", "KSQL_AGG_VARIABLE_0 AS COLLECTED" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_double_table_-_PROTOBUF/6.0.0_1585912758064/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_double_table_-_PROTOBUF/6.0.0_1585912758064/spec.json
@@ -1,0 +1,82 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912758064,
+  "schemas" : {
+    "CTAS_S2_0.KsqlTopic.Source" : "STRUCT<ID BIGINT, VALUE DOUBLE> NOT NULL",
+    "CTAS_S2_0.Aggregate.GroupBy" : "STRUCT<ID BIGINT, VALUE DOUBLE> NOT NULL",
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : "STRUCT<ID BIGINT, VALUE DOUBLE, KSQL_AGG_VARIABLE_0 ARRAY<DOUBLE>> NOT NULL",
+    "CTAS_S2_0.S2" : "STRUCT<ID BIGINT, COLLECTED ARRAY<DOUBLE>> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "VALUE" : 5.4
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "VALUE" : 100.1
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "VALUE" : 500.9
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "VALUE" : 300.8
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ 5.4 ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ 100.1 ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ 500.9 ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ 300.8 ]
+    }
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_double_table_-_PROTOBUF/6.0.0_1585912758064/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_double_table_-_PROTOBUF/6.0.0_1585912758064/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_int_table_-_AVRO/6.0.0_1585912757693/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_int_table_-_AVRO/6.0.0_1585912757693/plan.json
@@ -1,0 +1,165 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, VALUE INTEGER) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `VALUE` INTEGER",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_LIST(TEST.VALUE) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `COLLECTED` ARRAY<INTEGER>",
+      "keyField" : "ID",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "AVRO"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `VALUE` INTEGER"
+                },
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "AVRO"
+                }
+              },
+              "groupByExpressions" : [ "ID" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "AVRO"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_LIST(VALUE)" ]
+          },
+          "selectExpressions" : [ "ID AS ID", "KSQL_AGG_VARIABLE_0 AS COLLECTED" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_int_table_-_AVRO/6.0.0_1585912757693/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_int_table_-_AVRO/6.0.0_1585912757693/spec.json
@@ -1,0 +1,82 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912757693,
+  "schemas" : {
+    "CTAS_S2_0.KsqlTopic.Source" : "STRUCT<ID BIGINT, VALUE INT> NOT NULL",
+    "CTAS_S2_0.Aggregate.GroupBy" : "STRUCT<ID BIGINT, VALUE INT> NOT NULL",
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : "STRUCT<ID BIGINT, VALUE INT, KSQL_AGG_VARIABLE_0 ARRAY<INT>> NOT NULL",
+    "CTAS_S2_0.S2" : "STRUCT<ID BIGINT, COLLECTED ARRAY<INT>> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "VALUE" : 0
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "VALUE" : 100
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "VALUE" : 500
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "VALUE" : 100
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ 0 ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ 100 ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ 500 ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ 100 ]
+    }
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_int_table_-_AVRO/6.0.0_1585912757693/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_int_table_-_AVRO/6.0.0_1585912757693/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_int_table_-_JSON/6.0.0_1585912757785/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_int_table_-_JSON/6.0.0_1585912757785/plan.json
@@ -1,0 +1,165 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, VALUE INTEGER) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `VALUE` INTEGER",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_LIST(TEST.VALUE) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `COLLECTED` ARRAY<INTEGER>",
+      "keyField" : "ID",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `VALUE` INTEGER"
+                },
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              },
+              "groupByExpressions" : [ "ID" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_LIST(VALUE)" ]
+          },
+          "selectExpressions" : [ "ID AS ID", "KSQL_AGG_VARIABLE_0 AS COLLECTED" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_int_table_-_JSON/6.0.0_1585912757785/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_int_table_-_JSON/6.0.0_1585912757785/spec.json
@@ -1,0 +1,82 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912757785,
+  "schemas" : {
+    "CTAS_S2_0.KsqlTopic.Source" : "STRUCT<ID BIGINT, VALUE INT> NOT NULL",
+    "CTAS_S2_0.Aggregate.GroupBy" : "STRUCT<ID BIGINT, VALUE INT> NOT NULL",
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : "STRUCT<ID BIGINT, VALUE INT, KSQL_AGG_VARIABLE_0 ARRAY<INT>> NOT NULL",
+    "CTAS_S2_0.S2" : "STRUCT<ID BIGINT, COLLECTED ARRAY<INT>> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "VALUE" : 0
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "VALUE" : 100
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "VALUE" : 500
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "VALUE" : 100
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ 0 ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ 100 ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ 500 ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ 100 ]
+    }
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_int_table_-_JSON/6.0.0_1585912757785/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_int_table_-_JSON/6.0.0_1585912757785/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_int_table_-_PROTOBUF/6.0.0_1585912757817/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_int_table_-_PROTOBUF/6.0.0_1585912757817/plan.json
@@ -1,0 +1,165 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, VALUE INTEGER) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `VALUE` INTEGER",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_LIST(TEST.VALUE) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `COLLECTED` ARRAY<INTEGER>",
+      "keyField" : "ID",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "PROTOBUF"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `VALUE` INTEGER"
+                },
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "PROTOBUF"
+                }
+              },
+              "groupByExpressions" : [ "ID" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_LIST(VALUE)" ]
+          },
+          "selectExpressions" : [ "ID AS ID", "KSQL_AGG_VARIABLE_0 AS COLLECTED" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_int_table_-_PROTOBUF/6.0.0_1585912757817/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_int_table_-_PROTOBUF/6.0.0_1585912757817/spec.json
@@ -1,0 +1,82 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912757817,
+  "schemas" : {
+    "CTAS_S2_0.KsqlTopic.Source" : "STRUCT<ID BIGINT, VALUE INT> NOT NULL",
+    "CTAS_S2_0.Aggregate.GroupBy" : "STRUCT<ID BIGINT, VALUE INT> NOT NULL",
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : "STRUCT<ID BIGINT, VALUE INT, KSQL_AGG_VARIABLE_0 ARRAY<INT>> NOT NULL",
+    "CTAS_S2_0.S2" : "STRUCT<ID BIGINT, COLLECTED ARRAY<INT>> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "VALUE" : 0
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "VALUE" : 100
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "VALUE" : 500
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "VALUE" : 100
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ 0 ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ 100 ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ 500 ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ 100 ]
+    }
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_int_table_-_PROTOBUF/6.0.0_1585912757817/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_int_table_-_PROTOBUF/6.0.0_1585912757817/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_long_table_-_AVRO/6.0.0_1585912757851/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_long_table_-_AVRO/6.0.0_1585912757851/plan.json
@@ -1,0 +1,165 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, VALUE BIGINT) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_LIST(TEST.VALUE) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `COLLECTED` ARRAY<BIGINT>",
+      "keyField" : "ID",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "AVRO"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `VALUE` BIGINT"
+                },
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "AVRO"
+                }
+              },
+              "groupByExpressions" : [ "ID" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "AVRO"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_LIST(VALUE)" ]
+          },
+          "selectExpressions" : [ "ID AS ID", "KSQL_AGG_VARIABLE_0 AS COLLECTED" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_long_table_-_AVRO/6.0.0_1585912757851/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_long_table_-_AVRO/6.0.0_1585912757851/spec.json
@@ -1,0 +1,82 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912757851,
+  "schemas" : {
+    "CTAS_S2_0.KsqlTopic.Source" : "STRUCT<ID BIGINT, VALUE BIGINT> NOT NULL",
+    "CTAS_S2_0.Aggregate.GroupBy" : "STRUCT<ID BIGINT, VALUE BIGINT> NOT NULL",
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : "STRUCT<ID BIGINT, VALUE BIGINT, KSQL_AGG_VARIABLE_0 ARRAY<BIGINT>> NOT NULL",
+    "CTAS_S2_0.S2" : "STRUCT<ID BIGINT, COLLECTED ARRAY<BIGINT>> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "VALUE" : 2147483648
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "VALUE" : 100
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "VALUE" : 500
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "VALUE" : 100
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ 2147483648 ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ 100 ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ 500 ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ 100 ]
+    }
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_long_table_-_AVRO/6.0.0_1585912757851/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_long_table_-_AVRO/6.0.0_1585912757851/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_long_table_-_JSON/6.0.0_1585912757898/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_long_table_-_JSON/6.0.0_1585912757898/plan.json
@@ -1,0 +1,165 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, VALUE BIGINT) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_LIST(TEST.VALUE) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `COLLECTED` ARRAY<BIGINT>",
+      "keyField" : "ID",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `VALUE` BIGINT"
+                },
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              },
+              "groupByExpressions" : [ "ID" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_LIST(VALUE)" ]
+          },
+          "selectExpressions" : [ "ID AS ID", "KSQL_AGG_VARIABLE_0 AS COLLECTED" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_long_table_-_JSON/6.0.0_1585912757898/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_long_table_-_JSON/6.0.0_1585912757898/spec.json
@@ -1,0 +1,82 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912757898,
+  "schemas" : {
+    "CTAS_S2_0.KsqlTopic.Source" : "STRUCT<ID BIGINT, VALUE BIGINT> NOT NULL",
+    "CTAS_S2_0.Aggregate.GroupBy" : "STRUCT<ID BIGINT, VALUE BIGINT> NOT NULL",
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : "STRUCT<ID BIGINT, VALUE BIGINT, KSQL_AGG_VARIABLE_0 ARRAY<BIGINT>> NOT NULL",
+    "CTAS_S2_0.S2" : "STRUCT<ID BIGINT, COLLECTED ARRAY<BIGINT>> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "VALUE" : 2147483648
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "VALUE" : 100
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "VALUE" : 500
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "VALUE" : 100
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ 2147483648 ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ 100 ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ 500 ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ 100 ]
+    }
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_long_table_-_JSON/6.0.0_1585912757898/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_long_table_-_JSON/6.0.0_1585912757898/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_long_table_-_PROTOBUF/6.0.0_1585912757941/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_long_table_-_PROTOBUF/6.0.0_1585912757941/plan.json
@@ -1,0 +1,165 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, VALUE BIGINT) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_LIST(TEST.VALUE) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `COLLECTED` ARRAY<BIGINT>",
+      "keyField" : "ID",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "PROTOBUF"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `VALUE` BIGINT"
+                },
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "PROTOBUF"
+                }
+              },
+              "groupByExpressions" : [ "ID" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_LIST(VALUE)" ]
+          },
+          "selectExpressions" : [ "ID AS ID", "KSQL_AGG_VARIABLE_0 AS COLLECTED" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_long_table_-_PROTOBUF/6.0.0_1585912757941/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_long_table_-_PROTOBUF/6.0.0_1585912757941/spec.json
@@ -1,0 +1,82 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912757941,
+  "schemas" : {
+    "CTAS_S2_0.KsqlTopic.Source" : "STRUCT<ID BIGINT, VALUE BIGINT> NOT NULL",
+    "CTAS_S2_0.Aggregate.GroupBy" : "STRUCT<ID BIGINT, VALUE BIGINT> NOT NULL",
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : "STRUCT<ID BIGINT, VALUE BIGINT, KSQL_AGG_VARIABLE_0 ARRAY<BIGINT>> NOT NULL",
+    "CTAS_S2_0.S2" : "STRUCT<ID BIGINT, COLLECTED ARRAY<BIGINT>> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "VALUE" : 2147483648
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "VALUE" : 100
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "VALUE" : 500
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "VALUE" : 100
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ 2147483648 ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ 100 ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ 500 ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ 100 ]
+    }
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_long_table_-_PROTOBUF/6.0.0_1585912757941/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_long_table_-_PROTOBUF/6.0.0_1585912757941/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_AVRO/6.0.0_1585912758104/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_AVRO/6.0.0_1585912758104/plan.json
@@ -1,0 +1,165 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, VALUE STRING) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `VALUE` STRING",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_LIST(TEST.VALUE) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `COLLECTED` ARRAY<STRING>",
+      "keyField" : "ID",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "AVRO"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `VALUE` STRING"
+                },
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "AVRO"
+                }
+              },
+              "groupByExpressions" : [ "ID" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "AVRO"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_LIST(VALUE)" ]
+          },
+          "selectExpressions" : [ "ID AS ID", "KSQL_AGG_VARIABLE_0 AS COLLECTED" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_AVRO/6.0.0_1585912758104/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_AVRO/6.0.0_1585912758104/spec.json
@@ -1,0 +1,103 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912758104,
+  "schemas" : {
+    "CTAS_S2_0.KsqlTopic.Source" : "STRUCT<ID BIGINT, VALUE VARCHAR> NOT NULL",
+    "CTAS_S2_0.Aggregate.GroupBy" : "STRUCT<ID BIGINT, VALUE VARCHAR> NOT NULL",
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : "STRUCT<ID BIGINT, VALUE VARCHAR, KSQL_AGG_VARIABLE_0 ARRAY<VARCHAR>> NOT NULL",
+    "CTAS_S2_0.S2" : "STRUCT<ID BIGINT, COLLECTED ARRAY<VARCHAR>> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "VALUE" : "foo"
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "VALUE" : "baz"
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "VALUE" : "bar"
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "VALUE" : "baz"
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "VALUE" : "foo"
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ "foo" ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ "baz" ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ "bar" ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ "baz" ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ "foo" ]
+    }
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_AVRO/6.0.0_1585912758104/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_AVRO/6.0.0_1585912758104/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_JSON/6.0.0_1585912758148/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_JSON/6.0.0_1585912758148/plan.json
@@ -1,0 +1,165 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, VALUE STRING) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `VALUE` STRING",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_LIST(TEST.VALUE) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `COLLECTED` ARRAY<STRING>",
+      "keyField" : "ID",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `VALUE` STRING"
+                },
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              },
+              "groupByExpressions" : [ "ID" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_LIST(VALUE)" ]
+          },
+          "selectExpressions" : [ "ID AS ID", "KSQL_AGG_VARIABLE_0 AS COLLECTED" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_JSON/6.0.0_1585912758148/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_JSON/6.0.0_1585912758148/spec.json
@@ -1,0 +1,103 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912758148,
+  "schemas" : {
+    "CTAS_S2_0.KsqlTopic.Source" : "STRUCT<ID BIGINT, VALUE VARCHAR> NOT NULL",
+    "CTAS_S2_0.Aggregate.GroupBy" : "STRUCT<ID BIGINT, VALUE VARCHAR> NOT NULL",
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : "STRUCT<ID BIGINT, VALUE VARCHAR, KSQL_AGG_VARIABLE_0 ARRAY<VARCHAR>> NOT NULL",
+    "CTAS_S2_0.S2" : "STRUCT<ID BIGINT, COLLECTED ARRAY<VARCHAR>> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "VALUE" : "foo"
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "VALUE" : "baz"
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "VALUE" : "bar"
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "VALUE" : "baz"
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "VALUE" : "foo"
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ "foo" ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ "baz" ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ "bar" ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ "baz" ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ "foo" ]
+    }
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_JSON/6.0.0_1585912758148/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_JSON/6.0.0_1585912758148/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_PROTOBUF/6.0.0_1585912758193/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_PROTOBUF/6.0.0_1585912758193/plan.json
@@ -1,0 +1,165 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, VALUE STRING) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `VALUE` STRING",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_LIST(TEST.VALUE) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `COLLECTED` ARRAY<STRING>",
+      "keyField" : "ID",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "PROTOBUF"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `VALUE` STRING"
+                },
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "PROTOBUF"
+                }
+              },
+              "groupByExpressions" : [ "ID" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_LIST(VALUE)" ]
+          },
+          "selectExpressions" : [ "ID AS ID", "KSQL_AGG_VARIABLE_0 AS COLLECTED" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_PROTOBUF/6.0.0_1585912758193/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_PROTOBUF/6.0.0_1585912758193/spec.json
@@ -1,0 +1,103 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912758193,
+  "schemas" : {
+    "CTAS_S2_0.KsqlTopic.Source" : "STRUCT<ID BIGINT, VALUE VARCHAR> NOT NULL",
+    "CTAS_S2_0.Aggregate.GroupBy" : "STRUCT<ID BIGINT, VALUE VARCHAR> NOT NULL",
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : "STRUCT<ID BIGINT, VALUE VARCHAR, KSQL_AGG_VARIABLE_0 ARRAY<VARCHAR>> NOT NULL",
+    "CTAS_S2_0.S2" : "STRUCT<ID BIGINT, COLLECTED ARRAY<VARCHAR>> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "VALUE" : "foo"
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "VALUE" : "baz"
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "VALUE" : "bar"
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "VALUE" : "baz"
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "VALUE" : "foo"
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ "foo" ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ "baz" ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "COLLECTED" : [ "bar" ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ "baz" ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ ]
+    }
+  }, {
+    "topic" : "S2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "COLLECTED" : [ "foo" ]
+    }
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_PROTOBUF/6.0.0_1585912758193/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_PROTOBUF/6.0.0_1585912758193/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_constant_(table-_table)/6.0.0_1585912762710/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_constant_(table-_table)/6.0.0_1585912762710/plan.json
@@ -1,0 +1,164 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY INTEGER PRIMARY KEY, USER INTEGER, REGION STRING) WITH (KAFKA_TOPIC='test_topic', KEY='user', VALUE_FORMAT='DELIMITED');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` INTEGER KEY, `USER` INTEGER, `REGION` STRING",
+      "keyField" : "USER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT COUNT(*) KSQL_COL_0\nFROM TEST TEST\nGROUP BY 1\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` INTEGER KEY, `KSQL_COL_0` BIGINT",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "DELIMITED"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` INTEGER KEY, `USER` INTEGER, `REGION` STRING"
+                },
+                "selectExpressions" : [ "ROWTIME AS ROWTIME" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "DELIMITED"
+                }
+              },
+              "groupByExpressions" : [ "1" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "DELIMITED"
+              }
+            },
+            "nonAggregateColumns" : [ "ROWTIME" ],
+            "aggregationFunctions" : [ "COUNT(ROWTIME)" ]
+          },
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS KSQL_COL_0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_constant_(table-_table)/6.0.0_1585912762710/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_constant_(table-_table)/6.0.0_1585912762710/spec.json
@@ -1,0 +1,56 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912762710,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<USER INT, REGION VARCHAR> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : "STRUCT<ROWTIME BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : "STRUCT<ROWTIME BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<KSQL_COL_0 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 1,
+    "value" : "1,r0"
+  }, {
+    "topic" : "test_topic",
+    "key" : 2,
+    "value" : "2,r1"
+  }, {
+    "topic" : "test_topic",
+    "key" : 3,
+    "value" : "3,r0"
+  }, {
+    "topic" : "test_topic",
+    "key" : 1,
+    "value" : null
+  }, {
+    "topic" : "test_topic",
+    "key" : 2,
+    "value" : "2,r0"
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : "1"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : "2"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : "3"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : "2"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : "1"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : "2"
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_constant_(table-_table)/6.0.0_1585912762710/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_constant_(table-_table)/6.0.0_1585912762710/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_field_with_field_used_in_function_in_projection_(table-_table)/6.0.0_1585912762754/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_field_with_field_used_in_function_in_projection_(table-_table)/6.0.0_1585912762754/plan.json
@@ -1,0 +1,164 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY INTEGER PRIMARY KEY, USER INTEGER, REGION STRING) WITH (KAFKA_TOPIC='test_topic', KEY='user', VALUE_FORMAT='DELIMITED');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` INTEGER KEY, `USER` INTEGER, `REGION` STRING",
+      "keyField" : "USER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  SUBSTRING(TEST.REGION, 2, 1) KSQL_COL_0,\n  COUNT(*) KSQL_COL_1\nFROM TEST TEST\nGROUP BY TEST.REGION\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` STRING KEY, `KSQL_COL_0` STRING, `KSQL_COL_1` BIGINT",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "DELIMITED"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` INTEGER KEY, `USER` INTEGER, `REGION` STRING"
+                },
+                "selectExpressions" : [ "REGION AS REGION", "ROWTIME AS ROWTIME" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "DELIMITED"
+                }
+              },
+              "groupByExpressions" : [ "REGION" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "DELIMITED"
+              }
+            },
+            "nonAggregateColumns" : [ "REGION", "ROWTIME" ],
+            "aggregationFunctions" : [ "COUNT(ROWTIME)" ]
+          },
+          "selectExpressions" : [ "SUBSTRING(REGION, 2, 1) AS KSQL_COL_0", "KSQL_AGG_VARIABLE_0 AS KSQL_COL_1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_field_with_field_used_in_function_in_projection_(table-_table)/6.0.0_1585912762754/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_field_with_field_used_in_function_in_projection_(table-_table)/6.0.0_1585912762754/spec.json
@@ -1,0 +1,56 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912762754,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<USER INT, REGION VARCHAR> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : "STRUCT<REGION VARCHAR, ROWTIME BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : "STRUCT<REGION VARCHAR, ROWTIME BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<KSQL_COL_0 VARCHAR, KSQL_COL_1 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 1,
+    "value" : "1,r0"
+  }, {
+    "topic" : "test_topic",
+    "key" : 2,
+    "value" : "2,r1"
+  }, {
+    "topic" : "test_topic",
+    "key" : 3,
+    "value" : "3,r0"
+  }, {
+    "topic" : "test_topic",
+    "key" : 1,
+    "value" : null
+  }, {
+    "topic" : "test_topic",
+    "key" : 2,
+    "value" : "2,r0"
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : "r0",
+    "value" : "0,1"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "r1",
+    "value" : "1,1"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "r0",
+    "value" : "0,2"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "r0",
+    "value" : "0,1"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "r1",
+    "value" : "1,0"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "r0",
+    "value" : "0,2"
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_field_with_field_used_in_function_in_projection_(table-_table)/6.0.0_1585912762754/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_field_with_field_used_in_function_in_projection_(table-_table)/6.0.0_1585912762754/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_field_with_re-key_(table-_table)/6.0.0_1585912762184/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_field_with_re-key_(table-_table)/6.0.0_1585912762184/plan.json
@@ -1,0 +1,164 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY INTEGER PRIMARY KEY, USER INTEGER, REGION STRING) WITH (KAFKA_TOPIC='test_topic', KEY='user', VALUE_FORMAT='DELIMITED');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` INTEGER KEY, `USER` INTEGER, `REGION` STRING",
+      "keyField" : "USER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT COUNT(*) KSQL_COL_0\nFROM TEST TEST\nGROUP BY TEST.REGION\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` STRING KEY, `KSQL_COL_0` BIGINT",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "DELIMITED"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` INTEGER KEY, `USER` INTEGER, `REGION` STRING"
+                },
+                "selectExpressions" : [ "ROWTIME AS ROWTIME", "REGION AS REGION" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "DELIMITED"
+                }
+              },
+              "groupByExpressions" : [ "REGION" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "DELIMITED"
+              }
+            },
+            "nonAggregateColumns" : [ "ROWTIME", "REGION" ],
+            "aggregationFunctions" : [ "COUNT(ROWTIME)" ]
+          },
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS KSQL_COL_0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_field_with_re-key_(table-_table)/6.0.0_1585912762184/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_field_with_re-key_(table-_table)/6.0.0_1585912762184/spec.json
@@ -1,0 +1,63 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912762184,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<USER INT, REGION VARCHAR> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : "STRUCT<ROWTIME BIGINT, REGION VARCHAR> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : "STRUCT<ROWTIME BIGINT, REGION VARCHAR, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<KSQL_COL_0 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 1,
+    "value" : "1,r0"
+  }, {
+    "topic" : "test_topic",
+    "key" : 2,
+    "value" : "2,r1"
+  }, {
+    "topic" : "test_topic",
+    "key" : 3,
+    "value" : "3,r0"
+  }, {
+    "topic" : "test_topic",
+    "key" : 1,
+    "value" : null
+  }, {
+    "topic" : "test_topic",
+    "key" : 2,
+    "value" : "2,r0"
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : "r0",
+    "value" : "1"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "r1",
+    "value" : "1"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "r0",
+    "value" : "2"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "r0",
+    "value" : "1"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "r1",
+    "value" : "0"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "r0",
+    "value" : "2"
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "OUTPUT",
+      "type" : "table",
+      "schema" : "ROWKEY STRING KEY, KSQL_COL_0 BIGINT"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_field_with_re-key_(table-_table)/6.0.0_1585912762184/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_field_with_re-key_(table-_table)/6.0.0_1585912762184/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_fields_(table-_table)/6.0.0_1585912761850/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_fields_(table-_table)/6.0.0_1585912761850/plan.json
@@ -1,0 +1,164 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY INTEGER PRIMARY KEY, F1 INTEGER, F2 STRING) WITH (KAFKA_TOPIC='test_topic', KEY='f1', VALUE_FORMAT='DELIMITED');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` INTEGER KEY, `F1` INTEGER, `F2` STRING",
+      "keyField" : "F1",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  TEST.F1 F1,\n  TEST.F2 F2,\n  COUNT(*) KSQL_COL_0\nFROM TEST TEST\nGROUP BY TEST.F2, TEST.F1\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` STRING KEY, `F1` INTEGER, `F2` STRING, `KSQL_COL_0` BIGINT",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "DELIMITED"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` INTEGER KEY, `F1` INTEGER, `F2` STRING"
+                },
+                "selectExpressions" : [ "F1 AS F1", "F2 AS F2", "ROWTIME AS ROWTIME" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "DELIMITED"
+                }
+              },
+              "groupByExpressions" : [ "F2", "F1" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "DELIMITED"
+              }
+            },
+            "nonAggregateColumns" : [ "F1", "F2", "ROWTIME" ],
+            "aggregationFunctions" : [ "COUNT(ROWTIME)" ]
+          },
+          "selectExpressions" : [ "F1 AS F1", "F2 AS F2", "KSQL_AGG_VARIABLE_0 AS KSQL_COL_0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_fields_(table-_table)/6.0.0_1585912761850/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_fields_(table-_table)/6.0.0_1585912761850/spec.json
@@ -1,0 +1,95 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912761850,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<F1 INT, F2 VARCHAR> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : "STRUCT<F1 INT, F2 VARCHAR, ROWTIME BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : "STRUCT<F1 INT, F2 VARCHAR, ROWTIME BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<F1 INT, F2 VARCHAR, KSQL_COL_0 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 1,
+    "value" : "1,a"
+  }, {
+    "topic" : "test_topic",
+    "key" : 2,
+    "value" : "2,b"
+  }, {
+    "topic" : "test_topic",
+    "key" : 1,
+    "value" : "1,b"
+  }, {
+    "topic" : "test_topic",
+    "key" : 2,
+    "value" : null
+  }, {
+    "topic" : "test_topic",
+    "key" : 1,
+    "value" : "1,a"
+  } ],
+  "outputs" : [ {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "a|+|1",
+    "value" : "1,a,0,1"
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "b|+|2",
+    "value" : "2,b,0,1"
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "a|+|1",
+    "value" : "1,a,0,0"
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "b|+|1",
+    "value" : "1,b,0,1"
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "b|+|2",
+    "value" : "2,b,0,0"
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "b|+|1",
+    "value" : "1,b,0,0"
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "a|+|1",
+    "value" : "1,a,0,1"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "a|+|1",
+    "value" : "1,a,1"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "b|+|2",
+    "value" : "2,b,1"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "a|+|1",
+    "value" : "1,a,0"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "b|+|1",
+    "value" : "1,b,1"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "b|+|2",
+    "value" : "2,b,0"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "b|+|1",
+    "value" : "1,b,0"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "a|+|1",
+    "value" : "1,a,1"
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "OUTPUT",
+      "type" : "table",
+      "schema" : "ROWKEY STRING KEY, F1 INT, F2 STRING, KSQL_COL_0 BIGINT"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_fields_(table-_table)/6.0.0_1585912761850/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_fields_(table-_table)/6.0.0_1585912761850/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_fields_(table-_table)_-_format_-_AVRO/6.0.0_1585912761885/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_fields_(table-_table)_-_format_-_AVRO/6.0.0_1585912761885/plan.json
@@ -1,0 +1,164 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY INTEGER PRIMARY KEY, F1 INTEGER, F2 STRING) WITH (KAFKA_TOPIC='test_topic', KEY='f1', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` INTEGER KEY, `F1` INTEGER, `F2` STRING",
+      "keyField" : "F1",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  TEST.F1 F1,\n  TEST.F2 F2,\n  COUNT(*) KSQL_COL_0\nFROM TEST TEST\nGROUP BY TEST.F2, TEST.F1\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` STRING KEY, `F1` INTEGER, `F2` STRING, `KSQL_COL_0` BIGINT",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "AVRO"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` INTEGER KEY, `F1` INTEGER, `F2` STRING"
+                },
+                "selectExpressions" : [ "F1 AS F1", "F2 AS F2", "ROWTIME AS ROWTIME" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "AVRO"
+                }
+              },
+              "groupByExpressions" : [ "F2", "F1" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "AVRO"
+              }
+            },
+            "nonAggregateColumns" : [ "F1", "F2", "ROWTIME" ],
+            "aggregationFunctions" : [ "COUNT(ROWTIME)" ]
+          },
+          "selectExpressions" : [ "F1 AS F1", "F2 AS F2", "KSQL_AGG_VARIABLE_0 AS KSQL_COL_0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_fields_(table-_table)_-_format_-_AVRO/6.0.0_1585912761885/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_fields_(table-_table)_-_format_-_AVRO/6.0.0_1585912761885/spec.json
@@ -1,0 +1,170 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912761885,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<F1 INT, F2 VARCHAR> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : "STRUCT<F1 INT, F2 VARCHAR, ROWTIME BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : "STRUCT<F1 INT, F2 VARCHAR, ROWTIME BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<F1 INT, F2 VARCHAR, KSQL_COL_0 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 1,
+    "value" : {
+      "F1" : 1,
+      "F2" : "a"
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 2,
+    "value" : {
+      "F1" : 2,
+      "F2" : "b"
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 1,
+    "value" : {
+      "F1" : 1,
+      "F2" : "b"
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 2,
+    "value" : null
+  }, {
+    "topic" : "test_topic",
+    "key" : 1,
+    "value" : {
+      "F1" : 1,
+      "F2" : "a"
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "a|+|1",
+    "value" : {
+      "F1" : 1,
+      "F2" : "a",
+      "ROWTIME" : 0,
+      "KSQL_AGG_VARIABLE_0" : 1
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "b|+|2",
+    "value" : {
+      "F1" : 2,
+      "F2" : "b",
+      "ROWTIME" : 0,
+      "KSQL_AGG_VARIABLE_0" : 1
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "a|+|1",
+    "value" : {
+      "F1" : 1,
+      "F2" : "a",
+      "ROWTIME" : 0,
+      "KSQL_AGG_VARIABLE_0" : 0
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "b|+|1",
+    "value" : {
+      "F1" : 1,
+      "F2" : "b",
+      "ROWTIME" : 0,
+      "KSQL_AGG_VARIABLE_0" : 1
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "b|+|2",
+    "value" : {
+      "F1" : 2,
+      "F2" : "b",
+      "ROWTIME" : 0,
+      "KSQL_AGG_VARIABLE_0" : 0
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "b|+|1",
+    "value" : {
+      "F1" : 1,
+      "F2" : "b",
+      "ROWTIME" : 0,
+      "KSQL_AGG_VARIABLE_0" : 0
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "a|+|1",
+    "value" : {
+      "F1" : 1,
+      "F2" : "a",
+      "ROWTIME" : 0,
+      "KSQL_AGG_VARIABLE_0" : 1
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "a|+|1",
+    "value" : {
+      "F1" : 1,
+      "F2" : "a",
+      "KSQL_COL_0" : 1
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "b|+|2",
+    "value" : {
+      "F1" : 2,
+      "F2" : "b",
+      "KSQL_COL_0" : 1
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "a|+|1",
+    "value" : {
+      "F1" : 1,
+      "F2" : "a",
+      "KSQL_COL_0" : 0
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "b|+|1",
+    "value" : {
+      "F1" : 1,
+      "F2" : "b",
+      "KSQL_COL_0" : 1
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "b|+|2",
+    "value" : {
+      "F1" : 2,
+      "F2" : "b",
+      "KSQL_COL_0" : 0
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "b|+|1",
+    "value" : {
+      "F1" : 1,
+      "F2" : "b",
+      "KSQL_COL_0" : 0
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "a|+|1",
+    "value" : {
+      "F1" : 1,
+      "F2" : "a",
+      "KSQL_COL_0" : 1
+    }
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "OUTPUT",
+      "type" : "table",
+      "schema" : "ROWKEY STRING KEY, F1 INT, F2 STRING, KSQL_COL_0 BIGINT"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_fields_(table-_table)_-_format_-_AVRO/6.0.0_1585912761885/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_fields_(table-_table)_-_format_-_AVRO/6.0.0_1585912761885/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_fields_(table-_table)_-_format_-_JSON/6.0.0_1585912761920/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_fields_(table-_table)_-_format_-_JSON/6.0.0_1585912761920/plan.json
@@ -1,0 +1,164 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY INTEGER PRIMARY KEY, F1 INTEGER, F2 STRING) WITH (KAFKA_TOPIC='test_topic', KEY='f1', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` INTEGER KEY, `F1` INTEGER, `F2` STRING",
+      "keyField" : "F1",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  TEST.F1 F1,\n  TEST.F2 F2,\n  COUNT(*) KSQL_COL_0\nFROM TEST TEST\nGROUP BY TEST.F2, TEST.F1\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` STRING KEY, `F1` INTEGER, `F2` STRING, `KSQL_COL_0` BIGINT",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` INTEGER KEY, `F1` INTEGER, `F2` STRING"
+                },
+                "selectExpressions" : [ "F1 AS F1", "F2 AS F2", "ROWTIME AS ROWTIME" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              },
+              "groupByExpressions" : [ "F2", "F1" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "F1", "F2", "ROWTIME" ],
+            "aggregationFunctions" : [ "COUNT(ROWTIME)" ]
+          },
+          "selectExpressions" : [ "F1 AS F1", "F2 AS F2", "KSQL_AGG_VARIABLE_0 AS KSQL_COL_0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_fields_(table-_table)_-_format_-_JSON/6.0.0_1585912761920/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_fields_(table-_table)_-_format_-_JSON/6.0.0_1585912761920/spec.json
@@ -1,0 +1,170 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912761920,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<F1 INT, F2 VARCHAR> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : "STRUCT<F1 INT, F2 VARCHAR, ROWTIME BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : "STRUCT<F1 INT, F2 VARCHAR, ROWTIME BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<F1 INT, F2 VARCHAR, KSQL_COL_0 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 1,
+    "value" : {
+      "F1" : 1,
+      "F2" : "a"
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 2,
+    "value" : {
+      "F1" : 2,
+      "F2" : "b"
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 1,
+    "value" : {
+      "F1" : 1,
+      "F2" : "b"
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 2,
+    "value" : null
+  }, {
+    "topic" : "test_topic",
+    "key" : 1,
+    "value" : {
+      "F1" : 1,
+      "F2" : "a"
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "a|+|1",
+    "value" : {
+      "F1" : 1,
+      "F2" : "a",
+      "ROWTIME" : 0,
+      "KSQL_AGG_VARIABLE_0" : 1
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "b|+|2",
+    "value" : {
+      "F1" : 2,
+      "F2" : "b",
+      "ROWTIME" : 0,
+      "KSQL_AGG_VARIABLE_0" : 1
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "a|+|1",
+    "value" : {
+      "F1" : 1,
+      "F2" : "a",
+      "ROWTIME" : 0,
+      "KSQL_AGG_VARIABLE_0" : 0
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "b|+|1",
+    "value" : {
+      "F1" : 1,
+      "F2" : "b",
+      "ROWTIME" : 0,
+      "KSQL_AGG_VARIABLE_0" : 1
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "b|+|2",
+    "value" : {
+      "F1" : 2,
+      "F2" : "b",
+      "ROWTIME" : 0,
+      "KSQL_AGG_VARIABLE_0" : 0
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "b|+|1",
+    "value" : {
+      "F1" : 1,
+      "F2" : "b",
+      "ROWTIME" : 0,
+      "KSQL_AGG_VARIABLE_0" : 0
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "a|+|1",
+    "value" : {
+      "F1" : 1,
+      "F2" : "a",
+      "ROWTIME" : 0,
+      "KSQL_AGG_VARIABLE_0" : 1
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "a|+|1",
+    "value" : {
+      "F1" : 1,
+      "F2" : "a",
+      "KSQL_COL_0" : 1
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "b|+|2",
+    "value" : {
+      "F1" : 2,
+      "F2" : "b",
+      "KSQL_COL_0" : 1
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "a|+|1",
+    "value" : {
+      "F1" : 1,
+      "F2" : "a",
+      "KSQL_COL_0" : 0
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "b|+|1",
+    "value" : {
+      "F1" : 1,
+      "F2" : "b",
+      "KSQL_COL_0" : 1
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "b|+|2",
+    "value" : {
+      "F1" : 2,
+      "F2" : "b",
+      "KSQL_COL_0" : 0
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "b|+|1",
+    "value" : {
+      "F1" : 1,
+      "F2" : "b",
+      "KSQL_COL_0" : 0
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "a|+|1",
+    "value" : {
+      "F1" : 1,
+      "F2" : "a",
+      "KSQL_COL_0" : 1
+    }
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "OUTPUT",
+      "type" : "table",
+      "schema" : "ROWKEY STRING KEY, F1 INT, F2 STRING, KSQL_COL_0 BIGINT"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_fields_(table-_table)_-_format_-_JSON/6.0.0_1585912761920/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_fields_(table-_table)_-_format_-_JSON/6.0.0_1585912761920/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_fields_(table-_table)_-_format_-_PROTOBUF/6.0.0_1585912761956/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_fields_(table-_table)_-_format_-_PROTOBUF/6.0.0_1585912761956/plan.json
@@ -1,0 +1,164 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY INTEGER PRIMARY KEY, F1 INTEGER, F2 STRING) WITH (KAFKA_TOPIC='test_topic', KEY='f1', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` INTEGER KEY, `F1` INTEGER, `F2` STRING",
+      "keyField" : "F1",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  TEST.F1 F1,\n  TEST.F2 F2,\n  COUNT(*) KSQL_COL_0\nFROM TEST TEST\nGROUP BY TEST.F2, TEST.F1\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` STRING KEY, `F1` INTEGER, `F2` STRING, `KSQL_COL_0` BIGINT",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "PROTOBUF"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` INTEGER KEY, `F1` INTEGER, `F2` STRING"
+                },
+                "selectExpressions" : [ "F1 AS F1", "F2 AS F2", "ROWTIME AS ROWTIME" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "PROTOBUF"
+                }
+              },
+              "groupByExpressions" : [ "F2", "F1" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF"
+              }
+            },
+            "nonAggregateColumns" : [ "F1", "F2", "ROWTIME" ],
+            "aggregationFunctions" : [ "COUNT(ROWTIME)" ]
+          },
+          "selectExpressions" : [ "F1 AS F1", "F2 AS F2", "KSQL_AGG_VARIABLE_0 AS KSQL_COL_0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_fields_(table-_table)_-_format_-_PROTOBUF/6.0.0_1585912761956/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_fields_(table-_table)_-_format_-_PROTOBUF/6.0.0_1585912761956/spec.json
@@ -1,0 +1,170 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912761956,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<F1 INT, F2 VARCHAR> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : "STRUCT<F1 INT, F2 VARCHAR, ROWTIME BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : "STRUCT<F1 INT, F2 VARCHAR, ROWTIME BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<F1 INT, F2 VARCHAR, KSQL_COL_0 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 1,
+    "value" : {
+      "F1" : 1,
+      "F2" : "a"
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 2,
+    "value" : {
+      "F1" : 2,
+      "F2" : "b"
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 1,
+    "value" : {
+      "F1" : 1,
+      "F2" : "b"
+    }
+  }, {
+    "topic" : "test_topic",
+    "key" : 2,
+    "value" : null
+  }, {
+    "topic" : "test_topic",
+    "key" : 1,
+    "value" : {
+      "F1" : 1,
+      "F2" : "a"
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "a|+|1",
+    "value" : {
+      "F1" : 1,
+      "F2" : "a",
+      "ROWTIME" : 0,
+      "KSQL_AGG_VARIABLE_0" : 1
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "b|+|2",
+    "value" : {
+      "F1" : 2,
+      "F2" : "b",
+      "ROWTIME" : 0,
+      "KSQL_AGG_VARIABLE_0" : 1
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "a|+|1",
+    "value" : {
+      "F1" : 1,
+      "F2" : "a",
+      "ROWTIME" : 0,
+      "KSQL_AGG_VARIABLE_0" : 0
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "b|+|1",
+    "value" : {
+      "F1" : 1,
+      "F2" : "b",
+      "ROWTIME" : 0,
+      "KSQL_AGG_VARIABLE_0" : 1
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "b|+|2",
+    "value" : {
+      "F1" : 2,
+      "F2" : "b",
+      "ROWTIME" : 0,
+      "KSQL_AGG_VARIABLE_0" : 0
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "b|+|1",
+    "value" : {
+      "F1" : 1,
+      "F2" : "b",
+      "ROWTIME" : 0,
+      "KSQL_AGG_VARIABLE_0" : 0
+    }
+  }, {
+    "topic" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+    "key" : "a|+|1",
+    "value" : {
+      "F1" : 1,
+      "F2" : "a",
+      "ROWTIME" : 0,
+      "KSQL_AGG_VARIABLE_0" : 1
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "a|+|1",
+    "value" : {
+      "F1" : 1,
+      "F2" : "a",
+      "KSQL_COL_0" : 1
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "b|+|2",
+    "value" : {
+      "F1" : 2,
+      "F2" : "b",
+      "KSQL_COL_0" : 1
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "a|+|1",
+    "value" : {
+      "F1" : 1,
+      "F2" : "a",
+      "KSQL_COL_0" : 0
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "b|+|1",
+    "value" : {
+      "F1" : 1,
+      "F2" : "b",
+      "KSQL_COL_0" : 1
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "b|+|2",
+    "value" : {
+      "F1" : 2,
+      "F2" : "b",
+      "KSQL_COL_0" : 0
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "b|+|1",
+    "value" : {
+      "F1" : 1,
+      "F2" : "b",
+      "KSQL_COL_0" : 0
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "a|+|1",
+    "value" : {
+      "F1" : 1,
+      "F2" : "a",
+      "KSQL_COL_0" : 1
+    }
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "OUTPUT",
+      "type" : "table",
+      "schema" : "ROWKEY STRING KEY, F1 INT, F2 STRING, KSQL_COL_0 BIGINT"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_fields_(table-_table)_-_format_-_PROTOBUF/6.0.0_1585912761956/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_fields_(table-_table)_-_format_-_PROTOBUF/6.0.0_1585912761956/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_function_(table-_table)/6.0.0_1585912762364/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_function_(table-_table)/6.0.0_1585912762364/plan.json
@@ -1,0 +1,164 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY INTEGER PRIMARY KEY, USER INTEGER, REGION STRING) WITH (KAFKA_TOPIC='test_topic', KEY='user', VALUE_FORMAT='DELIMITED');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` INTEGER KEY, `USER` INTEGER, `REGION` STRING",
+      "keyField" : "USER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  SUBSTRING(TEST.REGION, 7, 2) KSQL_COL_0,\n  COUNT(*) KSQL_COL_1\nFROM TEST TEST\nGROUP BY SUBSTRING(TEST.REGION, 7, 2)\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` STRING KEY, `KSQL_COL_0` STRING, `KSQL_COL_1` BIGINT",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "DELIMITED"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` INTEGER KEY, `USER` INTEGER, `REGION` STRING"
+                },
+                "selectExpressions" : [ "REGION AS REGION", "ROWTIME AS ROWTIME" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "DELIMITED"
+                }
+              },
+              "groupByExpressions" : [ "SUBSTRING(REGION, 7, 2)" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "DELIMITED"
+              }
+            },
+            "nonAggregateColumns" : [ "REGION", "ROWTIME" ],
+            "aggregationFunctions" : [ "COUNT(ROWTIME)" ]
+          },
+          "selectExpressions" : [ "SUBSTRING(REGION, 7, 2) AS KSQL_COL_0", "KSQL_AGG_VARIABLE_0 AS KSQL_COL_1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_function_(table-_table)/6.0.0_1585912762364/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_function_(table-_table)/6.0.0_1585912762364/spec.json
@@ -1,0 +1,63 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912762364,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<USER INT, REGION VARCHAR> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : "STRUCT<REGION VARCHAR, ROWTIME BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : "STRUCT<REGION VARCHAR, ROWTIME BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<KSQL_COL_0 VARCHAR, KSQL_COL_1 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 1,
+    "value" : "1,prefixr0"
+  }, {
+    "topic" : "test_topic",
+    "key" : 2,
+    "value" : "2,prefixr1"
+  }, {
+    "topic" : "test_topic",
+    "key" : 3,
+    "value" : "3,prefixr0"
+  }, {
+    "topic" : "test_topic",
+    "key" : 1,
+    "value" : null
+  }, {
+    "topic" : "test_topic",
+    "key" : 2,
+    "value" : "2,prefixr0"
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : "r0",
+    "value" : "r0,1"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "r1",
+    "value" : "r1,1"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "r0",
+    "value" : "r0,2"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "r0",
+    "value" : "r0,1"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "r1",
+    "value" : "r1,0"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "r0",
+    "value" : "r0,2"
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "OUTPUT",
+      "type" : "table",
+      "schema" : "ROWKEY STRING KEY, KSQL_COL_0 STRING, KSQL_COL_1 BIGINT"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_function_(table-_table)/6.0.0_1585912762364/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_function_(table-_table)/6.0.0_1585912762364/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_on_join/6.0.0_1585912763734/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_on_join/6.0.0_1585912763734/plan.json
@@ -1,0 +1,224 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE T1 (ROWKEY BIGINT PRIMARY KEY, TOTAL INTEGER) WITH (KAFKA_TOPIC='T1', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "T1",
+      "schema" : "`ROWKEY` BIGINT KEY, `TOTAL` INTEGER",
+      "topicName" : "T1",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE T2 (ROWKEY BIGINT PRIMARY KEY, TOTAL INTEGER) WITH (KAFKA_TOPIC='T2', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "T2",
+      "schema" : "`ROWKEY` BIGINT KEY, `TOTAL` INTEGER",
+      "topicName" : "T2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT SUM((T1.TOTAL + (CASE WHEN (T2.TOTAL IS NULL) THEN 0 ELSE T2.TOTAL END))) SUM\nFROM T1 T1\nLEFT OUTER JOIN T2 T2 ON ((T1.ROWKEY = T2.ROWKEY))\nGROUP BY T1.ROWKEY\nHAVING (COUNT(1) > 0)\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` BIGINT KEY, `SUM` INTEGER",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "T1", "T2" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableFilterV1",
+            "properties" : {
+              "queryContext" : "Aggregate/HavingFilter"
+            },
+            "source" : {
+              "@type" : "tableAggregateV1",
+              "properties" : {
+                "queryContext" : "Aggregate/Aggregate"
+              },
+              "source" : {
+                "@type" : "tableGroupByV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/GroupBy"
+                },
+                "source" : {
+                  "@type" : "tableSelectV1",
+                  "properties" : {
+                    "queryContext" : "Aggregate/Prepare"
+                  },
+                  "source" : {
+                    "@type" : "tableTableJoinV1",
+                    "properties" : {
+                      "queryContext" : "Join"
+                    },
+                    "joinType" : "LEFT",
+                    "leftSource" : {
+                      "@type" : "tableSelectV1",
+                      "properties" : {
+                        "queryContext" : "PrependAliasLeft"
+                      },
+                      "source" : {
+                        "@type" : "tableSourceV1",
+                        "properties" : {
+                          "queryContext" : "KafkaTopic_Left/Source"
+                        },
+                        "topicName" : "T1",
+                        "formats" : {
+                          "keyFormat" : {
+                            "format" : "KAFKA"
+                          },
+                          "valueFormat" : {
+                            "format" : "AVRO"
+                          }
+                        },
+                        "sourceSchema" : "`ROWKEY` BIGINT KEY, `TOTAL` INTEGER"
+                      },
+                      "selectExpressions" : [ "TOTAL AS T1_TOTAL", "ROWTIME AS T1_ROWTIME", "ROWKEY AS T1_ROWKEY" ]
+                    },
+                    "rightSource" : {
+                      "@type" : "tableSelectV1",
+                      "properties" : {
+                        "queryContext" : "PrependAliasRight"
+                      },
+                      "source" : {
+                        "@type" : "tableSourceV1",
+                        "properties" : {
+                          "queryContext" : "KafkaTopic_Right/Source"
+                        },
+                        "topicName" : "T2",
+                        "formats" : {
+                          "keyFormat" : {
+                            "format" : "KAFKA"
+                          },
+                          "valueFormat" : {
+                            "format" : "AVRO"
+                          }
+                        },
+                        "sourceSchema" : "`ROWKEY` BIGINT KEY, `TOTAL` INTEGER"
+                      },
+                      "selectExpressions" : [ "TOTAL AS T2_TOTAL", "ROWTIME AS T2_ROWTIME", "ROWKEY AS T2_ROWKEY" ]
+                    }
+                  },
+                  "selectExpressions" : [ "T1_TOTAL AS T1_TOTAL", "T2_TOTAL AS T2_TOTAL", "T1_ROWKEY AS T1_ROWKEY", "(T1_TOTAL + (CASE WHEN (T2_TOTAL IS NULL) THEN 0 ELSE T2_TOTAL END)) AS KSQL_INTERNAL_COL_3", "1 AS KSQL_INTERNAL_COL_4" ]
+                },
+                "internalFormats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO"
+                  }
+                },
+                "groupByExpressions" : [ "T1_ROWKEY" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "AVRO"
+                }
+              },
+              "nonAggregateColumns" : [ "T1_TOTAL", "T2_TOTAL", "T1_ROWKEY" ],
+              "aggregationFunctions" : [ "SUM(KSQL_INTERNAL_COL_3)", "COUNT(KSQL_INTERNAL_COL_4)" ]
+            },
+            "filterExpression" : "(KSQL_AGG_VARIABLE_1 > 0)"
+          },
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS SUM" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_on_join/6.0.0_1585912763734/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_on_join/6.0.0_1585912763734/spec.json
@@ -1,0 +1,99 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912763734,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<TOTAL INT> NOT NULL",
+    "CTAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<TOTAL INT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : "STRUCT<T1_TOTAL INT, T2_TOTAL INT, T1_ROWKEY BIGINT, KSQL_INTERNAL_COL_3 INT, KSQL_INTERNAL_COL_4 INT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : "STRUCT<T1_TOTAL INT, T2_TOTAL INT, T1_ROWKEY BIGINT, KSQL_AGG_VARIABLE_0 INT, KSQL_AGG_VARIABLE_1 BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<SUM INT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "T1",
+    "key" : 0,
+    "value" : {
+      "total" : 100
+    }
+  }, {
+    "topic" : "T1",
+    "key" : 1,
+    "value" : {
+      "total" : 101
+    }
+  }, {
+    "topic" : "T2",
+    "key" : 0,
+    "value" : {
+      "total" : 5
+    }
+  }, {
+    "topic" : "T2",
+    "key" : 1,
+    "value" : {
+      "total" : 10
+    }
+  }, {
+    "topic" : "T2",
+    "key" : 0,
+    "value" : {
+      "total" : 20
+    }
+  }, {
+    "topic" : "T2",
+    "key" : 0,
+    "value" : null
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "SUM" : 100
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : {
+      "SUM" : 101
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : null
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "SUM" : 105
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : null
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : {
+      "SUM" : 111
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : null
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "SUM" : 120
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : null
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "SUM" : 100
+    }
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_on_join/6.0.0_1585912763734/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_on_join/6.0.0_1585912763734/topology
@@ -1,0 +1,72 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [T1])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [T2])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-FILTER-0000000012 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000014
+      <-- KTABLE-FILTER-0000000012
+    Sink: KSTREAM-SINK-0000000014 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000015 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000016
+    Processor: KTABLE-AGGREGATE-0000000016 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000015
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-HavingFilter-ApplyPredicate
+      <-- KTABLE-AGGREGATE-0000000016
+    Processor: Aggregate-HavingFilter-ApplyPredicate (stores: [])
+      --> Aggregate-HavingFilter-Filter
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-HavingFilter-Filter (stores: [])
+      --> Aggregate-HavingFilter-PostProcess
+      <-- Aggregate-HavingFilter-ApplyPredicate
+    Processor: Aggregate-HavingFilter-PostProcess (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-HavingFilter-Filter
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000022
+      <-- Aggregate-HavingFilter-PostProcess
+    Processor: KTABLE-TOSTREAM-0000000022 (stores: [])
+      --> KSTREAM-SINK-0000000023
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000023 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000022
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_with_aggregate_arithmetic_(table-_table)/6.0.0_1585912762240/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_with_aggregate_arithmetic_(table-_table)/6.0.0_1585912762240/plan.json
@@ -1,0 +1,164 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY INTEGER PRIMARY KEY, USER INTEGER, REGION STRING) WITH (KAFKA_TOPIC='test_topic', KEY='user', VALUE_FORMAT='DELIMITED');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` INTEGER KEY, `USER` INTEGER, `REGION` STRING",
+      "keyField" : "USER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT (COUNT(*) * 2) KSQL_COL_0\nFROM TEST TEST\nGROUP BY TEST.REGION\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` STRING KEY, `KSQL_COL_0` BIGINT",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "DELIMITED"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` INTEGER KEY, `USER` INTEGER, `REGION` STRING"
+                },
+                "selectExpressions" : [ "ROWTIME AS ROWTIME", "REGION AS REGION" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "DELIMITED"
+                }
+              },
+              "groupByExpressions" : [ "REGION" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "DELIMITED"
+              }
+            },
+            "nonAggregateColumns" : [ "ROWTIME", "REGION" ],
+            "aggregationFunctions" : [ "COUNT(ROWTIME)" ]
+          },
+          "selectExpressions" : [ "(KSQL_AGG_VARIABLE_0 * 2) AS KSQL_COL_0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_with_aggregate_arithmetic_(table-_table)/6.0.0_1585912762240/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_with_aggregate_arithmetic_(table-_table)/6.0.0_1585912762240/spec.json
@@ -1,0 +1,63 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912762240,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<USER INT, REGION VARCHAR> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : "STRUCT<ROWTIME BIGINT, REGION VARCHAR> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : "STRUCT<ROWTIME BIGINT, REGION VARCHAR, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<KSQL_COL_0 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 1,
+    "value" : "1,r0"
+  }, {
+    "topic" : "test_topic",
+    "key" : 2,
+    "value" : "2,r1"
+  }, {
+    "topic" : "test_topic",
+    "key" : 3,
+    "value" : "3,r0"
+  }, {
+    "topic" : "test_topic",
+    "key" : 1,
+    "value" : null
+  }, {
+    "topic" : "test_topic",
+    "key" : 2,
+    "value" : "2,r0"
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : "r0",
+    "value" : "2"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "r1",
+    "value" : "2"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "r0",
+    "value" : "4"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "r0",
+    "value" : "2"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "r1",
+    "value" : "0"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "r0",
+    "value" : "4"
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "OUTPUT",
+      "type" : "table",
+      "schema" : "ROWKEY STRING KEY, KSQL_COL_0 BIGINT"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_with_aggregate_arithmetic_(table-_table)/6.0.0_1585912762240/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_with_aggregate_arithmetic_(table-_table)/6.0.0_1585912762240/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_with_aggregate_arithmetic_involving_source_field_(table-_table)/6.0.0_1585912762311/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_with_aggregate_arithmetic_involving_source_field_(table-_table)/6.0.0_1585912762311/plan.json
@@ -1,0 +1,164 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY INTEGER PRIMARY KEY, F0 INTEGER, F1 INTEGER) WITH (KAFKA_TOPIC='test_topic', KEY='f0', VALUE_FORMAT='DELIMITED');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` INTEGER KEY, `F0` INTEGER, `F1` INTEGER",
+      "keyField" : "F0",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT (TEST.F0 * SUM(TEST.F1)) KSQL_COL_0\nFROM TEST TEST\nGROUP BY TEST.F0\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` INTEGER KEY, `KSQL_COL_0` INTEGER",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "DELIMITED"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` INTEGER KEY, `F0` INTEGER, `F1` INTEGER"
+                },
+                "selectExpressions" : [ "F0 AS F0", "F1 AS F1" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "DELIMITED"
+                }
+              },
+              "groupByExpressions" : [ "F0" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "DELIMITED"
+              }
+            },
+            "nonAggregateColumns" : [ "F0", "F1" ],
+            "aggregationFunctions" : [ "SUM(F1)" ]
+          },
+          "selectExpressions" : [ "(F0 * KSQL_AGG_VARIABLE_0) AS KSQL_COL_0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_with_aggregate_arithmetic_involving_source_field_(table-_table)/6.0.0_1585912762311/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_with_aggregate_arithmetic_involving_source_field_(table-_table)/6.0.0_1585912762311/spec.json
@@ -1,0 +1,52 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912762311,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<F0 INT, F1 INT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : "STRUCT<F0 INT, F1 INT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : "STRUCT<F0 INT, F1 INT, KSQL_AGG_VARIABLE_0 INT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<KSQL_COL_0 INT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 2,
+    "value" : "2,10"
+  }, {
+    "topic" : "test_topic",
+    "key" : 2,
+    "value" : "2,20"
+  }, {
+    "topic" : "test_topic",
+    "key" : 2,
+    "value" : "2,30"
+  }, {
+    "topic" : "test_topic",
+    "key" : 2,
+    "value" : null
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 2,
+    "value" : "20"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 2,
+    "value" : "0"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 2,
+    "value" : "40"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 2,
+    "value" : "0"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 2,
+    "value" : "60"
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 2,
+    "value" : "0"
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_with_aggregate_arithmetic_involving_source_field_(table-_table)/6.0.0_1585912762311/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_with_aggregate_arithmetic_involving_source_field_(table-_table)/6.0.0_1585912762311/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_stream_table_join_with_ts_extractor_both_sides_-_AVRO/6.0.0_1585912770147/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_stream_table_join_with_ts_extractor_both_sides_-_AVRO/6.0.0_1585912770147/plan.json
@@ -1,0 +1,208 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM S1 (ROWKEY BIGINT KEY, ID BIGINT, NAME STRING, TS BIGINT) WITH (KAFKA_TOPIC='s1', KEY='ID', TIMESTAMP='TS', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "S1",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `TS` BIGINT",
+      "keyField" : "ID",
+      "timestampColumn" : {
+        "column" : "TS"
+      },
+      "topicName" : "s1",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE T1 (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 STRING, RTS BIGINT) WITH (KAFKA_TOPIC='t1', KEY='ID', TIMESTAMP='RTS', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "T1",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` STRING, `RTS` BIGINT",
+      "keyField" : "ID",
+      "timestampColumn" : {
+        "column" : "RTS"
+      },
+      "topicName" : "t1",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM S1_JOIN_T1 WITH (TIMESTAMP='TS') AS SELECT\n  S1.ID ID,\n  S1.NAME NAME,\n  S1.TS TS,\n  T1.F1 F1,\n  T1.F2 F2\nFROM S1 S1\nINNER JOIN T1 T1 ON ((S1.ID = T1.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "S1_JOIN_T1",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `TS` BIGINT, `F1` STRING, `F2` STRING",
+      "keyField" : "ID",
+      "timestampColumn" : {
+        "column" : "TS"
+      },
+      "topicName" : "S1_JOIN_T1",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "S1", "T1" ],
+      "sink" : "S1_JOIN_T1",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "S1_JOIN_T1"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "AVRO"
+              }
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "s1",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO"
+                  }
+                },
+                "timestampColumn" : {
+                  "column" : "TS"
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `TS` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS S1_ID", "NAME AS S1_NAME", "TS AS S1_TS", "ROWTIME AS S1_ROWTIME", "ROWKEY AS S1_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "t1",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO"
+                  }
+                },
+                "timestampColumn" : {
+                  "column" : "RTS"
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` STRING, `RTS` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T1_ID", "F1 AS T1_F1", "F2 AS T1_F2", "RTS AS T1_RTS", "ROWTIME AS T1_ROWTIME", "ROWKEY AS T1_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "S1_ID AS ID", "S1_NAME AS NAME", "S1_TS AS TS", "T1_F1 AS F1", "T1_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          }
+        },
+        "topicName" : "S1_JOIN_T1",
+        "timestampColumn" : {
+          "column" : "TS"
+        }
+      },
+      "queryId" : "CSAS_S1_JOIN_T1_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_stream_table_join_with_ts_extractor_both_sides_-_AVRO/6.0.0_1585912770147/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_stream_table_join_with_ts_extractor_both_sides_-_AVRO/6.0.0_1585912770147/spec.json
@@ -1,0 +1,92 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912770147,
+  "schemas" : {
+    "CSAS_S1_JOIN_T1_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 VARCHAR, RTS BIGINT> NOT NULL",
+    "CSAS_S1_JOIN_T1_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, TS BIGINT> NOT NULL",
+    "CSAS_S1_JOIN_T1_0.Join.Left" : "STRUCT<S1_ID BIGINT, S1_NAME VARCHAR, S1_TS BIGINT, S1_ROWTIME BIGINT, S1_ROWKEY BIGINT> NOT NULL",
+    "CSAS_S1_JOIN_T1_0.S1_JOIN_T1" : "STRUCT<ID BIGINT, NAME VARCHAR, TS BIGINT, F1 VARCHAR, F2 VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "t1",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : "foo",
+      "RTS" : 10000
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "s1",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "TS" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "t1",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "F1" : "foo",
+      "F2" : "bar",
+      "RTS" : 13000
+    },
+    "timestamp" : 90000
+  }, {
+    "topic" : "s1",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "TS" : 11000
+    },
+    "timestamp" : 800000
+  }, {
+    "topic" : "s1",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "jan",
+      "TS" : 8000
+    },
+    "timestamp" : 0
+  } ],
+  "outputs" : [ {
+    "topic" : "S1_JOIN_T1",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "TS" : 0,
+      "F1" : "blah",
+      "F2" : "foo"
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "S1_JOIN_T1",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "TS" : 11000,
+      "F1" : "foo",
+      "F2" : "bar"
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "S1_JOIN_T1",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "jan",
+      "TS" : 8000,
+      "F1" : "blah",
+      "F2" : "foo"
+    },
+    "timestamp" : 8000
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_stream_table_join_with_ts_extractor_both_sides_-_AVRO/6.0.0_1585912770147/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_stream_table_join_with_ts_extractor_both_sides_-_AVRO/6.0.0_1585912770147/topology
@@ -1,0 +1,33 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [s1])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Source: KSTREAM-SOURCE-0000000000 (topics: [t1])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> ApplyTimestampTransform-S1_JOIN_T1
+      <-- Join
+    Processor: ApplyTimestampTransform-S1_JOIN_T1 (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Project
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Sink: KSTREAM-SINK-0000000009 (topic: S1_JOIN_T1)
+      <-- ApplyTimestampTransform-S1_JOIN_T1
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_stream_table_join_with_ts_extractor_both_sides_-_JSON/6.0.0_1585912770204/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_stream_table_join_with_ts_extractor_both_sides_-_JSON/6.0.0_1585912770204/plan.json
@@ -1,0 +1,208 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM S1 (ROWKEY BIGINT KEY, ID BIGINT, NAME STRING, TS BIGINT) WITH (KAFKA_TOPIC='s1', KEY='ID', TIMESTAMP='TS', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "S1",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `TS` BIGINT",
+      "keyField" : "ID",
+      "timestampColumn" : {
+        "column" : "TS"
+      },
+      "topicName" : "s1",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE T1 (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 STRING, RTS BIGINT) WITH (KAFKA_TOPIC='t1', KEY='ID', TIMESTAMP='RTS', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "T1",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` STRING, `RTS` BIGINT",
+      "keyField" : "ID",
+      "timestampColumn" : {
+        "column" : "RTS"
+      },
+      "topicName" : "t1",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM S1_JOIN_T1 WITH (TIMESTAMP='TS') AS SELECT\n  S1.ID ID,\n  S1.NAME NAME,\n  S1.TS TS,\n  T1.F1 F1,\n  T1.F2 F2\nFROM S1 S1\nINNER JOIN T1 T1 ON ((S1.ID = T1.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "S1_JOIN_T1",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `TS` BIGINT, `F1` STRING, `F2` STRING",
+      "keyField" : "ID",
+      "timestampColumn" : {
+        "column" : "TS"
+      },
+      "topicName" : "S1_JOIN_T1",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "S1", "T1" ],
+      "sink" : "S1_JOIN_T1",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "S1_JOIN_T1"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "s1",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "timestampColumn" : {
+                  "column" : "TS"
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `TS` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS S1_ID", "NAME AS S1_NAME", "TS AS S1_TS", "ROWTIME AS S1_ROWTIME", "ROWKEY AS S1_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "t1",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "timestampColumn" : {
+                  "column" : "RTS"
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` STRING, `RTS` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T1_ID", "F1 AS T1_F1", "F2 AS T1_F2", "RTS AS T1_RTS", "ROWTIME AS T1_ROWTIME", "ROWKEY AS T1_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "S1_ID AS ID", "S1_NAME AS NAME", "S1_TS AS TS", "T1_F1 AS F1", "T1_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "S1_JOIN_T1",
+        "timestampColumn" : {
+          "column" : "TS"
+        }
+      },
+      "queryId" : "CSAS_S1_JOIN_T1_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_stream_table_join_with_ts_extractor_both_sides_-_JSON/6.0.0_1585912770204/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_stream_table_join_with_ts_extractor_both_sides_-_JSON/6.0.0_1585912770204/spec.json
@@ -1,0 +1,92 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912770204,
+  "schemas" : {
+    "CSAS_S1_JOIN_T1_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 VARCHAR, RTS BIGINT> NOT NULL",
+    "CSAS_S1_JOIN_T1_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, TS BIGINT> NOT NULL",
+    "CSAS_S1_JOIN_T1_0.Join.Left" : "STRUCT<S1_ID BIGINT, S1_NAME VARCHAR, S1_TS BIGINT, S1_ROWTIME BIGINT, S1_ROWKEY BIGINT> NOT NULL",
+    "CSAS_S1_JOIN_T1_0.S1_JOIN_T1" : "STRUCT<ID BIGINT, NAME VARCHAR, TS BIGINT, F1 VARCHAR, F2 VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "t1",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : "foo",
+      "RTS" : 10000
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "s1",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "TS" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "t1",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "F1" : "foo",
+      "F2" : "bar",
+      "RTS" : 13000
+    },
+    "timestamp" : 90000
+  }, {
+    "topic" : "s1",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "TS" : 11000
+    },
+    "timestamp" : 800000
+  }, {
+    "topic" : "s1",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "jan",
+      "TS" : 8000
+    },
+    "timestamp" : 0
+  } ],
+  "outputs" : [ {
+    "topic" : "S1_JOIN_T1",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "TS" : 0,
+      "F1" : "blah",
+      "F2" : "foo"
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "S1_JOIN_T1",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "TS" : 11000,
+      "F1" : "foo",
+      "F2" : "bar"
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "S1_JOIN_T1",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "jan",
+      "TS" : 8000,
+      "F1" : "blah",
+      "F2" : "foo"
+    },
+    "timestamp" : 8000
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_stream_table_join_with_ts_extractor_both_sides_-_JSON/6.0.0_1585912770204/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_stream_table_join_with_ts_extractor_both_sides_-_JSON/6.0.0_1585912770204/topology
@@ -1,0 +1,33 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [s1])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Source: KSTREAM-SOURCE-0000000000 (topics: [t1])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> ApplyTimestampTransform-S1_JOIN_T1
+      <-- Join
+    Processor: ApplyTimestampTransform-S1_JOIN_T1 (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Project
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Sink: KSTREAM-SINK-0000000009 (topic: S1_JOIN_T1)
+      <-- ApplyTimestampTransform-S1_JOIN_T1
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_stream_table_join_with_ts_extractor_both_sides_-_PROTOBUF/6.0.0_1585912770284/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_stream_table_join_with_ts_extractor_both_sides_-_PROTOBUF/6.0.0_1585912770284/plan.json
@@ -1,0 +1,208 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM S1 (ROWKEY BIGINT KEY, ID BIGINT, NAME STRING, TS BIGINT) WITH (KAFKA_TOPIC='s1', KEY='ID', TIMESTAMP='TS', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "S1",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `TS` BIGINT",
+      "keyField" : "ID",
+      "timestampColumn" : {
+        "column" : "TS"
+      },
+      "topicName" : "s1",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE T1 (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 STRING, RTS BIGINT) WITH (KAFKA_TOPIC='t1', KEY='ID', TIMESTAMP='RTS', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "T1",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` STRING, `RTS` BIGINT",
+      "keyField" : "ID",
+      "timestampColumn" : {
+        "column" : "RTS"
+      },
+      "topicName" : "t1",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM S1_JOIN_T1 WITH (TIMESTAMP='TS') AS SELECT\n  S1.ID ID,\n  S1.NAME NAME,\n  S1.TS TS,\n  T1.F1 F1,\n  T1.F2 F2\nFROM S1 S1\nINNER JOIN T1 T1 ON ((S1.ID = T1.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "S1_JOIN_T1",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `TS` BIGINT, `F1` STRING, `F2` STRING",
+      "keyField" : "ID",
+      "timestampColumn" : {
+        "column" : "TS"
+      },
+      "topicName" : "S1_JOIN_T1",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "S1", "T1" ],
+      "sink" : "S1_JOIN_T1",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "S1_JOIN_T1"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF"
+              }
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "s1",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF"
+                  }
+                },
+                "timestampColumn" : {
+                  "column" : "TS"
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `TS` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS S1_ID", "NAME AS S1_NAME", "TS AS S1_TS", "ROWTIME AS S1_ROWTIME", "ROWKEY AS S1_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "t1",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF"
+                  }
+                },
+                "timestampColumn" : {
+                  "column" : "RTS"
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` STRING, `RTS` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T1_ID", "F1 AS T1_F1", "F2 AS T1_F2", "RTS AS T1_RTS", "ROWTIME AS T1_ROWTIME", "ROWKEY AS T1_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "S1_ID AS ID", "S1_NAME AS NAME", "S1_TS AS TS", "T1_F1 AS F1", "T1_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          }
+        },
+        "topicName" : "S1_JOIN_T1",
+        "timestampColumn" : {
+          "column" : "TS"
+        }
+      },
+      "queryId" : "CSAS_S1_JOIN_T1_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_stream_table_join_with_ts_extractor_both_sides_-_PROTOBUF/6.0.0_1585912770284/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_stream_table_join_with_ts_extractor_both_sides_-_PROTOBUF/6.0.0_1585912770284/spec.json
@@ -1,0 +1,92 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912770284,
+  "schemas" : {
+    "CSAS_S1_JOIN_T1_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 VARCHAR, RTS BIGINT> NOT NULL",
+    "CSAS_S1_JOIN_T1_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, TS BIGINT> NOT NULL",
+    "CSAS_S1_JOIN_T1_0.Join.Left" : "STRUCT<S1_ID BIGINT, S1_NAME VARCHAR, S1_TS BIGINT, S1_ROWTIME BIGINT, S1_ROWKEY BIGINT> NOT NULL",
+    "CSAS_S1_JOIN_T1_0.S1_JOIN_T1" : "STRUCT<ID BIGINT, NAME VARCHAR, TS BIGINT, F1 VARCHAR, F2 VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "t1",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : "foo",
+      "RTS" : 10000
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "s1",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "TS" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "t1",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "F1" : "foo",
+      "F2" : "bar",
+      "RTS" : 13000
+    },
+    "timestamp" : 90000
+  }, {
+    "topic" : "s1",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "TS" : 11000
+    },
+    "timestamp" : 800000
+  }, {
+    "topic" : "s1",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "jan",
+      "TS" : 8000
+    },
+    "timestamp" : 0
+  } ],
+  "outputs" : [ {
+    "topic" : "S1_JOIN_T1",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "TS" : 0,
+      "F1" : "blah",
+      "F2" : "foo"
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "S1_JOIN_T1",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "TS" : 11000,
+      "F1" : "foo",
+      "F2" : "bar"
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "S1_JOIN_T1",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "jan",
+      "TS" : 8000,
+      "F1" : "blah",
+      "F2" : "foo"
+    },
+    "timestamp" : 8000
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_stream_table_join_with_ts_extractor_both_sides_-_PROTOBUF/6.0.0_1585912770284/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_stream_table_join_with_ts_extractor_both_sides_-_PROTOBUF/6.0.0_1585912770284/topology
@@ -1,0 +1,33 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [s1])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Source: KSTREAM-SOURCE-0000000000 (topics: [t1])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> ApplyTimestampTransform-S1_JOIN_T1
+      <-- Join
+    Processor: ApplyTimestampTransform-S1_JOIN_T1 (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Project
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Sink: KSTREAM-SINK-0000000009 (topic: S1_JOIN_T1)
+      <-- ApplyTimestampTransform-S1_JOIN_T1
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_-_AVRO/6.0.0_1585912770341/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_-_AVRO/6.0.0_1585912770341/plan.json
@@ -1,0 +1,194 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S1 (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, NAME STRING, TS BIGINT) WITH (KAFKA_TOPIC='s1', KEY='ID', TIMESTAMP='TS', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S1",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `TS` BIGINT",
+      "keyField" : "ID",
+      "timestampColumn" : {
+        "column" : "TS"
+      },
+      "topicName" : "s1",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 STRING) WITH (KAFKA_TOPIC='s2', KEY='ID', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` STRING",
+      "keyField" : "ID",
+      "topicName" : "s2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S1_JOIN_S2 WITH (TIMESTAMP='TS') AS SELECT\n  S1.ID ID,\n  S1.NAME NAME,\n  S1.TS TS,\n  S2.F1 F1,\n  S2.F2 F2\nFROM S1 S1\nINNER JOIN S2 S2 ON ((S1.ID = S2.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S1_JOIN_S2",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `TS` BIGINT, `F1` STRING, `F2` STRING",
+      "keyField" : "ID",
+      "timestampColumn" : {
+        "column" : "TS"
+      },
+      "topicName" : "S1_JOIN_S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "S1", "S2" ],
+      "sink" : "S1_JOIN_S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S1_JOIN_S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "s1",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO"
+                  }
+                },
+                "timestampColumn" : {
+                  "column" : "TS"
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `TS` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS S1_ID", "NAME AS S1_NAME", "TS AS S1_TS", "ROWTIME AS S1_ROWTIME", "ROWKEY AS S1_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "s2",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` STRING"
+              },
+              "selectExpressions" : [ "ID AS S2_ID", "F1 AS S2_F1", "F2 AS S2_F2", "ROWTIME AS S2_ROWTIME", "ROWKEY AS S2_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "S1_ID AS ID", "S1_NAME AS NAME", "S1_TS AS TS", "S2_F1 AS F1", "S2_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          }
+        },
+        "topicName" : "S1_JOIN_S2",
+        "timestampColumn" : {
+          "column" : "TS"
+        }
+      },
+      "queryId" : "CTAS_S1_JOIN_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_-_AVRO/6.0.0_1585912770341/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_-_AVRO/6.0.0_1585912770341/spec.json
@@ -1,0 +1,89 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912770341,
+  "schemas" : {
+    "CTAS_S1_JOIN_S2_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, TS BIGINT> NOT NULL",
+    "CTAS_S1_JOIN_S2_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 VARCHAR> NOT NULL",
+    "CTAS_S1_JOIN_S2_0.S1_JOIN_S2" : "STRUCT<ID BIGINT, NAME VARCHAR, TS BIGINT, F1 VARCHAR, F2 VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "s1",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "TS" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "s2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : "foo"
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "s2",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "F1" : "foo",
+      "F2" : "bar"
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "s1",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "TS" : 19000
+    },
+    "timestamp" : 22000
+  }, {
+    "topic" : "s1",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "jan",
+      "TS" : 18000
+    },
+    "timestamp" : 33000
+  } ],
+  "outputs" : [ {
+    "topic" : "S1_JOIN_S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "TS" : 0,
+      "F1" : "blah",
+      "F2" : "foo"
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "S1_JOIN_S2",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "TS" : 19000,
+      "F1" : "foo",
+      "F2" : "bar"
+    },
+    "timestamp" : 19000
+  }, {
+    "topic" : "S1_JOIN_S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "jan",
+      "TS" : 18000,
+      "F1" : "blah",
+      "F2" : "foo"
+    },
+    "timestamp" : 18000
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_-_AVRO/6.0.0_1585912770341/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_-_AVRO/6.0.0_1585912770341/topology
@@ -1,0 +1,45 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [s1])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [s2])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> ApplyTimestampTransform-S1_JOIN_S2
+      <-- Project
+    Processor: ApplyTimestampTransform-S1_JOIN_S2 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- KTABLE-TOSTREAM-0000000012
+    Sink: KSTREAM-SINK-0000000013 (topic: S1_JOIN_S2)
+      <-- ApplyTimestampTransform-S1_JOIN_S2
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_-_JSON/6.0.0_1585912770394/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_-_JSON/6.0.0_1585912770394/plan.json
@@ -1,0 +1,194 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S1 (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, NAME STRING, TS BIGINT) WITH (KAFKA_TOPIC='s1', KEY='ID', TIMESTAMP='TS', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S1",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `TS` BIGINT",
+      "keyField" : "ID",
+      "timestampColumn" : {
+        "column" : "TS"
+      },
+      "topicName" : "s1",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 STRING) WITH (KAFKA_TOPIC='s2', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` STRING",
+      "keyField" : "ID",
+      "topicName" : "s2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S1_JOIN_S2 WITH (TIMESTAMP='TS') AS SELECT\n  S1.ID ID,\n  S1.NAME NAME,\n  S1.TS TS,\n  S2.F1 F1,\n  S2.F2 F2\nFROM S1 S1\nINNER JOIN S2 S2 ON ((S1.ID = S2.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S1_JOIN_S2",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `TS` BIGINT, `F1` STRING, `F2` STRING",
+      "keyField" : "ID",
+      "timestampColumn" : {
+        "column" : "TS"
+      },
+      "topicName" : "S1_JOIN_S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "S1", "S2" ],
+      "sink" : "S1_JOIN_S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S1_JOIN_S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "s1",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "timestampColumn" : {
+                  "column" : "TS"
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `TS` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS S1_ID", "NAME AS S1_NAME", "TS AS S1_TS", "ROWTIME AS S1_ROWTIME", "ROWKEY AS S1_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "s2",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` STRING"
+              },
+              "selectExpressions" : [ "ID AS S2_ID", "F1 AS S2_F1", "F2 AS S2_F2", "ROWTIME AS S2_ROWTIME", "ROWKEY AS S2_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "S1_ID AS ID", "S1_NAME AS NAME", "S1_TS AS TS", "S2_F1 AS F1", "S2_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "S1_JOIN_S2",
+        "timestampColumn" : {
+          "column" : "TS"
+        }
+      },
+      "queryId" : "CTAS_S1_JOIN_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_-_JSON/6.0.0_1585912770394/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_-_JSON/6.0.0_1585912770394/spec.json
@@ -1,0 +1,89 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912770394,
+  "schemas" : {
+    "CTAS_S1_JOIN_S2_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, TS BIGINT> NOT NULL",
+    "CTAS_S1_JOIN_S2_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 VARCHAR> NOT NULL",
+    "CTAS_S1_JOIN_S2_0.S1_JOIN_S2" : "STRUCT<ID BIGINT, NAME VARCHAR, TS BIGINT, F1 VARCHAR, F2 VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "s1",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "TS" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "s2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : "foo"
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "s2",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "F1" : "foo",
+      "F2" : "bar"
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "s1",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "TS" : 19000
+    },
+    "timestamp" : 22000
+  }, {
+    "topic" : "s1",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "jan",
+      "TS" : 18000
+    },
+    "timestamp" : 33000
+  } ],
+  "outputs" : [ {
+    "topic" : "S1_JOIN_S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "TS" : 0,
+      "F1" : "blah",
+      "F2" : "foo"
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "S1_JOIN_S2",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "TS" : 19000,
+      "F1" : "foo",
+      "F2" : "bar"
+    },
+    "timestamp" : 19000
+  }, {
+    "topic" : "S1_JOIN_S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "jan",
+      "TS" : 18000,
+      "F1" : "blah",
+      "F2" : "foo"
+    },
+    "timestamp" : 18000
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_-_JSON/6.0.0_1585912770394/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_-_JSON/6.0.0_1585912770394/topology
@@ -1,0 +1,45 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [s1])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [s2])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> ApplyTimestampTransform-S1_JOIN_S2
+      <-- Project
+    Processor: ApplyTimestampTransform-S1_JOIN_S2 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- KTABLE-TOSTREAM-0000000012
+    Sink: KSTREAM-SINK-0000000013 (topic: S1_JOIN_S2)
+      <-- ApplyTimestampTransform-S1_JOIN_S2
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_-_PROTOBUF/6.0.0_1585912770446/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_-_PROTOBUF/6.0.0_1585912770446/plan.json
@@ -1,0 +1,194 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S1 (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, NAME STRING, TS BIGINT) WITH (KAFKA_TOPIC='s1', KEY='ID', TIMESTAMP='TS', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S1",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `TS` BIGINT",
+      "keyField" : "ID",
+      "timestampColumn" : {
+        "column" : "TS"
+      },
+      "topicName" : "s1",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 STRING) WITH (KAFKA_TOPIC='s2', KEY='ID', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` STRING",
+      "keyField" : "ID",
+      "topicName" : "s2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S1_JOIN_S2 WITH (TIMESTAMP='TS') AS SELECT\n  S1.ID ID,\n  S1.NAME NAME,\n  S1.TS TS,\n  S2.F1 F1,\n  S2.F2 F2\nFROM S1 S1\nINNER JOIN S2 S2 ON ((S1.ID = S2.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S1_JOIN_S2",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `TS` BIGINT, `F1` STRING, `F2` STRING",
+      "keyField" : "ID",
+      "timestampColumn" : {
+        "column" : "TS"
+      },
+      "topicName" : "S1_JOIN_S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "S1", "S2" ],
+      "sink" : "S1_JOIN_S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S1_JOIN_S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "s1",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF"
+                  }
+                },
+                "timestampColumn" : {
+                  "column" : "TS"
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `TS` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS S1_ID", "NAME AS S1_NAME", "TS AS S1_TS", "ROWTIME AS S1_ROWTIME", "ROWKEY AS S1_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "s2",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` STRING"
+              },
+              "selectExpressions" : [ "ID AS S2_ID", "F1 AS S2_F1", "F2 AS S2_F2", "ROWTIME AS S2_ROWTIME", "ROWKEY AS S2_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "S1_ID AS ID", "S1_NAME AS NAME", "S1_TS AS TS", "S2_F1 AS F1", "S2_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          }
+        },
+        "topicName" : "S1_JOIN_S2",
+        "timestampColumn" : {
+          "column" : "TS"
+        }
+      },
+      "queryId" : "CTAS_S1_JOIN_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_-_PROTOBUF/6.0.0_1585912770446/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_-_PROTOBUF/6.0.0_1585912770446/spec.json
@@ -1,0 +1,89 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912770446,
+  "schemas" : {
+    "CTAS_S1_JOIN_S2_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, TS BIGINT> NOT NULL",
+    "CTAS_S1_JOIN_S2_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 VARCHAR> NOT NULL",
+    "CTAS_S1_JOIN_S2_0.S1_JOIN_S2" : "STRUCT<ID BIGINT, NAME VARCHAR, TS BIGINT, F1 VARCHAR, F2 VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "s1",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "TS" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "s2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : "foo"
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "s2",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "F1" : "foo",
+      "F2" : "bar"
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "s1",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "TS" : 19000
+    },
+    "timestamp" : 22000
+  }, {
+    "topic" : "s1",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "jan",
+      "TS" : 18000
+    },
+    "timestamp" : 33000
+  } ],
+  "outputs" : [ {
+    "topic" : "S1_JOIN_S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "TS" : 0,
+      "F1" : "blah",
+      "F2" : "foo"
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "S1_JOIN_S2",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "TS" : 19000,
+      "F1" : "foo",
+      "F2" : "bar"
+    },
+    "timestamp" : 19000
+  }, {
+    "topic" : "S1_JOIN_S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "jan",
+      "TS" : 18000,
+      "F1" : "blah",
+      "F2" : "foo"
+    },
+    "timestamp" : 18000
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_-_PROTOBUF/6.0.0_1585912770446/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_-_PROTOBUF/6.0.0_1585912770446/topology
@@ -1,0 +1,45 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [s1])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [s2])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> ApplyTimestampTransform-S1_JOIN_S2
+      <-- Project
+    Processor: ApplyTimestampTransform-S1_JOIN_S2 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- KTABLE-TOSTREAM-0000000012
+    Sink: KSTREAM-SINK-0000000013 (topic: S1_JOIN_S2)
+      <-- ApplyTimestampTransform-S1_JOIN_S2
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_extractor_both_sides_-_AVRO/6.0.0_1585912770499/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_extractor_both_sides_-_AVRO/6.0.0_1585912770499/plan.json
@@ -1,0 +1,200 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S1 (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, NAME STRING, TS BIGINT) WITH (KAFKA_TOPIC='s1', KEY='ID', TIMESTAMP='TS', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S1",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `TS` BIGINT",
+      "keyField" : "ID",
+      "timestampColumn" : {
+        "column" : "TS"
+      },
+      "topicName" : "s1",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 STRING, RTS BIGINT) WITH (KAFKA_TOPIC='s2', KEY='ID', TIMESTAMP='RTS', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` STRING, `RTS` BIGINT",
+      "keyField" : "ID",
+      "timestampColumn" : {
+        "column" : "RTS"
+      },
+      "topicName" : "s2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S1_JOIN_S2 WITH (TIMESTAMP='TS') AS SELECT\n  S1.ID ID,\n  S1.NAME NAME,\n  S1.TS TS,\n  S2.F1 F1,\n  S2.F2 F2\nFROM S1 S1\nINNER JOIN S2 S2 ON ((S1.ID = S2.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S1_JOIN_S2",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `TS` BIGINT, `F1` STRING, `F2` STRING",
+      "keyField" : "ID",
+      "timestampColumn" : {
+        "column" : "TS"
+      },
+      "topicName" : "S1_JOIN_S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "S1", "S2" ],
+      "sink" : "S1_JOIN_S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S1_JOIN_S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "s1",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO"
+                  }
+                },
+                "timestampColumn" : {
+                  "column" : "TS"
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `TS` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS S1_ID", "NAME AS S1_NAME", "TS AS S1_TS", "ROWTIME AS S1_ROWTIME", "ROWKEY AS S1_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "s2",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO"
+                  }
+                },
+                "timestampColumn" : {
+                  "column" : "RTS"
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` STRING, `RTS` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS S2_ID", "F1 AS S2_F1", "F2 AS S2_F2", "RTS AS S2_RTS", "ROWTIME AS S2_ROWTIME", "ROWKEY AS S2_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "S1_ID AS ID", "S1_NAME AS NAME", "S1_TS AS TS", "S2_F1 AS F1", "S2_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          }
+        },
+        "topicName" : "S1_JOIN_S2",
+        "timestampColumn" : {
+          "column" : "TS"
+        }
+      },
+      "queryId" : "CTAS_S1_JOIN_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_extractor_both_sides_-_AVRO/6.0.0_1585912770499/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_extractor_both_sides_-_AVRO/6.0.0_1585912770499/spec.json
@@ -1,0 +1,91 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912770499,
+  "schemas" : {
+    "CTAS_S1_JOIN_S2_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, TS BIGINT> NOT NULL",
+    "CTAS_S1_JOIN_S2_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 VARCHAR, RTS BIGINT> NOT NULL",
+    "CTAS_S1_JOIN_S2_0.S1_JOIN_S2" : "STRUCT<ID BIGINT, NAME VARCHAR, TS BIGINT, F1 VARCHAR, F2 VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "s1",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "TS" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "s2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : "foo",
+      "RTS" : 10000
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "s2",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "F1" : "foo",
+      "F2" : "bar",
+      "RTS" : 13000
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "s1",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "TS" : 11000
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "s1",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "jan",
+      "TS" : 8000
+    },
+    "timestamp" : 0
+  } ],
+  "outputs" : [ {
+    "topic" : "S1_JOIN_S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "TS" : 0,
+      "F1" : "blah",
+      "F2" : "foo"
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "S1_JOIN_S2",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "TS" : 11000,
+      "F1" : "foo",
+      "F2" : "bar"
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "S1_JOIN_S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "jan",
+      "TS" : 8000,
+      "F1" : "blah",
+      "F2" : "foo"
+    },
+    "timestamp" : 8000
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_extractor_both_sides_-_AVRO/6.0.0_1585912770499/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_extractor_both_sides_-_AVRO/6.0.0_1585912770499/topology
@@ -1,0 +1,45 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [s1])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [s2])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> ApplyTimestampTransform-S1_JOIN_S2
+      <-- Project
+    Processor: ApplyTimestampTransform-S1_JOIN_S2 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- KTABLE-TOSTREAM-0000000012
+    Sink: KSTREAM-SINK-0000000013 (topic: S1_JOIN_S2)
+      <-- ApplyTimestampTransform-S1_JOIN_S2
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_extractor_both_sides_-_JSON/6.0.0_1585912770556/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_extractor_both_sides_-_JSON/6.0.0_1585912770556/plan.json
@@ -1,0 +1,200 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S1 (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, NAME STRING, TS BIGINT) WITH (KAFKA_TOPIC='s1', KEY='ID', TIMESTAMP='TS', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S1",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `TS` BIGINT",
+      "keyField" : "ID",
+      "timestampColumn" : {
+        "column" : "TS"
+      },
+      "topicName" : "s1",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 STRING, RTS BIGINT) WITH (KAFKA_TOPIC='s2', KEY='ID', TIMESTAMP='RTS', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` STRING, `RTS` BIGINT",
+      "keyField" : "ID",
+      "timestampColumn" : {
+        "column" : "RTS"
+      },
+      "topicName" : "s2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S1_JOIN_S2 WITH (TIMESTAMP='TS') AS SELECT\n  S1.ID ID,\n  S1.NAME NAME,\n  S1.TS TS,\n  S2.F1 F1,\n  S2.F2 F2\nFROM S1 S1\nINNER JOIN S2 S2 ON ((S1.ID = S2.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S1_JOIN_S2",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `TS` BIGINT, `F1` STRING, `F2` STRING",
+      "keyField" : "ID",
+      "timestampColumn" : {
+        "column" : "TS"
+      },
+      "topicName" : "S1_JOIN_S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "S1", "S2" ],
+      "sink" : "S1_JOIN_S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S1_JOIN_S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "s1",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "timestampColumn" : {
+                  "column" : "TS"
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `TS` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS S1_ID", "NAME AS S1_NAME", "TS AS S1_TS", "ROWTIME AS S1_ROWTIME", "ROWKEY AS S1_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "s2",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "timestampColumn" : {
+                  "column" : "RTS"
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` STRING, `RTS` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS S2_ID", "F1 AS S2_F1", "F2 AS S2_F2", "RTS AS S2_RTS", "ROWTIME AS S2_ROWTIME", "ROWKEY AS S2_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "S1_ID AS ID", "S1_NAME AS NAME", "S1_TS AS TS", "S2_F1 AS F1", "S2_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "S1_JOIN_S2",
+        "timestampColumn" : {
+          "column" : "TS"
+        }
+      },
+      "queryId" : "CTAS_S1_JOIN_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_extractor_both_sides_-_JSON/6.0.0_1585912770556/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_extractor_both_sides_-_JSON/6.0.0_1585912770556/spec.json
@@ -1,0 +1,91 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912770556,
+  "schemas" : {
+    "CTAS_S1_JOIN_S2_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, TS BIGINT> NOT NULL",
+    "CTAS_S1_JOIN_S2_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 VARCHAR, RTS BIGINT> NOT NULL",
+    "CTAS_S1_JOIN_S2_0.S1_JOIN_S2" : "STRUCT<ID BIGINT, NAME VARCHAR, TS BIGINT, F1 VARCHAR, F2 VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "s1",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "TS" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "s2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : "foo",
+      "RTS" : 10000
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "s2",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "F1" : "foo",
+      "F2" : "bar",
+      "RTS" : 13000
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "s1",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "TS" : 11000
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "s1",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "jan",
+      "TS" : 8000
+    },
+    "timestamp" : 0
+  } ],
+  "outputs" : [ {
+    "topic" : "S1_JOIN_S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "TS" : 0,
+      "F1" : "blah",
+      "F2" : "foo"
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "S1_JOIN_S2",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "TS" : 11000,
+      "F1" : "foo",
+      "F2" : "bar"
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "S1_JOIN_S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "jan",
+      "TS" : 8000,
+      "F1" : "blah",
+      "F2" : "foo"
+    },
+    "timestamp" : 8000
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_extractor_both_sides_-_JSON/6.0.0_1585912770556/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_extractor_both_sides_-_JSON/6.0.0_1585912770556/topology
@@ -1,0 +1,45 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [s1])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [s2])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> ApplyTimestampTransform-S1_JOIN_S2
+      <-- Project
+    Processor: ApplyTimestampTransform-S1_JOIN_S2 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- KTABLE-TOSTREAM-0000000012
+    Sink: KSTREAM-SINK-0000000013 (topic: S1_JOIN_S2)
+      <-- ApplyTimestampTransform-S1_JOIN_S2
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_extractor_both_sides_-_PROTOBUF/6.0.0_1585912770618/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_extractor_both_sides_-_PROTOBUF/6.0.0_1585912770618/plan.json
@@ -1,0 +1,200 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S1 (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, NAME STRING, TS BIGINT) WITH (KAFKA_TOPIC='s1', KEY='ID', TIMESTAMP='TS', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S1",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `TS` BIGINT",
+      "keyField" : "ID",
+      "timestampColumn" : {
+        "column" : "TS"
+      },
+      "topicName" : "s1",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 STRING, RTS BIGINT) WITH (KAFKA_TOPIC='s2', KEY='ID', TIMESTAMP='RTS', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` STRING, `RTS` BIGINT",
+      "keyField" : "ID",
+      "timestampColumn" : {
+        "column" : "RTS"
+      },
+      "topicName" : "s2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S1_JOIN_S2 WITH (TIMESTAMP='TS') AS SELECT\n  S1.ID ID,\n  S1.NAME NAME,\n  S1.TS TS,\n  S2.F1 F1,\n  S2.F2 F2\nFROM S1 S1\nINNER JOIN S2 S2 ON ((S1.ID = S2.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S1_JOIN_S2",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `TS` BIGINT, `F1` STRING, `F2` STRING",
+      "keyField" : "ID",
+      "timestampColumn" : {
+        "column" : "TS"
+      },
+      "topicName" : "S1_JOIN_S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "S1", "S2" ],
+      "sink" : "S1_JOIN_S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S1_JOIN_S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "s1",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF"
+                  }
+                },
+                "timestampColumn" : {
+                  "column" : "TS"
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `TS` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS S1_ID", "NAME AS S1_NAME", "TS AS S1_TS", "ROWTIME AS S1_ROWTIME", "ROWKEY AS S1_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "s2",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF"
+                  }
+                },
+                "timestampColumn" : {
+                  "column" : "RTS"
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` STRING, `RTS` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS S2_ID", "F1 AS S2_F1", "F2 AS S2_F2", "RTS AS S2_RTS", "ROWTIME AS S2_ROWTIME", "ROWKEY AS S2_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "S1_ID AS ID", "S1_NAME AS NAME", "S1_TS AS TS", "S2_F1 AS F1", "S2_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          }
+        },
+        "topicName" : "S1_JOIN_S2",
+        "timestampColumn" : {
+          "column" : "TS"
+        }
+      },
+      "queryId" : "CTAS_S1_JOIN_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_extractor_both_sides_-_PROTOBUF/6.0.0_1585912770618/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_extractor_both_sides_-_PROTOBUF/6.0.0_1585912770618/spec.json
@@ -1,0 +1,91 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912770618,
+  "schemas" : {
+    "CTAS_S1_JOIN_S2_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, TS BIGINT> NOT NULL",
+    "CTAS_S1_JOIN_S2_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 VARCHAR, RTS BIGINT> NOT NULL",
+    "CTAS_S1_JOIN_S2_0.S1_JOIN_S2" : "STRUCT<ID BIGINT, NAME VARCHAR, TS BIGINT, F1 VARCHAR, F2 VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "s1",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "TS" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "s2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : "foo",
+      "RTS" : 10000
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "s2",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "F1" : "foo",
+      "F2" : "bar",
+      "RTS" : 13000
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "s1",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "TS" : 11000
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "s1",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "jan",
+      "TS" : 8000
+    },
+    "timestamp" : 0
+  } ],
+  "outputs" : [ {
+    "topic" : "S1_JOIN_S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "TS" : 0,
+      "F1" : "blah",
+      "F2" : "foo"
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "S1_JOIN_S2",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "TS" : 11000,
+      "F1" : "foo",
+      "F2" : "bar"
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "S1_JOIN_S2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "jan",
+      "TS" : 8000,
+      "F1" : "blah",
+      "F2" : "foo"
+    },
+    "timestamp" : 8000
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_extractor_both_sides_-_PROTOBUF/6.0.0_1585912770618/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/join-with-custom-timestamp_-_table_table_inner_join_with_ts_extractor_both_sides_-_PROTOBUF/6.0.0_1585912770618/topology
@@ -1,0 +1,45 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [s1])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [s2])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> ApplyTimestampTransform-S1_JOIN_S2
+      <-- Project
+    Processor: ApplyTimestampTransform-S1_JOIN_S2 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- KTABLE-TOSTREAM-0000000012
+    Sink: KSTREAM-SINK-0000000013 (topic: S1_JOIN_S2)
+      <-- ApplyTimestampTransform-S1_JOIN_S2
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_AVRO/6.0.0_1585912767886/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_AVRO/6.0.0_1585912767886/plan.json
@@ -1,0 +1,190 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='test_table', KEY='ID', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_table",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_TABLE TT ON ((T.ROWKEY = TT.ROWKEY))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "T_ID",
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "AVRO"
+              }
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "test_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "test_table",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          }
+        },
+        "topicName" : "INNER_JOIN"
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_AVRO/6.0.0_1585912767886/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_AVRO/6.0.0_1585912767886/spec.json
@@ -1,0 +1,114 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912767886,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "test_table",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "F1" : "100",
+      "F2" : 5
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 15000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "INNER_JOIN",
+      "type" : "stream"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_AVRO/6.0.0_1585912767886/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_AVRO/6.0.0_1585912767886/topology
@@ -1,0 +1,30 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: INNER_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_JSON/6.0.0_1585912767934/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_JSON/6.0.0_1585912767934/plan.json
@@ -1,0 +1,190 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='test_table', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_table",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_TABLE TT ON ((T.ROWKEY = TT.ROWKEY))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "T_ID",
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "test_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "test_table",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "INNER_JOIN"
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_JSON/6.0.0_1585912767934/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_JSON/6.0.0_1585912767934/spec.json
@@ -1,0 +1,114 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912767934,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "test_table",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "F1" : "100",
+      "F2" : 5
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 15000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "INNER_JOIN",
+      "type" : "stream"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_JSON/6.0.0_1585912767934/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_JSON/6.0.0_1585912767934/topology
@@ -1,0 +1,30 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: INNER_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_PROTOBUF/6.0.0_1585912767980/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_PROTOBUF/6.0.0_1585912767980/plan.json
@@ -1,0 +1,190 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='test_table', KEY='ID', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_table",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_TABLE TT ON ((T.ROWKEY = TT.ROWKEY))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "T_ID",
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF"
+              }
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "test_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "test_table",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          }
+        },
+        "topicName" : "INNER_JOIN"
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_PROTOBUF/6.0.0_1585912767980/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_PROTOBUF/6.0.0_1585912767980/spec.json
@@ -1,0 +1,114 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912767980,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "test_table",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "F1" : "100",
+      "F2" : 5
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 15000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "INNER_JOIN",
+      "type" : "stream"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_PROTOBUF/6.0.0_1585912767980/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_PROTOBUF/6.0.0_1585912767980/topology
@@ -1,0 +1,30 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: INNER_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_join_key_not_in_projection/6.0.0_1585912768079/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_join_key_not_in_projection/6.0.0_1585912768079/plan.json
@@ -1,0 +1,189 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='test_table', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_table",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_TABLE TT ON ((T.ROWKEY = TT.ROWKEY))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "test_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "test_table",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "INNER_JOIN"
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_join_key_not_in_projection/6.0.0_1585912768079/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_join_key_not_in_projection/6.0.0_1585912768079/spec.json
@@ -1,0 +1,111 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912768079,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "test_table",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "F1" : "100",
+      "F2" : 5
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 15000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "blah",
+      "VALUE" : 50,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "INNER_JOIN",
+      "type" : "stream"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_join_key_not_in_projection/6.0.0_1585912768079/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_join_key_not_in_projection/6.0.0_1585912768079/topology
@@ -1,0 +1,30 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: INNER_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_left_rowkey_in_projection/6.0.0_1585912768174/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_left_rowkey_in_projection/6.0.0_1585912768174/plan.json
@@ -1,0 +1,189 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='test_table', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_table",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  T.ROWKEY ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_TABLE TT ON ((T.ROWKEY = TT.ROWKEY))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "test_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "test_table",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "T_ROWKEY AS ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "INNER_JOIN"
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_left_rowkey_in_projection/6.0.0_1585912768174/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_left_rowkey_in_projection/6.0.0_1585912768174/spec.json
@@ -1,0 +1,114 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912768174,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "test_table",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "F1" : "100",
+      "F2" : 5
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 15000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "INNER_JOIN",
+      "type" : "stream"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_left_rowkey_in_projection/6.0.0_1585912768174/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_left_rowkey_in_projection/6.0.0_1585912768174/topology
@@ -1,0 +1,30 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: INNER_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_right_join_key_in_projection/6.0.0_1585912768127/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_right_join_key_in_projection/6.0.0_1585912768127/plan.json
@@ -1,0 +1,189 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='test_table', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_table",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  TT.ID TT_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_TABLE TT ON ((T.ROWKEY = TT.ROWKEY))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `TT_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "test_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "test_table",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "TT_ID AS TT_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "INNER_JOIN"
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_right_join_key_in_projection/6.0.0_1585912768127/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_right_join_key_in_projection/6.0.0_1585912768127/spec.json
@@ -1,0 +1,114 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912768127,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<TT_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "test_table",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "F1" : "100",
+      "F2" : 5
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 15000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "TT_ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "TT_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "TT_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "INNER_JOIN",
+      "type" : "stream"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_right_join_key_in_projection/6.0.0_1585912768127/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_right_join_key_in_projection/6.0.0_1585912768127/topology
@@ -1,0 +1,30 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: INNER_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_right_rowkey_in_projection/6.0.0_1585912768227/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_right_rowkey_in_projection/6.0.0_1585912768227/plan.json
@@ -1,0 +1,189 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='test_table', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_table",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  TT.ROWKEY ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_TABLE TT ON ((T.ROWKEY = TT.ROWKEY))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "test_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "test_table",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "TT_ROWKEY AS ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "INNER_JOIN"
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_right_rowkey_in_projection/6.0.0_1585912768227/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_right_rowkey_in_projection/6.0.0_1585912768227/spec.json
@@ -1,0 +1,114 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912768227,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "test_table",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "F1" : "100",
+      "F2" : 5
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 15000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "INNER_JOIN",
+      "type" : "stream"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_right_rowkey_in_projection/6.0.0_1585912768227/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_join_using_ROWKEY_in_the_criteria_-_right_rowkey_in_projection/6.0.0_1585912768227/topology
@@ -1,0 +1,30 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: INNER_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_multiple_join_keys_in_projection/6.0.0_1585912768273/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_multiple_join_keys_in_projection/6.0.0_1585912768273/plan.json
@@ -1,0 +1,190 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='test_table', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_table",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  T.ID ID1,\n  T.ID ID2,\n  T.ROWKEY ID3,\n  TT.ID ID4,\n  TT.ROWKEY ID5\nFROM TEST T\nINNER JOIN TEST_TABLE TT ON ((T.ROWKEY = TT.ROWKEY))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID1` BIGINT, `ID2` BIGINT, `ID3` BIGINT, `ID4` BIGINT, `ID5` BIGINT",
+      "keyField" : "ID1",
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "test_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "test_table",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS ID1", "T_ID AS ID2", "T_ROWKEY AS ID3", "TT_ID AS ID4", "TT_ROWKEY AS ID5" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "INNER_JOIN"
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_multiple_join_keys_in_projection/6.0.0_1585912768273/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_multiple_join_keys_in_projection/6.0.0_1585912768273/spec.json
@@ -1,0 +1,114 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912768273,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<ID1 BIGINT, ID2 BIGINT, ID3 BIGINT, ID4 BIGINT, ID5 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "test_table",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "F1" : "100",
+      "F2" : 5
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 15000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "ID1" : 0,
+      "ID2" : 0,
+      "ID3" : 0,
+      "ID4" : 0,
+      "ID5" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "ID1" : 0,
+      "ID2" : 0,
+      "ID3" : 0,
+      "ID4" : 0,
+      "ID5" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "ID1" : 0,
+      "ID2" : 0,
+      "ID3" : 0,
+      "ID4" : 0,
+      "ID5" : 0
+    },
+    "timestamp" : 15000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "INNER_JOIN",
+      "type" : "stream"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_multiple_join_keys_in_projection/6.0.0_1585912768273/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_multiple_join_keys_in_projection/6.0.0_1585912768273/topology
@@ -1,0 +1,30 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: INNER_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_key/6.0.0_1585912769122/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_key/6.0.0_1585912769122/plan.json
@@ -1,0 +1,187 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT_STREAM (ROWKEY BIGINT KEY, SF INTEGER) WITH (KAFKA_TOPIC='stream_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT_STREAM",
+      "schema" : "`ROWKEY` BIGINT KEY, `SF` INTEGER",
+      "topicName" : "stream_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE INPUT_TABLE (ROWKEY BIGINT PRIMARY KEY, TF INTEGER) WITH (KAFKA_TOPIC='table_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "INPUT_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `TF` INTEGER",
+      "topicName" : "table_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM INPUT_STREAM S\nINNER JOIN INPUT_TABLE T ON ((S.ROWKEY = T.ROWKEY))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` BIGINT KEY, `S_ROWTIME` BIGINT, `S_ROWKEY` BIGINT, `S_SF` INTEGER, `T_ROWTIME` BIGINT, `T_ROWKEY` BIGINT, `T_TF` INTEGER",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT_STREAM", "INPUT_TABLE" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "stream_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `SF` INTEGER"
+              },
+              "selectExpressions" : [ "SF AS S_SF", "ROWTIME AS S_ROWTIME", "ROWKEY AS S_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "table_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `TF` INTEGER"
+              },
+              "selectExpressions" : [ "TF AS T_TF", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "S_ROWTIME AS S_ROWTIME", "S_ROWKEY AS S_ROWKEY", "S_SF AS S_SF", "T_ROWTIME AS T_ROWTIME", "T_ROWKEY AS T_ROWKEY", "T_TF AS T_TF" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_key/6.0.0_1585912769122/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_key/6.0.0_1585912769122/spec.json
@@ -1,0 +1,62 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912769122,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<TF INT> NOT NULL",
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<SF INT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<S_SF INT, S_ROWTIME BIGINT, S_ROWKEY BIGINT> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<S_ROWTIME BIGINT, S_ROWKEY BIGINT, S_SF INT, T_ROWTIME BIGINT, T_ROWKEY BIGINT, T_TF INT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "table_topic",
+    "key" : 26589,
+    "value" : {
+      "TF" : 1
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "stream_topic",
+    "key" : 12589,
+    "value" : {
+      "SF" : 0
+    },
+    "timestamp" : 100
+  }, {
+    "topic" : "table_topic",
+    "key" : 12589,
+    "value" : {
+      "TF" : 12
+    },
+    "timestamp" : 200
+  }, {
+    "topic" : "stream_topic",
+    "key" : 12589,
+    "value" : {
+      "SF" : 10
+    },
+    "timestamp" : 300
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 12589,
+    "value" : {
+      "S_ROWKEY" : 12589,
+      "S_ROWTIME" : 300,
+      "S_SF" : 10,
+      "T_ROWKEY" : 12589,
+      "T_ROWTIME" : 300,
+      "T_TF" : 12
+    },
+    "timestamp" : 300
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "OUTPUT",
+      "type" : "stream",
+      "schema" : "ROWKEY BIGINT KEY, S_ROWTIME BIGINT, S_ROWKEY BIGINT, S_SF INT, T_ROWTIME BIGINT, T_ROWKEY BIGINT, T_TF INT",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      }
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_key/6.0.0_1585912769122/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_key/6.0.0_1585912769122/topology
@@ -1,0 +1,30 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [stream_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [table_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: OUTPUT)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_value_column/6.0.0_1585912769161/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_value_column/6.0.0_1585912769161/plan.json
@@ -1,0 +1,196 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT_STREAM (ROWKEY STRING KEY, SF BIGINT) WITH (KAFKA_TOPIC='stream_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT_STREAM",
+      "schema" : "`ROWKEY` STRING KEY, `SF` BIGINT",
+      "topicName" : "stream_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE INPUT_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, TF INTEGER) WITH (KAFKA_TOPIC='table_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "INPUT_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `TF` INTEGER",
+      "keyField" : "ID",
+      "topicName" : "table_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM INPUT_STREAM S\nINNER JOIN INPUT_TABLE T ON ((S.SF = T.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` BIGINT KEY, `S_ROWTIME` BIGINT, `S_ROWKEY` STRING, `S_SF` BIGINT, `T_ROWTIME` BIGINT, `T_ROWKEY` BIGINT, `T_ID` BIGINT, `T_TF` INTEGER",
+      "keyField" : "S_SF",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT_STREAM", "INPUT_TABLE" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "LeftSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Left/Source"
+                  },
+                  "topicName" : "stream_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` STRING KEY, `SF` BIGINT"
+                },
+                "keyExpression" : "SF"
+              },
+              "selectExpressions" : [ "SF AS S_SF", "ROWTIME AS S_ROWTIME", "ROWKEY AS S_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "table_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `TF` INTEGER"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "TF AS T_TF", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "S_ROWTIME AS S_ROWTIME", "S_ROWKEY AS S_ROWKEY", "S_SF AS S_SF", "T_ROWTIME AS T_ROWTIME", "T_ROWKEY AS T_ROWKEY", "T_ID AS T_ID", "T_TF AS T_TF" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_value_column/6.0.0_1585912769161/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_value_column/6.0.0_1585912769161/spec.json
@@ -1,0 +1,65 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912769161,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, TF INT> NOT NULL",
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<SF BIGINT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<S_SF BIGINT, S_ROWTIME BIGINT, S_ROWKEY VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<S_ROWTIME BIGINT, S_ROWKEY VARCHAR, S_SF BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT, T_ID BIGINT, T_TF INT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "table_topic",
+    "key" : 26589,
+    "value" : {
+      "ID" : 26589,
+      "TF" : 1
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "stream_topic",
+    "key" : "a",
+    "value" : {
+      "SF" : 12589
+    },
+    "timestamp" : 100
+  }, {
+    "topic" : "table_topic",
+    "key" : 12589,
+    "value" : {
+      "ID" : 12589,
+      "TF" : 12
+    },
+    "timestamp" : 200
+  }, {
+    "topic" : "stream_topic",
+    "key" : "b",
+    "value" : {
+      "SF" : 12589
+    },
+    "timestamp" : 300
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 12589,
+    "value" : {
+      "S_ROWKEY" : "b",
+      "S_ROWTIME" : 300,
+      "S_SF" : 12589,
+      "T_ROWKEY" : 12589,
+      "T_ROWTIME" : 300,
+      "T_ID" : 12589,
+      "T_TF" : 12
+    },
+    "timestamp" : 300
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "OUTPUT",
+      "type" : "stream",
+      "schema" : "ROWKEY BIGINT KEY, S_ROWTIME BIGINT, S_ROWKEY STRING, S_SF BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT, T_ID BIGINT, T_TF INT",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      }
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_value_column/6.0.0_1585912769161/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_value_column/6.0.0_1585912769161/topology
@@ -1,0 +1,45 @@
+Topologies:
+   Sub-topology: 0
+    Source: Join-repartition-source (topics: [Join-repartition])
+      --> Join
+    Source: KSTREAM-SOURCE-0000000000 (topics: [table_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- Join-repartition-source
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000014
+      <-- Join
+    Sink: KSTREAM-SINK-0000000014 (topic: OUTPUT)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000004 (topics: [stream_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> KSTREAM-FILTER-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KSTREAM-FILTER-0000000006 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000007
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-KEY-SELECT-0000000007 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000006
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000007
+    Processor: Join-repartition-filter (stores: [])
+      --> Join-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-repartition-sink (topic: Join-repartition)
+      <-- Join-repartition-filter
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_inner_join_-_AVRO/6.0.0_1585912767588/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_inner_join_-_AVRO/6.0.0_1585912767588/plan.json
@@ -1,0 +1,190 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='test_table', KEY='ID', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_table",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "T_ID",
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "AVRO"
+              }
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "test_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "test_table",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          }
+        },
+        "topicName" : "INNER_JOIN"
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_inner_join_-_AVRO/6.0.0_1585912767588/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_inner_join_-_AVRO/6.0.0_1585912767588/spec.json
@@ -1,0 +1,114 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912767588,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "test_table",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "F1" : "100",
+      "F2" : 5
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 15000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "INNER_JOIN",
+      "type" : "stream"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_inner_join_-_AVRO/6.0.0_1585912767588/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_inner_join_-_AVRO/6.0.0_1585912767588/topology
@@ -1,0 +1,30 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: INNER_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_inner_join_-_JSON/6.0.0_1585912767648/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_inner_join_-_JSON/6.0.0_1585912767648/plan.json
@@ -1,0 +1,190 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='test_table', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_table",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "T_ID",
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "test_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "test_table",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "INNER_JOIN"
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_inner_join_-_JSON/6.0.0_1585912767648/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_inner_join_-_JSON/6.0.0_1585912767648/spec.json
@@ -1,0 +1,114 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912767648,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "test_table",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "F1" : "100",
+      "F2" : 5
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 15000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "INNER_JOIN",
+      "type" : "stream"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_inner_join_-_JSON/6.0.0_1585912767648/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_inner_join_-_JSON/6.0.0_1585912767648/topology
@@ -1,0 +1,30 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: INNER_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_inner_join_-_PROTOBUF/6.0.0_1585912767708/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_inner_join_-_PROTOBUF/6.0.0_1585912767708/plan.json
@@ -1,0 +1,190 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='test_table', KEY='ID', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_table",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "T_ID",
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF"
+              }
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "test_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "test_table",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          }
+        },
+        "topicName" : "INNER_JOIN"
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_inner_join_-_PROTOBUF/6.0.0_1585912767708/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_inner_join_-_PROTOBUF/6.0.0_1585912767708/spec.json
@@ -1,0 +1,114 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912767708,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "test_table",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "F1" : "100",
+      "F2" : 5
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 15000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "INNER_JOIN",
+      "type" : "stream"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_inner_join_-_PROTOBUF/6.0.0_1585912767708/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_inner_join_-_PROTOBUF/6.0.0_1585912767708/topology
@@ -1,0 +1,30 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: INNER_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_inner_join_-_join_key_not_in_projection/6.0.0_1585912767767/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_inner_join_-_join_key_not_in_projection/6.0.0_1585912767767/plan.json
@@ -1,0 +1,189 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='test_table', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_table",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "test_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "test_table",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "INNER_JOIN"
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_inner_join_-_join_key_not_in_projection/6.0.0_1585912767767/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_inner_join_-_join_key_not_in_projection/6.0.0_1585912767767/spec.json
@@ -1,0 +1,111 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912767767,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "test_table",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "F1" : "100",
+      "F2" : 5
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 15000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "blah",
+      "VALUE" : 50,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "INNER_JOIN",
+      "type" : "stream"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_inner_join_-_join_key_not_in_projection/6.0.0_1585912767767/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_inner_join_-_join_key_not_in_projection/6.0.0_1585912767767/topology
@@ -1,0 +1,30 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: INNER_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_inner_join_-_right_join_key_in_projection/6.0.0_1585912767835/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_inner_join_-_right_join_key_in_projection/6.0.0_1585912767835/plan.json
@@ -1,0 +1,189 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='test_table', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_table",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INNER_JOIN AS SELECT\n  TT.ID TT_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `TT_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "test_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "test_table",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "TT_ID AS TT_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "INNER_JOIN"
+      },
+      "queryId" : "CSAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_inner_join_-_right_join_key_in_projection/6.0.0_1585912767835/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_inner_join_-_right_join_key_in_projection/6.0.0_1585912767835/spec.json
@@ -1,0 +1,114 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912767835,
+  "schemas" : {
+    "CSAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.Join.Left" : "STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL",
+    "CSAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<TT_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "test_table",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "F1" : "100",
+      "F2" : 5
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 15000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "TT_ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "TT_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "TT_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "INNER_JOIN",
+      "type" : "stream"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_inner_join_-_right_join_key_in_projection/6.0.0_1585912767835/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_inner_join_-_right_join_key_in_projection/6.0.0_1585912767835/topology
@@ -1,0 +1,30 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: INNER_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_left_join_-_AVRO/6.0.0_1585912767303/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_left_join_-_AVRO/6.0.0_1585912767303/plan.json
@@ -1,0 +1,190 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='test_table', KEY='ID', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_table",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM LEFT_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nLEFT OUTER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "LEFT_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "T_ID",
+      "topicName" : "LEFT_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "LEFT_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "LEFT_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "LEFT",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "AVRO"
+              }
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "test_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "test_table",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          }
+        },
+        "topicName" : "LEFT_JOIN"
+      },
+      "queryId" : "CSAS_LEFT_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_left_join_-_AVRO/6.0.0_1585912767303/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_left_join_-_AVRO/6.0.0_1585912767303/spec.json
@@ -1,0 +1,125 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912767303,
+  "schemas" : {
+    "CSAS_LEFT_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_LEFT_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_LEFT_JOIN_0.Join.Left" : "STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL",
+    "CSAS_LEFT_JOIN_0.LEFT_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "test_table",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "F1" : "100",
+      "F2" : 5
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 15000
+  } ],
+  "outputs" : [ {
+    "topic" : "LEFT_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "LEFT_JOIN",
+    "key" : 90,
+    "value" : {
+      "T_ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 15000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "LEFT_JOIN",
+      "type" : "stream"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_left_join_-_AVRO/6.0.0_1585912767303/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_left_join_-_AVRO/6.0.0_1585912767303/topology
@@ -1,0 +1,30 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: LEFT_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_left_join_-_JSON/6.0.0_1585912767363/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_left_join_-_JSON/6.0.0_1585912767363/plan.json
@@ -1,0 +1,190 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='test_table', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_table",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM LEFT_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nLEFT OUTER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "LEFT_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "T_ID",
+      "topicName" : "LEFT_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "LEFT_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "LEFT_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "LEFT",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "test_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "test_table",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "LEFT_JOIN"
+      },
+      "queryId" : "CSAS_LEFT_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_left_join_-_JSON/6.0.0_1585912767363/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_left_join_-_JSON/6.0.0_1585912767363/spec.json
@@ -1,0 +1,125 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912767363,
+  "schemas" : {
+    "CSAS_LEFT_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_LEFT_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_LEFT_JOIN_0.Join.Left" : "STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL",
+    "CSAS_LEFT_JOIN_0.LEFT_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "test_table",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "F1" : "100",
+      "F2" : 5
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 15000
+  } ],
+  "outputs" : [ {
+    "topic" : "LEFT_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "LEFT_JOIN",
+    "key" : 90,
+    "value" : {
+      "T_ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 15000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "LEFT_JOIN",
+      "type" : "stream"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_left_join_-_JSON/6.0.0_1585912767363/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_left_join_-_JSON/6.0.0_1585912767363/topology
@@ -1,0 +1,30 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: LEFT_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_left_join_-_PROTOBUF/6.0.0_1585912767419/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_left_join_-_PROTOBUF/6.0.0_1585912767419/plan.json
@@ -1,0 +1,190 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='test_table', KEY='ID', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_table",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM LEFT_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nLEFT OUTER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "LEFT_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "T_ID",
+      "topicName" : "LEFT_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "LEFT_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "LEFT_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "LEFT",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF"
+              }
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "test_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "test_table",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          }
+        },
+        "topicName" : "LEFT_JOIN"
+      },
+      "queryId" : "CSAS_LEFT_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_left_join_-_PROTOBUF/6.0.0_1585912767419/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_left_join_-_PROTOBUF/6.0.0_1585912767419/spec.json
@@ -1,0 +1,125 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912767419,
+  "schemas" : {
+    "CSAS_LEFT_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_LEFT_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_LEFT_JOIN_0.Join.Left" : "STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL",
+    "CSAS_LEFT_JOIN_0.LEFT_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "test_table",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "F1" : "100",
+      "F2" : 5
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 15000
+  } ],
+  "outputs" : [ {
+    "topic" : "LEFT_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "LEFT_JOIN",
+    "key" : 90,
+    "value" : {
+      "T_ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90,
+      "F1" : "",
+      "F2" : 0
+    },
+    "timestamp" : 15000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "LEFT_JOIN",
+      "type" : "stream"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_left_join_-_PROTOBUF/6.0.0_1585912767419/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_left_join_-_PROTOBUF/6.0.0_1585912767419/topology
@@ -1,0 +1,30 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: LEFT_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_left_join_-_join_key_not_in_projection/6.0.0_1585912767473/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_left_join_-_join_key_not_in_projection/6.0.0_1585912767473/plan.json
@@ -1,0 +1,189 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='test_table', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_table",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM LEFT_JOIN AS SELECT\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nLEFT OUTER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "LEFT_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "topicName" : "LEFT_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "LEFT_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "LEFT_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "LEFT",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "test_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "test_table",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "LEFT_JOIN"
+      },
+      "queryId" : "CSAS_LEFT_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_left_join_-_join_key_not_in_projection/6.0.0_1585912767473/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_left_join_-_join_key_not_in_projection/6.0.0_1585912767473/spec.json
@@ -1,0 +1,121 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912767473,
+  "schemas" : {
+    "CSAS_LEFT_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_LEFT_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_LEFT_JOIN_0.Join.Left" : "STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL",
+    "CSAS_LEFT_JOIN_0.LEFT_JOIN" : "STRUCT<NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "test_table",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "F1" : "100",
+      "F2" : 5
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 15000
+  } ],
+  "outputs" : [ {
+    "topic" : "LEFT_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "blah",
+      "VALUE" : 50,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "LEFT_JOIN",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 15000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "LEFT_JOIN",
+      "type" : "stream"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_left_join_-_join_key_not_in_projection/6.0.0_1585912767473/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_left_join_-_join_key_not_in_projection/6.0.0_1585912767473/topology
@@ -1,0 +1,30 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: LEFT_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_left_join_-_right_join_key_in_projection/6.0.0_1585912767528/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_left_join_-_right_join_key_in_projection/6.0.0_1585912767528/plan.json
@@ -1,0 +1,189 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='test_table', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "test_table",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM LEFT_JOIN AS SELECT\n  TT.ID TT_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nLEFT OUTER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "LEFT_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `TT_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "topicName" : "LEFT_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "LEFT_JOIN",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "LEFT_JOIN"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "LEFT",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "test_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "test_table",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "TT_ID AS TT_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "LEFT_JOIN"
+      },
+      "queryId" : "CSAS_LEFT_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_left_join_-_right_join_key_in_projection/6.0.0_1585912767528/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_left_join_-_right_join_key_in_projection/6.0.0_1585912767528/spec.json
@@ -1,0 +1,125 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912767528,
+  "schemas" : {
+    "CSAS_LEFT_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CSAS_LEFT_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CSAS_LEFT_JOIN_0.Join.Left" : "STRUCT<T_ID BIGINT, T_NAME VARCHAR, T_VALUE BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT> NOT NULL",
+    "CSAS_LEFT_JOIN_0.LEFT_JOIN" : "STRUCT<TT_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "test_table",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "F1" : "100",
+      "F2" : 5
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "test_table",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "test_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 15000
+  } ],
+  "outputs" : [ {
+    "topic" : "LEFT_JOIN",
+    "key" : 0,
+    "value" : {
+      "TT_ID" : 0,
+      "NAME" : "blah",
+      "VALUE" : 50,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_JOIN",
+    "key" : 0,
+    "value" : {
+      "TT_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "zero",
+      "F2" : 0
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_JOIN",
+    "key" : 0,
+    "value" : {
+      "TT_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "LEFT_JOIN",
+    "key" : 90,
+    "value" : {
+      "TT_ID" : null,
+      "NAME" : "ninety",
+      "VALUE" : 90,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 15000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "LEFT_JOIN",
+      "type" : "stream"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_left_join_-_right_join_key_in_projection/6.0.0_1585912767528/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_table_left_join_-_right_join_key_in_projection/6.0.0_1585912767528/topology
@@ -1,0 +1,30 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_table])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: LEFT_JOIN)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_to_table_when_neither_have_key_field_and_joining_by_table_key_column/6.0.0_1585912768474/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_to_table_when_neither_have_key_field_and_joining_by_table_key_column/6.0.0_1585912768474/plan.json
@@ -1,0 +1,195 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM S (ID BIGINT) WITH (KAFKA_TOPIC='S', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "S",
+      "schema" : "`ROWKEY` STRING KEY, `ID` BIGINT",
+      "topicName" : "S",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE NO_KEY (ROWKEY BIGINT PRIMARY KEY, NAME STRING) WITH (KAFKA_TOPIC='NO_KEY', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "NO_KEY",
+      "schema" : "`ROWKEY` BIGINT KEY, `NAME` STRING",
+      "topicName" : "NO_KEY",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  S.ID ID,\n  T.NAME NAME\nFROM S S\nINNER JOIN NO_KEY T ON ((S.ID = T.ROWKEY))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING",
+      "keyField" : "ID",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "NO_KEY", "S" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSelectKeyV1",
+                "properties" : {
+                  "queryContext" : "LeftSourceKeyed"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Left/Source"
+                  },
+                  "topicName" : "S",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` STRING KEY, `ID` BIGINT"
+                },
+                "keyExpression" : "ID"
+              },
+              "selectExpressions" : [ "ID AS S_ID", "ROWTIME AS S_ROWTIME", "ROWKEY AS S_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "NO_KEY",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `NAME` STRING"
+              },
+              "selectExpressions" : [ "NAME AS T_NAME", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "S_ID AS ID", "T_NAME AS NAME" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_to_table_when_neither_have_key_field_and_joining_by_table_key_column/6.0.0_1585912768474/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_to_table_when_neither_have_key_field_and_joining_by_table_key_column/6.0.0_1585912768474/spec.json
@@ -1,0 +1,42 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912768474,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<NAME VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<S_ID BIGINT, S_ROWTIME BIGINT, S_ROWKEY VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<ID BIGINT, NAME VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "NO_KEY",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "name" : "bob"
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "S",
+    "key" : "",
+    "value" : {
+      "ID" : 0
+    },
+    "timestamp" : 10
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bob"
+    },
+    "timestamp" : 10
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "OUTPUT",
+      "type" : "stream",
+      "schema" : "ROWKEY BIGINT KEY, ID BIGINT, NAME STRING"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_to_table_when_neither_have_key_field_and_joining_by_table_key_column/6.0.0_1585912768474/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_to_table_when_neither_have_key_field_and_joining_by_table_key_column/6.0.0_1585912768474/topology
@@ -1,0 +1,45 @@
+Topologies:
+   Sub-topology: 0
+    Source: Join-repartition-source (topics: [Join-repartition])
+      --> Join
+    Source: KSTREAM-SOURCE-0000000000 (topics: [NO_KEY])
+      --> KTABLE-SOURCE-0000000001
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- Join-repartition-source
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000014
+      <-- Join
+    Sink: KSTREAM-SINK-0000000014 (topic: OUTPUT)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000004 (topics: [S])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> KSTREAM-FILTER-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KSTREAM-FILTER-0000000006 (stores: [])
+      --> KSTREAM-KEY-SELECT-0000000007
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-KEY-SELECT-0000000007 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-FILTER-0000000006
+    Processor: PrependAliasLeft (stores: [])
+      --> Join-repartition-filter
+      <-- KSTREAM-KEY-SELECT-0000000007
+    Processor: Join-repartition-filter (stores: [])
+      --> Join-repartition-sink
+      <-- PrependAliasLeft
+    Sink: Join-repartition-sink (topic: Join-repartition)
+      <-- Join-repartition-filter
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_to_table_when_table_does_not_have_key_field_and_joining_by_table_ROWKEY/6.0.0_1585912768507/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_to_table_when_table_does_not_have_key_field_and_joining_by_table_ROWKEY/6.0.0_1585912768507/plan.json
@@ -1,0 +1,189 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM S (ROWKEY BIGINT KEY, ID BIGINT) WITH (KAFKA_TOPIC='S', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "S",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "S",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE NO_KEY (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, NAME STRING) WITH (KAFKA_TOPIC='NO_KEY', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "NO_KEY",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING",
+      "topicName" : "NO_KEY",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  S.ID S_ID,\n  T.NAME NAME\nFROM S S\nINNER JOIN NO_KEY T ON ((S.ID = T.ROWKEY))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` BIGINT KEY, `S_ID` BIGINT, `NAME` STRING",
+      "keyField" : "S_ID",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "NO_KEY", "S" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "leftSource" : {
+              "@type" : "streamSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "streamSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "S",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS S_ID", "ROWTIME AS S_ROWTIME", "ROWKEY AS S_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "NO_KEY",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "S_ID AS S_ID", "T_NAME AS NAME" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_to_table_when_table_does_not_have_key_field_and_joining_by_table_ROWKEY/6.0.0_1585912768507/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_to_table_when_table_does_not_have_key_field_and_joining_by_table_ROWKEY/6.0.0_1585912768507/spec.json
@@ -1,0 +1,41 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912768507,
+  "schemas" : {
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, NAME VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT> NOT NULL",
+    "CSAS_OUTPUT_0.Join.Left" : "STRUCT<S_ID BIGINT, S_ROWTIME BIGINT, S_ROWKEY BIGINT> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<S_ID BIGINT, NAME VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "NO_KEY",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "name" : "bob"
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "S",
+    "key" : 0,
+    "value" : {
+      "ID" : 0
+    },
+    "timestamp" : 10
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "S_ID" : 0,
+      "NAME" : "bob"
+    },
+    "timestamp" : 10
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "OUTPUT",
+      "type" : "stream"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_to_table_when_table_does_not_have_key_field_and_joining_by_table_ROWKEY/6.0.0_1585912768507/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_to_table_when_table_does_not_have_key_field_and_joining_by_table_ROWKEY/6.0.0_1585912768507/topology
@@ -1,0 +1,30 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000004 (topics: [S])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> PrependAliasLeft
+      <-- KSTREAM-SOURCE-0000000004
+    Source: KSTREAM-SOURCE-0000000000 (topics: [NO_KEY])
+      --> KTABLE-SOURCE-0000000001
+    Processor: PrependAliasLeft (stores: [])
+      --> Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- PrependAliasLeft
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000009
+      <-- Join
+    Sink: KSTREAM-SINK-0000000009 (topic: OUTPUT)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_join_pipeline_-_JSON/6.0.0_1585912768320/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_join_pipeline_-_JSON/6.0.0_1585912768320/plan.json
@@ -1,0 +1,298 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE_2 (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F3 STRING) WITH (KAFKA_TOPIC='right_topic_2', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE_2",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F3` STRING",
+      "keyField" : "ID",
+      "topicName" : "right_topic_2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE INNER_JOIN WITH (PARTITIONS=4) AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "T_ID",
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "INNER_JOIN"
+      },
+      "queryId" : "CTAS_INNER_JOIN_0"
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE INNER_JOIN_2 AS SELECT\n  TT.T_ID T_ID,\n  TT.NAME NAME,\n  TT.F1 F1,\n  T.F3 F3\nFROM INNER_JOIN TT\nINNER JOIN TEST_TABLE_2 T ON ((T.ID = TT.T_ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "INNER_JOIN_2",
+      "schema" : "`ROWKEY` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `F1` STRING, `F3` STRING",
+      "keyField" : "T_ID",
+      "topicName" : "INNER_JOIN_2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INNER_JOIN", "TEST_TABLE_2" ],
+      "sink" : "INNER_JOIN_2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN_2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "INNER_JOIN",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "T_ID AS TT_T_ID", "NAME AS TT_NAME", "VALUE AS TT_VALUE", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic_2",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F3` STRING"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "F3 AS T_F3", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "TT_T_ID AS T_ID", "TT_NAME AS NAME", "TT_F1 AS F1", "T_F3 AS F3" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "INNER_JOIN_2"
+      },
+      "queryId" : "CTAS_INNER_JOIN_2_1"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_join_pipeline_-_JSON/6.0.0_1585912768320/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_join_pipeline_-_JSON/6.0.0_1585912768320/spec.json
@@ -1,0 +1,69 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912768320,
+  "schemas" : {
+    "CTAS_INNER_JOIN_2_1.KafkaTopic_Left.Source" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CTAS_INNER_JOIN_2_1.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F3 VARCHAR> NOT NULL",
+    "CTAS_INNER_JOIN_2_1.INNER_JOIN_2" : "STRUCT<T_ID BIGINT, NAME VARCHAR, F1 VARCHAR, F3 VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "X",
+      "VALUE" : 0,
+      "F1" : "yo dawg",
+      "F2" : 50
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic_2",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F3" : "I heard you like joins"
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 100,
+    "value" : {
+      "T_ID" : 100,
+      "NAME" : "X",
+      "VALUE" : 0,
+      "F1" : "KSQL has table-table joins",
+      "F2" : 50
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic_2",
+    "key" : 100,
+    "value" : {
+      "ID" : 100,
+      "F3" : "so now you can join your join"
+    },
+    "timestamp" : 20000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN_2",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "X",
+      "F1" : "yo dawg",
+      "F3" : "I heard you like joins"
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN_2",
+    "key" : 100,
+    "value" : {
+      "T_ID" : 100,
+      "NAME" : "X",
+      "F1" : "KSQL has table-table joins",
+      "F3" : "so now you can join your join"
+    },
+    "timestamp" : 20000
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_join_pipeline_-_JSON/6.0.0_1585912768320/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_join_pipeline_-_JSON/6.0.0_1585912768320/topology
@@ -1,0 +1,42 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [INNER_JOIN])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic_2])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: INNER_JOIN_2)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_inner_join_-_AVRO/6.0.0_1585912766790/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_inner_join_-_AVRO/6.0.0_1585912766790/plan.json
@@ -1,0 +1,182 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', KEY='ID', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', KEY='ID', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE INNER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "T_ID",
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          }
+        },
+        "topicName" : "INNER_JOIN"
+      },
+      "queryId" : "CTAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_inner_join_-_AVRO/6.0.0_1585912766790/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_inner_join_-_AVRO/6.0.0_1585912766790/spec.json
@@ -1,0 +1,133 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912766790,
+  "schemas" : {
+    "CTAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CTAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CTAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 15,
+    "value" : {
+      "ID" : 15,
+      "F1" : "c",
+      "F2" : 20
+    },
+    "timestamp" : 15500
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 16000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "INNER_JOIN",
+      "type" : "table"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_inner_join_-_AVRO/6.0.0_1585912766790/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_inner_join_-_AVRO/6.0.0_1585912766790/topology
@@ -1,0 +1,42 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: INNER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_inner_join_-_JSON/6.0.0_1585912766856/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_inner_join_-_JSON/6.0.0_1585912766856/plan.json
@@ -1,0 +1,182 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE INNER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "T_ID",
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "INNER_JOIN"
+      },
+      "queryId" : "CTAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_inner_join_-_JSON/6.0.0_1585912766856/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_inner_join_-_JSON/6.0.0_1585912766856/spec.json
@@ -1,0 +1,133 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912766856,
+  "schemas" : {
+    "CTAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CTAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CTAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 15,
+    "value" : {
+      "ID" : 15,
+      "F1" : "c",
+      "F2" : 20
+    },
+    "timestamp" : 15500
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 16000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "INNER_JOIN",
+      "type" : "table"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_inner_join_-_JSON/6.0.0_1585912766856/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_inner_join_-_JSON/6.0.0_1585912766856/topology
@@ -1,0 +1,42 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: INNER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_inner_join_-_PROTOBUF/6.0.0_1585912766921/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_inner_join_-_PROTOBUF/6.0.0_1585912766921/plan.json
@@ -1,0 +1,182 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', KEY='ID', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', KEY='ID', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE INNER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "T_ID",
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          }
+        },
+        "topicName" : "INNER_JOIN"
+      },
+      "queryId" : "CTAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_inner_join_-_PROTOBUF/6.0.0_1585912766921/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_inner_join_-_PROTOBUF/6.0.0_1585912766921/spec.json
@@ -1,0 +1,133 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912766921,
+  "schemas" : {
+    "CTAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CTAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CTAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 15,
+    "value" : {
+      "ID" : 15,
+      "F1" : "c",
+      "F2" : 20
+    },
+    "timestamp" : 15500
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 16000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "INNER_JOIN",
+      "type" : "table"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_inner_join_-_PROTOBUF/6.0.0_1585912766921/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_inner_join_-_PROTOBUF/6.0.0_1585912766921/topology
@@ -1,0 +1,42 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: INNER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_inner_join_-_join_key_not_in_projection/6.0.0_1585912766977/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_inner_join_-_join_key_not_in_projection/6.0.0_1585912766977/plan.json
@@ -1,0 +1,181 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE INNER_JOIN AS SELECT\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "INNER_JOIN"
+      },
+      "queryId" : "CTAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_inner_join_-_join_key_not_in_projection/6.0.0_1585912766977/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_inner_join_-_join_key_not_in_projection/6.0.0_1585912766977/spec.json
@@ -1,0 +1,129 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912766977,
+  "schemas" : {
+    "CTAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CTAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CTAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 15,
+    "value" : {
+      "ID" : 15,
+      "F1" : "c",
+      "F2" : 20
+    },
+    "timestamp" : 15500
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 16000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "INNER_JOIN",
+      "type" : "table"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_inner_join_-_join_key_not_in_projection/6.0.0_1585912766977/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_inner_join_-_join_key_not_in_projection/6.0.0_1585912766977/topology
@@ -1,0 +1,42 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: INNER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_inner_join_-_right_join_key_in_projection/6.0.0_1585912767027/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_inner_join_-_right_join_key_in_projection/6.0.0_1585912767027/plan.json
@@ -1,0 +1,181 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE INNER_JOIN AS SELECT\n  TT.ID TT_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "INNER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `TT_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "topicName" : "INNER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "INNER_JOIN",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "INNER_JOIN"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "TT_ID AS TT_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "INNER_JOIN"
+      },
+      "queryId" : "CTAS_INNER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_inner_join_-_right_join_key_in_projection/6.0.0_1585912767027/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_inner_join_-_right_join_key_in_projection/6.0.0_1585912767027/spec.json
@@ -1,0 +1,133 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912767027,
+  "schemas" : {
+    "CTAS_INNER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CTAS_INNER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CTAS_INNER_JOIN_0.INNER_JOIN" : "STRUCT<TT_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 15,
+    "value" : {
+      "ID" : 15,
+      "F1" : "c",
+      "F2" : 20
+    },
+    "timestamp" : 15500
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  } ],
+  "outputs" : [ {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "TT_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "TT_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "TT_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "INNER_JOIN",
+    "key" : 0,
+    "value" : {
+      "TT_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 16000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "INNER_JOIN",
+      "type" : "table"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_inner_join_-_right_join_key_in_projection/6.0.0_1585912767027/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_inner_join_-_right_join_key_in_projection/6.0.0_1585912767027/topology
@@ -1,0 +1,42 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: INNER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_join_with_where_clause/6.0.0_1585912768423/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_join_with_where_clause/6.0.0_1585912768423/plan.json
@@ -1,0 +1,189 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nINNER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nWHERE ((T.VALUE > 10) AND (TT.F2 > 5))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `F1` STRING, `F2` BIGINT",
+      "keyField" : "T_ID",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableFilterV1",
+            "properties" : {
+              "queryContext" : "WhereFilter"
+            },
+            "source" : {
+              "@type" : "tableTableJoinV1",
+              "properties" : {
+                "queryContext" : "Join"
+              },
+              "joinType" : "INNER",
+              "leftSource" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "PrependAliasLeft"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Left/Source"
+                  },
+                  "topicName" : "left_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+                },
+                "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+              },
+              "rightSource" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "PrependAliasRight"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_Right/Source"
+                  },
+                  "topicName" : "right_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+                },
+                "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+              }
+            },
+            "filterExpression" : "((T_VALUE > 10) AND (TT_F2 > 5))"
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_join_with_where_clause/6.0.0_1585912768423/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_join_with_where_clause/6.0.0_1585912768423/spec.json
@@ -1,0 +1,130 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912768423,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<T_ID BIGINT, NAME VARCHAR, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : 4
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  }, {
+    "topic" : "right_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 0,
+      "F1" : "b",
+      "F2" : 10
+    },
+    "timestamp" : 18000
+  }, {
+    "topic" : "right_topic",
+    "key" : 90,
+    "value" : null,
+    "timestamp" : 19000
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : null,
+    "timestamp" : 10000
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : null,
+    "timestamp" : 13000
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 90,
+    "value" : {
+      "T_ID" : 90,
+      "NAME" : "ninety",
+      "F1" : "b",
+      "F2" : 10
+    },
+    "timestamp" : 18000
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 90,
+    "value" : null,
+    "timestamp" : 19000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "OUTPUT",
+      "type" : "table"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_join_with_where_clause/6.0.0_1585912768423/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_join_with_where_clause/6.0.0_1585912768423/topology
@@ -1,0 +1,51 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> WhereFilter-ApplyPredicate
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: WhereFilter-ApplyPredicate (stores: [])
+      --> WhereFilter-Filter
+      <-- KTABLE-MERGE-0000000008
+    Processor: WhereFilter-Filter (stores: [])
+      --> WhereFilter-PostProcess
+      <-- WhereFilter-ApplyPredicate
+    Processor: WhereFilter-PostProcess (stores: [])
+      --> Project
+      <-- WhereFilter-Filter
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000015
+      <-- WhereFilter-PostProcess
+    Processor: KTABLE-TOSTREAM-0000000015 (stores: [])
+      --> KSTREAM-SINK-0000000016
+      <-- Project
+    Sink: KSTREAM-SINK-0000000016 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000015
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_AVRO/6.0.0_1585912766424/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_AVRO/6.0.0_1585912766424/plan.json
@@ -1,0 +1,182 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', KEY='ID', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', KEY='ID', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE LEFT_OUTER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nLEFT OUTER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "LEFT_OUTER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "T_ID",
+      "topicName" : "LEFT_OUTER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "LEFT_OUTER_JOIN",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "LEFT_OUTER_JOIN"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "LEFT",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          }
+        },
+        "topicName" : "LEFT_OUTER_JOIN"
+      },
+      "queryId" : "CTAS_LEFT_OUTER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_AVRO/6.0.0_1585912766424/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_AVRO/6.0.0_1585912766424/spec.json
@@ -1,0 +1,157 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912766424,
+  "schemas" : {
+    "CTAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CTAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CTAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  } ],
+  "outputs" : [ {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 10,
+    "value" : {
+      "T_ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 90,
+    "value" : {
+      "T_ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 17000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "LEFT_OUTER_JOIN",
+      "type" : "table"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_AVRO/6.0.0_1585912766424/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_AVRO/6.0.0_1585912766424/topology
@@ -1,0 +1,42 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: LEFT_OUTER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_JSON/6.0.0_1585912766478/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_JSON/6.0.0_1585912766478/plan.json
@@ -1,0 +1,182 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE LEFT_OUTER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nLEFT OUTER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "LEFT_OUTER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "T_ID",
+      "topicName" : "LEFT_OUTER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "LEFT_OUTER_JOIN",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "LEFT_OUTER_JOIN"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "LEFT",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "LEFT_OUTER_JOIN"
+      },
+      "queryId" : "CTAS_LEFT_OUTER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_JSON/6.0.0_1585912766478/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_JSON/6.0.0_1585912766478/spec.json
@@ -1,0 +1,157 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912766478,
+  "schemas" : {
+    "CTAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CTAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CTAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  } ],
+  "outputs" : [ {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 10,
+    "value" : {
+      "T_ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 90,
+    "value" : {
+      "T_ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 17000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "LEFT_OUTER_JOIN",
+      "type" : "table"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_JSON/6.0.0_1585912766478/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_JSON/6.0.0_1585912766478/topology
@@ -1,0 +1,42 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: LEFT_OUTER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_PROTOBUF/6.0.0_1585912766546/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_PROTOBUF/6.0.0_1585912766546/plan.json
@@ -1,0 +1,182 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', KEY='ID', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', KEY='ID', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE LEFT_OUTER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nLEFT OUTER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "LEFT_OUTER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "T_ID",
+      "topicName" : "LEFT_OUTER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "LEFT_OUTER_JOIN",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "LEFT_OUTER_JOIN"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "LEFT",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          }
+        },
+        "topicName" : "LEFT_OUTER_JOIN"
+      },
+      "queryId" : "CTAS_LEFT_OUTER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_PROTOBUF/6.0.0_1585912766546/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_PROTOBUF/6.0.0_1585912766546/spec.json
@@ -1,0 +1,157 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912766546,
+  "schemas" : {
+    "CTAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CTAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CTAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  } ],
+  "outputs" : [ {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 10,
+    "value" : {
+      "T_ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5,
+      "F1" : "",
+      "F2" : 0
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 90,
+    "value" : {
+      "T_ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90,
+      "F1" : "",
+      "F2" : 0
+    },
+    "timestamp" : 17000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "LEFT_OUTER_JOIN",
+      "type" : "table"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_PROTOBUF/6.0.0_1585912766546/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_PROTOBUF/6.0.0_1585912766546/topology
@@ -1,0 +1,42 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: LEFT_OUTER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_both_join_keys_in_projection/6.0.0_1585912766732/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_both_join_keys_in_projection/6.0.0_1585912766732/plan.json
@@ -1,0 +1,182 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE LEFT_OUTER_JOIN AS SELECT\n  T.ID T_ID,\n  TT.ID TT_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nLEFT OUTER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "LEFT_OUTER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `T_ID` BIGINT, `TT_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "T_ID",
+      "topicName" : "LEFT_OUTER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "LEFT_OUTER_JOIN",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "LEFT_OUTER_JOIN"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "LEFT",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "TT_ID AS TT_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "LEFT_OUTER_JOIN"
+      },
+      "queryId" : "CTAS_LEFT_OUTER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_both_join_keys_in_projection/6.0.0_1585912766732/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_both_join_keys_in_projection/6.0.0_1585912766732/spec.json
@@ -1,0 +1,164 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912766732,
+  "schemas" : {
+    "CTAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CTAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CTAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN" : "STRUCT<T_ID BIGINT, TT_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  } ],
+  "outputs" : [ {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "TT_ID" : null,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "TT_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 10,
+    "value" : {
+      "T_ID" : 10,
+      "TT_ID" : null,
+      "NAME" : "100",
+      "VALUE" : 5,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "TT_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "TT_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "TT_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 90,
+    "value" : {
+      "T_ID" : 90,
+      "TT_ID" : null,
+      "NAME" : "ninety",
+      "VALUE" : 90,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 17000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "LEFT_OUTER_JOIN",
+      "type" : "table"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_both_join_keys_in_projection/6.0.0_1585912766732/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_both_join_keys_in_projection/6.0.0_1585912766732/topology
@@ -1,0 +1,42 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: LEFT_OUTER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_join_key_not_in_projection/6.0.0_1585912766613/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_join_key_not_in_projection/6.0.0_1585912766613/plan.json
@@ -1,0 +1,181 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE LEFT_OUTER_JOIN AS SELECT\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nLEFT OUTER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "LEFT_OUTER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "topicName" : "LEFT_OUTER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "LEFT_OUTER_JOIN",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "LEFT_OUTER_JOIN"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "LEFT",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "LEFT_OUTER_JOIN"
+      },
+      "queryId" : "CTAS_LEFT_OUTER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_join_key_not_in_projection/6.0.0_1585912766613/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_join_key_not_in_projection/6.0.0_1585912766613/spec.json
@@ -1,0 +1,150 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912766613,
+  "schemas" : {
+    "CTAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CTAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CTAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN" : "STRUCT<NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  } ],
+  "outputs" : [ {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 10,
+    "value" : {
+      "NAME" : "100",
+      "VALUE" : 5,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 90,
+    "value" : {
+      "NAME" : "ninety",
+      "VALUE" : 90,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 17000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "LEFT_OUTER_JOIN",
+      "type" : "table"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_join_key_not_in_projection/6.0.0_1585912766613/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_join_key_not_in_projection/6.0.0_1585912766613/topology
@@ -1,0 +1,42 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: LEFT_OUTER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_right_join_key_in_projection/6.0.0_1585912766684/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_right_join_key_in_projection/6.0.0_1585912766684/plan.json
@@ -1,0 +1,181 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE LEFT_OUTER_JOIN AS SELECT\n  TT.ID TT_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nLEFT OUTER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "LEFT_OUTER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `TT_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "topicName" : "LEFT_OUTER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "LEFT_OUTER_JOIN",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "LEFT_OUTER_JOIN"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "LEFT",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "TT_ID AS TT_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "LEFT_OUTER_JOIN"
+      },
+      "queryId" : "CTAS_LEFT_OUTER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_right_join_key_in_projection/6.0.0_1585912766684/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_right_join_key_in_projection/6.0.0_1585912766684/spec.json
@@ -1,0 +1,157 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912766684,
+  "schemas" : {
+    "CTAS_LEFT_OUTER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CTAS_LEFT_OUTER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CTAS_LEFT_OUTER_JOIN_0.LEFT_OUTER_JOIN" : "STRUCT<TT_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "left_topic",
+    "key" : 90,
+    "value" : {
+      "ID" : 90,
+      "NAME" : "ninety",
+      "VALUE" : 90
+    },
+    "timestamp" : 17000
+  } ],
+  "outputs" : [ {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "TT_ID" : null,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "TT_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 10,
+    "value" : {
+      "TT_ID" : null,
+      "NAME" : "100",
+      "VALUE" : 5,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "TT_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "TT_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "TT_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 16000
+  }, {
+    "topic" : "LEFT_OUTER_JOIN",
+    "key" : 90,
+    "value" : {
+      "TT_ID" : null,
+      "NAME" : "ninety",
+      "VALUE" : 90,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 17000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "LEFT_OUTER_JOIN",
+      "type" : "table"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_right_join_key_in_projection/6.0.0_1585912766684/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_left_join_-_right_join_key_in_projection/6.0.0_1585912766684/topology
@@ -1,0 +1,42 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: LEFT_OUTER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_outer_join_-_AVRO/6.0.0_1585912767085/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_outer_join_-_AVRO/6.0.0_1585912767085/plan.json
@@ -1,0 +1,181 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', KEY='ID', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', KEY='ID', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nFULL OUTER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "topicName" : "OUTER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "OUTER_JOIN",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTER_JOIN"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "OUTER",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "AVRO"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          }
+        },
+        "topicName" : "OUTER_JOIN"
+      },
+      "queryId" : "CTAS_OUTER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_outer_join_-_AVRO/6.0.0_1585912767085/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_outer_join_-_AVRO/6.0.0_1585912767085/spec.json
@@ -1,0 +1,157 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912767085,
+  "schemas" : {
+    "CTAS_OUTER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CTAS_OUTER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CTAS_OUTER_JOIN_0.OUTER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 15,
+    "value" : {
+      "ID" : 15,
+      "F1" : "c",
+      "F2" : 20
+    },
+    "timestamp" : 15500
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 16000
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 10,
+    "value" : {
+      "T_ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 15,
+    "value" : {
+      "T_ID" : null,
+      "NAME" : null,
+      "VALUE" : null,
+      "F1" : "c",
+      "F2" : 20
+    },
+    "timestamp" : 15500
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 16000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "OUTER_JOIN",
+      "type" : "table"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_outer_join_-_AVRO/6.0.0_1585912767085/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_outer_join_-_AVRO/6.0.0_1585912767085/topology
@@ -1,0 +1,42 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: OUTER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_outer_join_-_JSON/6.0.0_1585912767141/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_outer_join_-_JSON/6.0.0_1585912767141/plan.json
@@ -1,0 +1,181 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nFULL OUTER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "topicName" : "OUTER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "OUTER_JOIN",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTER_JOIN"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "OUTER",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTER_JOIN"
+      },
+      "queryId" : "CTAS_OUTER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_outer_join_-_JSON/6.0.0_1585912767141/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_outer_join_-_JSON/6.0.0_1585912767141/spec.json
@@ -1,0 +1,157 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912767141,
+  "schemas" : {
+    "CTAS_OUTER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CTAS_OUTER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CTAS_OUTER_JOIN_0.OUTER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 15,
+    "value" : {
+      "ID" : 15,
+      "F1" : "c",
+      "F2" : 20
+    },
+    "timestamp" : 15500
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 16000
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 10,
+    "value" : {
+      "T_ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 15,
+    "value" : {
+      "T_ID" : null,
+      "NAME" : null,
+      "VALUE" : null,
+      "F1" : "c",
+      "F2" : 20
+    },
+    "timestamp" : 15500
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 16000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "OUTER_JOIN",
+      "type" : "table"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_outer_join_-_JSON/6.0.0_1585912767141/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_outer_join_-_JSON/6.0.0_1585912767141/topology
@@ -1,0 +1,42 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: OUTER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_outer_join_-_PROTOBUF/6.0.0_1585912767196/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_outer_join_-_PROTOBUF/6.0.0_1585912767196/plan.json
@@ -1,0 +1,181 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', KEY='ID', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', KEY='ID', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTER_JOIN AS SELECT\n  T.ID T_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nFULL OUTER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "topicName" : "OUTER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "OUTER_JOIN",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTER_JOIN"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "OUTER",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "T_ID AS T_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          }
+        },
+        "topicName" : "OUTER_JOIN"
+      },
+      "queryId" : "CTAS_OUTER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_outer_join_-_PROTOBUF/6.0.0_1585912767196/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_outer_join_-_PROTOBUF/6.0.0_1585912767196/spec.json
@@ -1,0 +1,157 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912767196,
+  "schemas" : {
+    "CTAS_OUTER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CTAS_OUTER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CTAS_OUTER_JOIN_0.OUTER_JOIN" : "STRUCT<T_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 15,
+    "value" : {
+      "ID" : 15,
+      "F1" : "c",
+      "F2" : 20
+    },
+    "timestamp" : 15500
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 16000
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "",
+      "F2" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 10,
+    "value" : {
+      "T_ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5,
+      "F1" : "",
+      "F2" : 0
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 15,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "",
+      "VALUE" : 0,
+      "F1" : "c",
+      "F2" : 20
+    },
+    "timestamp" : 15500
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "T_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 16000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "OUTER_JOIN",
+      "type" : "table"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_outer_join_-_PROTOBUF/6.0.0_1585912767196/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_outer_join_-_PROTOBUF/6.0.0_1585912767196/topology
@@ -1,0 +1,42 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: OUTER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_outer_join_-_right_join_key_in_projection/6.0.0_1585912767248/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_outer_join_-_right_join_key_in_projection/6.0.0_1585912767248/plan.json
@@ -1,0 +1,181 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, NAME STRING, VALUE BIGINT) WITH (KAFKA_TOPIC='left_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, F1 STRING, F2 BIGINT) WITH (KAFKA_TOPIC='right_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST_TABLE",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT",
+      "keyField" : "ID",
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTER_JOIN AS SELECT\n  TT.ID TT_ID,\n  T.NAME NAME,\n  T.VALUE VALUE,\n  TT.F1 F1,\n  TT.F2 F2\nFROM TEST T\nFULL OUTER JOIN TEST_TABLE TT ON ((T.ID = TT.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTER_JOIN",
+      "schema" : "`ROWKEY` BIGINT KEY, `TT_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT",
+      "topicName" : "OUTER_JOIN",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST", "TEST_TABLE" ],
+      "sink" : "OUTER_JOIN",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTER_JOIN"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "OUTER",
+            "leftSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasLeft"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Left/Source"
+                },
+                "topicName" : "left_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `VALUE` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS T_ID", "NAME AS T_NAME", "VALUE AS T_VALUE", "ROWTIME AS T_ROWTIME", "ROWKEY AS T_ROWKEY" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F1` STRING, `F2` BIGINT"
+              },
+              "selectExpressions" : [ "ID AS TT_ID", "F1 AS TT_F1", "F2 AS TT_F2", "ROWTIME AS TT_ROWTIME", "ROWKEY AS TT_ROWKEY" ]
+            }
+          },
+          "selectExpressions" : [ "TT_ID AS TT_ID", "T_NAME AS NAME", "T_VALUE AS VALUE", "TT_F1 AS F1", "TT_F2 AS F2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTER_JOIN"
+      },
+      "queryId" : "CTAS_OUTER_JOIN_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_outer_join_-_right_join_key_in_projection/6.0.0_1585912767248/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_outer_join_-_right_join_key_in_projection/6.0.0_1585912767248/spec.json
@@ -1,0 +1,157 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912767248,
+  "schemas" : {
+    "CTAS_OUTER_JOIN_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, VALUE BIGINT> NOT NULL",
+    "CTAS_OUTER_JOIN_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL",
+    "CTAS_OUTER_JOIN_0.OUTER_JOIN" : "STRUCT<TT_ID BIGINT, NAME VARCHAR, VALUE BIGINT, F1 VARCHAR, F2 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "left_topic",
+    "key" : 10,
+    "value" : {
+      "ID" : 10,
+      "NAME" : "100",
+      "VALUE" : 5
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "right_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "right_topic",
+    "key" : 15,
+    "value" : {
+      "ID" : 15,
+      "F1" : "c",
+      "F2" : 20
+    },
+    "timestamp" : 15500
+  }, {
+    "topic" : "left_topic",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99
+    },
+    "timestamp" : 16000
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "TT_ID" : null,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 0
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "TT_ID" : 0,
+      "NAME" : "zero",
+      "VALUE" : 0,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 10000
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 10,
+    "value" : {
+      "TT_ID" : null,
+      "NAME" : "100",
+      "VALUE" : 5,
+      "F1" : null,
+      "F2" : null
+    },
+    "timestamp" : 11000
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "TT_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "blah",
+      "F2" : 50
+    },
+    "timestamp" : 13000
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "TT_ID" : 0,
+      "NAME" : "foo",
+      "VALUE" : 100,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 15000
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 15,
+    "value" : {
+      "TT_ID" : 15,
+      "NAME" : null,
+      "VALUE" : null,
+      "F1" : "c",
+      "F2" : 20
+    },
+    "timestamp" : 15500
+  }, {
+    "topic" : "OUTER_JOIN",
+    "key" : 0,
+    "value" : {
+      "TT_ID" : 0,
+      "NAME" : "bar",
+      "VALUE" : 99,
+      "F1" : "a",
+      "F2" : 10
+    },
+    "timestamp" : 16000
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "OUTER_JOIN",
+      "type" : "table"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_outer_join_-_right_join_key_in_projection/6.0.0_1585912767248/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_table_outer_join_-_right_join_key_in_projection/6.0.0_1585912767248/topology
@@ -1,0 +1,42 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Project
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-TOSTREAM-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- Project
+    Sink: KSTREAM-SINK-0000000013 (topic: OUTER_JOIN)
+      <-- KTABLE-TOSTREAM-0000000012
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(different)___key_in_value___aliasing/6.0.0_1585912771182/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(different)___key_in_value___aliasing/6.0.0_1585912771182/plan.json
@@ -1,0 +1,165 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE INPUT (ROWKEY INTEGER PRIMARY KEY, FOO INTEGER, BAR INTEGER) WITH (KAFKA_TOPIC='input_topic', KEY='foo', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ROWKEY` INTEGER KEY, `FOO` INTEGER, `BAR` INTEGER",
+      "keyField" : "FOO",
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.BAR ALIASED,\n  COUNT(*) KSQL_COL_0\nFROM INPUT INPUT\nGROUP BY INPUT.BAR\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` INTEGER KEY, `ALIASED` INTEGER, `KSQL_COL_0` BIGINT",
+      "keyField" : "ALIASED",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "input_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` INTEGER KEY, `FOO` INTEGER, `BAR` INTEGER"
+                },
+                "selectExpressions" : [ "BAR AS BAR", "ROWTIME AS ROWTIME" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              },
+              "groupByExpressions" : [ "BAR" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "BAR", "ROWTIME" ],
+            "aggregationFunctions" : [ "COUNT(ROWTIME)" ]
+          },
+          "selectExpressions" : [ "BAR AS ALIASED", "KSQL_AGG_VARIABLE_0 AS KSQL_COL_0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(different)___key_in_value___aliasing/6.0.0_1585912771182/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(different)___key_in_value___aliasing/6.0.0_1585912771182/spec.json
@@ -1,0 +1,32 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912771182,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<FOO INT, BAR INT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : "STRUCT<BAR INT, ROWTIME BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : "STRUCT<BAR INT, ROWTIME BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<ALIASED INT, KSQL_COL_0 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "input_topic",
+    "key" : 1,
+    "value" : {
+      "foo" : 1,
+      "bar" : 2
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 2,
+    "value" : {
+      "ALIASED" : 2,
+      "KSQL_COL_0" : 1
+    }
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "OUTPUT",
+      "type" : "table"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(different)___key_in_value___aliasing/6.0.0_1585912771182/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(different)___key_in_value___aliasing/6.0.0_1585912771182/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(different)___key_in_value___no_aliasing/6.0.0_1585912771153/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(different)___key_in_value___no_aliasing/6.0.0_1585912771153/plan.json
@@ -1,0 +1,165 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE INPUT (ROWKEY INTEGER PRIMARY KEY, FOO INTEGER, BAR INTEGER) WITH (KAFKA_TOPIC='input_topic', KEY='foo', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ROWKEY` INTEGER KEY, `FOO` INTEGER, `BAR` INTEGER",
+      "keyField" : "FOO",
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.BAR BAR,\n  COUNT(*) KSQL_COL_0\nFROM INPUT INPUT\nGROUP BY INPUT.BAR\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` INTEGER KEY, `BAR` INTEGER, `KSQL_COL_0` BIGINT",
+      "keyField" : "BAR",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "input_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` INTEGER KEY, `FOO` INTEGER, `BAR` INTEGER"
+                },
+                "selectExpressions" : [ "BAR AS BAR", "ROWTIME AS ROWTIME" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              },
+              "groupByExpressions" : [ "BAR" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "BAR", "ROWTIME" ],
+            "aggregationFunctions" : [ "COUNT(ROWTIME)" ]
+          },
+          "selectExpressions" : [ "BAR AS BAR", "KSQL_AGG_VARIABLE_0 AS KSQL_COL_0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(different)___key_in_value___no_aliasing/6.0.0_1585912771153/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(different)___key_in_value___no_aliasing/6.0.0_1585912771153/spec.json
@@ -1,0 +1,32 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912771153,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<FOO INT, BAR INT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : "STRUCT<BAR INT, ROWTIME BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : "STRUCT<BAR INT, ROWTIME BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<BAR INT, KSQL_COL_0 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "input_topic",
+    "key" : 1,
+    "value" : {
+      "foo" : 1,
+      "bar" : 2
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 2,
+    "value" : {
+      "BAR" : 2,
+      "KSQL_COL_0" : 1
+    }
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "OUTPUT",
+      "type" : "table"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(different)___key_in_value___no_aliasing/6.0.0_1585912771153/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(different)___key_in_value___no_aliasing/6.0.0_1585912771153/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(different)___key_not_in_value___-/6.0.0_1585912771234/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(different)___key_not_in_value___-/6.0.0_1585912771234/plan.json
@@ -1,0 +1,164 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE INPUT (ROWKEY INTEGER PRIMARY KEY, FOO INTEGER, BAR INTEGER) WITH (KAFKA_TOPIC='input_topic', KEY='foo', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ROWKEY` INTEGER KEY, `FOO` INTEGER, `BAR` INTEGER",
+      "keyField" : "FOO",
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT COUNT(*) KSQL_COL_0\nFROM INPUT INPUT\nGROUP BY INPUT.BAR\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` INTEGER KEY, `KSQL_COL_0` BIGINT",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "input_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` INTEGER KEY, `FOO` INTEGER, `BAR` INTEGER"
+                },
+                "selectExpressions" : [ "ROWTIME AS ROWTIME", "BAR AS BAR" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              },
+              "groupByExpressions" : [ "BAR" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ROWTIME", "BAR" ],
+            "aggregationFunctions" : [ "COUNT(ROWTIME)" ]
+          },
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS KSQL_COL_0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(different)___key_not_in_value___-/6.0.0_1585912771234/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(different)___key_not_in_value___-/6.0.0_1585912771234/spec.json
@@ -1,0 +1,31 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912771234,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<FOO INT, BAR INT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : "STRUCT<ROWTIME BIGINT, BAR INT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : "STRUCT<ROWTIME BIGINT, BAR INT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<KSQL_COL_0 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "input_topic",
+    "key" : 1,
+    "value" : {
+      "foo" : 1,
+      "bar" : 2
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 2,
+    "value" : {
+      "KSQL_COL_0" : 1
+    }
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "OUTPUT",
+      "type" : "table"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(different)___key_not_in_value___-/6.0.0_1585912771234/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(different)___key_not_in_value___-/6.0.0_1585912771234/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(same)___key_in_value___aliasing/6.0.0_1585912771100/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(same)___key_in_value___aliasing/6.0.0_1585912771100/plan.json
@@ -1,0 +1,165 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE INPUT (ROWKEY INTEGER PRIMARY KEY, FOO INTEGER, BAR INTEGER) WITH (KAFKA_TOPIC='input_topic', KEY='foo', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ROWKEY` INTEGER KEY, `FOO` INTEGER, `BAR` INTEGER",
+      "keyField" : "FOO",
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.FOO ALIASED,\n  COUNT(*) KSQL_COL_0\nFROM INPUT INPUT\nGROUP BY INPUT.FOO\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` INTEGER KEY, `ALIASED` INTEGER, `KSQL_COL_0` BIGINT",
+      "keyField" : "ALIASED",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "input_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` INTEGER KEY, `FOO` INTEGER, `BAR` INTEGER"
+                },
+                "selectExpressions" : [ "FOO AS FOO", "ROWTIME AS ROWTIME" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              },
+              "groupByExpressions" : [ "FOO" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "FOO", "ROWTIME" ],
+            "aggregationFunctions" : [ "COUNT(ROWTIME)" ]
+          },
+          "selectExpressions" : [ "FOO AS ALIASED", "KSQL_AGG_VARIABLE_0 AS KSQL_COL_0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(same)___key_in_value___aliasing/6.0.0_1585912771100/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(same)___key_in_value___aliasing/6.0.0_1585912771100/spec.json
@@ -1,0 +1,32 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912771100,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<FOO INT, BAR INT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : "STRUCT<FOO INT, ROWTIME BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : "STRUCT<FOO INT, ROWTIME BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<ALIASED INT, KSQL_COL_0 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "input_topic",
+    "key" : 1,
+    "value" : {
+      "foo" : 1,
+      "bar" : 2
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : {
+      "ALIASED" : 1,
+      "KSQL_COL_0" : 1
+    }
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "OUTPUT",
+      "type" : "table"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(same)___key_in_value___aliasing/6.0.0_1585912771100/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(same)___key_in_value___aliasing/6.0.0_1585912771100/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(same)___key_in_value___no_aliasing/6.0.0_1585912771067/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(same)___key_in_value___no_aliasing/6.0.0_1585912771067/plan.json
@@ -1,0 +1,165 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE INPUT (ROWKEY INTEGER PRIMARY KEY, FOO INTEGER, BAR INTEGER) WITH (KAFKA_TOPIC='input_topic', KEY='foo', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ROWKEY` INTEGER KEY, `FOO` INTEGER, `BAR` INTEGER",
+      "keyField" : "FOO",
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.FOO FOO,\n  COUNT(*) KSQL_COL_0\nFROM INPUT INPUT\nGROUP BY INPUT.FOO\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` INTEGER KEY, `FOO` INTEGER, `KSQL_COL_0` BIGINT",
+      "keyField" : "FOO",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "input_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` INTEGER KEY, `FOO` INTEGER, `BAR` INTEGER"
+                },
+                "selectExpressions" : [ "FOO AS FOO", "ROWTIME AS ROWTIME" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              },
+              "groupByExpressions" : [ "FOO" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "FOO", "ROWTIME" ],
+            "aggregationFunctions" : [ "COUNT(ROWTIME)" ]
+          },
+          "selectExpressions" : [ "FOO AS FOO", "KSQL_AGG_VARIABLE_0 AS KSQL_COL_0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(same)___key_in_value___no_aliasing/6.0.0_1585912771067/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(same)___key_in_value___no_aliasing/6.0.0_1585912771067/spec.json
@@ -1,0 +1,32 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912771067,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<FOO INT, BAR INT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : "STRUCT<FOO INT, ROWTIME BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : "STRUCT<FOO INT, ROWTIME BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<FOO INT, KSQL_COL_0 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "input_topic",
+    "key" : 1,
+    "value" : {
+      "foo" : 1,
+      "bar" : 2
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : {
+      "FOO" : 1,
+      "KSQL_COL_0" : 1
+    }
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "OUTPUT",
+      "type" : "table"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(same)___key_in_value___no_aliasing/6.0.0_1585912771067/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(same)___key_in_value___no_aliasing/6.0.0_1585912771067/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(same)___key_not_in_value___-/6.0.0_1585912771125/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(same)___key_not_in_value___-/6.0.0_1585912771125/plan.json
@@ -1,0 +1,164 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE INPUT (ROWKEY INTEGER PRIMARY KEY, FOO INTEGER, BAR INTEGER) WITH (KAFKA_TOPIC='input_topic', KEY='foo', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ROWKEY` INTEGER KEY, `FOO` INTEGER, `BAR` INTEGER",
+      "keyField" : "FOO",
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT COUNT(*) KSQL_COL_0\nFROM INPUT INPUT\nGROUP BY INPUT.FOO\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` INTEGER KEY, `KSQL_COL_0` BIGINT",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "input_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` INTEGER KEY, `FOO` INTEGER, `BAR` INTEGER"
+                },
+                "selectExpressions" : [ "ROWTIME AS ROWTIME", "FOO AS FOO" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              },
+              "groupByExpressions" : [ "FOO" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ROWTIME", "FOO" ],
+            "aggregationFunctions" : [ "COUNT(ROWTIME)" ]
+          },
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS KSQL_COL_0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(same)___key_not_in_value___-/6.0.0_1585912771125/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(same)___key_not_in_value___-/6.0.0_1585912771125/spec.json
@@ -1,0 +1,31 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912771125,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<FOO INT, BAR INT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : "STRUCT<ROWTIME BIGINT, FOO INT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : "STRUCT<ROWTIME BIGINT, FOO INT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<KSQL_COL_0 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "input_topic",
+    "key" : 1,
+    "value" : {
+      "foo" : 1,
+      "bar" : 2
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : {
+      "KSQL_COL_0" : 1
+    }
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "OUTPUT",
+      "type" : "table"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(same)___key_not_in_value___-/6.0.0_1585912771125/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___group_by_(same)___key_not_in_value___-/6.0.0_1585912771125/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___no_key_change___key_in_value___aliasing/6.0.0_1585912771043/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___no_key_change___key_in_value___aliasing/6.0.0_1585912771043/plan.json
@@ -1,0 +1,127 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE INPUT (ROWKEY INTEGER PRIMARY KEY, FOO INTEGER, BAR INTEGER) WITH (KAFKA_TOPIC='input_topic', KEY='foo', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ROWKEY` INTEGER KEY, `FOO` INTEGER, `BAR` INTEGER",
+      "keyField" : "FOO",
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.FOO ALIASED,\n  INPUT.BAR BAR\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` INTEGER KEY, `ALIASED` INTEGER, `BAR` INTEGER",
+      "keyField" : "ALIASED",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ROWKEY` INTEGER KEY, `FOO` INTEGER, `BAR` INTEGER"
+          },
+          "selectExpressions" : [ "FOO AS ALIASED", "BAR AS BAR" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___no_key_change___key_in_value___aliasing/6.0.0_1585912771043/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___no_key_change___key_in_value___aliasing/6.0.0_1585912771043/spec.json
@@ -1,0 +1,33 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912771043,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<FOO INT, BAR INT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<ALIASED INT, BAR INT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "input_topic",
+    "key" : 1,
+    "value" : {
+      "foo" : 1,
+      "bar" : 2
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : {
+      "ALIASED" : 1,
+      "BAR" : 2
+    }
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "INPUT",
+      "type" : "table"
+    }, {
+      "name" : "OUTPUT",
+      "type" : "table"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___no_key_change___key_in_value___aliasing/6.0.0_1585912771043/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___no_key_change___key_in_value___aliasing/6.0.0_1585912771043/topology
@@ -1,0 +1,19 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Project
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-TOSTREAM-0000000004 (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- Project
+    Sink: KSTREAM-SINK-0000000005 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000004
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___no_key_change___key_in_value___no_aliasing/6.0.0_1585912771030/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___no_key_change___key_in_value___no_aliasing/6.0.0_1585912771030/plan.json
@@ -1,0 +1,127 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE INPUT (ROWKEY INTEGER PRIMARY KEY, FOO INTEGER, BAR INTEGER) WITH (KAFKA_TOPIC='input_topic', KEY='foo', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ROWKEY` INTEGER KEY, `FOO` INTEGER, `BAR` INTEGER",
+      "keyField" : "FOO",
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT *\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` INTEGER KEY, `FOO` INTEGER, `BAR` INTEGER",
+      "keyField" : "FOO",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ROWKEY` INTEGER KEY, `FOO` INTEGER, `BAR` INTEGER"
+          },
+          "selectExpressions" : [ "FOO AS FOO", "BAR AS BAR" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___no_key_change___key_in_value___no_aliasing/6.0.0_1585912771030/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___no_key_change___key_in_value___no_aliasing/6.0.0_1585912771030/spec.json
@@ -1,0 +1,33 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912771030,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<FOO INT, BAR INT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<FOO INT, BAR INT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "input_topic",
+    "key" : 1,
+    "value" : {
+      "foo" : 1,
+      "bar" : 2
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : {
+      "FOO" : 1,
+      "BAR" : 2
+    }
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "INPUT",
+      "type" : "table"
+    }, {
+      "name" : "OUTPUT",
+      "type" : "table"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___no_key_change___key_in_value___no_aliasing/6.0.0_1585912771030/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___no_key_change___key_in_value___no_aliasing/6.0.0_1585912771030/topology
@@ -1,0 +1,19 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Project
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-TOSTREAM-0000000004 (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- Project
+    Sink: KSTREAM-SINK-0000000005 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000004
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___no_key_change___key_not_in_value___-/6.0.0_1585912771054/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___no_key_change___key_not_in_value___-/6.0.0_1585912771054/plan.json
@@ -1,0 +1,126 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE INPUT (ROWKEY INTEGER PRIMARY KEY, FOO INTEGER, BAR INTEGER) WITH (KAFKA_TOPIC='input_topic', KEY='foo', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ROWKEY` INTEGER KEY, `FOO` INTEGER, `BAR` INTEGER",
+      "keyField" : "FOO",
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT INPUT.BAR BAR\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` INTEGER KEY, `BAR` INTEGER",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ROWKEY` INTEGER KEY, `FOO` INTEGER, `BAR` INTEGER"
+          },
+          "selectExpressions" : [ "BAR AS BAR" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___no_key_change___key_not_in_value___-/6.0.0_1585912771054/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___no_key_change___key_not_in_value___-/6.0.0_1585912771054/spec.json
@@ -1,0 +1,29 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912771054,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<FOO INT, BAR INT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<BAR INT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "input_topic",
+    "key" : 1,
+    "value" : {
+      "foo" : 1,
+      "bar" : 2
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : {
+      "BAR" : 2
+    }
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "OUTPUT",
+      "type" : "table"
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___no_key_change___key_not_in_value___-/6.0.0_1585912771054/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-field_-_table___initially_set___no_key_change___key_not_in_value___-/6.0.0_1585912771054/topology
@@ -1,0 +1,19 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Project
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-TOSTREAM-0000000004 (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- Project
+    Sink: KSTREAM-SINK-0000000005 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000004
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-schemas_-_table_explicit_KAFKA_BIGINT_ROWKEY/6.0.0_1585912771452/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-schemas_-_table_explicit_KAFKA_BIGINT_ROWKEY/6.0.0_1585912771452/plan.json
@@ -1,0 +1,125 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE INPUT (ROWKEY BIGINT PRIMARY KEY, ID BIGINT) WITH (KAFKA_TOPIC='input', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT",
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  INPUT.ROWKEY KEY\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `KEY` BIGINT",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT"
+          },
+          "selectExpressions" : [ "ID AS ID", "ROWKEY AS KEY" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-schemas_-_table_explicit_KAFKA_BIGINT_ROWKEY/6.0.0_1585912771452/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-schemas_-_table_explicit_KAFKA_BIGINT_ROWKEY/6.0.0_1585912771452/spec.json
@@ -1,0 +1,59 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912771452,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<ID BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<ID BIGINT, KEY BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "input",
+    "key" : 3,
+    "value" : {
+      "id" : 1
+    }
+  }, {
+    "topic" : "input",
+    "key" : 2,
+    "value" : {
+      "id" : 2
+    }
+  }, {
+    "topic" : "input",
+    "key" : 1,
+    "value" : {
+      "id" : 3
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 3,
+    "value" : {
+      "ID" : 1,
+      "KEY" : 3
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 2,
+    "value" : {
+      "ID" : 2,
+      "KEY" : 2
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : {
+      "ID" : 3,
+      "KEY" : 1
+    }
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "OUTPUT",
+      "type" : "table",
+      "schema" : "ROWKEY BIGINT KEY, ID BIGINT, KEY BIGINT",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      }
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-schemas_-_table_explicit_KAFKA_BIGINT_ROWKEY/6.0.0_1585912771452/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-schemas_-_table_explicit_KAFKA_BIGINT_ROWKEY/6.0.0_1585912771452/topology
@@ -1,0 +1,19 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Project
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-TOSTREAM-0000000004 (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- Project
+    Sink: KSTREAM-SINK-0000000005 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000004
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-schemas_-_table_explicit_KAFKA_DOUBLE_ROWKEY/6.0.0_1585912771474/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-schemas_-_table_explicit_KAFKA_DOUBLE_ROWKEY/6.0.0_1585912771474/plan.json
@@ -1,0 +1,125 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE INPUT (ROWKEY DOUBLE PRIMARY KEY, ID BIGINT) WITH (KAFKA_TOPIC='input', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ROWKEY` DOUBLE KEY, `ID` BIGINT",
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  INPUT.ROWKEY KEY\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` DOUBLE KEY, `ID` BIGINT, `KEY` DOUBLE",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ROWKEY` DOUBLE KEY, `ID` BIGINT"
+          },
+          "selectExpressions" : [ "ID AS ID", "ROWKEY AS KEY" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-schemas_-_table_explicit_KAFKA_DOUBLE_ROWKEY/6.0.0_1585912771474/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-schemas_-_table_explicit_KAFKA_DOUBLE_ROWKEY/6.0.0_1585912771474/spec.json
@@ -1,0 +1,59 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912771474,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<ID BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<ID BIGINT, KEY DOUBLE> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "input",
+    "key" : 3.0,
+    "value" : {
+      "id" : 1
+    }
+  }, {
+    "topic" : "input",
+    "key" : 2.0,
+    "value" : {
+      "id" : 2
+    }
+  }, {
+    "topic" : "input",
+    "key" : 1.0,
+    "value" : {
+      "id" : 3
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 3.0,
+    "value" : {
+      "ID" : 1,
+      "KEY" : 3.0
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 2.0,
+    "value" : {
+      "ID" : 2,
+      "KEY" : 2.0
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 1.0,
+    "value" : {
+      "ID" : 3,
+      "KEY" : 1.0
+    }
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "OUTPUT",
+      "type" : "table",
+      "schema" : "ROWKEY DOUBLE KEY, ID BIGINT, KEY DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      }
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-schemas_-_table_explicit_KAFKA_DOUBLE_ROWKEY/6.0.0_1585912771474/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-schemas_-_table_explicit_KAFKA_DOUBLE_ROWKEY/6.0.0_1585912771474/topology
@@ -1,0 +1,19 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Project
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-TOSTREAM-0000000004 (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- Project
+    Sink: KSTREAM-SINK-0000000005 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000004
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-schemas_-_table_explicit_KAFKA_INT_ROWKEY/6.0.0_1585912771432/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-schemas_-_table_explicit_KAFKA_INT_ROWKEY/6.0.0_1585912771432/plan.json
@@ -1,0 +1,125 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE INPUT (ROWKEY INTEGER PRIMARY KEY, ID BIGINT) WITH (KAFKA_TOPIC='input', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ROWKEY` INTEGER KEY, `ID` BIGINT",
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  INPUT.ROWKEY KEY\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` INTEGER KEY, `ID` BIGINT, `KEY` INTEGER",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ROWKEY` INTEGER KEY, `ID` BIGINT"
+          },
+          "selectExpressions" : [ "ID AS ID", "ROWKEY AS KEY" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-schemas_-_table_explicit_KAFKA_INT_ROWKEY/6.0.0_1585912771432/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-schemas_-_table_explicit_KAFKA_INT_ROWKEY/6.0.0_1585912771432/spec.json
@@ -1,0 +1,59 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912771432,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<ID BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<ID BIGINT, KEY INT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "input",
+    "key" : 3,
+    "value" : {
+      "id" : 1
+    }
+  }, {
+    "topic" : "input",
+    "key" : 2,
+    "value" : {
+      "id" : 2
+    }
+  }, {
+    "topic" : "input",
+    "key" : 1,
+    "value" : {
+      "id" : 3
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 3,
+    "value" : {
+      "ID" : 1,
+      "KEY" : 3
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 2,
+    "value" : {
+      "ID" : 2,
+      "KEY" : 2
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : {
+      "ID" : 3,
+      "KEY" : 1
+    }
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "OUTPUT",
+      "type" : "table",
+      "schema" : "ROWKEY INT KEY, ID BIGINT, KEY INT",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      }
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-schemas_-_table_explicit_KAFKA_INT_ROWKEY/6.0.0_1585912771432/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-schemas_-_table_explicit_KAFKA_INT_ROWKEY/6.0.0_1585912771432/topology
@@ -1,0 +1,19 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Project
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-TOSTREAM-0000000004 (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- Project
+    Sink: KSTREAM-SINK-0000000005 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000004
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-schemas_-_table_explicit_KAFKA_STRING_ROWKEY/6.0.0_1585912771411/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-schemas_-_table_explicit_KAFKA_STRING_ROWKEY/6.0.0_1585912771411/plan.json
@@ -1,0 +1,125 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE INPUT (ROWKEY STRING PRIMARY KEY, ID BIGINT) WITH (KAFKA_TOPIC='input', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ROWKEY` STRING KEY, `ID` BIGINT",
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  INPUT.ROWKEY KEY\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` STRING KEY, `ID` BIGINT, `KEY` STRING",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ROWKEY` STRING KEY, `ID` BIGINT"
+          },
+          "selectExpressions" : [ "ID AS ID", "ROWKEY AS KEY" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-schemas_-_table_explicit_KAFKA_STRING_ROWKEY/6.0.0_1585912771411/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-schemas_-_table_explicit_KAFKA_STRING_ROWKEY/6.0.0_1585912771411/spec.json
@@ -1,0 +1,59 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912771411,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<ID BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<ID BIGINT, KEY VARCHAR> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "input",
+    "key" : "1",
+    "value" : {
+      "id" : 1
+    }
+  }, {
+    "topic" : "input",
+    "key" : "1",
+    "value" : {
+      "id" : 2
+    }
+  }, {
+    "topic" : "input",
+    "key" : "",
+    "value" : {
+      "id" : 3
+    }
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : "1",
+    "value" : {
+      "ID" : 1,
+      "KEY" : "1"
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "1",
+    "value" : {
+      "ID" : 2,
+      "KEY" : "1"
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : "",
+    "value" : {
+      "ID" : 3,
+      "KEY" : ""
+    }
+  } ],
+  "postConditions" : {
+    "sources" : [ {
+      "name" : "OUTPUT",
+      "type" : "table",
+      "schema" : "ROWKEY STRING KEY, ID BIGINT, KEY STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      }
+    } ]
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-schemas_-_table_explicit_KAFKA_STRING_ROWKEY/6.0.0_1585912771411/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-schemas_-_table_explicit_KAFKA_STRING_ROWKEY/6.0.0_1585912771411/topology
@@ -1,0 +1,19 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Project
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-TOSTREAM-0000000004 (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- Project
+    Sink: KSTREAM-SINK-0000000005 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000004
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/sum_-_sum_int_left_join_of_table/6.0.0_1585912774479/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/sum_-_sum_int_left_join_of_table/6.0.0_1585912774479/plan.json
@@ -1,0 +1,220 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE T1 (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, TOTAL INTEGER) WITH (KAFKA_TOPIC='T1', KEY='ID', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "T1",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `TOTAL` INTEGER",
+      "keyField" : "ID",
+      "topicName" : "T1",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE T2 (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, TOTAL INTEGER) WITH (KAFKA_TOPIC='T2', KEY='ID', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "T2",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `TOTAL` INTEGER",
+      "keyField" : "ID",
+      "topicName" : "T2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  T1.ID ID,\n  SUM(T2.TOTAL) SUM\nFROM T1 T1\nLEFT OUTER JOIN T2 T2 ON ((T1.ID = T2.ID))\nGROUP BY T1.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `SUM` INTEGER",
+      "keyField" : "ID",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "T1", "T2" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableTableJoinV1",
+                  "properties" : {
+                    "queryContext" : "Join"
+                  },
+                  "joinType" : "LEFT",
+                  "leftSource" : {
+                    "@type" : "tableSelectV1",
+                    "properties" : {
+                      "queryContext" : "PrependAliasLeft"
+                    },
+                    "source" : {
+                      "@type" : "tableSourceV1",
+                      "properties" : {
+                        "queryContext" : "KafkaTopic_Left/Source"
+                      },
+                      "topicName" : "T1",
+                      "formats" : {
+                        "keyFormat" : {
+                          "format" : "KAFKA"
+                        },
+                        "valueFormat" : {
+                          "format" : "AVRO"
+                        }
+                      },
+                      "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `TOTAL` INTEGER"
+                    },
+                    "selectExpressions" : [ "ID AS T1_ID", "TOTAL AS T1_TOTAL", "ROWTIME AS T1_ROWTIME", "ROWKEY AS T1_ROWKEY" ]
+                  },
+                  "rightSource" : {
+                    "@type" : "tableSelectV1",
+                    "properties" : {
+                      "queryContext" : "PrependAliasRight"
+                    },
+                    "source" : {
+                      "@type" : "tableSourceV1",
+                      "properties" : {
+                        "queryContext" : "KafkaTopic_Right/Source"
+                      },
+                      "topicName" : "T2",
+                      "formats" : {
+                        "keyFormat" : {
+                          "format" : "KAFKA"
+                        },
+                        "valueFormat" : {
+                          "format" : "AVRO"
+                        }
+                      },
+                      "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `TOTAL` INTEGER"
+                    },
+                    "selectExpressions" : [ "ID AS T2_ID", "TOTAL AS T2_TOTAL", "ROWTIME AS T2_ROWTIME", "ROWKEY AS T2_ROWKEY" ]
+                  }
+                },
+                "selectExpressions" : [ "T1_ID AS T1_ID", "T2_TOTAL AS T2_TOTAL" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "AVRO"
+                }
+              },
+              "groupByExpressions" : [ "T1_ID" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "AVRO"
+              }
+            },
+            "nonAggregateColumns" : [ "T1_ID", "T2_TOTAL" ],
+            "aggregationFunctions" : [ "SUM(T2_TOTAL)" ]
+          },
+          "selectExpressions" : [ "T1_ID AS ID", "KSQL_AGG_VARIABLE_0 AS SUM" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/sum_-_sum_int_left_join_of_table/6.0.0_1585912774479/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/sum_-_sum_int_left_join_of_table/6.0.0_1585912774479/spec.json
@@ -1,0 +1,122 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912774479,
+  "schemas" : {
+    "CTAS_OUTPUT_0.KafkaTopic_Left.Source" : "STRUCT<ID BIGINT, TOTAL INT> NOT NULL",
+    "CTAS_OUTPUT_0.KafkaTopic_Right.Source" : "STRUCT<ID BIGINT, TOTAL INT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : "STRUCT<T1_ID BIGINT, T2_TOTAL INT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : "STRUCT<T1_ID BIGINT, T2_TOTAL INT, KSQL_AGG_VARIABLE_0 INT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<ID BIGINT, SUM INT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "T1",
+    "key" : 0,
+    "value" : {
+      "id" : 0,
+      "total" : 100
+    }
+  }, {
+    "topic" : "T1",
+    "key" : 1,
+    "value" : {
+      "id" : 1,
+      "total" : 101
+    }
+  }, {
+    "topic" : "T2",
+    "key" : 0,
+    "value" : {
+      "id" : 0,
+      "total" : 5
+    }
+  }, {
+    "topic" : "T2",
+    "key" : 1,
+    "value" : {
+      "id" : 1,
+      "total" : 10
+    }
+  }, {
+    "topic" : "T2",
+    "key" : 0,
+    "value" : {
+      "id" : 0,
+      "total" : 20
+    }
+  }, {
+    "topic" : "T2",
+    "key" : 0,
+    "value" : null
+  } ],
+  "outputs" : [ {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "SUM" : 0
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : {
+      "ID" : 1,
+      "SUM" : 0
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "SUM" : 0
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "SUM" : 5
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : {
+      "ID" : 1,
+      "SUM" : 0
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 1,
+    "value" : {
+      "ID" : 1,
+      "SUM" : 10
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "SUM" : 0
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "SUM" : 20
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "SUM" : 0
+    }
+  }, {
+    "topic" : "OUTPUT",
+    "key" : 0,
+    "value" : {
+      "ID" : 0,
+      "SUM" : 0
+    }
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/sum_-_sum_int_left_join_of_table/6.0.0_1585912774479/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/sum_-_sum_int_left_join_of_table/6.0.0_1585912774479/topology
@@ -1,0 +1,63 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [T1])
+      --> KTABLE-SOURCE-0000000001
+    Source: KSTREAM-SOURCE-0000000004 (topics: [T2])
+      --> KTABLE-SOURCE-0000000005
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-SOURCE-0000000005 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000006
+      <-- KSTREAM-SOURCE-0000000004
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> PrependAliasLeft
+      <-- KTABLE-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000006 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-SOURCE-0000000005
+    Processor: PrependAliasLeft (stores: [])
+      --> KTABLE-JOINTHIS-0000000009
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000010
+      <-- KTABLE-TRANSFORMVALUES-0000000006
+    Processor: KTABLE-JOINOTHER-0000000010 (stores: [KafkaTopic_Left-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000009 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000008
+      <-- PrependAliasLeft
+    Processor: KTABLE-MERGE-0000000008 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-JOINTHIS-0000000009, KTABLE-JOINOTHER-0000000010
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000012
+      <-- KTABLE-MERGE-0000000008
+    Processor: KTABLE-FILTER-0000000012 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000014
+      <-- KTABLE-FILTER-0000000012
+    Sink: KSTREAM-SINK-0000000014 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000015 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000016
+    Processor: KTABLE-AGGREGATE-0000000016 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000015
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000016
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000019
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000019 (stores: [])
+      --> KSTREAM-SINK-0000000020
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000020 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000019
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/test-custom-udaf_-_test_udaf_on_a_table/6.0.0_1585912775211/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/test-custom-udaf_-_test_udaf_on_a_table/6.0.0_1585912775211/plan.json
@@ -1,0 +1,165 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, NAME STRING, REGION STRING) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='DELIMITED');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `REGION` STRING",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE SUM_ID_BY_REGION AS SELECT\n  TEST.REGION REGION,\n  TEST_UDAF(TEST.ID) KSQL_COL_0\nFROM TEST TEST\nGROUP BY TEST.REGION\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "SUM_ID_BY_REGION",
+      "schema" : "`ROWKEY` STRING KEY, `REGION` STRING, `KSQL_COL_0` BIGINT",
+      "keyField" : "REGION",
+      "topicName" : "SUM_ID_BY_REGION",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "SUM_ID_BY_REGION",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "SUM_ID_BY_REGION"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "DELIMITED"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `NAME` STRING, `REGION` STRING"
+                },
+                "selectExpressions" : [ "REGION AS REGION", "ID AS ID" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "DELIMITED"
+                }
+              },
+              "groupByExpressions" : [ "REGION" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "DELIMITED"
+              }
+            },
+            "nonAggregateColumns" : [ "REGION", "ID" ],
+            "aggregationFunctions" : [ "TEST_UDAF(ID)" ]
+          },
+          "selectExpressions" : [ "REGION AS REGION", "KSQL_AGG_VARIABLE_0 AS KSQL_COL_0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          }
+        },
+        "topicName" : "SUM_ID_BY_REGION"
+      },
+      "queryId" : "CTAS_SUM_ID_BY_REGION_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.authentication.plugin.class" : null,
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/test-custom-udaf_-_test_udaf_on_a_table/6.0.0_1585912775211/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/test-custom-udaf_-_test_udaf_on_a_table/6.0.0_1585912775211/spec.json
@@ -1,0 +1,64 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1585912775211,
+  "schemas" : {
+    "CTAS_SUM_ID_BY_REGION_0.KsqlTopic.Source" : "STRUCT<ID BIGINT, NAME VARCHAR, REGION VARCHAR> NOT NULL",
+    "CTAS_SUM_ID_BY_REGION_0.Aggregate.GroupBy" : "STRUCT<REGION VARCHAR, ID BIGINT> NOT NULL",
+    "CTAS_SUM_ID_BY_REGION_0.Aggregate.Aggregate.Materialize" : "STRUCT<REGION VARCHAR, ID BIGINT, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL",
+    "CTAS_SUM_ID_BY_REGION_0.SUM_ID_BY_REGION" : "STRUCT<REGION VARCHAR, KSQL_COL_0 BIGINT> NOT NULL"
+  },
+  "inputs" : [ {
+    "topic" : "test_topic",
+    "key" : 0,
+    "value" : "0,alice,east"
+  }, {
+    "topic" : "test_topic",
+    "key" : 1,
+    "value" : "1,bob,east"
+  }, {
+    "topic" : "test_topic",
+    "key" : 2,
+    "value" : "2,carol,west"
+  }, {
+    "topic" : "test_topic",
+    "key" : 3,
+    "value" : "3,dave,west"
+  }, {
+    "topic" : "test_topic",
+    "key" : 1,
+    "value" : "1,bob,west"
+  }, {
+    "topic" : "test_topic",
+    "key" : 1,
+    "value" : null
+  } ],
+  "outputs" : [ {
+    "topic" : "SUM_ID_BY_REGION",
+    "key" : "east",
+    "value" : "east,0"
+  }, {
+    "topic" : "SUM_ID_BY_REGION",
+    "key" : "east",
+    "value" : "east,1"
+  }, {
+    "topic" : "SUM_ID_BY_REGION",
+    "key" : "west",
+    "value" : "west,2"
+  }, {
+    "topic" : "SUM_ID_BY_REGION",
+    "key" : "west",
+    "value" : "west,5"
+  }, {
+    "topic" : "SUM_ID_BY_REGION",
+    "key" : "east",
+    "value" : "east,0"
+  }, {
+    "topic" : "SUM_ID_BY_REGION",
+    "key" : "west",
+    "value" : "west,6"
+  }, {
+    "topic" : "SUM_ID_BY_REGION",
+    "key" : "west",
+    "value" : "west,5"
+  } ]
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/test-custom-udaf_-_test_udaf_on_a_table/6.0.0_1585912775211/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/test-custom-udaf_-_test_udaf_on_a_table/6.0.0_1585912775211/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-FILTER-0000000004 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000006
+      <-- KTABLE-FILTER-0000000004
+    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000007 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000008
+    Processor: KTABLE-AGGREGATE-0000000008 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000008
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: SUM_ID_BY_REGION)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/collect-list.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/collect-list.json
@@ -112,7 +112,7 @@
       "name": "collect_list int table",
       "format": ["AVRO", "JSON", "PROTOBUF"],
       "statements": [
-        "CREATE TABLE TEST (ROWKEY BIGINT KEY, ID bigint, VALUE integer) WITH (kafka_topic='test_topic',value_format='{FORMAT}', key='ID');",
+        "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID bigint, VALUE integer) WITH (kafka_topic='test_topic',value_format='{FORMAT}', key='ID');",
         "CREATE TABLE S2 as SELECT id, collect_list(value) as collected FROM test group by id;"
       ],
       "inputs": [
@@ -134,7 +134,7 @@
       "name": "collect_list long table",
       "format": ["AVRO", "JSON", "PROTOBUF"],
       "statements": [
-        "CREATE TABLE TEST (ROWKEY BIGINT KEY, ID bigint, VALUE bigint) WITH (kafka_topic='test_topic', value_format='{FORMAT}', key='ID');",
+        "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID bigint, VALUE bigint) WITH (kafka_topic='test_topic', value_format='{FORMAT}', key='ID');",
         "CREATE TABLE S2 as SELECT id, collect_list(value) as collected FROM test group by id;"
       ],
       "inputs": [
@@ -156,7 +156,7 @@
       "name": "collect_list double table",
       "format": ["AVRO", "JSON", "PROTOBUF"],
       "statements": [
-        "CREATE TABLE TEST (ROWKEY BIGINT KEY, ID bigint, VALUE double) WITH (kafka_topic='test_topic', value_format='{FORMAT}', key='ID');",
+        "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID bigint, VALUE double) WITH (kafka_topic='test_topic', value_format='{FORMAT}', key='ID');",
         "CREATE TABLE S2 as SELECT id, collect_list(value) as collected FROM test group by id;"
       ],
       "inputs": [
@@ -178,7 +178,7 @@
       "name": "collect_list string table",
       "format": ["AVRO", "JSON", "PROTOBUF"],
       "statements": [
-        "CREATE TABLE TEST (ROWKEY BIGINT KEY, ID bigint, VALUE varchar) WITH (kafka_topic='test_topic', value_format='{FORMAT}', key='ID');",
+        "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID bigint, VALUE varchar) WITH (kafka_topic='test_topic', value_format='{FORMAT}', key='ID');",
         "CREATE TABLE S2 as SELECT id, collect_list(value) as collected FROM test group by id;"
       ],
       "inputs": [
@@ -203,7 +203,7 @@
       "name": "collect_list bool map table",
       "format": ["JSON", "PROTOBUF"],
       "statements": [
-        "CREATE TABLE TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, VALUE map<varchar, boolean>) WITH (kafka_topic='test_topic', value_format='{FORMAT}', key='ID');",
+        "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID bigint, NAME varchar, VALUE map<varchar, boolean>) WITH (kafka_topic='test_topic', value_format='{FORMAT}', key='ID');",
         "CREATE TABLE S2 as SELECT id, collect_list(value['key1']) AS collected FROM test group by id;"
       ],
       "inputs": [

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/elements.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/elements.json
@@ -908,6 +908,45 @@
       "outputs": [
         {"topic": "OUTPUT", "key": 1, "value": {"KSQL_COL_2": 2, "KSQL_COL_4": 4, "KSQL_COL_0": 2, "KSQL_COL_1": 2, "KSQL_COL_5": 2}}
       ]
+    },
+    {
+      "name": "multiple key columns",
+      "statements": [
+        "CREATE STREAM INPUT (ID1 INT KEY, ID2 INT KEY, NAME STRING) WITH (kafka_topic='input',value_format='JSON');"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.parser.exception.ParseFailedException",
+        "message": "Only single KEY column supported. Multiple KEY columns found: `ID1` (Line: 1, Col: 22), `ID2` (Line: 1, Col: 35)"
+      }
+    },
+    {
+      "name": "table with key column",
+      "statements": [
+        "CREATE TABLE INPUT (ID INT KEY, NAME STRING) WITH (kafka_topic='input',value_format='JSON');"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.parser.exception.ParseFailedException",
+        "message": "Line: 1, Col: 21: Column `ID` is a 'KEY' column: please use 'PRIMARY KEY' for tables."
+      }
+    },
+    {
+      "name": "stream with primary key column",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT PRIMARY KEY, NAME STRING) WITH (kafka_topic='input',value_format='JSON');"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.parser.exception.ParseFailedException",
+        "message": "Line: 1, Col: 22: Column `ID` is a 'PRIMARY KEY' column: please use 'KEY' for streams."
+      }
     }
   ]
 }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
@@ -551,7 +551,7 @@
     {
       "name": "fields (table->table)",
       "statements": [
-        "CREATE TABLE TEST (ROWKEY INT KEY, f1 INT, f2 VARCHAR) WITH (kafka_topic='test_topic', KEY='f1', value_format='DELIMITED');",
+        "CREATE TABLE TEST (ROWKEY INT PRIMARY KEY, f1 INT, f2 VARCHAR) WITH (kafka_topic='test_topic', KEY='f1', value_format='DELIMITED');",
         "CREATE TABLE OUTPUT AS SELECT f1, f2, COUNT(*) FROM TEST GROUP BY f2, f1;"
       ],
       "inputs": [
@@ -586,7 +586,7 @@
     {
       "name": "fields (table->table) - format",
       "statements": [
-        "CREATE TABLE TEST (ROWKEY INT KEY, f1 INT, f2 VARCHAR) WITH (kafka_topic='test_topic', KEY='f1', value_format='{FORMAT}');",
+        "CREATE TABLE TEST (ROWKEY INT PRIMARY KEY, f1 INT, f2 VARCHAR) WITH (kafka_topic='test_topic', KEY='f1', value_format='{FORMAT}');",
         "CREATE TABLE OUTPUT AS SELECT f1, f2, COUNT(*) FROM TEST GROUP BY f2, f1;"
       ],
       "format": ["AVRO", "JSON", "PROTOBUF"],
@@ -731,7 +731,7 @@
     {
       "name": "field with re-key (table->table)",
       "statements": [
-        "CREATE TABLE TEST (ROWKEY INT KEY, user INT, region VARCHAR) WITH (kafka_topic='test_topic', KEY='user', value_format='DELIMITED');",
+        "CREATE TABLE TEST (ROWKEY INT PRIMARY KEY, user INT, region VARCHAR) WITH (kafka_topic='test_topic', KEY='user', value_format='DELIMITED');",
         "CREATE TABLE OUTPUT AS SELECT COUNT(*) FROM TEST GROUP BY region;"
       ],
       "inputs": [
@@ -780,7 +780,7 @@
     {
       "name": "with aggregate arithmetic (table->table)",
       "statements": [
-        "CREATE TABLE TEST (ROWKEY INT KEY, user INT, region VARCHAR) WITH (kafka_topic='test_topic', KEY='user', value_format='DELIMITED');",
+        "CREATE TABLE TEST (ROWKEY INT PRIMARY KEY, user INT, region VARCHAR) WITH (kafka_topic='test_topic', KEY='user', value_format='DELIMITED');",
         "CREATE TABLE OUTPUT AS SELECT COUNT(*) * 2 FROM TEST GROUP BY region;"
       ],
       "inputs": [
@@ -826,7 +826,7 @@
     {
       "name": "with aggregate arithmetic involving source field (table->table)",
       "statements": [
-        "CREATE TABLE TEST (ROWKEY INT KEY, f0 INT, f1 INT) WITH (kafka_topic='test_topic', key='f0', value_format='DELIMITED');",
+        "CREATE TABLE TEST (ROWKEY INT PRIMARY KEY, f0 INT, f1 INT) WITH (kafka_topic='test_topic', key='f0', value_format='DELIMITED');",
         "CREATE TABLE OUTPUT AS SELECT f0 * SUM(f1) FROM TEST GROUP BY f0;"
       ],
       "inputs": [
@@ -847,7 +847,7 @@
     {
       "name": "with aggregate arithmetic involving source field not in group by (table->table)",
       "statements": [
-        "CREATE TABLE TEST (ROWKEY INT KEY, f0 INT, f1 INT, f2 INT) WITH (kafka_topic='test_topic', key='f0', value_format='DELIMITED');",
+        "CREATE TABLE TEST (ROWKEY INT PRIMARY KEY, f0 INT, f1 INT, f2 INT) WITH (kafka_topic='test_topic', key='f0', value_format='DELIMITED');",
         "CREATE TABLE OUTPUT AS SELECT f1 * SUM(f2) FROM TEST GROUP BY f0;"
       ],
       "expectedException": {
@@ -886,7 +886,7 @@
     {
       "name": "function (table->table)",
       "statements": [
-        "CREATE TABLE TEST (ROWKEY INT KEY, user INT, region VARCHAR) WITH (kafka_topic='test_topic', KEY='user', value_format='DELIMITED');",
+        "CREATE TABLE TEST (ROWKEY INT PRIMARY KEY, user INT, region VARCHAR) WITH (kafka_topic='test_topic', KEY='user', value_format='DELIMITED');",
         "CREATE TABLE OUTPUT AS SELECT SUBSTRING(region, 7, 2), COUNT(*) FROM TEST GROUP BY SUBSTRING(region, 7, 2);"
       ],
       "inputs": [
@@ -951,7 +951,7 @@
     {
       "name": "function with select field that is a subset of group by (table->table)",
       "statements": [
-        "CREATE TABLE TEST (ROWKEY INT KEY, user INT, region VARCHAR) WITH (kafka_topic='test_topic', KEY='user', value_format='DELIMITED');",
+        "CREATE TABLE TEST (ROWKEY INT PRIMARY KEY, user INT, region VARCHAR) WITH (kafka_topic='test_topic', KEY='user', value_format='DELIMITED');",
         "CREATE TABLE OUTPUT AS SELECT SUBSTRING(region, 7, 1), COUNT(*) FROM TEST GROUP BY SUBSTRING(region, 7, 2);"
       ],
       "expectedException": {
@@ -973,7 +973,7 @@
     {
       "name": "function with select field that is a superset of group by (table->table)",
       "statements": [
-        "CREATE TABLE TEST (ROWKEY INT KEY, user INT, region VARCHAR) WITH (kafka_topic='test_topic', KEY='user', value_format='DELIMITED');",
+        "CREATE TABLE TEST (ROWKEY INT PRIMARY KEY, user INT, region VARCHAR) WITH (kafka_topic='test_topic', KEY='user', value_format='DELIMITED');",
         "CREATE TABLE OUTPUT AS SELECT SUBSTRING(region, 7, 3), COUNT(*) FROM TEST GROUP BY SUBSTRING(region, 7, 2);"
       ],
       "expectedException": {
@@ -1089,7 +1089,7 @@
     {
       "name": "constant (table->table)",
       "statements": [
-        "CREATE TABLE TEST (ROWKEY INT KEY, user INT, region VARCHAR) WITH (kafka_topic='test_topic', KEY='user', value_format='DELIMITED');",
+        "CREATE TABLE TEST (ROWKEY INT PRIMARY KEY, user INT, region VARCHAR) WITH (kafka_topic='test_topic', KEY='user', value_format='DELIMITED');",
         "CREATE TABLE OUTPUT AS SELECT COUNT(*) FROM TEST GROUP BY 1;"
       ],
       "inputs": [
@@ -1132,7 +1132,7 @@
     {
       "name": "field with field used in function in projection (table->table)",
       "statements": [
-        "CREATE TABLE TEST (ROWKEY INT KEY, user INT, region VARCHAR) WITH (kafka_topic='test_topic', KEY='user', value_format='DELIMITED');",
+        "CREATE TABLE TEST (ROWKEY INT PRIMARY KEY, user INT, region VARCHAR) WITH (kafka_topic='test_topic', KEY='user', value_format='DELIMITED');",
         "CREATE TABLE OUTPUT AS SELECT SUBSTRING(region, 2, 1), COUNT(*) FROM TEST GROUP BY region;"
       ],
       "inputs": [
@@ -1825,8 +1825,8 @@
     {
       "name": "on join",
       "statements": [
-        "CREATE TABLE t1 (ROWKEY BIGINT KEY, TOTAL integer) WITH (kafka_topic='T1', value_format='AVRO');",
-        "CREATE TABLE t2 (ROWKEY BIGINT KEY, TOTAL integer) WITH (kafka_topic='T2', value_format='AVRO');",
+        "CREATE TABLE t1 (ROWKEY BIGINT PRIMARY KEY, TOTAL integer) WITH (kafka_topic='T1', value_format='AVRO');",
+        "CREATE TABLE t2 (ROWKEY BIGINT PRIMARY KEY, TOTAL integer) WITH (kafka_topic='T2', value_format='AVRO');",
         "CREATE TABLE OUTPUT AS SELECT SUM(t1.total + CASE WHEN t2.total IS NULL THEN 0 ELSE t2.total END) as SUM FROM T1 LEFT JOIN T2 ON (t1.rowkey = t2.rowkey) GROUP BY t1.rowkey HAVING COUNT(1) > 0;"
       ],
       "inputs": [

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/join-with-custom-timestamp.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/join-with-custom-timestamp.json
@@ -55,7 +55,7 @@
       "format": ["AVRO", "JSON", "PROTOBUF"],
       "statements": [
         "CREATE STREAM S1 (ROWKEY BIGINT KEY, ID bigint, NAME varchar, TS bigint) WITH (timestamp='TS', kafka_topic='s1', value_format='{FORMAT}', key='ID');",
-        "CREATE TABLE  T1 (ROWKEY BIGINT KEY, ID bigint, F1 varchar, F2 varchar, RTS bigint) WITH (timestamp='RTS', kafka_topic='t1', value_format='{FORMAT}', key='ID');",
+        "CREATE TABLE  T1 (ROWKEY BIGINT PRIMARY KEY, ID bigint, F1 varchar, F2 varchar, RTS bigint) WITH (timestamp='RTS', kafka_topic='t1', value_format='{FORMAT}', key='ID');",
         "CREATE STREAM S1_JOIN_T1 WITH(timestamp='TS') as SELECT S1.id as id, S1.name as name, S1.ts as ts, T1.f1, T1.f2 from S1 inner join T1 ON s1.id = t1.id;"
       ],
       "inputs": [
@@ -75,8 +75,8 @@
       "name": "table table inner join with ts",
       "format": ["AVRO", "JSON", "PROTOBUF"],
       "statements": [
-        "CREATE TABLE S1 (ROWKEY BIGINT KEY, ID bigint, NAME varchar, TS bigint) WITH (timestamp='TS', kafka_topic='s1', value_format='{FORMAT}', key='ID');",
-        "CREATE TABLE S2 (ROWKEY BIGINT KEY, ID bigint, F1 varchar, F2 varchar) WITH (kafka_topic='s2', value_format='{FORMAT}', key='ID');",
+        "CREATE TABLE S1 (ROWKEY BIGINT PRIMARY KEY, ID bigint, NAME varchar, TS bigint) WITH (timestamp='TS', kafka_topic='s1', value_format='{FORMAT}', key='ID');",
+        "CREATE TABLE S2 (ROWKEY BIGINT PRIMARY KEY, ID bigint, F1 varchar, F2 varchar) WITH (kafka_topic='s2', value_format='{FORMAT}', key='ID');",
         "CREATE TABLE S1_JOIN_S2 WITH(timestamp='TS') as SELECT S1.id as id, S1.name as name, S1.ts as ts, s2.f1, s2.f2 from S1 join S2 ON s1.id = s2.id;"
       ],
       "inputs": [
@@ -96,8 +96,8 @@
       "name": "table table inner join with ts extractor both sides",
       "format": ["AVRO", "JSON", "PROTOBUF"],
       "statements": [
-        "CREATE TABLE S1 (ROWKEY BIGINT KEY, ID bigint, NAME varchar, TS bigint) WITH (timestamp='TS', kafka_topic='s1', value_format='{FORMAT}', key='ID');",
-        "CREATE TABLE S2 (ROWKEY BIGINT KEY, ID bigint, F1 varchar, F2 varchar, RTS bigint) WITH (timestamp='RTS', kafka_topic='s2', value_format='{FORMAT}', key='ID');",
+        "CREATE TABLE S1 (ROWKEY BIGINT PRIMARY KEY, ID bigint, NAME varchar, TS bigint) WITH (timestamp='TS', kafka_topic='s1', value_format='{FORMAT}', key='ID');",
+        "CREATE TABLE S2 (ROWKEY BIGINT PRIMARY KEY, ID bigint, F1 varchar, F2 varchar, RTS bigint) WITH (timestamp='RTS', kafka_topic='s2', value_format='{FORMAT}', key='ID');",
         "CREATE TABLE S1_JOIN_S2 WITH(timestamp='TS') as SELECT S1.id as id, S1.name as name, S1.ts as ts, s2.f1, s2.f2 from S1 join S2 ON s1.id = s2.id;"
       ],
       "inputs": [

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/joins.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/joins.json
@@ -643,8 +643,8 @@
       "name": "table-table left join",
       "format": ["AVRO", "JSON"],
       "statements": [
-        "CREATE TABLE TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
-        "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
+        "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
+        "CREATE TABLE TEST_TABLE (ID BIGINT PRIMARY KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
         "CREATE TABLE LEFT_OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t left join TEST_TABLE tt on t.id = tt.id;"
       ],
       "properties": {
@@ -677,8 +677,8 @@
     {
       "name": "table-table left join - PROTOBUF",
       "statements": [
-        "CREATE TABLE TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='PROTOBUF');",
-        "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='PROTOBUF');",
+        "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='PROTOBUF');",
+        "CREATE TABLE TEST_TABLE (ID BIGINT PRIMARY KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='PROTOBUF');",
         "CREATE TABLE LEFT_OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t left join TEST_TABLE tt on t.id = tt.id;"
       ],
       "properties": {
@@ -712,8 +712,8 @@
       "name": "table-table inner join",
       "format": ["AVRO", "JSON", "PROTOBUF"],
       "statements": [
-        "CREATE TABLE TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
-        "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
+        "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
+        "CREATE TABLE TEST_TABLE (ID BIGINT PRIMARY KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
         "CREATE TABLE INNER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t join TEST_TABLE tt on t.id = tt.id;"
       ],
       "properties": {
@@ -745,8 +745,8 @@
       "name": "table-table outer join",
       "format": ["AVRO", "JSON"],
       "statements": [
-        "CREATE TABLE TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
-        "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
+        "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
+        "CREATE TABLE TEST_TABLE (ID BIGINT PRIMARY KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
         "CREATE TABLE OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t FULL OUTER join TEST_TABLE tt on t.id = tt.id;"
       ],
       "properties": {
@@ -779,8 +779,8 @@
     {
       "name": "table-table outer join - PROTOBUF",
       "statements": [
-        "CREATE TABLE TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='PROTOBUF');",
-        "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='PROTOBUF');",
+        "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='PROTOBUF');",
+        "CREATE TABLE TEST_TABLE (ID BIGINT PRIMARY KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='PROTOBUF');",
         "CREATE TABLE OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t FULL OUTER join TEST_TABLE tt on t.id = tt.id;"
       ],
       "properties": {
@@ -815,7 +815,7 @@
       "format": ["AVRO", "JSON"],
       "statements": [
         "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='test_topic', value_format='{FORMAT}');",
-        "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='{FORMAT}');",
+        "CREATE TABLE TEST_TABLE (ID BIGINT PRIMARY KEY, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='{FORMAT}');",
         "CREATE STREAM LEFT_JOIN as SELECT t.id, name, value, f1, f2 FROM test t left join test_table tt on t.id = tt.id;"
       ],
       "properties": {
@@ -846,7 +846,7 @@
       "name": "stream-table left join - PROTOBUF",
       "statements": [
         "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='test_topic', value_format='PROTOBUF');",
-        "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='PROTOBUF');",
+        "CREATE TABLE TEST_TABLE (ID BIGINT PRIMARY KEY, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='PROTOBUF');",
         "CREATE STREAM LEFT_JOIN as SELECT t.id, name, value, f1, f2 FROM test t left join test_table tt on t.id = tt.id;"
       ],
       "properties": {
@@ -878,7 +878,7 @@
       "format": ["AVRO", "JSON", "PROTOBUF"],
       "statements": [
         "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='test_topic', value_format='{FORMAT}');",
-        "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='{FORMAT}');",
+        "CREATE TABLE TEST_TABLE (ID BIGINT PRIMARY KEY, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='{FORMAT}');",
         "CREATE STREAM INNER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t join test_table tt on t.id = tt.id;"
       ],
       "properties": {
@@ -908,9 +908,9 @@
       "name": "a table join pipeline",
       "format": ["JSON"],
       "statements": [
-        "CREATE TABLE TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
-        "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
-        "CREATE TABLE TEST_TABLE_2 (ID BIGINT KEY, F3 varchar) WITH (kafka_topic='right_topic_2', value_format='{FORMAT}');",
+        "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
+        "CREATE TABLE TEST_TABLE (ID BIGINT PRIMARY KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
+        "CREATE TABLE TEST_TABLE_2 (ID BIGINT PRIMARY KEY, F3 varchar) WITH (kafka_topic='right_topic_2', value_format='{FORMAT}');",
         "CREATE TABLE INNER_JOIN WITH (PARTITIONS=4) as SELECT name, value, f1, f2 FROM test t join TEST_TABLE tt on t.id = tt.id;",
         "CREATE TABLE INNER_JOIN_2 AS SELECT name, f1, f3 FROM inner_join tt join TEST_TABLE_2 t ON t.id = tt.id;"
       ],
@@ -938,8 +938,8 @@
     {
       "name": "table-table join with where clause",
       "statements": [
-        "CREATE TABLE TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='JSON');",
-        "CREATE TABLE TEST_TABLE (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE TABLE TEST_TABLE (ID BIGINT PRIMARY KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
         "CREATE TABLE OUTPUT as SELECT t.id, name, tt.f1, f2 FROM test t JOIN test_table tt ON t.id = tt.id WHERE t.value > 10 AND tt.f2 > 5;"
       ],
       "properties": {
@@ -1061,7 +1061,7 @@
       "name": "stream-table wrapped single field value schema on inputs",
       "statements": [
         "CREATE STREAM S (ID BIGINT KEY, NAME STRING) WITH (kafka_topic='S', value_format='JSON');",
-        "CREATE TABLE T (ID BIGINT KEY, NAME STRING) WITH (kafka_topic='T', value_format='JSON');",
+        "CREATE TABLE T (ID BIGINT PRIMARY KEY, NAME STRING) WITH (kafka_topic='T', value_format='JSON');",
         "CREATE STREAM OUTPUT as SELECT s.name name1, t.name name2 FROM S JOIN T ON S.id = T.id;"
       ],
       "properties": {
@@ -1091,7 +1091,7 @@
       ],
       "statements": [
         "CREATE STREAM S (ID BIGINT KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='S', value_format='JSON');",
-        "CREATE TABLE T (ID BIGINT KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='T', value_format='JSON');",
+        "CREATE TABLE T (ID BIGINT PRIMARY KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='T', value_format='JSON');",
         "CREATE STREAM OUTPUT as SELECT s.name name1, t.name name2 FROM S JOIN T ON S.id = T.id;"
       ],
       "properties": {
@@ -1117,7 +1117,7 @@
       ],
       "statements": [
         "CREATE STREAM S (ID BIGINT KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='S', value_format='JSON');",
-        "CREATE TABLE T (ID BIGINT KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='T', value_format='JSON');",
+        "CREATE TABLE T (ID BIGINT PRIMARY KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='T', value_format='JSON');",
         "CREATE STREAM OUTPUT WITH (WRAP_SINGLE_VALUE=false) AS SELECT s.name name FROM S JOIN T ON S.id = T.id;"
       ],
       "properties": {
@@ -1137,8 +1137,8 @@
     {
       "name": "table-table wrapped single field value schema on inputs",
       "statements": [
-        "CREATE TABLE T1 (ID BIGINT KEY, NAME STRING) WITH (kafka_topic='T1', value_format='JSON');",
-        "CREATE TABLE T2 (ID BIGINT KEY, NAME STRING) WITH (kafka_topic='T2', value_format='JSON');",
+        "CREATE TABLE T1 (ID BIGINT PRIMARY KEY, NAME STRING) WITH (kafka_topic='T1', value_format='JSON');",
+        "CREATE TABLE T2 (ID BIGINT PRIMARY KEY, NAME STRING) WITH (kafka_topic='T2', value_format='JSON');",
         "CREATE TABLE OUTPUT as SELECT t1.name name1, t2.name name2 FROM T1 JOIN T2 ON T1.id = T2.id;"
       ],
       "properties": {
@@ -1164,8 +1164,8 @@
     {
       "name": "table-table unwrapped single field value schema on inputs",
       "statements": [
-        "CREATE TABLE T1 (ID BIGINT KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='T1', value_format='JSON');",
-        "CREATE TABLE T2 (ID BIGINT KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='T2', value_format='JSON');",
+        "CREATE TABLE T1 (ID BIGINT PRIMARY KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='T1', value_format='JSON');",
+        "CREATE TABLE T2 (ID BIGINT PRIMARY KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='T2', value_format='JSON');",
         "CREATE TABLE OUTPUT as SELECT t1.name name1, t2.name name2 FROM T1 JOIN T2 ON T1.id = T2.id;"
       ],
       "properties": {
@@ -1186,8 +1186,8 @@
     {
       "name": "table-table unwrapped single field value schema on inputs and output",
       "statements": [
-        "CREATE TABLE T1 (ID BIGINT KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='T1', value_format='JSON');",
-        "CREATE TABLE T2 (ID BIGINT KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='T2', value_format='JSON');",
+        "CREATE TABLE T1 (ID BIGINT PRIMARY KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='T1', value_format='JSON');",
+        "CREATE TABLE T2 (ID BIGINT PRIMARY KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='T2', value_format='JSON');",
         "CREATE TABLE OUTPUT WITH (WRAP_SINGLE_VALUE=false) AS SELECT t1.name name FROM T1 JOIN T2 ON T1.id = T2.id;"
       ],
       "properties": {
@@ -1470,7 +1470,7 @@
       "name": "on non STRING value column",
       "statements": [
         "CREATE STREAM INPUT_STREAM (K STRING KEY, SF BIGINT) WITH (kafka_topic='stream_topic', value_format='JSON');",
-        "CREATE TABLE INPUT_TABLE (ID BIGINT KEY, TF INT) WITH (kafka_topic='table_topic', value_format='JSON');",
+        "CREATE TABLE INPUT_TABLE (ID BIGINT PRIMARY KEY, TF INT) WITH (kafka_topic='table_topic', value_format='JSON');",
         "CREATE STREAM OUTPUT AS SELECT * FROM INPUT_STREAM S JOIN INPUT_TABLE T on S.SF = T.ID;"
       ],
       "properties": {
@@ -1500,7 +1500,7 @@
       "name": "on non key table column",
       "statements": [
         "CREATE STREAM INPUT_STREAM (ID BIGINT KEY, SF BIGINT) WITH (kafka_topic='stream_topic', value_format='JSON');",
-        "CREATE TABLE INPUT_TABLE (K BIGINT KEY, ID BIGINT, TF INT) WITH (kafka_topic='table_topic', value_format='JSON');",
+        "CREATE TABLE INPUT_TABLE (K BIGINT PRIMARY KEY, ID BIGINT, TF INT) WITH (kafka_topic='table_topic', value_format='JSON');",
         "CREATE STREAM OUTPUT AS SELECT * FROM INPUT_STREAM S JOIN INPUT_TABLE T on S.ID = T.ID;"
       ],
       "properties": {
@@ -2495,8 +2495,8 @@
       "name": "table table left join",
       "format": ["AVRO", "JSON"],
       "statements": [
-        "CREATE TABLE TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}', key='ID');",
-        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}', key='ID');",
+        "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}', key='ID');",
+        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}', key='ID');",
         "CREATE TABLE LEFT_OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t left join TEST_TABLE tt on t.id = tt.id;"
       ],
       "inputs": [
@@ -2526,8 +2526,8 @@
     {
       "name": "table table left join - PROTOBUF",
       "statements": [
-        "CREATE TABLE TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='PROTOBUF', key='ID');",
-        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='PROTOBUF', key='ID');",
+        "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='PROTOBUF', key='ID');",
+        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='PROTOBUF', key='ID');",
         "CREATE TABLE LEFT_OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t left join TEST_TABLE tt on t.id = tt.id;"
       ],
       "inputs": [
@@ -2557,8 +2557,8 @@
     {
       "name": "table table left join - join key not in projection",
       "statements": [
-        "CREATE TABLE TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='JSON', key='ID');",
-        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='JSON', key='ID');",
+        "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='JSON', key='ID');",
+        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='JSON', key='ID');",
         "CREATE TABLE LEFT_OUTER_JOIN as SELECT name, value, f1, f2 FROM test t left join TEST_TABLE tt on t.id = tt.id;"
       ],
       "inputs": [
@@ -2588,8 +2588,8 @@
     {
       "name": "table table left join - right join key in projection",
       "statements": [
-        "CREATE TABLE TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='JSON', key='ID');",
-        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='JSON', key='ID');",
+        "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='JSON', key='ID');",
+        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='JSON', key='ID');",
         "CREATE TABLE LEFT_OUTER_JOIN as SELECT tt.id, name, value, f1, f2 FROM test t left join TEST_TABLE tt on t.id = tt.id;"
       ],
       "inputs": [
@@ -2622,8 +2622,8 @@
     {
       "name": "table table left join - both join keys in projection",
       "statements": [
-        "CREATE TABLE TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='JSON', key='ID');",
-        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='JSON', key='ID');",
+        "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='JSON', key='ID');",
+        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='JSON', key='ID');",
         "CREATE TABLE LEFT_OUTER_JOIN as SELECT t.id, tt.id, name, value, f1, f2 FROM test t left join TEST_TABLE tt on t.id = tt.id;"
       ],
       "inputs": [
@@ -2654,8 +2654,8 @@
       "name": "table table inner join",
       "format": ["AVRO", "JSON", "PROTOBUF"],
       "statements": [
-        "CREATE TABLE TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}', key='ID');",
-        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}', key='ID');",
+        "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}', key='ID');",
+        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}', key='ID');",
         "CREATE TABLE INNER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t join TEST_TABLE tt on t.id = tt.id;"
       ],
       "inputs": [
@@ -2683,8 +2683,8 @@
     {
       "name": "table table inner join - join key not in projection",
       "statements": [
-        "CREATE TABLE TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='JSON', key='ID');",
-        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='JSON', key='ID');",
+        "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='JSON', key='ID');",
+        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='JSON', key='ID');",
         "CREATE TABLE INNER_JOIN as SELECT name, value, f1, f2 FROM test t join TEST_TABLE tt on t.id = tt.id;"
       ],
       "inputs": [
@@ -2712,8 +2712,8 @@
     {
       "name": "table table inner join - right join key in projection",
       "statements": [
-        "CREATE TABLE TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='JSON', key='ID');",
-        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='JSON', key='ID');",
+        "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='JSON', key='ID');",
+        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='JSON', key='ID');",
         "CREATE TABLE INNER_JOIN as SELECT tt.id, name, value, f1, f2 FROM test t join TEST_TABLE tt on t.id = tt.id;"
       ],
       "inputs": [
@@ -2745,8 +2745,8 @@
       "name": "table table outer join",
       "format": ["AVRO", "JSON"],
       "statements": [
-        "CREATE TABLE TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}', key='ID');",
-        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}', key='ID');",
+        "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}', key='ID');",
+        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}', key='ID');",
         "CREATE TABLE OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t FULL OUTER join TEST_TABLE tt on t.id = tt.id;"
       ],
       "inputs": [
@@ -2779,8 +2779,8 @@
     {
       "name": "table table outer join - PROTOBUF",
       "statements": [
-        "CREATE TABLE TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='PROTOBUF', key='ID');",
-        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='PROTOBUF', key='ID');",
+        "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='PROTOBUF', key='ID');",
+        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='PROTOBUF', key='ID');",
         "CREATE TABLE OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t FULL OUTER join TEST_TABLE tt on t.id = tt.id;"
       ],
       "inputs": [
@@ -2813,8 +2813,8 @@
     {
       "name": "table table outer join - right join key in projection",
       "statements": [
-        "CREATE TABLE TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='JSON', key='ID');",
-        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='JSON', key='ID');",
+        "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='JSON', key='ID');",
+        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='JSON', key='ID');",
         "CREATE TABLE OUTER_JOIN as SELECT tt.id, name, value, f1, f2 FROM test t FULL OUTER join TEST_TABLE tt on t.id = tt.id;"
       ],
       "inputs": [
@@ -2849,7 +2849,7 @@
       "format": ["AVRO", "JSON"],
       "statements": [
         "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='test_topic', value_format='{FORMAT}', key='ID');",
-        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='{FORMAT}', key='ID');",
+        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='{FORMAT}', key='ID');",
         "CREATE STREAM LEFT_JOIN as SELECT t.id, name, value, f1, f2 FROM test t left join test_table tt on t.id = tt.id;"
       ],
       "inputs": [
@@ -2877,7 +2877,7 @@
       "name": "stream table left join - PROTOBUF",
       "statements": [
         "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='test_topic', value_format='PROTOBUF', key='ID');",
-        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='PROTOBUF', key='ID');",
+        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='PROTOBUF', key='ID');",
         "CREATE STREAM LEFT_JOIN as SELECT t.id, name, value, f1, f2 FROM test t left join test_table tt on t.id = tt.id;"
       ],
       "inputs": [
@@ -2905,7 +2905,7 @@
       "name": "stream table left join - join key not in projection",
       "statements": [
         "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
-        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='JSON', key='ID');",
+        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='JSON', key='ID');",
         "CREATE STREAM LEFT_JOIN as SELECT name, value, f1, f2 FROM test t left join test_table tt on t.id = tt.id;"
       ],
       "inputs": [
@@ -2933,7 +2933,7 @@
       "name": "stream table left join - right join key in projection",
       "statements": [
         "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
-        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='JSON', key='ID');",
+        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='JSON', key='ID');",
         "CREATE STREAM LEFT_JOIN as SELECT tt.id, name, value, f1, f2 FROM test t left join test_table tt on t.id = tt.id;"
       ],
       "inputs": [
@@ -2965,7 +2965,7 @@
       "format": ["AVRO", "JSON", "PROTOBUF"],
       "statements": [
         "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='test_topic', value_format='{FORMAT}', key='ID');",
-        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='{FORMAT}', key='ID');",
+        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='{FORMAT}', key='ID');",
         "CREATE STREAM INNER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t join test_table tt on t.id = tt.id;"
       ],
       "inputs": [
@@ -2992,7 +2992,7 @@
       "name": "stream table inner join - join key not in projection",
       "statements": [
         "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
-        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='JSON', key='ID');",
+        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='JSON', key='ID');",
         "CREATE STREAM INNER_JOIN as SELECT name, value, f1, f2 FROM test t join test_table tt on t.id = tt.id;"
       ],
       "inputs": [
@@ -3019,7 +3019,7 @@
       "name": "stream table inner join - right join key in projection",
       "statements": [
         "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
-        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='JSON', key='ID');",
+        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='JSON', key='ID');",
         "CREATE STREAM INNER_JOIN as SELECT tt.id, name, value, f1, f2 FROM test t join test_table tt on t.id = tt.id;"
       ],
       "inputs": [
@@ -3050,7 +3050,7 @@
       "format": ["AVRO", "JSON", "PROTOBUF"],
       "statements": [
         "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='test_topic', value_format='{FORMAT}', key='ID');",
-        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='{FORMAT}', key='ID');",
+        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='{FORMAT}', key='ID');",
         "CREATE STREAM INNER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t join test_table tt on t.ROWKEY = tt.ROWKEY;"
       ],
       "inputs": [
@@ -3109,7 +3109,7 @@
       "name": "join using ROWKEY in the criteria - join key not in projection",
       "statements": [
         "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
-        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='JSON', key='ID');",
+        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='JSON', key='ID');",
         "CREATE STREAM INNER_JOIN as SELECT name, value, f1, f2 FROM test t join test_table tt on t.ROWKEY = tt.ROWKEY;"
       ],
       "inputs": [
@@ -3136,7 +3136,7 @@
       "name": "join using ROWKEY in the criteria - right join key in projection",
       "statements": [
         "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
-        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='JSON', key='ID');",
+        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='JSON', key='ID');",
         "CREATE STREAM INNER_JOIN as SELECT tt.id, name, value, f1, f2 FROM test t join test_table tt on t.ROWKEY = tt.ROWKEY;"
       ],
       "inputs": [
@@ -3166,7 +3166,7 @@
       "name": "join using ROWKEY in the criteria - left rowkey in projection",
       "statements": [
         "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
-        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='JSON', key='ID');",
+        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='JSON', key='ID');",
         "CREATE STREAM INNER_JOIN as SELECT t.rowkey AS ID, name, value, f1, f2 FROM test t join test_table tt on t.ROWKEY = tt.ROWKEY;"
       ],
       "inputs": [
@@ -3196,7 +3196,7 @@
       "name": "join using ROWKEY in the criteria - right rowkey in projection",
       "statements": [
         "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
-        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='JSON', key='ID');",
+        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='JSON', key='ID');",
         "CREATE STREAM INNER_JOIN as SELECT tt.rowkey AS ID, name, value, f1, f2 FROM test t join test_table tt on t.ROWKEY = tt.ROWKEY;"
       ],
       "inputs": [
@@ -3226,7 +3226,7 @@
       "name": "multiple join keys in projection",
       "statements": [
         "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
-        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='JSON', key='ID');",
+        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='JSON', key='ID');",
         "CREATE STREAM INNER_JOIN as SELECT t.ID AS ID1, t.ID AS ID2, t.rowkey AS ID3, tt.ID AS ID4, tt.ROWKEY AS ID5 FROM test t join test_table tt on t.ROWKEY = tt.ROWKEY;"
       ],
       "inputs": [
@@ -3258,9 +3258,9 @@
       "name": "table join pipeline",
       "format": ["JSON"],
       "statements": [
-        "CREATE TABLE TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}', key='ID');",
-        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}', key='ID');",
-        "CREATE TABLE TEST_TABLE_2 (ROWKEY BIGINT KEY, ID bigint, F3 varchar) WITH (kafka_topic='right_topic_2', value_format='{FORMAT}', key='ID');",
+        "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}', key='ID');",
+        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}', key='ID');",
+        "CREATE TABLE TEST_TABLE_2 (ROWKEY BIGINT PRIMARY KEY, ID bigint, F3 varchar) WITH (kafka_topic='right_topic_2', value_format='{FORMAT}', key='ID');",
         "CREATE TABLE INNER_JOIN WITH (PARTITIONS=4) as SELECT t.id, name, value, f1, f2 FROM test t join TEST_TABLE tt on t.id = tt.id;",
         "CREATE TABLE INNER_JOIN_2 AS SELECT t_id, name, f1, f3 FROM inner_join tt join TEST_TABLE_2 t ON t.id = tt.t_id;"
       ],
@@ -3285,8 +3285,8 @@
     {
       "name": "table table join with where clause",
       "statements": [
-        "CREATE TABLE TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='JSON', key='ID');",
-        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='JSON', key='ID');",
+        "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='JSON', key='ID');",
+        "CREATE TABLE TEST_TABLE (ROWKEY BIGINT PRIMARY KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='JSON', key='ID');",
         "CREATE TABLE OUTPUT as SELECT t.id, name, tt.f1, f2 FROM test t JOIN test_table tt ON t.id = tt.id WHERE t.value > 10 AND tt.f2 > 5;"
       ],
       "inputs": [
@@ -3329,7 +3329,7 @@
       "name": "stream to table when neither have key field and joining by table key column",
       "statements": [
         "CREATE STREAM S (ID bigint) WITH (kafka_topic='S', value_format='JSON');",
-        "CREATE TABLE NO_KEY (ROWKEY BIGINT KEY, NAME string) WITH (kafka_topic='NO_KEY', value_format='JSON');",
+        "CREATE TABLE NO_KEY (ROWKEY BIGINT PRIMARY KEY, NAME string) WITH (kafka_topic='NO_KEY', value_format='JSON');",
         "CREATE STREAM OUTPUT as SELECT s.id as ID, name FROM S JOIN NO_KEY t ON s.id = t.ROWKEY;"
       ],
       "inputs": [
@@ -3349,7 +3349,7 @@
       "name": "stream to table when table does not have key field and joining by table ROWKEY",
       "statements": [
         "CREATE STREAM S (ROWKEY BIGINT KEY, ID bigint) WITH (kafka_topic='S', value_format='JSON', key='ID');",
-        "CREATE TABLE NO_KEY (ROWKEY BIGINT KEY, ID bigint, NAME string) WITH (kafka_topic='NO_KEY', value_format='JSON');",
+        "CREATE TABLE NO_KEY (ROWKEY BIGINT PRIMARY KEY, ID bigint, NAME string) WITH (kafka_topic='NO_KEY', value_format='JSON');",
         "CREATE STREAM OUTPUT as SELECT s.id, name FROM S JOIN NO_KEY t ON s.id = t.ROWKEY;"
       ],
       "inputs": [
@@ -3779,7 +3779,7 @@
       "name": "on non-STRING key",
       "statements": [
         "CREATE STREAM INPUT_STREAM (ROWKEY BIGINT KEY, SF INT) WITH (kafka_topic='stream_topic', value_format='JSON');",
-        "CREATE TABLE INPUT_TABLE (ROWKEY BIGINT KEY, TF INT) WITH (kafka_topic='table_topic', value_format='JSON');",
+        "CREATE TABLE INPUT_TABLE (ROWKEY BIGINT PRIMARY KEY, TF INT) WITH (kafka_topic='table_topic', value_format='JSON');",
         "CREATE STREAM OUTPUT AS SELECT * FROM INPUT_STREAM S JOIN INPUT_TABLE T on S.ROWKEY = T.ROWKEY;"
       ],
       "inputs": [
@@ -3806,7 +3806,7 @@
       "name": "on non-STRING value column",
       "statements": [
         "CREATE STREAM INPUT_STREAM (ROWKEY STRING KEY, SF BIGINT) WITH (kafka_topic='stream_topic', value_format='JSON');",
-        "CREATE TABLE INPUT_TABLE (ROWKEY BIGINT KEY, ID BIGINT, TF INT) WITH (kafka_topic='table_topic', value_format='JSON', key='ID');",
+        "CREATE TABLE INPUT_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, TF INT) WITH (kafka_topic='table_topic', value_format='JSON', key='ID');",
         "CREATE STREAM OUTPUT AS SELECT * FROM INPUT_STREAM S JOIN INPUT_TABLE T on S.SF = T.ID;"
       ],
       "inputs": [
@@ -3833,7 +3833,7 @@
       "name": "on non-key table column",
       "statements": [
         "CREATE STREAM INPUT_STREAM (ROWKEY BIGINT KEY, SF BIGINT) WITH (kafka_topic='stream_topic', value_format='JSON');",
-        "CREATE TABLE INPUT_TABLE (ROWKEY BIGINT KEY, ID BIGINT, TF INT) WITH (kafka_topic='table_topic', value_format='JSON');",
+        "CREATE TABLE INPUT_TABLE (ROWKEY BIGINT PRIMARY KEY, ID BIGINT, TF INT) WITH (kafka_topic='table_topic', value_format='JSON');",
         "CREATE STREAM OUTPUT AS SELECT * FROM INPUT_STREAM S JOIN INPUT_TABLE T on S.ROWKEY = T.ID;"
       ],
       "expectedException": {
@@ -4056,8 +4056,8 @@
       "name": "join with multiple sources",
       "statements": [
         "CREATE STREAM S1 (ROWKEY INT KEY, ID bigint) WITH (kafka_topic='left_topic', value_format='JSON');",
-        "CREATE TABLE T2 (ROWKEY INT KEY, ID bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
-        "CREATE TABLE T3 (ROWKEY INT KEY, ID bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE TABLE T2 (ROWKEY INT PRIMARY KEY, ID bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE TABLE T3 (ROWKEY INT PRIMARY KEY, ID bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
         "CREATE STREAM OUTPUT as SELECT * FROM S1 JOIN T2 ON S1.ID = T2.ID JOIN T3 ON S1.ID = T3.ID;"
       ],
       "expectedException": {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/key-field.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/key-field.json
@@ -538,7 +538,7 @@
     {
       "name": "table | initially set | no key change | key in value | no aliasing",
       "statements": [
-        "CREATE TABLE INPUT (ROWKEY INT KEY, foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE TABLE INPUT (ROWKEY INT PRIMARY KEY, foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT * FROM INPUT;"
       ],
       "inputs": [
@@ -557,7 +557,7 @@
     {
       "name": "table | initially set | no key change | key in value | aliasing",
       "statements": [
-        "CREATE TABLE INPUT (ROWKEY INT KEY, foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE TABLE INPUT (ROWKEY INT PRIMARY KEY, foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT foo AS aliased, bar FROM INPUT;"
       ],
       "inputs": [
@@ -576,7 +576,7 @@
     {
       "name": "table | initially set | no key change | key not in value | -",
       "statements": [
-        "CREATE TABLE INPUT (ROWKEY INT KEY, foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE TABLE INPUT (ROWKEY INT PRIMARY KEY, foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT bar FROM INPUT;"
       ],
       "inputs": [
@@ -594,7 +594,7 @@
     {
       "name": "table | initially set | group by (same) | key in value | no aliasing",
       "statements": [
-        "CREATE TABLE INPUT (ROWKEY INT KEY, foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE TABLE INPUT (ROWKEY INT PRIMARY KEY, foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT foo, COUNT(*) FROM INPUT GROUP BY foo;"
       ],
       "inputs": [
@@ -612,7 +612,7 @@
     {
       "name": "table | initially set | group by (same) | key in value | aliasing",
       "statements": [
-        "CREATE TABLE INPUT (ROWKEY INT KEY, foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE TABLE INPUT (ROWKEY INT PRIMARY KEY, foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT foo AS aliased, COUNT(*) FROM INPUT GROUP BY foo;"
       ],
       "inputs": [
@@ -630,7 +630,7 @@
     {
       "name": "table | initially set | group by (same) | key not in value | -",
       "statements": [
-        "CREATE TABLE INPUT (ROWKEY INT KEY, foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE TABLE INPUT (ROWKEY INT PRIMARY KEY, foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT COUNT(*) FROM INPUT GROUP BY foo;"
       ],
       "inputs": [
@@ -648,7 +648,7 @@
     {
       "name": "table | initially set | group by (different) | key in value | no aliasing",
       "statements": [
-        "CREATE TABLE INPUT (ROWKEY INT KEY, foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE TABLE INPUT (ROWKEY INT PRIMARY KEY, foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT bar, COUNT(*) FROM INPUT GROUP BY bar;"
       ],
       "inputs": [
@@ -666,7 +666,7 @@
     {
       "name": "table | initially set | group by (different) | key in value | aliasing",
       "statements": [
-        "CREATE TABLE INPUT (ROWKEY INT KEY, foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE TABLE INPUT (ROWKEY INT PRIMARY KEY, foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT bar AS aliased, COUNT(*) FROM INPUT GROUP BY bar;"
       ],
       "inputs": [
@@ -684,7 +684,7 @@
     {
       "name": "table | initially set | group by (different) | key not in value | -",
       "statements": [
-        "CREATE TABLE INPUT (ROWKEY INT KEY, foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE TABLE INPUT (ROWKEY INT PRIMARY KEY, foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT COUNT(*) FROM INPUT GROUP BY bar;"
       ],
       "inputs": [

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/key-schemas.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/key-schemas.json
@@ -88,7 +88,7 @@
     {
       "name": "table explicit KAFKA STRING ROWKEY",
       "statements": [
-        "CREATE TABLE INPUT (ROWKEY STRING KEY, ID bigint) WITH (kafka_topic='input',value_format='JSON');",
+        "CREATE TABLE INPUT (ROWKEY STRING PRIMARY KEY, ID bigint) WITH (kafka_topic='input',value_format='JSON');",
         "CREATE TABLE OUTPUT as SELECT ID, ROWKEY as KEY FROM INPUT;"
       ],
       "inputs": [
@@ -142,7 +142,7 @@
     {
       "name": "table explicit KAFKA INT ROWKEY",
       "statements": [
-        "CREATE TABLE INPUT (ROWKEY INT KEY, ID bigint) WITH (kafka_topic='input',value_format='JSON');",
+        "CREATE TABLE INPUT (ROWKEY INT PRIMARY KEY, ID bigint) WITH (kafka_topic='input',value_format='JSON');",
         "CREATE TABLE OUTPUT as SELECT ID, ROWKEY as KEY FROM INPUT;"
       ],
       "inputs": [
@@ -196,7 +196,7 @@
     {
       "name": "table explicit KAFKA BIGINT ROWKEY",
       "statements": [
-        "CREATE TABLE INPUT (ROWKEY BIGINT KEY, ID bigint) WITH (kafka_topic='input',value_format='JSON');",
+        "CREATE TABLE INPUT (ROWKEY BIGINT PRIMARY KEY, ID bigint) WITH (kafka_topic='input',value_format='JSON');",
         "CREATE TABLE OUTPUT as SELECT ID, ROWKEY as KEY FROM INPUT;"
       ],
       "inputs": [
@@ -250,7 +250,7 @@
     {
       "name": "table explicit KAFKA DOUBLE ROWKEY",
       "statements": [
-        "CREATE TABLE INPUT (ROWKEY DOUBLE KEY, ID bigint) WITH (kafka_topic='input',value_format='JSON');",
+        "CREATE TABLE INPUT (ROWKEY DOUBLE PRIMARY KEY, ID bigint) WITH (kafka_topic='input',value_format='JSON');",
         "CREATE TABLE OUTPUT as SELECT ID, ROWKEY as KEY FROM INPUT;"
       ],
       "inputs": [
@@ -287,7 +287,7 @@
     {
       "name": "create table explicit unsupported ROWKEY type",
       "statements": [
-        "CREATE TABLE INPUT (ROWKEY DECIMAL(21,19) KEY, ID bigint) WITH (kafka_topic='input',value_format='JSON');"
+        "CREATE TABLE INPUT (ROWKEY DECIMAL(21,19) PRIMARY KEY, ID bigint) WITH (kafka_topic='input',value_format='JSON');"
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/sum.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/sum.json
@@ -26,8 +26,8 @@
       "name": "sum int left join of table",
       "comment": "from https://github.com/confluentinc/ksql/issues/2490",
       "statements": [
-        "CREATE TABLE t1 (ROWKEY BIGINT KEY, ID bigint, TOTAL integer) WITH (kafka_topic='T1', value_format='AVRO', key='ID');",
-        "CREATE TABLE t2 (ROWKEY BIGINT KEY, ID bigint, TOTAL integer) WITH (kafka_topic='T2', value_format='AVRO', key='ID');",
+        "CREATE TABLE t1 (ROWKEY BIGINT PRIMARY KEY, ID bigint, TOTAL integer) WITH (kafka_topic='T1', value_format='AVRO', key='ID');",
+        "CREATE TABLE t2 (ROWKEY BIGINT PRIMARY KEY, ID bigint, TOTAL integer) WITH (kafka_topic='T2', value_format='AVRO', key='ID');",
         "CREATE TABLE OUTPUT AS SELECT t1.id as ID, SUM(t2.total) as SUM FROM T1 LEFT JOIN T2 ON (t1.id = t2.id) GROUP BY t1.id;"
       ],
       "inputs": [

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/test-custom-udaf.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/test-custom-udaf.json
@@ -31,7 +31,7 @@
     {
       "name": "test_udaf on a table",
       "statements": [
-        "CREATE TABLE TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar, REGION string) WITH (kafka_topic='test_topic', value_format='DELIMITED', key='ID');",
+        "CREATE TABLE TEST (ROWKEY BIGINT PRIMARY KEY, ID bigint, NAME varchar, REGION string) WITH (kafka_topic='test_topic', value_format='DELIMITED', key='ID');",
         "CREATE TABLE SUM_ID_BY_REGION AS SELECT REGION, test_udaf(id) FROM TEST GROUP BY REGION;"
       ],
       "inputs": [

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
@@ -234,7 +234,7 @@
     {
       "name": "imported windowed table - DOUBLE KEY",
       "statements": [
-        "CREATE TABLE INPUT (ROWKEY DOUBLE KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON', WINDOW_TYPE='Tumbling', WINDOW_SIZE='1 SECOND');",
+        "CREATE TABLE INPUT (ROWKEY DOUBLE PRIMARY KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON', WINDOW_TYPE='Tumbling', WINDOW_SIZE='1 SECOND');",
         "SELECT * FROM INPUT WHERE ROWKEY = 11.1 AND WINDOWSTART=12000 EMIT CHANGES LIMIT 1;"
       ],
       "inputs": [

--- a/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -91,7 +91,7 @@ tableElements
     ;
 
 tableElement
-    : identifier type (KEY)?
+    : identifier type ((PRIMARY)? KEY)?
     ;
 
 tableProperties
@@ -332,7 +332,7 @@ nonReserved
     | SET | RESET
     | IF
     | SOURCE | SINK
-    | KEY
+    | PRIMARY | KEY
     | EMIT
     | CHANGES
     ;

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -1080,7 +1080,9 @@ public class AstBuilder {
     public Node visitTableElement(final SqlBaseParser.TableElementContext context) {
       return new TableElement(
           getLocation(context),
-          context.KEY() == null ? Namespace.VALUE : Namespace.KEY,
+          context.KEY() == null
+              ? Namespace.VALUE
+              : context.PRIMARY() == null ? Namespace.KEY : Namespace.PRIMARY_KEY,
           ColumnName.of(ParserUtil.getIdentifierText(context.identifier())),
           typeParser.getType(context.type())
       );

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SchemaParser.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SchemaParser.java
@@ -87,7 +87,9 @@ public final class SchemaParser {
         .stream()
         .map(ctx -> new TableElement(
             getLocation(ctx),
-            ctx.KEY() == null ? Namespace.VALUE : Namespace.KEY,
+            ctx.KEY() == null
+                ? Namespace.VALUE
+                : ctx.PRIMARY() == null ? Namespace.KEY : Namespace.PRIMARY_KEY,
             ColumnName.of(ParserUtil.getIdentifierText(ctx.identifier())),
             typeParser.getType(ctx.type())
         ))

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
@@ -55,7 +55,6 @@ import io.confluent.ksql.parser.tree.ShowColumns;
 import io.confluent.ksql.parser.tree.SingleColumn;
 import io.confluent.ksql.parser.tree.Table;
 import io.confluent.ksql.parser.tree.TableElement;
-import io.confluent.ksql.parser.tree.TableElement.Namespace;
 import io.confluent.ksql.parser.tree.TerminateQuery;
 import io.confluent.ksql.parser.tree.UnsetProperty;
 import io.confluent.ksql.query.QueryId;
@@ -495,11 +494,24 @@ public final class SqlFormatter {
     }
 
     private static String formatTableElement(final TableElement e) {
+      final String postFix;
+      switch (e.getNamespace()) {
+        case PRIMARY_KEY:
+          postFix = " PRIMARY KEY";
+          break;
+        case KEY:
+          postFix = " KEY";
+          break;
+        default:
+          postFix = "";
+          break;
+      }
+
       return escapedName(e.getName())
           + " "
           + ExpressionFormatter.formatExpression(
-              e.getType(), FormatOptions.of(IdentifierUtil::needsQuotes))
-          + (e.getNamespace() == Namespace.KEY ? " KEY" : "");
+          e.getType(), FormatOptions.of(IdentifierUtil::needsQuotes))
+          + postFix;
     }
   }
 

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateSource.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateSource.java
@@ -20,8 +20,8 @@ import static java.util.Objects.requireNonNull;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.NodeLocation;
+import io.confluent.ksql.parser.exception.ParseFailedException;
 import io.confluent.ksql.parser.properties.with.CreateSourceProperties;
-import io.confluent.ksql.util.KsqlException;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -101,8 +101,8 @@ public abstract class CreateSource extends Statement {
               .orElse(""))
           .collect(Collectors.joining(", "));
 
-      throw new KsqlException("Only single KEY column supported. Multiple KEY columns found: "
-          + namesAndLocs);
+      throw new ParseFailedException("Only single KEY column supported. "
+          + "Multiple KEY columns found: " + namesAndLocs);
     }
   }
 }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStream.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStream.java
@@ -20,9 +20,9 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.NodeLocation;
+import io.confluent.ksql.parser.exception.ParseFailedException;
 import io.confluent.ksql.parser.properties.with.CreateSourceProperties;
 import io.confluent.ksql.parser.tree.TableElement.Namespace;
-import io.confluent.ksql.util.KsqlException;
 import java.util.Optional;
 
 @Immutable
@@ -95,7 +95,7 @@ public class CreateStream extends CreateSource implements ExecutableDdlStatement
 
     wrongKey.ifPresent(col -> {
       final String loc = col.getLocation().map(NodeLocation::asPrefix).orElse("");
-      throw new KsqlException(
+      throw new ParseFailedException(
           loc + "Column " + col.getName() + " is a 'PRIMARY KEY' column: "
               + "please use 'KEY' for streams."
               + System.lineSeparator()

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTable.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTable.java
@@ -20,9 +20,9 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.NodeLocation;
+import io.confluent.ksql.parser.exception.ParseFailedException;
 import io.confluent.ksql.parser.properties.with.CreateSourceProperties;
 import io.confluent.ksql.parser.tree.TableElement.Namespace;
-import io.confluent.ksql.util.KsqlException;
 import java.util.Optional;
 
 @Immutable
@@ -95,7 +95,7 @@ public class CreateTable extends CreateSource implements ExecutableDdlStatement 
 
     wrongKey.ifPresent(col -> {
       final String loc = col.getLocation().map(NodeLocation::asPrefix).orElse("");
-      throw new KsqlException(
+      throw new ParseFailedException(
           loc + "Column " + col.getName() + " is a 'KEY' column: "
               + "please use 'PRIMARY KEY' for tables."
               + System.lineSeparator()

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/TableElement.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/TableElement.java
@@ -31,8 +31,22 @@ import java.util.Optional;
 public final class TableElement extends AstNode {
 
   public enum Namespace {
+    /**
+     * Table's have PRIMARY KEYs:
+     */
+    PRIMARY_KEY,
+    /**
+     * Stream's just have KEYs:
+     */
     KEY,
-    VALUE
+    /**
+     * Non-key colunns:
+     */
+    VALUE;
+
+    public boolean isKey() {
+      return this != VALUE;
+    }
   }
 
   private final Namespace namespace;

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/TableElements.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/TableElements.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.parser.tree;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.name.ColumnName;
-import io.confluent.ksql.parser.tree.TableElement.Namespace;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.LogicalSchema.Builder;
 import io.confluent.ksql.schema.ksql.types.SqlType;
@@ -91,7 +90,7 @@ public final class TableElements implements Iterable<TableElement> {
     if (withImplicitColumns) {
       builder.withRowTime();
 
-      final boolean noKey = elements.stream().noneMatch(e -> e.getNamespace() == Namespace.KEY);
+      final boolean noKey = elements.stream().noneMatch(e -> e.getNamespace().isKey());
       if (noKey) {
         builder.keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING);
       }
@@ -101,7 +100,7 @@ public final class TableElements implements Iterable<TableElement> {
       final ColumnName fieldName = tableElement.getName();
       final SqlType fieldType = tableElement.getType().getSqlType();
 
-      if (tableElement.getNamespace() == Namespace.KEY) {
+      if (tableElement.getNamespace().isKey()) {
         builder.keyColumn(fieldName, fieldType);
       } else {
         builder.valueColumn(fieldName, fieldType);

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/SchemaParserTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/SchemaParserTest.java
@@ -29,7 +29,6 @@ import io.confluent.ksql.parser.tree.TableElement.Namespace;
 import io.confluent.ksql.parser.tree.TableElements;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlException;
-import io.confluent.ksql.util.SchemaUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -72,21 +71,6 @@ public class SchemaParserTest {
   }
 
   @Test
-  public void shouldParseValidSchemaWithRowKeyField() {
-    // Given:
-    final String schema = "ROWKEY STRING KEY, bar INT";
-
-    // When:
-    final TableElements elements = parser.parse(schema);
-
-    // Then:
-    assertThat(elements, contains(
-        new TableElement(Namespace.KEY, SchemaUtil.ROWKEY_NAME, new Type(SqlTypes.STRING)),
-        new TableElement(Namespace.VALUE, BAR, new Type(SqlTypes.INTEGER))
-    ));
-  }
-
-  @Test
   public void shouldParseValidSchemaWithKeyField() {
     // Given:
     final String schema = "K STRING KEY, bar INT";
@@ -97,6 +81,21 @@ public class SchemaParserTest {
     // Then:
     assertThat(elements, contains(
         new TableElement(Namespace.KEY, ColumnName.of("K"), new Type(SqlTypes.STRING)),
+        new TableElement(Namespace.VALUE, BAR, new Type(SqlTypes.INTEGER))
+    ));
+  }
+
+  @Test
+  public void shouldParseValidSchemaWithPrimaryKeyField() {
+    // Given:
+    final String schema = "K STRING PRIMARY KEY, bar INT";
+
+    // When:
+    final TableElements elements = parser.parse(schema);
+
+    // Then:
+    assertThat(elements, contains(
+        new TableElement(Namespace.PRIMARY_KEY, ColumnName.of("K"), new Type(SqlTypes.STRING)),
         new TableElement(Namespace.VALUE, BAR, new Type(SqlTypes.INTEGER))
     ));
   }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
@@ -142,8 +142,13 @@ public class SqlFormatterTest {
           CommonCreateConfigs.KAFKA_TOPIC_NAME_PROPERTY, new StringLiteral("topic_test"))
   );
 
-  private static final TableElements ELEMENTS_WITH_KEY = TableElements.of(
+  private static final TableElements STREAM_ELEMENTS_WITH_KEY = TableElements.of(
       new TableElement(Namespace.KEY, ColumnName.of("k3"), new Type(SqlTypes.STRING)),
+      new TableElement(Namespace.VALUE, ColumnName.of("Foo"), new Type(SqlTypes.STRING))
+  );
+
+  private static final TableElements TABLE_ELEMENTS_WITH_KEY = TableElements.of(
+      new TableElement(Namespace.PRIMARY_KEY, ColumnName.of("k3"), new Type(SqlTypes.STRING)),
       new TableElement(Namespace.VALUE, ColumnName.of("Foo"), new Type(SqlTypes.STRING))
   );
 
@@ -221,7 +226,7 @@ public class SqlFormatterTest {
     // Given:
     final CreateStream createStream = new CreateStream(
         TEST,
-        ELEMENTS_WITH_KEY,
+        STREAM_ELEMENTS_WITH_KEY,
         false,
         SOME_WITH_PROPS);
 
@@ -262,7 +267,7 @@ public class SqlFormatterTest {
     );
     final CreateTable createTable = new CreateTable(
         TEST,
-        ELEMENTS_WITH_KEY,
+        TABLE_ELEMENTS_WITH_KEY,
         false,
         props);
 
@@ -270,7 +275,7 @@ public class SqlFormatterTest {
     final String sql = SqlFormatter.formatSql(createTable);
 
     // Then:
-    assertThat(sql, is("CREATE TABLE TEST (`k3` STRING KEY, `Foo` STRING) "
+    assertThat(sql, is("CREATE TABLE TEST (`k3` STRING PRIMARY KEY, `Foo` STRING) "
         + "WITH (KAFKA_TOPIC='topic_test', KEY='ORDERID', "
         + "TIMESTAMP='Foo', TIMESTAMP_FORMAT='%s', VALUE_FORMAT='JSON');"));
   }
@@ -280,7 +285,7 @@ public class SqlFormatterTest {
     // Given:
     final CreateTable createTable = new CreateTable(
         TEST,
-        ELEMENTS_WITH_KEY,
+        TABLE_ELEMENTS_WITH_KEY,
         false,
         SOME_WITH_PROPS);
 
@@ -288,7 +293,7 @@ public class SqlFormatterTest {
     final String sql = SqlFormatter.formatSql(createTable);
 
     // Then:
-    assertThat(sql, is("CREATE TABLE TEST (`k3` STRING KEY, `Foo` STRING) "
+    assertThat(sql, is("CREATE TABLE TEST (`k3` STRING PRIMARY KEY, `Foo` STRING) "
         + "WITH (KAFKA_TOPIC='topic_test', KEY='ORDERID', VALUE_FORMAT='JSON');"));
   }
 

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateSourceTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateSourceTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser.tree;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.execution.expression.tree.StringLiteral;
+import io.confluent.ksql.execution.expression.tree.Type;
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.parser.NodeLocation;
+import io.confluent.ksql.parser.properties.with.CreateSourceProperties;
+import io.confluent.ksql.parser.tree.TableElement.Namespace;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.util.KsqlException;
+import java.util.Optional;
+import org.junit.Test;
+
+public class CreateSourceTest {
+
+  public static final NodeLocation SOME_LOCATION = new NodeLocation(0, 0);
+
+  private static final SourceName SOME_NAME = SourceName.of("bob");
+
+  private static final CreateSourceProperties SOME_PROPS = CreateSourceProperties.from(
+      ImmutableMap.of(
+          "value_format", new StringLiteral("json"),
+          "kafka_topic", new StringLiteral("foo")
+      ));
+
+  @Test
+  public void shouldThrowOnMultipleKeyColumns() {
+    // Given:
+    final NodeLocation loc1 = new NodeLocation(2, 3);
+    final ColumnName key1 = ColumnName.of("K1");
+
+    final NodeLocation loc2 = new NodeLocation(4, 5);
+    final ColumnName key2 = ColumnName.of("K2");
+
+    final TableElements multipleKeys = TableElements.of(
+        new TableElement(
+            Optional.of(loc1),
+            Namespace.PRIMARY_KEY,
+            key1,
+            new Type(SqlTypes.STRING)
+        ),
+        new TableElement(
+            Optional.of(new NodeLocation(3, 4)),
+            Namespace.VALUE,
+            ColumnName.of("values are always valid"),
+            new Type(SqlTypes.STRING)
+        ),
+        new TableElement(
+            Optional.of(loc2),
+            Namespace.KEY,
+            key2,
+            new Type(SqlTypes.STRING)
+        )
+    );
+
+    // When:
+    final KsqlException e = assertThrows(
+        KsqlException.class,
+        () -> new TestCreateSource(Optional.empty(), SOME_NAME, multipleKeys, false, SOME_PROPS)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), is("Only single KEY column supported. "
+        + "Multiple KEY columns found: `K1` (Line: 2, Col: 4), `K2` (Line: 4, Col: 6)"));
+  }
+
+  private static final class TestCreateSource extends CreateSource {
+
+    TestCreateSource(
+        final Optional<NodeLocation> location,
+        final SourceName name,
+        final TableElements elements,
+        final boolean notExists,
+        final CreateSourceProperties properties
+    ) {
+      super(location, name, elements, notExists, properties);
+    }
+
+    @Override
+    public CreateSource copyWith(final TableElements elements,
+        final CreateSourceProperties properties) {
+      return null;
+    }
+
+    @Override
+    public String toString() {
+      return null;
+    }
+  }
+}

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateSourceTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateSourceTest.java
@@ -105,7 +105,7 @@ public class CreateSourceTest {
 
     @Override
     public String toString() {
-      return null;
+      return "";
     }
   }
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateSourceTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateSourceTest.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.parser.tree;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableMap;
@@ -25,10 +25,10 @@ import io.confluent.ksql.execution.expression.tree.Type;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.NodeLocation;
+import io.confluent.ksql.parser.exception.ParseFailedException;
 import io.confluent.ksql.parser.properties.with.CreateSourceProperties;
 import io.confluent.ksql.parser.tree.TableElement.Namespace;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.util.KsqlException;
 import java.util.Optional;
 import org.junit.Test;
 
@@ -75,13 +75,13 @@ public class CreateSourceTest {
     );
 
     // When:
-    final KsqlException e = assertThrows(
-        KsqlException.class,
+    final ParseFailedException e = assertThrows(
+        ParseFailedException.class,
         () -> new TestCreateSource(Optional.empty(), SOME_NAME, multipleKeys, false, SOME_PROPS)
     );
 
     // Then:
-    assertThat(e.getMessage(), is("Only single KEY column supported. "
+    assertThat(e.getMessage(), containsString("Only single KEY column supported. "
         + "Multiple KEY columns found: `K1` (Line: 2, Col: 4), `K2` (Line: 4, Col: 6)"));
   }
 

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateStreamTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateStreamTest.java
@@ -15,6 +15,10 @@
 
 package io.confluent.ksql.parser.tree;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThrows;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
@@ -26,6 +30,7 @@ import io.confluent.ksql.parser.properties.with.CreateSourceProperties;
 import io.confluent.ksql.parser.tree.TableElement.Namespace;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.util.KsqlException;
 import java.util.Optional;
 import org.junit.Test;
 
@@ -49,6 +54,7 @@ public class CreateStreamTest {
           CommonCreateConfigs.TIMESTAMP_NAME_PROPERTY, new StringLiteral("foo"))
   );
 
+  @SuppressWarnings("UnstableApiUsage")
   @Test
   public void shouldImplementHashCodeAndEqualsProperty() {
     new EqualsTester()
@@ -72,5 +78,53 @@ public class CreateStreamTest {
             new CreateStream(SOME_NAME, SOME_ELEMENTS, true, OTHER_PROPS)
         )
         .testEquals();
+  }
+
+  @Test
+  public void shouldThrowOnNonePrimaryKey() {
+    // Given:
+    final NodeLocation loc1 = new NodeLocation(2, 3);
+    final ColumnName invalid1 = ColumnName.of("invalid primary key column!");
+
+    final NodeLocation loc2 = new NodeLocation(4, 5);
+    final ColumnName invalid2 = ColumnName.of("another invalid primary key column");
+
+    final TableElements invalidElements = TableElements.of(
+        new TableElement(
+            Optional.of(new NodeLocation(1, 2)),
+            Namespace.KEY,
+            ColumnName.of("keys are valid"),
+            new Type(SqlTypes.STRING)
+        ),
+        new TableElement(
+            Optional.of(loc1),
+            Namespace.PRIMARY_KEY,
+            invalid1,
+            new Type(SqlTypes.STRING)
+        ),
+        new TableElement(
+            Optional.of(new NodeLocation(3, 4)),
+            Namespace.VALUE,
+            ColumnName.of("values are always valid"),
+            new Type(SqlTypes.STRING)
+        ),
+        new TableElement(
+            Optional.of(loc2),
+            Namespace.PRIMARY_KEY,
+            invalid2,
+            new Type(SqlTypes.STRING)
+        )
+    );
+
+    // When:
+    final KsqlException e = assertThrows(
+        KsqlException.class,
+        () -> new CreateStream(SOME_NAME, invalidElements, false, SOME_PROPS)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString("Streams do not support PRIMARY KEY columns"));
+    assertThat(e.getMessage(), containsString(loc1.asPrefix() + invalid1));
+    assertThat(e.getMessage(), containsString(loc2.asPrefix() + invalid2));
   }
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateStreamTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateStreamTest.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.parser.tree;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableMap;
@@ -83,35 +83,20 @@ public class CreateStreamTest {
   @Test
   public void shouldThrowOnNonePrimaryKey() {
     // Given:
-    final NodeLocation loc1 = new NodeLocation(2, 3);
-    final ColumnName invalid1 = ColumnName.of("invalid primary key column!");
-
-    final NodeLocation loc2 = new NodeLocation(4, 5);
-    final ColumnName invalid2 = ColumnName.of("another invalid primary key column");
+    final NodeLocation loc = new NodeLocation(2, 3);
+    final ColumnName name = ColumnName.of("PK");
 
     final TableElements invalidElements = TableElements.of(
         new TableElement(
-            Optional.of(new NodeLocation(1, 2)),
-            Namespace.KEY,
-            ColumnName.of("keys are valid"),
-            new Type(SqlTypes.STRING)
-        ),
-        new TableElement(
-            Optional.of(loc1),
+            Optional.of(loc),
             Namespace.PRIMARY_KEY,
-            invalid1,
+            name,
             new Type(SqlTypes.STRING)
         ),
         new TableElement(
             Optional.of(new NodeLocation(3, 4)),
             Namespace.VALUE,
             ColumnName.of("values are always valid"),
-            new Type(SqlTypes.STRING)
-        ),
-        new TableElement(
-            Optional.of(loc2),
-            Namespace.PRIMARY_KEY,
-            invalid2,
             new Type(SqlTypes.STRING)
         )
     );
@@ -123,8 +108,9 @@ public class CreateStreamTest {
     );
 
     // Then:
-    assertThat(e.getMessage(), containsString("Streams do not support PRIMARY KEY columns"));
-    assertThat(e.getMessage(), containsString(loc1.asPrefix() + invalid1));
-    assertThat(e.getMessage(), containsString(loc2.asPrefix() + invalid2));
+    assertThat(e.getMessage(), is("Line: 2, Col: 4: Column `PK` is a 'PRIMARY KEY' column: "
+        + "please use 'KEY' for streams.\n"
+        + "Tables have PRIMARY KEYs, which are unique and NON NULL.\n"
+        + "Streams have KEYs, which have no uniqueness or NON NULL constraints."));
   }
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateStreamTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateStreamTest.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.parser.tree;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableMap;
@@ -26,11 +26,11 @@ import io.confluent.ksql.execution.expression.tree.Type;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.NodeLocation;
+import io.confluent.ksql.parser.exception.ParseFailedException;
 import io.confluent.ksql.parser.properties.with.CreateSourceProperties;
 import io.confluent.ksql.parser.tree.TableElement.Namespace;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.util.KsqlException;
 import java.util.Optional;
 import org.junit.Test;
 
@@ -102,15 +102,16 @@ public class CreateStreamTest {
     );
 
     // When:
-    final KsqlException e = assertThrows(
-        KsqlException.class,
+    final ParseFailedException e = assertThrows(
+        ParseFailedException.class,
         () -> new CreateStream(SOME_NAME, invalidElements, false, SOME_PROPS)
     );
 
     // Then:
-    assertThat(e.getMessage(), is("Line: 2, Col: 4: Column `PK` is a 'PRIMARY KEY' column: "
-        + "please use 'KEY' for streams.\n"
-        + "Tables have PRIMARY KEYs, which are unique and NON NULL.\n"
-        + "Streams have KEYs, which have no uniqueness or NON NULL constraints."));
+    assertThat(e.getMessage(),
+        containsString("Line: 2, Col: 4: Column `PK` is a 'PRIMARY KEY' column: "
+            + "please use 'KEY' for streams.\n"
+            + "Tables have PRIMARY KEYs, which are unique and NON NULL.\n"
+            + "Streams have KEYs, which have no uniqueness or NON NULL constraints."));
   }
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateTableTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateTableTest.java
@@ -15,6 +15,10 @@
 
 package io.confluent.ksql.parser.tree;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThrows;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
@@ -26,6 +30,7 @@ import io.confluent.ksql.parser.properties.with.CreateSourceProperties;
 import io.confluent.ksql.parser.tree.TableElement.Namespace;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.util.KsqlException;
 import java.util.Optional;
 import org.junit.Test;
 
@@ -49,6 +54,7 @@ public class CreateTableTest {
           CommonCreateConfigs.TIMESTAMP_NAME_PROPERTY, new StringLiteral("foo"))
   );
 
+  @SuppressWarnings("UnstableApiUsage")
   @Test
   public void shouldImplementHashCodeAndEqualsProperty() {
     new EqualsTester()
@@ -72,5 +78,53 @@ public class CreateTableTest {
             new CreateTable(SOME_NAME, SOME_ELEMENTS, true, OTHER_PROPS)
         )
         .testEquals();
+  }
+
+  @Test
+  public void shouldThrowOnNonePrimaryKey() {
+    // Given:
+    final NodeLocation loc1 = new NodeLocation(2, 3);
+    final ColumnName invalid1 = ColumnName.of("invalid key column!");
+
+    final NodeLocation loc2 = new NodeLocation(4, 5);
+    final ColumnName invalid2 = ColumnName.of("another invalid key column");
+
+    final TableElements invalidElements = TableElements.of(
+        new TableElement(
+            Optional.of(new NodeLocation(1, 2)),
+            Namespace.PRIMARY_KEY,
+            ColumnName.of("primary keys are valid"),
+            new Type(SqlTypes.STRING)
+        ),
+        new TableElement(
+            Optional.of(loc1),
+            Namespace.KEY,
+            invalid1,
+            new Type(SqlTypes.STRING)
+        ),
+        new TableElement(
+            Optional.of(new NodeLocation(3, 4)),
+            Namespace.VALUE,
+            ColumnName.of("values are always valid"),
+            new Type(SqlTypes.STRING)
+        ),
+        new TableElement(
+            Optional.of(loc2),
+            Namespace.KEY,
+            invalid2,
+            new Type(SqlTypes.STRING)
+        )
+    );
+
+    // When:
+    final KsqlException e = assertThrows(
+        KsqlException.class,
+        () -> new CreateTable(SOME_NAME, invalidElements, false, SOME_PROPS)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString("Tables do not support KEY columns"));
+    assertThat(e.getMessage(), containsString(loc1.asPrefix() + invalid1));
+    assertThat(e.getMessage(), containsString(loc2.asPrefix() + invalid2));
   }
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateTableTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateTableTest.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.parser.tree;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableMap;
@@ -83,35 +83,20 @@ public class CreateTableTest {
   @Test
   public void shouldThrowOnNonePrimaryKey() {
     // Given:
-    final NodeLocation loc1 = new NodeLocation(2, 3);
-    final ColumnName invalid1 = ColumnName.of("invalid key column!");
-
-    final NodeLocation loc2 = new NodeLocation(4, 5);
-    final ColumnName invalid2 = ColumnName.of("another invalid key column");
+    final NodeLocation loc = new NodeLocation(2, 3);
+    final ColumnName name = ColumnName.of("K");
 
     final TableElements invalidElements = TableElements.of(
         new TableElement(
-            Optional.of(new NodeLocation(1, 2)),
-            Namespace.PRIMARY_KEY,
-            ColumnName.of("primary keys are valid"),
-            new Type(SqlTypes.STRING)
-        ),
-        new TableElement(
-            Optional.of(loc1),
+            Optional.of(loc),
             Namespace.KEY,
-            invalid1,
+            name,
             new Type(SqlTypes.STRING)
         ),
         new TableElement(
             Optional.of(new NodeLocation(3, 4)),
             Namespace.VALUE,
             ColumnName.of("values are always valid"),
-            new Type(SqlTypes.STRING)
-        ),
-        new TableElement(
-            Optional.of(loc2),
-            Namespace.KEY,
-            invalid2,
             new Type(SqlTypes.STRING)
         )
     );
@@ -123,8 +108,9 @@ public class CreateTableTest {
     );
 
     // Then:
-    assertThat(e.getMessage(), containsString("Tables do not support KEY columns"));
-    assertThat(e.getMessage(), containsString(loc1.asPrefix() + invalid1));
-    assertThat(e.getMessage(), containsString(loc2.asPrefix() + invalid2));
+    assertThat(e.getMessage(), is("Line: 2, Col: 4: Column `K` is a 'KEY' column: "
+        + "please use 'PRIMARY KEY' for tables.\n"
+        + "Tables have PRIMARY KEYs, which are unique and NON NULL.\n"
+        + "Streams have KEYs, which have no uniqueness or NON NULL constraints."));
   }
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateTableTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateTableTest.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.parser.tree;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableMap;
@@ -26,11 +26,11 @@ import io.confluent.ksql.execution.expression.tree.Type;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.NodeLocation;
+import io.confluent.ksql.parser.exception.ParseFailedException;
 import io.confluent.ksql.parser.properties.with.CreateSourceProperties;
 import io.confluent.ksql.parser.tree.TableElement.Namespace;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.util.KsqlException;
 import java.util.Optional;
 import org.junit.Test;
 
@@ -102,13 +102,13 @@ public class CreateTableTest {
     );
 
     // When:
-    final KsqlException e = assertThrows(
-        KsqlException.class,
+    final ParseFailedException e = assertThrows(
+        ParseFailedException.class,
         () -> new CreateTable(SOME_NAME, invalidElements, false, SOME_PROPS)
     );
 
     // Then:
-    assertThat(e.getMessage(), is("Line: 2, Col: 4: Column `K` is a 'KEY' column: "
+    assertThat(e.getMessage(), containsString("Line: 2, Col: 4: Column `K` is a 'KEY' column: "
         + "please use 'PRIMARY KEY' for tables.\n"
         + "Tables have PRIMARY KEYs, which are unique and NON NULL.\n"
         + "Streams have KEYs, which have no uniqueness or NON NULL constraints."));

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/TableElementTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/TableElementTest.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.parser.tree;
 
 import static io.confluent.ksql.parser.tree.TableElement.Namespace.KEY;
+import static io.confluent.ksql.parser.tree.TableElement.Namespace.PRIMARY_KEY;
 import static io.confluent.ksql.parser.tree.TableElement.Namespace.VALUE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -56,6 +57,9 @@ public class TableElementTest {
         )
         .addEqualityGroup(
             new TableElement(KEY, NAME, new Type(SqlTypes.STRING))
+        )
+        .addEqualityGroup(
+            new TableElement(PRIMARY_KEY, NAME, new Type(SqlTypes.STRING))
         )
         .testEquals();
   }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/TableElementsTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/TableElementsTest.java
@@ -47,6 +47,7 @@ public class TableElementsTest {
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
 
+  @SuppressWarnings("UnstableApiUsage")
   @Test
   public void shouldImplementHashCodeAndEqualsProperty() {
     final List<TableElement> someElements = ImmutableList.of(

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryFunctionalTest.java
@@ -157,7 +157,7 @@ public class PullQueryFunctionalTest {
 
     makeAdminRequest(
         "CREATE STREAM " + USERS_STREAM
-            + " (" + USER_PROVIDER.ksqlSchemaString() + ")"
+            + " (" + USER_PROVIDER.ksqlSchemaString(false) + ")"
             + " WITH ("
             + "   kafka_topic='" + USER_TOPIC + "', "
             + "   key='" + USER_PROVIDER.key() + "', "

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
@@ -210,7 +210,7 @@ public class PullQueryRoutingFunctionalTest {
     makeAdminRequest(
         REST_APP_0,
         "CREATE STREAM " + USERS_STREAM
-            + " (" + USER_PROVIDER.ksqlSchemaString() + ")"
+            + " (" + USER_PROVIDER.ksqlSchemaString(false) + ")"
             + " WITH ("
             + "   kafka_topic='" + USER_TOPIC + "', "
             + "   key='" + USER_PROVIDER.key() + "', "

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
@@ -160,7 +160,7 @@ public final class RestIntegrationTestUtil {
     makeKsqlRequest(
         restApp,
         "CREATE STREAM " + dataProvider.kstreamName()
-            + " (" + dataProvider.ksqlSchemaString() + ") "
+            + " (" + dataProvider.ksqlSchemaString(false) + ") "
             + "WITH (kafka_topic='" + dataProvider.topicName() + "', value_format='json');"
     );
   }


### PR DESCRIPTION
### Description 

KLIP for this (which needs approving first): https://github.com/confluentinc/ksql/pull/5008

fixes: #3681

The commit introduces `PRIMARY KEY` columns into the ksqlDB syntax for tables. Streams will continue to have `KEY` columns. For example,

```sql
CREATE TABLE ORDERS (ID BIGINT PRIMARY KEY, USER_ID BIGINT, ...
--vs
CREATE STREAM ORDER_UPDATES (ID BIGINT KEY, USER_ID BIGINT, ...
```

Note: this change only introduces the `PRIMARY KEY` syntax. It does not change how data is processed by ksqlDB.

This change in syntax differentiates the key handling semantics for tables vs streams:

A ksqlDB TABLE works much like tables in other SQL systems: Each row is identified by its `PRIMARY KEY`. `PRIMARY KEY` column(s) can not be NULL.
A message in the underlying Kafka topic with the same key as an existing row will _replaces_ the earlier row in the table,
or _deletes_ the row if the message's value is NULL, as long as the earlier row does not have a later timestamp / `ROWTIME`.

A ksqlDB STREAM is a stream of _facts_. Each _fact_ is immutable and is unique. A stream can store its data in either `KEY` or `VALUE` columns.  Columns stored in the key of the Kafka message are _not_ `PRIMARY KEY` columns. They are just non-primary-key columns that happen to be stored in the key of the Kafka message.
Both `KEY` and `VALUE` columns can be NULL. No special processing is done if two rows have the same key.

The table below contrasts key handling for streams and tables:

|                          |  STREAM                                                       | TABLE                                                             |
| ------------------------ | --------------------------------------------------------------| ----------------------------------------------------------------- |
| Key column type          | `KEY`                                                         | `PRIMARY KEY`                                                     |
| NON NULL key constraint  | No                                                            | Yes  <br> Messages in the Kafka topic with a NULL `PRIMARY KEY` are ignored                                                             |
| Unique key constraint    | No                                                            | Yes                                                               <br> Messages with the same key as another have no special meaning : Later messages with the same key _replace_ earlier |
| Tombstones               | No  <br> Messages with NULL values are ignored                                                          | Yes  <br> NULL message values are treated as a _tombstone_ <br> Any existing row with a matching key is deleted |

### Testing done 

usual

### Reviewing notes:

Commits broken down into:
  * First commit:  Prod code changes and associated tests.
  * Second commit: doc updates
  * Third commit: Updates to other tests, i.e. adding the `PRIMARY` to other tests that use tables.
  * Fourth commit: New historical query plans (The change is just the addition of the `PRIMARY` key word in the SQL).
  * Fifth commit: doc update to fix table layout. Turns out github does support multi-line tables :(
   

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

