### PR TITLE
chore: update dockerfile for ubi base image

### DIFF
--- a/ksqldb-docker/Dockerfile
+++ b/ksqldb-docker/Dockerfile
@@ -6,13 +6,15 @@ FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 
+USER root
+
 # target directory must be one of the projects that ksql-run-class sets on the KSQL_CLASSPATH,
 # of which the artifact ID (ksqldb-docker) is not one. thus the workaround of using ksqldb-rest-app
-ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/ksqldb-rest-app/
-ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/bin/* /usr/bin/
-ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/bin/docker/* /usr/bin/docker/
-ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/etc/* /etc/ksqldb/
-ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/
+ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/ksqldb-rest-app/
+ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/bin/* /usr/bin/
+ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/bin/docker/* /usr/bin/docker/
+ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/etc/* /etc/ksqldb/
+ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/
 
 RUN echo "===> Installing confluent-hub..." \
     && wget http://client.hub.confluent.io/confluent-hub-client-latest.tar.gz \
@@ -21,5 +23,7 @@ RUN echo "===> Installing confluent-hub..." \
 
 RUN chmod +x /usr/bin/docker/configure
 RUN chmod +x /usr/bin/docker/run
+
+USER appuser
 
 CMD ["/usr/bin/docker/run"]


### PR DESCRIPTION
### Description 

Our Docker images used to use a Debian base image, but we're now moving to UBI for the base image instead. The changes in this PR are necessary because

> the debian images were run as root, but the ubi8 base image runs using another user “appuser” which does not have root or sudo privileges. so it doesn’t have permission to [run the chmod command on line 22]

Quote and debugging courtesy of @elismaga .

### Testing done 

Built an image locally, verified the server comes up and accepts statements. Also tried using confluent-hub for good measure.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

