### PR TITLE
refactor: refactor QTT to remove Topic from Record

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/engine/StubInsertValuesExecutor.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/engine/StubInsertValuesExecutor.java
@@ -20,7 +20,6 @@ import static java.util.Objects.requireNonNull;
 import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.test.tools.Record;
-import io.confluent.ksql.test.tools.Topic;
 import io.confluent.ksql.test.tools.TopicInfoCache;
 import io.confluent.ksql.test.tools.TopicInfoCache.TopicInfo;
 import io.confluent.ksql.test.tools.exceptions.InvalidFieldException;
@@ -66,8 +65,6 @@ public final class StubInsertValuesExecutor {
     }
 
     void sendRecord(final ProducerRecord<byte[], byte[]> record) {
-      final Topic topic = stubKafkaService.getTopic(record.topic());
-
       final Object key = deserializeKey(record);
 
       final Object value = deserializeValue(record);
@@ -77,14 +74,14 @@ public final class StubInsertValuesExecutor {
       this.stubKafkaService.writeRecord(record.topic(),
           StubKafkaRecord.of(
               new Record(
-                  topic,
+                  record.topic(),
                   key,
                   value,
                   null,
                   timestamp,
                   null
-              ),
-              null)
+              )
+          )
       );
     }
 

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/RecordNode.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/RecordNode.java
@@ -30,12 +30,10 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import io.confluent.ksql.test.tools.Record;
-import io.confluent.ksql.test.tools.Topic;
 import io.confluent.ksql.test.tools.exceptions.InvalidFieldException;
 import io.confluent.ksql.test.tools.exceptions.MissingFieldException;
 import io.confluent.ksql.test.utils.JsonParsingUtil;
 import java.io.IOException;
-import java.util.Map;
 import java.util.Optional;
 
 @JsonDeserialize(using = RecordNode.Deserializer.class)
@@ -72,13 +70,11 @@ public final class RecordNode {
     return topicName;
   }
 
