### PR TITLE
fix: Allows unclosed quote characters to exist in comments

### DIFF
--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/JLineReader.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/JLineReader.java
@@ -91,7 +91,6 @@ public class JLineReader implements io.confluent.ksql.cli.console.LineReader {
   ) {
     final DefaultParser parser = new DefaultParser();
     parser.setEofOnEscapedNewLine(true);
-    parser.setEofOnUnclosedQuote(true);
     parser.setQuoteChars(new char[]{'\''});
     parser.setEscapeChars(new char[]{'\\'});
 

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/KsqlLineParser.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/KsqlLineParser.java
@@ -47,6 +47,10 @@ final class KsqlLineParser implements Parser {
       return parsed;
     }
 
+    if (UnclosedQuoteChecker.isUnclosedQuote(line)) {
+      throw new EOFError(-1, -1, "Missing end quote", "end quote char");
+    }
+
     final String bare = CommentStripper.strip(parsed.line());
     if (bare.isEmpty()) {
       return parsed;

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/UnclosedQuoteChecker.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/UnclosedQuoteChecker.java
@@ -1,0 +1,48 @@
+package io.confluent.ksql.cli.console;
+
+/**
+ * Checks to see if the line is in the middle of a quote.  Unlike
+ * org.jline.reader.impl.DefaultParser, this is comment aware.
+ */
+public class UnclosedQuoteChecker {
+  private static final String COMMENT = "--";
+
+  public static boolean isUnclosedQuote(String line) {
+    int quoteStart = -1;
+    for(int i = 0; line != null && i < line.length(); ++i) {
+      if (quoteStart < 0 && isQuoteChar(line, i)) {
+        quoteStart = i;
+      } else if (quoteStart >= 0 && line.charAt(quoteStart) == line.charAt(i) &&
+          !isEscaped(line, i)) {
+        quoteStart = -1;
+      }
+    }
+    int commentInd = line.indexOf(COMMENT);
+    if (commentInd < 0) {
+      return quoteStart >= 0;
+    } else if (quoteStart < 0) {
+      return false;
+    } else {
+      return commentInd > quoteStart;
+    }
+  }
+
+  private static boolean isQuoteChar(String line, int ind) {
+    char c = line.charAt(ind);
+    if (c == '\'') {
+      return true;
+    }
+    return false;
+  }
+
+  private static boolean isEscaped(String line, int ind) {
+    if (ind == 0) {
+      return false;
+    }
+    char c = line.charAt(ind-1);
+    if (c == '\\') {
+      return true;
+    }
+    return false;
+  }
+}

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/UnclosedQuoteChecker.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/UnclosedQuoteChecker.java
@@ -32,8 +32,7 @@ public final class UnclosedQuoteChecker {
     for (int i = 0; line != null && i < line.length(); ++i) {
       if (quoteStart < 0 && isQuoteChar(line, i)) {
         quoteStart = i;
-      } else if (quoteStart >= 0 && line.charAt(quoteStart) == line.charAt(i)
-          && !isEscaped(line, i)) {
+      } else if (quoteStart >= 0 && isQuoteChar(line, i) && !isEscaped(line, i)) {
         quoteStart = -1;
       }
     }

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/UnclosedQuoteChecker.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/UnclosedQuoteChecker.java
@@ -1,23 +1,43 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.cli.console;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Checks to see if the line is in the middle of a quote.  Unlike
  * org.jline.reader.impl.DefaultParser, this is comment aware.
  */
-public class UnclosedQuoteChecker {
+public final class UnclosedQuoteChecker {
   private static final String COMMENT = "--";
 
-  public static boolean isUnclosedQuote(String line) {
+  private UnclosedQuoteChecker() {}
+
+  public static boolean isUnclosedQuote(final String line) {
+    requireNonNull(line, "line");
     int quoteStart = -1;
-    for(int i = 0; line != null && i < line.length(); ++i) {
+    for (int i = 0; line != null && i < line.length(); ++i) {
       if (quoteStart < 0 && isQuoteChar(line, i)) {
         quoteStart = i;
-      } else if (quoteStart >= 0 && line.charAt(quoteStart) == line.charAt(i) &&
-          !isEscaped(line, i)) {
+      } else if (quoteStart >= 0 && line.charAt(quoteStart) == line.charAt(i)
+          && !isEscaped(line, i)) {
         quoteStart = -1;
       }
     }
-    int commentInd = line.indexOf(COMMENT);
+    final int commentInd = line.indexOf(COMMENT);
     if (commentInd < 0) {
       return quoteStart >= 0;
     } else if (quoteStart < 0) {
@@ -27,19 +47,19 @@ public class UnclosedQuoteChecker {
     }
   }
 
-  private static boolean isQuoteChar(String line, int ind) {
-    char c = line.charAt(ind);
+  private static boolean isQuoteChar(final String line, final int ind) {
+    final char c = line.charAt(ind);
     if (c == '\'') {
       return true;
     }
     return false;
   }
 
-  private static boolean isEscaped(String line, int ind) {
+  private static boolean isEscaped(final String line, final int ind) {
     if (ind == 0) {
       return false;
     }
-    char c = line.charAt(ind-1);
+    final char c = line.charAt(ind - 1);
     if (c == '\\') {
       return true;
     }

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/UnclosedQuoteChecker.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/UnclosedQuoteChecker.java
@@ -24,7 +24,9 @@ public final class UnclosedQuoteChecker {
 
   private UnclosedQuoteChecker() {}
 
+  // CHECKSTYLE_RULES.OFF: CyclomaticComplexity
   public static boolean isUnclosedQuote(final String line) {
+    // CHECKSTYLE_RULES.ON: CyclomaticComplexity
     int quoteStart = -1;
     for (int i = 0; i < line.length(); ++i) {
       if (quoteStart < 0 && isQuoteChar(line, i)) {

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/util/CmdLineUtil.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/util/CmdLineUtil.java
@@ -97,7 +97,9 @@ public final class CmdLineUtil {
       return output.build();
     }
 
+    // CHECKSTYLE_RULES.OFF: CyclomaticComplexity
     private int processCharAt(final int pos) {
+      // CHECKSTYLE_RULES.ON: CyclomaticComplexity
       final char c = input.charAt(pos);
       int returnPos = pos;
 
@@ -133,7 +135,7 @@ public final class CmdLineUtil {
     }
   }
 
-  private static boolean isLineComment(char prevChar, char current) {
+  private static boolean isLineComment(final char prevChar, final char current) {
     return prevChar == '-' && current == '-';
   }
 

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/UnclosedQuoteCheckerTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/UnclosedQuoteCheckerTest.java
@@ -1,5 +1,19 @@
-package io.confluent.ksql.cli.console;
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 
+package io.confluent.ksql.cli.console;
 
 import org.junit.Assert;
 import org.junit.Test;

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/UnclosedQuoteCheckerTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/UnclosedQuoteCheckerTest.java
@@ -23,7 +23,7 @@ public class UnclosedQuoteCheckerTest {
   @Test
   public void shouldFindUnclosedQuote() {
     // Given:
-    final String line = "some line 'this is in a comment";
+    final String line = "some line 'this is in a quote";
 
     // Then:
     Assert.assertTrue(UnclosedQuoteChecker.isUnclosedQuote(line));
@@ -32,7 +32,7 @@ public class UnclosedQuoteCheckerTest {
   @Test
   public void shouldFindUnclosedQuote_escaped() {
     // Given:
-    final String line = "some line 'this is in a comment\\'";
+    final String line = "some line 'this is in a quote\\'";
 
     // Then:
     Assert.assertTrue(UnclosedQuoteChecker.isUnclosedQuote(line));
@@ -59,7 +59,7 @@ public class UnclosedQuoteCheckerTest {
   @Test
   public void shouldNotFindUnclosedQuote_inComment() {
     // Given:
-    final String line = "some line -- 'this is in a quote";
+    final String line = "some line -- 'this is in a comment";
 
     // Then:
     Assert.assertFalse(UnclosedQuoteChecker.isUnclosedQuote(line));

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/UnclosedQuoteCheckerTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/UnclosedQuoteCheckerTest.java
@@ -15,7 +15,9 @@
 
 package io.confluent.ksql.cli.console;
 
-import org.junit.Assert;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 import org.junit.Test;
 
 public class UnclosedQuoteCheckerTest {
@@ -26,7 +28,25 @@ public class UnclosedQuoteCheckerTest {
     final String line = "some line 'this is in a quote";
 
     // Then:
-    Assert.assertTrue(UnclosedQuoteChecker.isUnclosedQuote(line));
+    assertThat(UnclosedQuoteChecker.isUnclosedQuote(line), is(true));
+  }
+
+  @Test
+  public void shouldFindUnclosedQuote_commentCharsInside() {
+    // Given:
+    final String line = "some line 'this is in a quote -- not a comment";
+
+    // Then:
+    assertThat(UnclosedQuoteChecker.isUnclosedQuote(line), is(true));
+  }
+
+  @Test
+  public void shouldNotFindUnclosedQuote_commentCharsInside() {
+    // Given:
+    final String line = "some line 'this is in a quote -- not a comment'";
+
+    // Then:
+    assertThat(UnclosedQuoteChecker.isUnclosedQuote(line), is(false));
   }
 
   @Test
@@ -35,7 +55,25 @@ public class UnclosedQuoteCheckerTest {
     final String line = "some line 'this is in a quote\\'";
 
     // Then:
-    Assert.assertTrue(UnclosedQuoteChecker.isUnclosedQuote(line));
+    assertThat(UnclosedQuoteChecker.isUnclosedQuote(line), is(true));
+  }
+
+  @Test
+  public void shouldFindUnclosedQuote_escapedEscape() {
+    // Given:
+    final String line = "some line 'this is in a quote\\\\'";
+
+    // Then:
+    assertThat(UnclosedQuoteChecker.isUnclosedQuote(line), is(false));
+  }
+
+  @Test
+  public void shouldFindUnclosedQuote_twoQuote() {
+    // Given:
+    final String line = "some line 'this is in a quote''";
+
+    // Then:
+    assertThat(UnclosedQuoteChecker.isUnclosedQuote(line), is(true));
   }
 
   @Test
@@ -44,7 +82,7 @@ public class UnclosedQuoteCheckerTest {
     final String line = "some line 'this is in a quote'";
 
     // Then:
-    Assert.assertFalse(UnclosedQuoteChecker.isUnclosedQuote(line));
+    assertThat(UnclosedQuoteChecker.isUnclosedQuote(line), is(false));
   }
 
   @Test
@@ -53,7 +91,70 @@ public class UnclosedQuoteCheckerTest {
     final String line = "some line 'this is in a quote' more";
 
     // Then:
-    Assert.assertFalse(UnclosedQuoteChecker.isUnclosedQuote(line));
+    assertThat(UnclosedQuoteChecker.isUnclosedQuote(line), is(false));
+  }
+
+  @Test
+  public void shouldNotFindUnclosedQuote_containsDoubleQuote() {
+    // Given:
+    final String line = "some line 'this is \"in\" a quote'";
+
+    // Then:
+    assertThat(UnclosedQuoteChecker.isUnclosedQuote(line), is(false));
+  }
+
+  @Test
+  public void shouldNotFindUnclosedQuote_containsUnclosedDoubleQuote() {
+    // Given:
+    final String line = "some line 'this is \"in a quote'";
+
+    // Then:
+    assertThat(UnclosedQuoteChecker.isUnclosedQuote(line), is(false));
+  }
+
+  @Test
+  public void shouldNotFindUnclosedQuote_escaped() {
+    // Given:
+    final String line = "some line 'this is in a quote\\''";
+
+    // Then:
+    assertThat(UnclosedQuoteChecker.isUnclosedQuote(line), is(false));
+  }
+
+  @Test
+  public void shouldNotFindUnclosedQuote_twoQuote() {
+    // Given:
+    final String line = "some line 'this is in a quote'''";
+
+    // Then:
+    assertThat(UnclosedQuoteChecker.isUnclosedQuote(line), is(false));
+  }
+
+  @Test
+  public void shouldFindUnclosedQuote_manyQuote() {
+    // Given:
+    final String line = "some line 'this is in a quote''''";
+
+    // Then:
+    assertThat(UnclosedQuoteChecker.isUnclosedQuote(line), is(true));
+  }
+
+  @Test
+  public void shouldNotFindUnclosedQuote_manyQuote() {
+    // Given:
+    final String line = "some line 'this is in a quote'''''";
+
+    // Then:
+    assertThat(UnclosedQuoteChecker.isUnclosedQuote(line), is(false));
+  }
+
+  @Test
+  public void shouldNotFindUnclosedQuote_escapedAndMultipleQuotes() {
+    // Given:
+    final String line = "some line 'this is in a quote\\''''";
+
+    // Then:
+    assertThat(UnclosedQuoteChecker.isUnclosedQuote(line), is(false));
   }
 
   @Test
@@ -62,7 +163,7 @@ public class UnclosedQuoteCheckerTest {
     final String line = "some line -- 'this is in a comment";
 
     // Then:
-    Assert.assertFalse(UnclosedQuoteChecker.isUnclosedQuote(line));
+    assertThat(UnclosedQuoteChecker.isUnclosedQuote(line), is(false));
   }
 
   @Test
@@ -71,6 +172,15 @@ public class UnclosedQuoteCheckerTest {
     final String line = "some line -- this is a comment";
 
     // Then:
-    Assert.assertFalse(UnclosedQuoteChecker.isUnclosedQuote(line));
+    assertThat(UnclosedQuoteChecker.isUnclosedQuote(line), is(false));
+  }
+
+  @Test
+  public void shouldNotFindUnclosedQuote_commentAfterQuote() {
+    // Given:
+    final String line = "some line 'quoted text' -- this is a comment";
+
+    // Then:
+    assertThat(UnclosedQuoteChecker.isUnclosedQuote(line), is(false));
   }
 }

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/UnclosedQuoteCheckerTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/UnclosedQuoteCheckerTest.java
@@ -1,0 +1,62 @@
+package io.confluent.ksql.cli.console;
+
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class UnclosedQuoteCheckerTest {
+
+  @Test
+  public void shouldFindUnclosedQuote() {
+    // Given:
+    final String line = "some line 'this is in a comment";
+
+    // Then:
+    Assert.assertTrue(UnclosedQuoteChecker.isUnclosedQuote(line));
+  }
+
+  @Test
+  public void shouldFindUnclosedQuote_escaped() {
+    // Given:
+    final String line = "some line 'this is in a comment\\'";
+
+    // Then:
+    Assert.assertTrue(UnclosedQuoteChecker.isUnclosedQuote(line));
+  }
+
+  @Test
+  public void shouldNotFindUnclosedQuote_endsQuote() {
+    // Given:
+    final String line = "some line 'this is in a quote'";
+
+    // Then:
+    Assert.assertFalse(UnclosedQuoteChecker.isUnclosedQuote(line));
+  }
+
+  @Test
+  public void shouldNotFindUnclosedQuote_endsNonQuote() {
+    // Given:
+    final String line = "some line 'this is in a quote' more";
+
+    // Then:
+    Assert.assertFalse(UnclosedQuoteChecker.isUnclosedQuote(line));
+  }
+
+  @Test
+  public void shouldNotFindUnclosedQuote_inComment() {
+    // Given:
+    final String line = "some line -- 'this is in a quote";
+
+    // Then:
+    Assert.assertFalse(UnclosedQuoteChecker.isUnclosedQuote(line));
+  }
+
+  @Test
+  public void shouldNotFindUnclosedQuote_onlyComment() {
+    // Given:
+    final String line = "some line -- this is a comment";
+
+    // Then:
+    Assert.assertFalse(UnclosedQuoteChecker.isUnclosedQuote(line));
+  }
+}

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/UnclosedQuoteCheckerTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/UnclosedQuoteCheckerTest.java
@@ -68,6 +68,15 @@ public class UnclosedQuoteCheckerTest {
   }
 
   @Test
+  public void shouldFindUnclosedQuote_escapedThree() {
+    // Given:
+    final String line = "some line 'this is in a quote\\\'";
+
+    // Then:
+    assertThat(UnclosedQuoteChecker.isUnclosedQuote(line), is(true));
+  }
+
+  @Test
   public void shouldFindUnclosedQuote_twoQuote() {
     // Given:
     final String line = "some line 'this is in a quote''";

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/util/CmdLineUtilTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/util/CmdLineUtilTest.java
@@ -109,6 +109,14 @@ public class CmdLineUtilTest {
   }
 
   @Test
+  public void shouldCheckSplitIgnoreCommentedQuote() {
+    assertSplit("-- '\nSHOW TABLES;", "-- '", "SHOW", "TABLES;");
+
+    assertSplit("COMMAND -- '\nSHOW TABLES;", "COMMAND", "-- '", "SHOW", "TABLES;");
+    assertSplit("COMMAND-- '\nSHOW TABLES;", "COMMAND-- '", "SHOW", "TABLES;");
+  }
+
+  @Test
   public void shouldRemoveQuotesFromUnQuotedString() {
     assertMatchedQuotesRemoved(" some input ", " some input ");
   }


### PR DESCRIPTION
### Description 
This allows support for unclosed quotes in comments. e.g. "SELECT -- It's a comment ".

There's actually a lot of code now that reparses the same line.  The better longer term solution is to have a single parser and not delegate to DefaultParser, but I wanted to avoid making this too complex, since this fixes a small bug.

#4075  

### Testing done 
`mvn package`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

