### PR TITLE
fix: make endpoints available while waiting for precondition

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -352,14 +352,13 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
 
       final KsqlConfig ksqlConfigWithPort = buildConfigWithPort();
       configurables.forEach(c -> c.configure(ksqlConfigWithPort));
+
       startKsql(ksqlConfigWithPort);
       final Properties metricsProperties = new Properties();
       metricsProperties.putAll(getConfiguration().getOriginals());
       if (versionCheckerAgent != null) {
         versionCheckerAgent.start(KsqlModuleType.SERVER, metricsProperties);
       }
-
-      apiServer.setJettyPort(getJettyPort());
 
       log.info("KSQL RESTful API listening on {}", StringUtils.join(getListeners(), ", "));
       displayWelcomeMessage();
@@ -389,6 +388,7 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
     apiServerConfig = new ApiServerConfig(ksqlConfigWithPort.originals());
     apiServer = new Server(vertx, apiServerConfig, endpoints, true, securityExtension,
         authenticationPlugin);
+    apiServer.setJettyPort(getJettyPort());
     apiServer.start();
     log.info("KSQL New API Server started");
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PreconditionFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PreconditionFunctionalTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.integration;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+
+import io.confluent.common.utils.IntegrationTest;
+import io.confluent.ksql.integration.IntegrationTestHarness;
+import io.confluent.ksql.integration.Retry;
+import io.confluent.ksql.rest.entity.CommandStatus.Status;
+import io.confluent.ksql.rest.entity.CommandStatusEntity;
+import io.confluent.ksql.rest.entity.KsqlEntity;
+import io.confluent.ksql.rest.entity.KsqlErrorMessage;
+import io.confluent.ksql.rest.entity.StreamsList;
+import io.confluent.ksql.rest.server.KsqlRestConfig;
+import io.confluent.ksql.rest.server.KsqlServerPrecondition;
+import io.confluent.ksql.rest.server.TestKsqlRestAppWaitingOnPrecondition;
+import io.confluent.ksql.services.ServiceContext;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import kafka.zookeeper.ZooKeeperClientException;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+
+@SuppressWarnings("unchecked")
+@Category({IntegrationTest.class})
+public class PreconditionFunctionalTest {
+
+  private static final String SERVER_PRECONDITIONS_CONFIG = "ksql.server.preconditions";
+
+  private static CountDownLatch latch = new CountDownLatch(1);
+
+  private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
+
+  private static final TestKsqlRestAppWaitingOnPrecondition REST_APP = TestKsqlRestAppWaitingOnPrecondition
+      .builder(TEST_HARNESS::kafkaBootstrapServers)
+      .withStaticServiceContext(TEST_HARNESS::getServiceContext)
+      .withProperty(
+          SERVER_PRECONDITIONS_CONFIG,
+          "io.confluent.ksql.rest.integration.PreconditionFunctionalTest$TestFailedPrecondition")
+      .buildWaitingOnPrecondition(latch);
+
+  @ClassRule
+  public static final RuleChain CHAIN = RuleChain
+      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .around(TEST_HARNESS)
+      .around(REST_APP);
+
+  @BeforeClass
+  public static void setUpClass() {
+    System.out.println("starting class setup");
+    REST_APP.startAndWaitForPrecondition();
+    System.out.println("finished class setup");
+  }
+
+  @After
+  public void cleanUp() {
+    REST_APP.closePersistentQueries();
+  }
+
+  @Test
+  public void shouldDistributeMultipleInterDependantDmlStatements() {
+    // When:
+    final List<KsqlEntity> results = makeKsqlRequest();
+
+    // Then:
+    assertThat(results, contains(
+        instanceOf(CommandStatusEntity.class),
+        instanceOf(CommandStatusEntity.class)
+    ));
+
+    assertSuccessful(results);
+  }
+
+  private static void assertSuccessful(final List<KsqlEntity> results) {
+    results.stream()
+        .filter(e -> e instanceof StreamsList)
+        .map(CommandStatusEntity.class::cast)
+        .forEach(r -> assertThat(
+            r.getStatementText() + " : " + r.getCommandStatus().getMessage(),
+            r.getCommandStatus().getStatus(),
+            is(Status.SUCCESS)));
+  }
+
+  private static List<KsqlEntity> makeKsqlRequest() {
+    return RestIntegrationTestUtil.makeKsqlRequest(REST_APP, "SHOW STREAMS;");
+  }
+
+  public static class TestFailedPrecondition implements KsqlServerPrecondition {
+
+    private boolean first = true;
+
+    @Override
+    public Optional<KsqlErrorMessage> checkPrecondition(
+        final KsqlRestConfig restConfig,
+        final ServiceContext serviceContext) {
+      return fail();
+    }
+
+    private Optional<KsqlErrorMessage> pass() {
+      if (first) {
+        latch.countDown();
+        first = false;
+      }
+      return Optional.empty();
+    }
+
+    private Optional<KsqlErrorMessage> fail() {
+      if (first) {
+        latch.countDown();
+        first = false;
+      }
+      return Optional.of(new KsqlErrorMessage(40370, "purposefully failed precondition"));
+    }
+  }
+}

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
@@ -74,6 +74,20 @@ public final class RestIntegrationTestUtil {
     }
   }
 