-  public Record build(final Map<String, Topic> topics) {
-    final Topic topic = topics.get(topicName);
-
+  public Record build() {
     final Object recordValue = buildValue();
 
     return new Record(
-        topic,
+        topicName,
         key.orElse(null),
         recordValue,
         value,
@@ -89,7 +85,7 @@ public final class RecordNode {
 
   public static RecordNode from(final Record record) {
     return new RecordNode(
-        record.getTopic().getName(),
+        record.getTopicName(),
         Optional.ofNullable(record.rawKey()),
         record.getJsonValue().orElse(NullNode.getInstance()),
         record.timestamp(),

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestCaseBuilder.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestCaseBuilder.java
@@ -19,11 +19,12 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.test.model.PostConditionsNode;
+import io.confluent.ksql.test.model.RecordNode;
 import io.confluent.ksql.test.model.TestCaseNode;
 import io.confluent.ksql.test.tools.conditions.PostConditions;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -76,7 +77,7 @@ public final class TestCaseBuilder {
       final Optional<Matcher<Throwable>> ee = test.expectedException()
           .map(een -> een.build(Iterables.getLast(statements)));
 
-      final Map<String, Topic> topics = TestCaseBuilderUtil.getTopicsByName(
+      final Collection<Topic> topics = TestCaseBuilderUtil.getTopicsByName(
           statements,
           test.topics(),
           test.outputs(),
@@ -86,11 +87,11 @@ public final class TestCaseBuilder {
       );
 
       final List<Record> inputRecords = test.inputs().stream()
-          .map(node -> node.build(topics))
+          .map(RecordNode::build)
           .collect(Collectors.toList());
 
       final List<Record> outputRecords = test.outputs().stream()
-          .map(node -> node.build(topics))
+          .map(RecordNode::build)
           .collect(Collectors.toList());
 
       final PostConditions post = test.postConditions()
@@ -102,7 +103,7 @@ public final class TestCaseBuilder {
           testName,
           versionBounds,
           test.properties(),
-          topics.values(),
+          topics,
           inputRecords,
           outputRecords,
           statements,

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestCaseBuilderUtil.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestCaseBuilderUtil.java
@@ -17,7 +17,7 @@ package io.confluent.ksql.test.tools;
 
 import static com.google.common.io.Files.getNameWithoutExtension;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
@@ -41,6 +41,7 @@ import io.confluent.ksql.test.tools.exceptions.InvalidFieldException;
 import io.confluent.ksql.topic.TopicFactory;
 import io.confluent.ksql.util.KsqlConstants;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -87,7 +88,7 @@ public final class TestCaseBuilderUtil {
         .collect(Collectors.toList());
   }
 
-  public static Map<String, Topic> getTopicsByName(
+  public static Collection<Topic> getTopicsByName(
       final List<String> statements,
       final List<TopicNode> topics,
       final List<RecordNode> outputs,
@@ -110,7 +111,7 @@ public final class TestCaseBuilderUtil {
 
     if (allTopics.isEmpty()) {
       if (expectsException) {
-        return ImmutableMap.of();
+        return ImmutableList.of();
       }
       throw new InvalidFieldException("statements/topics", "The test does not define any topics. "
           + "Topics can be provided explicitly, but are more commonly extracted from the "
@@ -124,7 +125,7 @@ public final class TestCaseBuilderUtil {
         .map(recordNode -> new Topic(recordNode.topicName(), 4, 1, Optional.empty()))
         .forEach(topic -> allTopics.putIfAbsent(topic.getName(), topic));
 
-    return allTopics;
+    return allTopics.values();
   }
 
   private static Topic createTopicFromStatement(

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
@@ -142,7 +142,7 @@ public class TestExecutor implements Closeable {
       writeInputIntoTopics(testCase.getInputRecords(), stubKafkaService);
       final Set<String> inputTopics = testCase.getInputRecords()
           .stream()
-          .map(record -> record.getTopic().getName())
+          .map(record -> record.getTopicName())
           .collect(Collectors.toSet());
 
       final Set<String> allTopicNames = new HashSet<>();
@@ -200,7 +200,7 @@ public class TestExecutor implements Closeable {
     final boolean ranWithInsertStatements = testCase.getInputRecords().size() == 0;
 
     final Map<String, List<Record>> expectedByTopic = testCase.getOutputRecords().stream()
-        .collect(Collectors.groupingBy(r -> r.topic().getName()));
+        .collect(Collectors.groupingBy(Record::getTopicName));
 
     final Map<String, List<StubKafkaRecord>> actualByTopic = expectedByTopic.keySet().stream()
         .collect(Collectors.toMap(Function.identity(), stubKafkaService::readRecords));
@@ -291,14 +291,14 @@ public class TestExecutor implements Closeable {
 
     int inputRecordIndex = 0;
     for (final Record record : testCase.getInputRecords()) {
-      if (topologyTestDriverContainer.getSourceTopicNames().contains(record.getTopic().getName())) {
+      if (topologyTestDriverContainer.getSourceTopicNames().contains(record.getTopicName())) {
 
-        final TopicInfo topicInfo = topicInfoCache.get(record.getTopic().getName());
+        final TopicInfo topicInfo = topicInfoCache.get(record.getTopicName());
 
         final Record coerced = topicInfo.coerceRecordKey(record, inputRecordIndex);
 
         processSingleRecord(
-            StubKafkaRecord.of(coerced, null),
+            StubKafkaRecord.of(coerced),
             topologyTestDriverContainer,
             ImmutableSet.copyOf(stubKafkaService.getAllTopics())
         );
@@ -326,7 +326,7 @@ public class TestExecutor implements Closeable {
       final Set<Topic> possibleSinkTopics
   ) {
     final Topic recordTopic = stubKafkaService
-        .getTopic(inputRecord.getTestRecord().getTopic().getName());
+        .getTopic(inputRecord.getTestRecord().getTopicName());
 
     final TopicInfo topicInfo = topicInfoCache.get(recordTopic.getName());
 
@@ -376,7 +376,6 @@ public class TestExecutor implements Closeable {
       stubKafkaService.writeRecord(
           sinkTopic.getName(),
           StubKafkaRecord.of(
-              sinkTopic,
               producerRecord)
       );
     }
@@ -452,8 +451,8 @@ public class TestExecutor implements Closeable {
   ) {
     inputRecords.forEach(
         record -> stubKafkaService.writeRecord(
-            record.getTopic().getName(),
-            StubKafkaRecord.of(record, null))
+            record.getTopicName(),
+            StubKafkaRecord.of(record))
     );
   }
 

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TopicInfoCache.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TopicInfoCache.java
@@ -236,7 +236,7 @@ public class TopicInfoCache {
         return record.withKey(coerced);
       } catch (final Exception e) {
         throw new AssertionError(
-            "Topic '" + record.getTopic().getName() + "', message " + msgIndex
+            "Topic '" + record.getTopicName() + "', message " + msgIndex
                 + ": Invalid test-case: could not coerce key in test case to required type. "
                 + e.getMessage(),
             e);

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/stubs/StubKafkaRecord.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/stubs/StubKafkaRecord.java
@@ -15,10 +15,10 @@
 
 package io.confluent.ksql.test.tools.stubs;
 
+import static java.util.Objects.requireNonNull;
+
 import io.confluent.ksql.test.model.WindowData;
 import io.confluent.ksql.test.tools.Record;
-import io.confluent.ksql.test.tools.Topic;
-import java.util.Objects;
 import java.util.Optional;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -29,25 +29,17 @@ public final class StubKafkaRecord {
   private final ProducerRecord<?,?> producerRecord;
 
   private StubKafkaRecord(final Record testRecord, final ProducerRecord<?,?> producerRecord) {
-    this.testRecord = testRecord;
+    this.testRecord = requireNonNull(testRecord, "testRecord");
     this.producerRecord = producerRecord;
   }
 
-  public static StubKafkaRecord of(
-      final Record testRecord,
-      final ProducerRecord<?,?> producerRecord
-  ) {
-    Objects.requireNonNull(testRecord, "testRecord");
-    return new StubKafkaRecord(testRecord, producerRecord);
+  public static StubKafkaRecord of(final Record testRecord) {
+    return new StubKafkaRecord(testRecord, null);
   }
 
-  public static StubKafkaRecord of(
-      final Topic topic,
-      final ProducerRecord<?,?> producerRecord) {
-    Objects.requireNonNull(producerRecord);
-    Objects.requireNonNull(topic, "topic");
+  public static StubKafkaRecord of(final ProducerRecord<?, ?> producerRecord) {
     final Record testRecord = new Record(
-        topic,
+        producerRecord.topic(),
         producerRecord.key(),
         producerRecord.value(),
         null,

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/engine/StubInsertValuesExecutorTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/engine/StubInsertValuesExecutorTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.when;
 
 import io.confluent.ksql.engine.StubInsertValuesExecutor.StubProducer;
 import io.confluent.ksql.test.tools.Record;
-import io.confluent.ksql.test.tools.Topic;
 import io.confluent.ksql.test.tools.TopicInfoCache;
 import io.confluent.ksql.test.tools.TopicInfoCache.TopicInfo;
 import io.confluent.ksql.test.tools.stubs.StubKafkaRecord;
@@ -61,13 +60,6 @@ public final class StubInsertValuesExecutorTest {
   @SuppressWarnings({"unchecked", "rawtypes"})
   @Before
   public void setUp() {
-    when(stubKafkaService.getTopic(SOME_TOPIC)).thenReturn(new Topic(
-        SOME_TOPIC,
-        1,
-        1,
-        Optional.empty()
-    ));
-
     when(topicInfoCache.get(SOME_TOPIC)).thenReturn(topicInfo);
     when(topicInfo.getKeyDeserializer()).thenReturn((Deserializer) new StringDeserializer());
     when(topicInfo.getValueDeserializer()).thenReturn((Deserializer) new StringDeserializer());

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/SchemaTranslationTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/SchemaTranslationTest.java
@@ -74,31 +74,34 @@ public class SchemaTranslationTest {
         .collect(Collectors.toList());
   }
 
-  private static List<Record> generateInputRecords(
-      final Topic topic, final org.apache.avro.Schema avroSchema) {
+  private static List<Record> generateInputRecords(final Schema avroSchema) {
     final Generator generator = new Generator(avroSchema, new Random());
+
     final List<Record> list = new ArrayList<>();
     for (int i = 0; i < 100; i++) {
       final Object avro = generator.generate();
+
       final JsonNode spec = avroToJson(avro, avroSchema, true);
+
       final Record record = new Record(
-          topic,
+          TOPIC_NAME,
           "test-key",
           avroToValueSpec(avro, avroSchema, true),
           spec,
           Optional.of(0L),
           null
       );
+
       list.add(record);
     }
     return list;
   }
 
-  private static List<Record> getOutputRecords(final Topic topic, final List<Record> inputRecords) {
+  private static List<Record> getOutputRecords(final List<Record> inputRecords) {
     return inputRecords.stream()
         .map(
             r -> new Record(
-                topic,
+                OUTPUT_TOPIC_NAME,
                 "test-key",
                 r.value(),
                 r.getJsonValue().orElse(null),
@@ -173,8 +176,8 @@ public class SchemaTranslationTest {
             Optional.of(schema)
         );
 
-        final List<Record> inputRecords = generateInputRecords(srcTopic, schema.rawSchema());
-        final List<Record> outputRecords = getOutputRecords(OUTPUT_TOPIC, inputRecords);
+        final List<Record> inputRecords = generateInputRecords(schema.rawSchema());
+        final List<Record> outputRecords = getOutputRecords(inputRecords);
 
         final String csasStatement = schema.rawSchema().getFields()
             .stream()

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestUtils.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestUtils.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.ksql.execution.json.PlanJsonMapper;
 import io.confluent.ksql.test.model.KsqlVersion;
 import io.confluent.ksql.test.model.PostConditionsNode;
+import io.confluent.ksql.test.model.RecordNode;
 import io.confluent.ksql.test.tools.TestCase;
 import io.confluent.ksql.test.tools.Topic;
 import io.confluent.ksql.test.tools.TopologyAndConfigs;
@@ -100,10 +101,10 @@ public final class PlannedTestUtils {
             planAtVersionNode.getPlanNode().getConfigs()
         ),
         planAtVersionNode.getSpecNode().getInputs().stream()
-            .map(n -> n.build(topicsByName))
+            .map(RecordNode::build)
             .collect(Collectors.toList()),
         planAtVersionNode.getSpecNode().getOutputs().stream()
-            .map(n -> n.build(topicsByName))
+            .map(RecordNode::build)
             .collect(Collectors.toList()),
         planAtVersionNode.getSpecNode().getPostConditions()
             .map(PostConditionsNode::build)

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestUtils.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestUtils.java
@@ -23,7 +23,6 @@ import io.confluent.ksql.test.model.KsqlVersion;
 import io.confluent.ksql.test.model.PostConditionsNode;
 import io.confluent.ksql.test.model.RecordNode;
 import io.confluent.ksql.test.tools.TestCase;
-import io.confluent.ksql.test.tools.Topic;
 import io.confluent.ksql.test.tools.TopologyAndConfigs;
 import io.confluent.ksql.test.tools.conditions.PostConditions;
 import io.confluent.ksql.util.KsqlConfig;
@@ -33,7 +32,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -88,8 +86,6 @@ public final class PlannedTestUtils {
       final TestCase testCase,
       final TestCasePlan planAtVersionNode
   ) {
-    final Map<String, Topic> topicsByName = testCase.getTopics().stream()
-        .collect(Collectors.toMap(Topic::getName, t -> t));
     final KsqlVersion version = KsqlVersion.parse(planAtVersionNode.getSpecNode().getVersion())
         .withTimestamp(planAtVersionNode.getSpecNode().getTimestamp());
     return testCase.withPlan(

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestCase.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestCase.java
@@ -84,14 +84,14 @@ class RestTestCase implements Test {
     return statements;
   }
 
-  Map<Topic, List<Record>> getInputsByTopic() {
+  Map<String, List<Record>> getInputsByTopic() {
     return inputRecords.stream()
-        .collect(Collectors.groupingBy(Record::topic));
+        .collect(Collectors.groupingBy(Record::getTopicName));
   }
 
-  Map<Topic, List<Record>> getOutputsByTopic() {
+  Map<String, List<Record>> getOutputsByTopic() {
     return outputRecords.stream()
-        .collect(Collectors.groupingBy(Record::topic));
+        .collect(Collectors.groupingBy(Record::getTopicName));
   }
 
   List<Response> getExpectedResponses() {

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestCaseBuilder.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestCaseBuilder.java
@@ -20,12 +20,13 @@ import com.google.common.collect.Iterables;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.function.TestFunctionRegistry;
 import io.confluent.ksql.rest.client.RestResponse;
+import io.confluent.ksql.test.model.RecordNode;
 import io.confluent.ksql.test.tools.Record;
 import io.confluent.ksql.test.tools.TestCaseBuilderUtil;
 import io.confluent.ksql.test.tools.Topic;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -76,7 +77,7 @@ final class RestTestCaseBuilder {
       final Optional<Matcher<RestResponse<?>>> ee = test.expectedError()
           .map(een -> een.build(Iterables.getLast(statements)));
 
-      final Map<String, Topic> topics = TestCaseBuilderUtil.getTopicsByName(
+      final Collection<Topic> topics = TestCaseBuilderUtil.getTopicsByName(
           statements,
           test.topics(),
           test.outputs(),
@@ -86,18 +87,18 @@ final class RestTestCaseBuilder {
       );
 
       final List<Record> inputRecords = test.inputs().stream()
-          .map(node -> node.build(topics))
+          .map(RecordNode::build)
           .collect(Collectors.toList());
 
       final List<Record> outputRecords = test.outputs().stream()
-          .map(node -> node.build(topics))
+          .map(RecordNode::build)
           .collect(Collectors.toList());
 
       return new RestTestCase(
           testPath,
           testName,
           test.properties(),
-          topics.values(),
+          topics,
           inputRecords,
           outputRecords,
           statements,

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
@@ -183,10 +183,10 @@ public class RestTestExecutor implements Closeable {
     });
   }
 
-  private void produceInputs(final Map<Topic, List<Record>> inputs) {
-    inputs.forEach((topic, records) -> {
+  private void produceInputs(final Map<String, List<Record>> inputs) {
+    inputs.forEach((topicName, records) -> {
 
-      final TopicInfo topicInfo = topicInfoCache.get(topic.getName());
+      final TopicInfo topicInfo = topicInfoCache.get(topicName);
 
       try (KafkaProducer<Object, Object> producer = new KafkaProducer<>(
           kafkaCluster.producerConfig(),
@@ -199,7 +199,7 @@ public class RestTestExecutor implements Closeable {
           final Record coerced = topicInfo.coerceRecordKey(record, idx);
 
           producer.send(new ProducerRecord<>(
-              topic.getName(),
+              topicName,
               null,
               coerced.timestamp().orElse(0L),
               coerced.key(),
@@ -207,7 +207,7 @@ public class RestTestExecutor implements Closeable {
           ));
         }
       } catch (final Exception e) {
-        throw new RuntimeException("Failed to send record to " + topic.getName(), e);
+        throw new RuntimeException("Failed to send record to " + topicName, e);
       }
     });
   }
@@ -293,13 +293,13 @@ public class RestTestExecutor implements Closeable {
   }
 
   private void verifyOutput(final RestTestCase testCase) {
-    testCase.getOutputsByTopic().forEach((topic, records) -> {
+    testCase.getOutputsByTopic().forEach((topicName, records) -> {
 
-      final TopicInfo topicInfo = topicInfoCache.get(topic.getName());
+      final TopicInfo topicInfo = topicInfoCache.get(topicName);
 
       final List<? extends ConsumerRecord<?, ?>> received = kafkaCluster
           .verifyAvailableRecords(
-              topic.getName(),
+              topicName,
               records.size(),
               topicInfo.getKeyDeserializer(),
               topicInfo.getValueDeserializer()

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/RecordTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/RecordTest.java
@@ -25,26 +25,22 @@ import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.SessionWindow;
 import org.apache.kafka.streams.kstream.internals.TimeWindow;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
-@SuppressWarnings("rawtypes")
-@RunWith(MockitoJUnitRunner.class)
 public class RecordTest {
 
-  @Mock
-  private Topic topic;
+  private static final String TOPIC_NAME = "bob";
 
   @Test
   public void shouldGetKey() {
     // Given:
-    final Record record = new Record(topic,
+    final Record record = new Record(
+        TOPIC_NAME,
         10,
         "bar",
         null,
         Optional.of(1000L),
-        null);
+        null
+    );
 
     // When:
     final Object key = record.key();
@@ -56,19 +52,21 @@ public class RecordTest {
   @Test
   public void shouldGetTimeWindowKey() {
     // Given:
-    final Record record = new Record(topic,
+    final Record record = new Record(
+        TOPIC_NAME,
         "foo",
         "bar",
         null,
         Optional.of(1000L),
-        new WindowData(100L, 1000L, "TIME"));
+        new WindowData(100L, 1000L, "TIME")
+    );
 
     // When:
     final Object key = record.key();
 
     // Then:
     assertThat(key, instanceOf(Windowed.class));
-    final Windowed windowed = (Windowed) key;
+    final Windowed<?> windowed = (Windowed<?>) key;
     assertThat(windowed.window(), instanceOf(TimeWindow.class));
     assertThat(windowed.window().start(), equalTo(100L));
     assertThat(windowed.window().end(), equalTo(1000L));
@@ -77,19 +75,21 @@ public class RecordTest {
   @Test
   public void shouldGetSessionWindowKey() {
     // Given:
-    final Record record = new Record(topic,
+    final Record record = new Record(
+        TOPIC_NAME,
         "foo",
         "bar",
         null,
         Optional.of(1000L),
-        new WindowData(100L, 1000L, "SESSION"));
+        new WindowData(100L, 1000L, "SESSION")
+    );
 
     // When:
     final Object key = record.key();
 
     // Then:
     assertThat(key, instanceOf(Windowed.class));
-    final Windowed windowed = (Windowed) key;
+    final Windowed<?> windowed = (Windowed<?>) key;
     assertThat(windowed.window(), instanceOf(SessionWindow.class));
     assertThat(windowed.window().start(), equalTo(100L));
     assertThat(windowed.window().end(), equalTo(1000L));

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/StubKafkaServiceTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/StubKafkaServiceTest.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.test.tools;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
 
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.ksql.test.tools.stubs.StubKafkaRecord;
@@ -37,9 +38,8 @@ public class StubKafkaServiceTest {
   @Mock
   private ParsedSchema avroSchema;
   @Mock
-  private ProducerRecord<?, ?> producerRecord;
-  @Mock
-  private Record record;
+  private ProducerRecord<String, String> producerRecord;
+
   private StubKafkaRecord stubKafkaRecord;
 
   private StubKafkaService stubKafkaService;
@@ -47,15 +47,19 @@ public class StubKafkaServiceTest {
 
   @Before
   public void setUp() {
-    stubKafkaRecord = StubKafkaRecord.of(record, producerRecord);
+    when(producerRecord.topic()).thenReturn("topic-name");
+    when(producerRecord.key()).thenReturn("key");
+    when(producerRecord.value()).thenReturn("value");
+
+    stubKafkaRecord = StubKafkaRecord.of(producerRecord);
+
     stubKafkaService = StubKafkaService.create();
+
     topic = new Topic("foo", 1, 1, Optional.of(avroSchema));
   }
 
-
   @Test
   public void shouldCreateTopicCorrectly() {
-
     // When:
     stubKafkaService.createTopic(topic);
 
@@ -65,7 +69,7 @@ public class StubKafkaServiceTest {
 
   @Test
   public void shouldWriteSingleRecordToTopic() {
-    // Givien:
+    // Given:
     stubKafkaService.createTopic(topic);
 
     // When:
@@ -75,9 +79,9 @@ public class StubKafkaServiceTest {
     assertThat(stubKafkaService.getTopicData().get("foo").get(0), is(stubKafkaRecord));
   }
 
-
+  @Test
   public void shouldReadRecordFromTopic() {
-    // Givien:
+    // Given:
     stubKafkaService.createTopic(topic);
     stubKafkaService.writeRecord("foo", stubKafkaRecord);
 
@@ -87,8 +91,5 @@ public class StubKafkaServiceTest {
     // Then:
     assertThat(records.size(), CoreMatchers.equalTo(1));
     assertThat(records.get(0), is(stubKafkaRecord));
-
   }
-
-
 }

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorTest.java
@@ -228,8 +228,8 @@ public class TestExecutorTest {
     final StubKafkaRecord actual_0 = kafkaRecord(sinkTopic, 123456719L, "k1", "v1");
     when(kafkaService.readRecords(SINK_TOPIC_NAME)).thenReturn(ImmutableList.of(actual_0));
 
-    final Record expected_0 = new Record(sinkTopic, "k1", "v1", null, Optional.of(1L), null);
-    final Record expected_1 = new Record(sinkTopic, "k1", "v1", null, Optional.of(1L), null);
+    final Record expected_0 = new Record(SINK_TOPIC_NAME,"k1", "v1", null, Optional.of(1L), null);
+    final Record expected_1 = new Record(SINK_TOPIC_NAME,"k1", "v1", null, Optional.of(1L), null);
     when(testCase.getOutputRecords()).thenReturn(ImmutableList.of(expected_0, expected_1));
 
     // Expect
@@ -250,7 +250,7 @@ public class TestExecutorTest {
     when(kafkaService.readRecords(SINK_TOPIC_NAME))
         .thenReturn(ImmutableList.of(actual_0, actual_1));
 
-    final Record expected_0 = new Record(sinkTopic, "k1", "v1", null, Optional.of(1L), null);
+    final Record expected_0 = new Record(SINK_TOPIC_NAME,"k1", "v1", null, Optional.of(1L), null);
     when(testCase.getOutputRecords()).thenReturn(ImmutableList.of(expected_0));
 
     // Expect
@@ -272,8 +272,8 @@ public class TestExecutorTest {
     when(kafkaService.readRecords(SINK_TOPIC_NAME))
         .thenReturn(ImmutableList.of(actual_0, actual_1));
 
-    final Record expected_0 = new Record(sinkTopic, "k1", "v1", TextNode.valueOf("v1"), Optional.of(123456719L), null);
-    final Record expected_1 = new Record(sinkTopic, "k2", "different", TextNode.valueOf("different"), Optional.of(123456789L), null);
+    final Record expected_0 = new Record(SINK_TOPIC_NAME,"k1", "v1", TextNode.valueOf("v1"), Optional.of(123456719L), null);
+    final Record expected_1 = new Record(SINK_TOPIC_NAME,"k2", "different", TextNode.valueOf("different"), Optional.of(123456789L), null);
     when(testCase.getOutputRecords()).thenReturn(ImmutableList.of(expected_0, expected_1));
 
     // Expect
@@ -293,8 +293,8 @@ public class TestExecutorTest {
     when(kafkaService.readRecords(SINK_TOPIC_NAME))
         .thenReturn(ImmutableList.of(actual_0, actual_1));
 
-    final Record expected_0 = new Record(sinkTopic, "k1", "v1", TextNode.valueOf("v1"), Optional.of(123456719L), null);
-    final Record expected_1 = new Record(sinkTopic, "k2", "v2", TextNode.valueOf("v2"), Optional.of(123456789L), null);
+    final Record expected_0 = new Record(SINK_TOPIC_NAME,"k1", "v1", TextNode.valueOf("v1"), Optional.of(123456719L), null);
+    final Record expected_1 = new Record(SINK_TOPIC_NAME,"k2", "v2", TextNode.valueOf("v2"), Optional.of(123456789L), null);
     when(testCase.getOutputRecords()).thenReturn(ImmutableList.of(expected_0, expected_1));
 
     // When:
@@ -311,8 +311,8 @@ public class TestExecutorTest {
     when(kafkaService.readRecords(SINK_TOPIC_NAME))
         .thenReturn(ImmutableList.of(actual_0, actual_1));
 
-    final Record expected_0 = new Record(sinkTopic, 1, "v1", TextNode.valueOf("v1"), Optional.of(123456719L), null);
-    final Record expected_1 = new Record(sinkTopic, 1, "v2", TextNode.valueOf("v2"), Optional.of(123456789L), null);
+    final Record expected_0 = new Record(SINK_TOPIC_NAME,1, "v1", TextNode.valueOf("v1"), Optional.of(123456719L), null);
+    final Record expected_1 = new Record(SINK_TOPIC_NAME, 1, "v2", TextNode.valueOf("v2"), Optional.of(123456789L), null);
     when(testCase.getOutputRecords()).thenReturn(ImmutableList.of(expected_0, expected_1));
 
     final LogicalSchema schema = LogicalSchema.builder()
@@ -385,6 +385,6 @@ public class TestExecutorTest {
         value
     );
 
-    return StubKafkaRecord.of(topic, record);
+    return StubKafkaRecord.of(record);
   }
 }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
@@ -159,7 +159,7 @@
     {
       "name": "single expression with alias (table->table)",
       "statements": [
-        "CREATE TABLE TEST (ID INT KEY, data STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE TEST (ID INT PRIMARY KEY, data STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT COUNT(*) AS COUNT FROM TEST GROUP BY DATA AS NEW_KEY;"
       ],
       "properties": {


### PR DESCRIPTION
### Description 

Simplification of the test framework code.

This change replaces the `Topic` field in the `Record` class with just the topic's name. This is all that is every required anyway.  This simplifies the model and allows a lot of code to be removed.

### Testing done 

usual.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

