### PR TITLE
refactor: return single status based on aggregate results in state field

### DIFF
--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/QueriesTableBuilder.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/QueriesTableBuilder.java
@@ -32,7 +32,7 @@ public class QueriesTableBuilder implements TableBuilder<Queries> {
     final Stream<List<String>> rows = entity.getQueries().stream()
         .map(r -> ImmutableList.of(
             r.getId().toString(),
-            r.getState().orElse("N/A"),
+            r.getStatusCount().toString(),
             String.join(",", r.getSinks()),
             String.join(",", r.getSinkKafkaTopics()),
             r.getQuerySingleLine()

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -106,6 +106,7 @@ public class ConsoleTest {
   private static final String WHITE_SPACE = " \t ";
   private static final String NEWLINE = System.lineSeparator();
   private static final String STATUS_COUNT_STRING = "RUNNING:1,ERROR:2";
+  private static final String AGGREGATE_STATUS = "ERROR";
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
       .withRowTime()
@@ -162,6 +163,7 @@ public class ConsoleTest {
   public void setUp() {
     MockitoAnnotations.initMocks(this);
     when(queryStatusCount.toString()).thenReturn(STATUS_COUNT_STRING);
+    when(queryStatusCount.getAggregateStatus()).thenReturn(KsqlQueryStatus.valueOf(AGGREGATE_STATUS));
     final EnumMap<KsqlQueryStatus, Integer> mockStatusCount = new EnumMap<>(KsqlQueryStatus.class);
     mockStatusCount.put(KsqlQueryStatus.RUNNING, 1);
     mockStatusCount.put(KsqlQueryStatus.ERROR, 2);
@@ -333,7 +335,7 @@ public class ConsoleTest {
           + "      \"RUNNING\" : 1," + NEWLINE
           + "      \"ERROR\" : 2" + NEWLINE
           + "    }," + NEWLINE
-          + "    \"state\" : \"" + STATUS_COUNT_STRING +"\"" + NEWLINE
+          + "    \"state\" : \"" + AGGREGATE_STATUS +"\"" + NEWLINE
           + "  } ]," + NEWLINE
           + "  \"warnings\" : [ ]" + NEWLINE
           + "} ]" + NEWLINE));
@@ -417,7 +419,7 @@ public class ConsoleTest {
           + "        \"RUNNING\" : 1," + NEWLINE
           + "        \"ERROR\" : 2" + NEWLINE
           + "      }," + NEWLINE
-          + "      \"state\" : \"" + STATUS_COUNT_STRING +"\"" + NEWLINE
+          + "      \"state\" : \"" + AGGREGATE_STATUS +"\"" + NEWLINE
           + "    } ]," + NEWLINE
           + "    \"writeQueries\" : [ {" + NEWLINE
           + "      \"queryString\" : \"write query\"," + NEWLINE
@@ -428,7 +430,7 @@ public class ConsoleTest {
           + "        \"RUNNING\" : 1," + NEWLINE
           + "        \"ERROR\" : 2" + NEWLINE
           + "      }," + NEWLINE
-          + "      \"state\" : \"" + STATUS_COUNT_STRING +"\"" + NEWLINE
+          + "      \"state\" : \"" + AGGREGATE_STATUS +"\"" + NEWLINE
           + "    } ]," + NEWLINE
           + "    \"fields\" : [ {" + NEWLINE
           + "      \"name\" : \"ROWTIME\"," + NEWLINE
@@ -1084,7 +1086,7 @@ public class ConsoleTest {
           + "        \"RUNNING\" : 1," + NEWLINE
           + "        \"ERROR\" : 2" + NEWLINE
           + "      }," + NEWLINE
-          + "      \"state\" : \"" + STATUS_COUNT_STRING +"\"" + NEWLINE
+          + "      \"state\" : \"" + AGGREGATE_STATUS +"\"" + NEWLINE
           + "    } ]," + NEWLINE
           + "    \"writeQueries\" : [ {" + NEWLINE
           + "      \"queryString\" : \"write query\"," + NEWLINE
@@ -1095,7 +1097,7 @@ public class ConsoleTest {
           + "        \"RUNNING\" : 1," + NEWLINE
           + "        \"ERROR\" : 2" + NEWLINE
           + "      }," + NEWLINE
-          + "      \"state\" : \"" + STATUS_COUNT_STRING +"\"" + NEWLINE
+          + "      \"state\" : \"" + AGGREGATE_STATUS +"\"" + NEWLINE
           + "    } ]," + NEWLINE
           + "    \"fields\" : [ {" + NEWLINE
           + "      \"name\" : \"ROWTIME\"," + NEWLINE
@@ -1156,13 +1158,13 @@ public class ConsoleTest {
           + "" + NEWLINE
           + "Queries that read from this TABLE" + NEWLINE
           + "-----------------------------------" + NEWLINE
-          + "readId (" + STATUS_COUNT_STRING +") : read query" + NEWLINE
+          + "readId (" + AGGREGATE_STATUS +") : read query" + NEWLINE
           + "\n"
           + "For query topology and execution plan please run: EXPLAIN <QueryId>" + NEWLINE
           + "" + NEWLINE
           + "Queries that write from this TABLE" + NEWLINE
           + "-----------------------------------" + NEWLINE
-          + "writeId (" + STATUS_COUNT_STRING + ") : write query" + NEWLINE
+          + "writeId (" + AGGREGATE_STATUS + ") : write query" + NEWLINE
           + "\n"
           + "For query topology and execution plan please run: EXPLAIN <QueryId>" + NEWLINE
           + "" + NEWLINE

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ShowQueriesMultiNodeFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ShowQueriesMultiNodeFunctionalTest.java
@@ -118,7 +118,7 @@ public class ShowQueriesMultiNodeFunctionalTest {
       return "Expected 1 running query, got " + runningQueries.size();
     }
 
-    return runningQueries.get(0).getState().orElse("N/A");
+    return runningQueries.get(0).getStatusCount().toString();
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ShowQueriesMultiNodeWithTlsFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ShowQueriesMultiNodeWithTlsFunctionalTest.java
@@ -115,7 +115,7 @@ public class ShowQueriesMultiNodeWithTlsFunctionalTest {
       return "Expected 1 running query, got " + runningQueries.size();
     }
 
-    return runningQueries.get(0).getState().orElse("N/A");
+    return runningQueries.get(0).getStatusCount().toString();
   }
 
 }

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryDescription.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryDescription.java
@@ -116,7 +116,13 @@ public class QueryDescription {
   // kept for backwards compatibility
   @JsonProperty("state")
   public Optional<String> getState() {
-    return Optional.of(ksqlHostQueryStatus.toString());
+    if (ksqlHostQueryStatus.isEmpty()) {
+      return Optional.empty();
+    }
+
+    return Optional.of(
+        (ksqlHostQueryStatus.containsValue(KsqlQueryStatus.ERROR)
+            ? KsqlQueryStatus.ERROR : KsqlQueryStatus. RUNNING).toString());
   }
 
   public void updateKsqlHostQueryStatus(

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryStatusCount.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryStatusCount.java
@@ -77,6 +77,13 @@ public class QueryStatusCount {
     return Collections.unmodifiableMap(statuses);
   }
 
+  public KsqlQueryStatus getAggregateStatus() {
+    if (statuses.getOrDefault(KsqlQueryStatus.ERROR, 0) != 0) {
+      return KsqlQueryStatus.ERROR;
+    }
+    return KsqlQueryStatus.RUNNING;
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/RunningQuery.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/RunningQuery.java
@@ -72,9 +72,9 @@ public class RunningQuery {
   // kept for backwards compatibility
   @JsonProperty("state")
   public Optional<String> getState() {
-    return Optional.of(statusCount.toString());
+    return Optional.of(statusCount.getAggregateStatus().toString());
   }
-  
+
   public QueryStatusCount getStatusCount() {
     return statusCount;
   }

--- a/ksqldb-rest-model/src/test/java/io/confluent/ksql/rest/entity/QueryStatusCountTest.java
+++ b/ksqldb-rest-model/src/test/java/io/confluent/ksql/rest/entity/QueryStatusCountTest.java
@@ -66,6 +66,18 @@ public class QueryStatusCountTest {
   }
 
   @Test
+  public void shouldReturnAggregateStatus() {
+    queryStatusCount.updateStatusCount(KafkaStreams.State.RUNNING, 2);
+    assertThat(
+        queryStatusCount.getAggregateStatus(),
+        is(KsqlQueryStatus.RUNNING));
+    queryStatusCount.updateStatusCount(KafkaStreams.State.ERROR, 1);
+    assertThat(
+        queryStatusCount.getAggregateStatus(),
+        is(KsqlQueryStatus.ERROR));
+  }
+
+  @Test
   public void shouldToString() {
     queryStatusCount.updateStatusCount(KafkaStreams.State.RUNNING, 2);
     assertThat(


### PR DESCRIPTION
### Description 
https://github.com/confluentinc/ksql/pull/4875 changed the `state` field to return a string representation of all host query statuses. However, the C3 UI expects a single status in the `state` field and wouldn't be able to properly render multiple host query statuses right now.

Changed `getState` in RunningQuery and QueryDescription classes to return a single status based on the aggregated query statuses.

### Testing done 
Unit Tests
### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