+  static KsqlErrorMessage makeKsqlRequestWithError(
+      final TestKsqlRestApp restApp,
+      final String sql
+  ) {
+    try (final KsqlRestClient restClient = restApp.buildKsqlClient(Optional.empty())) {
+
+      final RestResponse<KsqlEntityList> res = restClient.makeKsqlRequest(sql);
+
+      throwOnNoError(res);
+
+      return res.getErrorMessage();
+    }
+  }
+
   static List<StreamedRow> makeQueryRequest(
       final TestKsqlRestApp restApp,
       final String sql,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -67,6 +67,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
@@ -99,26 +100,26 @@ import org.junit.rules.ExternalResource;
  */
 public class TestKsqlRestApp extends ExternalResource {
 
-  private static final AtomicInteger COUNTER = new AtomicInteger();
+  protected static final AtomicInteger COUNTER = new AtomicInteger();
 
-  private final String metricsPrefix = "app-" + COUNTER.getAndIncrement() + "-";
-  private final Map<String, ?> baseConfig;
-  private final Supplier<String> bootstrapServers;
-  private final Supplier<ServiceContext> serviceContext;
-  private final BiFunction<KsqlConfig, KsqlSecurityExtension, Binder> serviceContextBinderFactory;
-  private final KsqlSecurityContextProvider securityContextProvider;
-  private final List<URL> listeners = new ArrayList<>();
-  private final Optional<BasicCredentials> credentials;
-  private ExecutableServer<KsqlRestConfig> restServer;
-  private KsqlExecutionContext ksqlEngine;
-  private KsqlRestApplication ksqlRestApplication;
+  protected final String metricsPrefix = "app-" + COUNTER.getAndIncrement() + "-";
+  protected final Map<String, ?> baseConfig;
+  protected final Supplier<String> bootstrapServers;
+  protected final Supplier<ServiceContext> serviceContext;
+  protected final BiFunction<KsqlConfig, KsqlSecurityExtension, Binder> serviceContextBinderFactory;
+  protected final KsqlSecurityContextProvider securityContextProvider;
+  protected final List<URL> listeners = new ArrayList<>();
+  protected final Optional<BasicCredentials> credentials;
+  protected ExecutableServer<KsqlRestConfig> restServer;
+  protected KsqlExecutionContext ksqlEngine;
+  protected KsqlRestApplication ksqlRestApplication;
 
   static {
     // Increase the default - it's low (100)
     System.setProperty("sun.net.maxDatagramSockets", "1024");
   }
 
-  private TestKsqlRestApp(
+  protected TestKsqlRestApp(
       final Supplier<String> bootstrapServers,
       final Map<String, Object> additionalProps,
       final Supplier<ServiceContext> serviceContext,
@@ -253,29 +254,7 @@ public class TestKsqlRestApp extends ExternalResource {
 
   @Override
   protected void before() {
-    if (restServer != null) {
-      after();
-    }
-
-    final KsqlRestConfig config = buildConfig(bootstrapServers, baseConfig);
-
-    try {
-      ksqlRestApplication = KsqlRestApplication.buildApplication(
-          metricsPrefix,
-          convertToApiServerConfig(config),
-          (booleanSupplier) -> niceMock(VersionCheckerAgent.class),
-          3,
-          serviceContext.get(),
-          serviceContextBinderFactory,
-          ksqlSecurityExtension -> securityContextProvider);
-
-      restServer = new ExecutableServer<>(
-          new ApplicationServer<>(convertToLocalListener(config)),
-          ImmutableList.of(ksqlRestApplication)
-      );
-    } catch (final Exception e) {
-      throw new RuntimeException("Failed to initialise", e);
-    }
+    initialize();
 
     try {
       restServer.startAsync();
@@ -300,6 +279,32 @@ public class TestKsqlRestApp extends ExternalResource {
       throw new RuntimeException(e);
     }
     restServer = null;
+  }
+
+  protected void initialize() {
+    if (restServer != null) {
+      after();
+    }
+
+    final KsqlRestConfig config = buildConfig(bootstrapServers, baseConfig);
+
+    try {
+      ksqlRestApplication = KsqlRestApplication.buildApplication(
+          metricsPrefix,
+          convertToApiServerConfig(config),
+          (booleanSupplier) -> niceMock(VersionCheckerAgent.class),
+          3,
+          serviceContext.get(),
+          serviceContextBinderFactory,
+          ksqlSecurityExtension -> securityContextProvider);
+
+      restServer = new ExecutableServer<>(
+          new ApplicationServer<>(convertToLocalListener(config)),
+          ImmutableList.of(ksqlRestApplication)
+      );
+    } catch (final Exception e) {
+      throw new RuntimeException("Failed to initialise", e);
+    }
   }
 
   public static Builder builder(final Supplier<String> bootstrapServers) {
@@ -537,6 +542,18 @@ public class TestKsqlRestApp extends ExternalResource {
           securityContextBinder,
           securityContextProvider,
           credentials
+      );
+    }
+
+    public TestKsqlRestAppWaitingOnPrecondition buildWaitingOnPrecondition(final CountDownLatch latch) {
+      return new TestKsqlRestAppWaitingOnPrecondition(
+          bootstrapServers,
+          additionalProps,
+          serviceContext,
+          securityContextBinder,
+          securityContextProvider,
+          credentials,
+          latch
       );
     }
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestAppWaitingOnPrecondition.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestAppWaitingOnPrecondition.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server;
+
+import io.confluent.ksql.api.endpoints.KsqlSecurityContextProvider;
+import io.confluent.ksql.rest.client.BasicCredentials;
+import io.confluent.ksql.security.KsqlSecurityExtension;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.util.KsqlConfig;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+import org.glassfish.hk2.utilities.Binder;
+
+/**
+ * A {@link TestKsqlRestApp} for testing behavior of a server stuck waiting on a precondition.
+ *
+ * The server is not started automatically. Rather, {@code startAndWaitForPrecondition()} should
+ * be called by the test suite. A {@code CountDownLatch} provided in the constructor counts down
+ * when a precondition check is called, in order to finish configuring the app once the server
+ * is waiting for preconditions.
+ */
+public class TestKsqlRestAppWaitingOnPrecondition extends TestKsqlRestApp {
+
+  private CountDownLatch latch;
+
+  TestKsqlRestAppWaitingOnPrecondition(
+      final Supplier<String> bootstrapServers,
+      final Map<String, Object> additionalProps,
+      final Supplier<ServiceContext> serviceContext,
+      final BiFunction<KsqlConfig, KsqlSecurityExtension, Binder> serviceContextBinderFactory,
+      final KsqlSecurityContextProvider securityContextProvider,
+      final Optional<BasicCredentials> credentials,
+      final CountDownLatch latch
+  ) {
+    super(bootstrapServers, additionalProps, serviceContext, serviceContextBinderFactory, securityContextProvider, credentials);
+    this.latch = latch;
+  }
+
+  @Override
+  protected void before() {
+    initialize();
+  }
+
+  public void startAndWaitForPrecondition() {
+    try {
+      new Thread(() -> {
+        try {
+          restServer.startAsync();
+        } catch (Exception e) {
+          throw new RuntimeException("Error starting server", e);
+        }
+      }).start();
+      latch.await();
+    } catch (final Exception var2) {
+      throw new RuntimeException("Failed to start Ksql rest server", var2);
+    }
+
+    listeners.addAll(ksqlRestApplication.getListeners());
+    ksqlEngine = ksqlRestApplication.getEngine();
+  }
+}


### PR DESCRIPTION
### Description 

The current order of events when starting the ksql rest app is:
1. Start Jetty server
1. Start vert.x server, including proxy handler to proxy requests to Jetty server
1. Initialize ksql, including waiting for preconditions, creating command topic, etc.
1. Configure Jetty port on vert.x server in order for vert.x server to proxy requests to Jetty

As a consequence, ksql is unable to serve requests made to Jetty endpoints if we're blocked waiting for preconditions. (We'd hit an internal server error since vert.x tries to proxy the request but there's no Jetty port configured yet.) This is a regression from before the proxy handler was introduced. This PR fixes the regression by updating the order of events to become:
1. Start Jetty server
1. Start vert.x server, including proxy handler to proxy requests to Jetty server
1. Configure Jetty port on vert.x server in order for vert.x server to proxy requests to Jetty
1. Initialize ksql, including waiting for preconditions, creating command topic, etc.

I don't love how the new integration test was implemented. Suggestions welcome!

### Testing done 

Added integration test.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

