### PR TITLE
fix: query id for TERMINATE should be case insensitive

### DIFF
--- a/docs-md/tutorials/basics-docker.md
+++ b/docs-md/tutorials/basics-docker.md
@@ -1263,7 +1263,7 @@ Your output should resemble:
 ```
  Message                                                    
 ------------------------------------------------------------
- Insert Into query is running with query ID: InsertQuery_43 
+ Insert Into query is running with query ID: INSERTQUERY_43
 ------------------------------------------------------------
 ```
 
@@ -1305,7 +1305,7 @@ Your output should resemble:
 ```
  Query ID                         | Status  | Sink Name                | Sink Kafka Topic         | Query String                                                                                                                                                                                                                                                                                                                                                                                                 
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- InsertQuery_43                   | RUNNING | ALL_ORDERS               | ALL_ORDERS               | INSERT INTO ALL_ORDERS SELECT '3RD PARTY' AS SRC, * FROM ORDERS_SRC_3RDPARTY EMIT CHANGES;                                                                                                                                                                                                                                                                                                                   
+ INSERTQUERY_43                   | RUNNING | ALL_ORDERS               | ALL_ORDERS               | INSERT INTO ALL_ORDERS SELECT '3RD PARTY' AS SRC, * FROM ORDERS_SRC_3RDPARTY EMIT CHANGES;
  CSAS_ALL_ORDERS_17               | RUNNING | ALL_ORDERS               | ALL_ORDERS               | CREATE STREAM ALL_ORDERS WITH (KAFKA_TOPIC='ALL_ORDERS', PARTITIONS=1, REPLICAS=1) AS SELECT  'LOCAL' SRC,  *FROM ORDERS_SRC_LOCAL ORDERS_SRC_LOCALEMIT CHANGES;                                                                                                                                                                                                                                             
 ...
 ```

--- a/docs/includes/ksql-includes.rst
+++ b/docs/includes/ksql-includes.rst
@@ -931,7 +931,7 @@ Your output should resemble:
     Query ID          | Kafka Topic | Query String
     -------------------------------------------------------------------------------------------------------------------
     CSAS_ALL_ORDERS_0 | ALL_ORDERS  | CREATE STREAM ALL_ORDERS AS SELECT 'LOCAL' AS SRC, * FROM ORDERS_SRC_LOCAL;
-    InsertQuery_1     | ALL_ORDERS  | INSERT INTO ALL_ORDERS SELECT '3RD PARTY' AS SRC, * FROM ORDERS_SRC_3RDPARTY;
+    INSERTQUERY_1     | ALL_ORDERS  | INSERT INTO ALL_ORDERS SELECT '3RD PARTY' AS SRC, * FROM ORDERS_SRC_3RDPARTY;
     -------------------------------------------------------------------------------------------------------------------
 
 .. insert-into_02_end

--- a/ksqldb-common/src/main/java/io/confluent/ksql/query/QueryId.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/query/QueryId.java
@@ -22,21 +22,32 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.errorprone.annotations.Immutable;
 import java.util.Objects;
 
+/**
+ * A query id.
+ *
+ * <p>For backwards compatibility reasons query ids must preserve their case, as their text
+ * representation is used, amoung other things, for internal topic naming.
+ *
+ * <p>However, two ids with the same text, with different case, should compare equal. This is needed
+ * so that look ups against query ids are not case-sensitive.
+ */
 @Immutable
 public class QueryId {
 
   private final String id;
+  private final String cachedUpperCase;
 
   @JsonCreator
   public QueryId(final String id) {
     this.id = requireNonNull(id, "id");
+    this.cachedUpperCase = id.toUpperCase();
   }
 
-  @JsonValue
   public String getId() {
     return id;
   }
 
+  @JsonValue
   public String toString() {
     return id;
   }
@@ -50,11 +61,11 @@ public class QueryId {
       return false;
     }
     final QueryId queryId = (QueryId) o;
-    return Objects.equals(id.toUpperCase(), queryId.id.toUpperCase());
+    return Objects.equals(cachedUpperCase, queryId.cachedUpperCase);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id.toUpperCase());
+    return Objects.hash(cachedUpperCase);
   }
 }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/query/QueryId.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/query/QueryId.java
@@ -50,11 +50,11 @@ public class QueryId {
       return false;
     }
     final QueryId queryId = (QueryId) o;
-    return Objects.equals(id, queryId.id);
+    return Objects.equals(id.toUpperCase(), queryId.id.toUpperCase());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id);
+    return Objects.hash(id.toUpperCase());
   }
 }

--- a/ksqldb-common/src/test/java/io/confluent/ksql/query/QueryIdTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/query/QueryIdTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.testing.EqualsTester;
 import io.confluent.ksql.json.JsonMapper;
 import org.junit.Test;
 
