### PR TITLE
docs: remove dead links to window bounds udafs

### DIFF
--- a/docs-md/developer-guide/ksqldb-reference/aggregate-functions.md
+++ b/docs-md/developer-guide/ksqldb-reference/aggregate-functions.md
@@ -22,8 +22,6 @@ For more information, see
   - [SUM](#sum)
   - [TOPK](#topk)
   - [TOPKDISTINCT](#topkdistinct)
-  - [WindowStart](#windowstart)
-  - [WindowEnd](#windowend)
 
 AVG
 ---


### PR DESCRIPTION
### Description 

Remove the dead links to `WindowStart` and `WindowEnd` UDAFs. (These were removed a release or two ago)