### PR TITLE
feat: speed up restarts by not building topologies for terminated queries

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlPlan.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlPlan.java
@@ -33,6 +33,8 @@ public interface KsqlPlan {
 
   String getStatementText();
 
+  KsqlPlan withoutQuery();
+
   static KsqlPlan ddlPlanCurrent(final String statementText, final DdlCommand ddlCommand) {
     return new KsqlPlanV1(statementText, Optional.of(ddlCommand), Optional.empty());
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlPlanV1.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlPlanV1.java
@@ -52,6 +52,11 @@ final class KsqlPlanV1 implements KsqlPlan {
   }
 
   @Override
+  public KsqlPlan withoutQuery() {
+    return new KsqlPlanV1(statementText, ddlCommand, Optional.empty());
+  }
+
+  @Override
   public boolean equals(final Object o) {
     if (this == o) {
       return true;
@@ -67,7 +72,6 @@ final class KsqlPlanV1 implements KsqlPlan {
 
   @Override
   public int hashCode() {
-
     return Objects.hash(statementText, ddlCommand, queryPlan);
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
@@ -165,7 +165,9 @@ public class CommandRunner implements Closeable {
         return;
       }
 
-      restoreCommands.forEach(
+      final List<QueuedCommand> compacted = RestoreCommandsCompactor.compact(restoreCommands);
+
+      compacted.forEach(
           command -> {
             currentCommandRef.set(new Pair<>(command, clock.instant()));
             RetryUtil.retryWithBackoff(

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/RestoreCommandsCompactor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/RestoreCommandsCompactor.java
@@ -18,11 +18,11 @@ package io.confluent.ksql.rest.server.computation;
 import io.confluent.ksql.engine.KsqlPlan;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.entity.CommandId.Type;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -50,7 +50,7 @@ public final class RestoreCommandsCompactor {
    * @return the compacted list of commands.
    */
   static List<QueuedCommand> compact(final List<QueuedCommand> restoreCommands) {
-    final List<QueuedCommand> compacted = new ArrayList<>(restoreCommands);
+    final List<QueuedCommand> compacted = new LinkedList<>(restoreCommands);
 
     final Set<QueuedCommand> terminatedQueries =
         findTerminatedQueriesAndRemoveTerminateCommands(compacted);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/RestoreCommandsCompactor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/RestoreCommandsCompactor.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.computation;
+
+import io.confluent.ksql.engine.KsqlPlan;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.rest.entity.CommandId.Type;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Util for compacting the restore commands
+ */
+public final class RestoreCommandsCompactor {
+
+  private RestoreCommandsCompactor() {
+  }
+
+  /**
+   * Compact the list of commands to restore.
+   *
+   * <p>Finds any command's whose queries plans that are later terminated. Any such commands have
+   * their query plan and associated terminate command removed.
+   *
+   * <p>This compaction stops unnecessary creation of Streams topologies on a server restart.
+   * Building such topologies is relatively slow and best avoided.
+   *
+   * @param restoreCommands the list of commands to compact.
+   * @return the compacted list of commands.
+   */
+  static List<QueuedCommand> compact(final List<QueuedCommand> restoreCommands) {
+    final List<QueuedCommand> compacted = new ArrayList<>(restoreCommands);
+
+    final Set<QueuedCommand> terminatedQueries =
+        findTerminatedQueriesAndRemoveTerminateCommands(compacted);
+
+    removeQueryPlansOfTerminated(compacted, terminatedQueries);
+
+    return compacted;
+  }
+
+  private static Set<QueuedCommand> findTerminatedQueriesAndRemoveTerminateCommands(
+      final List<QueuedCommand> commands
+  ) {
+    final Map<QueryId, QueuedCommand> queries = new HashMap<>();
+    final Set<QueuedCommand> terminatedQueries = Collections.newSetFromMap(new IdentityHashMap<>());
+
+    final Iterator<QueuedCommand> it = commands.iterator();
+    while (it.hasNext()) {
+      final QueuedCommand cmd = it.next();
+
+      // Find known queries:
+      if (cmd.getCommand().getPlan().isPresent()
+          && cmd.getCommand().getPlan().get().getQueryPlan().isPresent()
+      ) {
+        final QueryId queryId = cmd.getCommand().getPlan().get().getQueryPlan().get().getQueryId();
+        queries.putIfAbsent(queryId, cmd);
+      }
+
+      // Find TERMINATE's that match known queries:
+      if (cmd.getCommandId().getType() == Type.TERMINATE) {
+        final QueryId queryId = new QueryId(cmd.getCommandId().getEntity());
+        final QueuedCommand terminated = queries.remove(queryId);
+        if (terminated != null) {
+          terminatedQueries.add(terminated);
+          it.remove();
+        }
+      }
+    }
+
+    return terminatedQueries;
+  }
+
+  private static void removeQueryPlansOfTerminated(final List<QueuedCommand> compacted,
+      final Set<QueuedCommand> terminatedQueries
+  ) {
+    final ListIterator<QueuedCommand> it = compacted.listIterator();
+    while (it.hasNext()) {
+      final QueuedCommand cmd = it.next();
+      if (!terminatedQueries.remove(cmd)) {
+        continue;
+      }
+
+      it.set(buildNewCmdWithoutQuery(cmd));
+    }
+  }
+
+  private static QueuedCommand buildNewCmdWithoutQuery(final QueuedCommand cmd) {
+    final Command command = cmd.getCommand();
+
+    final Command newCommand = new Command(
+        command.getStatement(),
+        command.getOverwriteProperties(),
+        command.getOriginalProperties(),
+        command.getPlan().map(KsqlPlan::withoutQuery)
+    );
+
+    return new QueuedCommand(
+        cmd.getCommandId(),
+        newCommand,
+        cmd.getStatus(),
+        cmd.getOffset()
+    );
+  }
+}

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -272,14 +272,20 @@ public class KsqlResource implements KsqlConfigurable {
               requestConfig.getBoolean(KsqlRequestConfig.KSQL_REQUEST_INTERNAL_REQUEST)
           )
       );
+
+      LOG.info("Processed successfully: " + request);
       return Response.ok(entities).build();
     } catch (final KsqlRestException e) {
+      LOG.info("Processed unsuccessfully: " + request + ", reason: " + e.getMessage());
       throw e;
     } catch (final KsqlStatementException e) {
+      LOG.info("Processed unsuccessfully: " + request + ", reason: " + e.getMessage());
       return Errors.badStatement(e.getRawMessage(), e.getSqlStatement());
     } catch (final KsqlException e) {
+      LOG.info("Processed unsuccessfully: " + request + ", reason: " + e.getMessage());
       return errorHandler.generateResponse(e, Errors.badRequest(e));
     } catch (final Exception e) {
+      LOG.info("Processed unsuccessfully: " + request + ", reason: " + e.getMessage());
       return errorHandler.generateResponse(
           e, Errors.serverErrorForStatement(e, request.getKsql()));
     }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
@@ -576,11 +576,35 @@ public class RecoveryTest {
   }
 
   @Test
+  public void shouldRecoverInsertIntos() {
+    server1.submitCommands(
+        "CREATE STREAM A (COLUMN STRING) WITH (KAFKA_TOPIC='A', VALUE_FORMAT='JSON');",
+        "CREATE STREAM B (COLUMN STRING) WITH (KAFKA_TOPIC='B', VALUE_FORMAT='JSON', PARTITIONS=1);",
+        "INSERT INTO B SELECT * FROM A;"
+    );
+    shouldRecover(commands);
+  }
+
+  @Test
+  public void shouldRecoverInsertIntosRecreates() {
+    server1.submitCommands(
+        "CREATE STREAM A (COLUMN STRING) WITH (KAFKA_TOPIC='A', VALUE_FORMAT='JSON');",
+        "CREATE STREAM B (COLUMN STRING) WITH (KAFKA_TOPIC='B', VALUE_FORMAT='JSON', PARTITIONS=1);",
+        "INSERT INTO B SELECT * FROM A;",
+        "TERMINATE InsertQuery_0;",
+        "INSERT INTO B SELECT * FROM A;"
+    );
+    shouldRecover(commands);
+  }
+
+  @Test
   public void shouldRecoverTerminates() {
     server1.submitCommands(
         "CREATE STREAM A (COLUMN STRING) WITH (KAFKA_TOPIC='A', VALUE_FORMAT='JSON');",
         "CREATE STREAM B AS SELECT * FROM A;",
-        "TERMINATE CSAS_B_0;"
+        "INSERT INTO B SELECT * FROM A;",
+        "TERMINATE CSAS_B_0;",
+        "TERMINATE InsertQuery_2;"
     );
     shouldRecover(commands);
   }


### PR DESCRIPTION
### Description 

fixes: https://github.com/confluentinc/ksql/issues/4923

Previously, on a restart, each ksqlDB node would build a query topology for each previously submitted persistent queries, i.e. CREATE TABLE AS SELECT, CREATE STREAM AS SELECT or INSERT INTO statement, _even if the associated query has already been terminated_.

Building the query topology takes a reasonable amount of time. By avoiding building these topologies for terminated queries the restart time will be much reduced for clusters with a lot of historic commands in the command topic.

A more complete solution to this problem is to move to a compacted topic for storing commands: https://github.com/confluentinc/ksql/pull/4659

### Testing done 

Usual.

### Reviewing notes:

I didn't take the approach suggested in #4923 by @rodesai :

> the fix should be simple - just store a Supplier<KafkaStreams> instead of KafkaStreams in QueryMetadata and only get it from start()

IMHO, such an approach would:
1. Complicate the `QueryMetadata` type unnecessarily. 
2. Be very hard to test that the topologies weren't being built, e.g. in `RecoveryTest`.
3. Brittle: a regression could easily be introduced if someone were to add code in the recovery processes that called any getting on `QueryMetadata` that caused the supplied to be invoked.

Hence, I went with a different approach: to compact the list of commands to be restored. This compaction searches through the list of commands, keeping track of any commands that start a persistent query. If it later finds a terminate for that query, it removes the terminate _and_ updates the originating command to no longer start a persistent query.

TBH, I don't really like either fix, but it serves a purpose in the short term until we have a better solution, i.e. https://github.com/confluentinc/ksql/pull/4659

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