@@ -26,26 +27,53 @@ public class QueryIdTest {
 
   private final ObjectMapper objectMapper = JsonMapper.INSTANCE.mapper;
 
+  @SuppressWarnings("UnstableApiUsage")
   @Test
-  public void shouldSerializeCorrectly() throws Exception {
+  public void shouldImplementEqualsProperly() {
+    new EqualsTester()
+        .addEqualityGroup(new QueryId("matching"), new QueryId("MaTcHiNg"))
+        .addEqualityGroup(new QueryId("different"))
+        .testEquals();
+  }
+
+  @Test
+  public void shouldBeCaseInsensitiveOnCommparison() {
+    // When:
+    final QueryId id = new QueryId("Mixed-Case-Id");
+
+    // Then:
+    assertThat(id, is(new QueryId("MIXED-CASE-ID")));
+  }
+
+  @Test
+  public void shouldPreserveCase() {
+    // When:
+    final QueryId id = new QueryId("Mixed-Case-Id");
+
+    // Then:
+    assertThat(id.toString(), is("Mixed-Case-Id"));
+  }
+
+  @Test
+  public void shouldSerializeMaintainingCase() throws Exception {
     // Given:
-    final QueryId id = new QueryId("query-id");
+    final QueryId id = new QueryId("Query-Id");
 
     // When:
     final String serialized = objectMapper.writeValueAsString(id);
 
-    assertThat(serialized, is("\"query-id\""));
+    assertThat(serialized, is("\"Query-Id\""));
   }
 
   @Test
-  public void shouldDeserializeCorrectly() throws Exception {
+  public void shouldDeserializeMaintainingCase() throws Exception {
     // Given:
-    final String serialized = "\"an-id\"";
+    final String serialized = "\"An-Id\"";
 
     // When:
     final QueryId deserialized = objectMapper.readValue(serialized, QueryId.class);
 
     // Then:
-    assertThat(deserialized, is(new QueryId("an-id")));
+    assertThat(deserialized.getId(), is("An-Id"));
   }
 }

--- a/ksqldb-common/src/test/java/io/confluent/ksql/query/QueryIdTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/query/QueryIdTest.java
@@ -74,6 +74,6 @@ public class QueryIdTest {
     final QueryId deserialized = objectMapper.readValue(serialized, QueryId.class);
 
     // Then:
-    assertThat(deserialized.getId(), is("An-Id"));
+    assertThat(deserialized.toString(), is("An-Id"));
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
@@ -101,14 +101,14 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
 
   @Override
   public QueryId getQueryId(final QueryIdGenerator queryIdGenerator) {
-    final String base = queryIdGenerator.getNext();
+    final String base = queryIdGenerator.getNext().toUpperCase();
     if (!doCreateInto) {
-      return new QueryId("InsertQuery_" + base);
+      return new QueryId("INSERTQUERY_" + base);
     }
     if (getNodeOutputType().equals(DataSourceType.KTABLE)) {
-      return new QueryId("CTAS_" + getId().toString() + "_" + base);
+      return new QueryId("CTAS_" + getId().toString().toUpperCase() + "_" + base);
     }
-    return new QueryId("CSAS_" + getId().toString() + "_" + base);
+    return new QueryId("CSAS_" + getId().toString().toUpperCase() + "_" + base);
   }
 
   @Override

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -247,11 +247,11 @@ public class PhysicalPlanBuilderTest {
     final String[] lines = planText.split("\n");
     Assert.assertTrue(lines.length == 3);
     Assert.assertEquals(lines[0],
-        " > [ SINK ] | Schema: ROWKEY STRING KEY, COL0 BIGINT, COL1 STRING, COL2 DOUBLE | Logger: InsertQuery_1.S1");
+        " > [ SINK ] | Schema: ROWKEY STRING KEY, COL0 BIGINT, COL1 STRING, COL2 DOUBLE | Logger: INSERTQUERY_1.S1");
     Assert.assertEquals(lines[1],
-        "\t\t > [ PROJECT ] | Schema: ROWKEY STRING KEY, COL0 BIGINT, COL1 STRING, COL2 DOUBLE | Logger: InsertQuery_1.Project");
+        "\t\t > [ PROJECT ] | Schema: ROWKEY STRING KEY, COL0 BIGINT, COL1 STRING, COL2 DOUBLE | Logger: INSERTQUERY_1.Project");
     Assert.assertEquals(lines[2],
-        "\t\t\t\t > [ SOURCE ] | Schema: ROWKEY STRING KEY, COL0 BIGINT, COL1 STRING, COL2 DOUBLE, ROWTIME BIGINT, ROWKEY STRING | Logger: InsertQuery_1.KsqlTopic.Source");
+        "\t\t\t\t > [ SOURCE ] | Schema: ROWKEY STRING KEY, COL0 BIGINT, COL1 STRING, COL2 DOUBLE, ROWTIME BIGINT, ROWKEY STRING | Logger: INSERTQUERY_1.KsqlTopic.Source");
     assertThat(queryMetadataList.get(1), instanceOf(PersistentQueryMetadata.class));
     final PersistentQueryMetadata persistentQuery = (PersistentQueryMetadata)
         queryMetadataList.get(1);
@@ -299,12 +299,12 @@ public class PhysicalPlanBuilderTest {
     final String[] lines = planText.split("\n");
     assertThat(lines.length, equalTo(4));
     assertThat(lines[0], equalTo(" > [ SINK ] | Schema: ROWKEY BIGINT KEY, COL0 BIGINT, COL1 STRING, COL2 "
-        + "DOUBLE | Logger: InsertQuery_1.S1"));
+        + "DOUBLE | Logger: INSERTQUERY_1.S1"));
     assertThat(lines[2],
         containsString("[ REKEY ] | Schema: ROWKEY BIGINT KEY, COL0 BIGINT, COL1 STRING, COL2 DOUBLE, ROWTIME BIGINT, ROWKEY STRING "
-            + "| Logger: InsertQuery_1.PartitionBy"));
+            + "| Logger: INSERTQUERY_1.PartitionBy"));
     assertThat(lines[1], containsString("[ PROJECT ] | Schema: ROWKEY BIGINT KEY, COL0 BIGINT, COL1 STRING"
-        + ", COL2 DOUBLE | Logger: InsertQuery_1.Project"));
+        + ", COL2 DOUBLE | Logger: INSERTQUERY_1.Project"));
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -189,7 +189,7 @@ public class KsqlStructuredDataOutputNodeTest {
 
     // Then:
     verify(queryIdGenerator, times(1)).getNext();
-    assertThat(queryId, equalTo(new QueryId("InsertQuery_" + QUERY_ID_VALUE)));
+    assertThat(queryId, equalTo(new QueryId("INSERTQUERY_" + QUERY_ID_VALUE)));
   }
 
   @Test

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -651,8 +651,7 @@ public class AstBuilder {
           ? TerminateQuery.all(location)
           : TerminateQuery.query(
               location,
-              // use case sensitive parsing here to maintain backwards compatibility
-              new QueryId(ParserUtil.getIdentifierText(true, context.identifier()))
+              new QueryId(ParserUtil.getIdentifierText(false, context.identifier()))
           );
     }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
