### PR TITLE
fix: allow trailing slash in listeners config (MINOR)

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/ServerUtil.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/ServerUtil.java
@@ -52,8 +52,6 @@ public final class ServerUtil {
       return StreamsMetadataState.UNKNOWN_HOST;
     }
 
-    // the getHost/getPort utilities don't handle URLs that end with `/` - since this issue
-    // has come up multiple times for ksqlDB we special case it here
     final String serverId = applicationServerId.endsWith("/")
         ? applicationServerId.substring(0, applicationServerId.lastIndexOf("/"))
         : applicationServerId;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/ServerUtil.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/ServerUtil.java
@@ -51,8 +51,15 @@ public final class ServerUtil {
     if (applicationServerId == null || applicationServerId.trim().isEmpty()) {
       return StreamsMetadataState.UNKNOWN_HOST;
     }
-    final String host = getHost(applicationServerId);
-    final Integer port = getPort(applicationServerId);
+
+    // the getHost/getPort utilities don't handle URLs that end with `/` - since this issue
+    // has come up multiple times for ksqlDB we special case it here
+    final String serverId = applicationServerId.endsWith("/")
+        ? applicationServerId.substring(0, applicationServerId.lastIndexOf("/"))
+        : applicationServerId;
+
+    final String host = getHost(serverId);
+    final Integer port = getPort(serverId);
 
     if (host == null || port == null) {
       throw new KsqlException(String.format(

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/ServerUtilTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/ServerUtilTest.java
@@ -15,9 +15,13 @@
 
 package io.confluent.ksql.rest.server;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import io.confluent.rest.RestConfig;
 import java.util.Collections;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.streams.state.HostInfo;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -51,6 +55,15 @@ public class ServerUtilTest {
 
     // Then:
     ServerUtil.getServerAddress(restConfig);
+  }
+
+  @Test
+  public void shouldReturnServerPortWithTrailingSlash() {
+    // When:
+    final HostInfo hostInfo = ServerUtil.parseHostInfo("http://localhost:8088/");
+
+    // Then:
+    assertThat(hostInfo.port(), Matchers.is(8088));
   }
 
 }


### PR DESCRIPTION
fixes #4668

### Description 

See the description in the issue, we should allow listener IPs with trailing slash (e.g. `http://localhost:8080/`)

### Testing done 

Unit testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

