### PR TITLE
docs: cherry-pick fix for STRUCT example in syntax-reference (DOCS-3839)

### DIFF
--- a/docs-md/developer-guide/syntax-reference.md
+++ b/docs-md/developer-guide/syntax-reference.md
@@ -327,7 +327,7 @@ Also, you can output a struct from a query by using a SELECT statement.
 The following example creates a struct from a stream named `s1`.
 
 ```sql
-SELECT {f1 v1, f2 v2} FROM s1 EMIT CHANGES;
+SELECT STRUCT(f1 := v1, f2 := v2) FROM s1 EMIT CHANGES;
 ```
 
 ### Decimal


### PR DESCRIPTION
Cherry-pick https://github.com/confluentinc/ksql/pull/4982.