@@ -568,7 +568,7 @@ public class RecoveryTest {
     server1.submitCommands(
         "CREATE STREAM A (C1 STRING, C2 INT) WITH (KAFKA_TOPIC='A', VALUE_FORMAT='JSON');",
         "CREATE STREAM B AS SELECT C1 FROM A;",
-        "TERMINATE CSAS_B_0;",
+        "TERMINATE CsAs_b_0;",
         "DROP STREAM B;",
         "CREATE STREAM B AS SELECT C2 FROM A;"
     );

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -1218,7 +1218,7 @@ public class KsqlResourceTest {
     expectedException.expect(KsqlRestException.class);
     expectedException.expect(exceptionStatusCode(is(Code.BAD_REQUEST)));
     expectedException.expect(exceptionErrorMessage(errorMessage(is(
-        "Unknown queryId: unknown_query_id"))));
+        "Unknown queryId: UNKNOWN_QUERY_ID"))));
     expectedException.expect(exceptionStatementErrorMessage(statement(is(
         "TERMINATE unknown_query_id;"))));
 


### PR DESCRIPTION
### Description - WIP - hold off reviewing

fixes: #5003

The query id passed to `TERMINATE <queryId>` is currently case-sensitive. So, for example, 

```
TERMINATE CSAS_A_0;
```

May work, but:

```
TERMINATE csas_a_0;
```

Won't.

CSAS and CTAS create queries with upper case ids.  However, `INSERT INTO` creates mixed case queries, e.g. `InsertQuery_3`.  Again, users must get the case right to terminate them.

SQL is meant to be case-insensitive by default!   Hence this change switches terminate to be case-insensitive.

### Testing done 

Because the command topics of users will contain existing queries with query ids in upper and mixed case, we need to be a little careful any fix doesn't stop users from terminating historic queries or meaning restores leave previously terminated queries running. There is also another open PR that we need to ensure works with any change made here: https://github.com/confluentinc/ksql/pull/5002

To this end I went through the following steps, and ensured each worked, (this is also roughly the commit list):

1. I first made `QueryId` internally case-insensitive, but externally case-preserving, i.e. a queryId of `ID` and `id` would generate the same hash code and return true from `equals`, but we return `ID` and `id` from `toString`.   This is the least invasive fix.  I ran both the master branch and #5002 to ensure this wouldn't cause any issues elsewhere in the code.
1. I updated `RecoveryTest` to have some terminates with the wrong case.
1. (added some tests to QueryId)
1. Changed the generation of queryIds to ensure they are always upper case - this means all new queries will have uppercase query ids.  If all else fails, on the next breaking change release we can switch `QueryId` to be always uppercase.

It was not easily achievable to update `QueryId` to just uppercase its query id, as the text representation is used to, among other things, build the names for internal topics.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

