### PR TITLE
chore: add JoinTree in preparation for multi-way join support

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analysis.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analysis.java
@@ -388,6 +388,17 @@ public class Analysis implements ImmutableAnalysis {
     public Optional<WithinExpression> getWithinExpression() {
       return withinExpression;
     }
+
+    public JoinInfo flip() {
+      return new JoinInfo(
+          rightSource,
+          rightJoinExpression,
+          leftSource,
+          leftJoinExpression,
+          type,
+          withinExpression
+      );
+    }
   }
 }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analysis.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analysis.java
@@ -345,25 +345,32 @@ public class Analysis implements ImmutableAnalysis {
     private final Expression rightJoinExpression;
     private final JoinNode.JoinType type;
     private final Optional<WithinExpression> withinExpression;
-    private final ImmutableList<AliasedDataSource> joinedSources;
+    private final AliasedDataSource leftSource;
+    private final AliasedDataSource rightSource;
 
     JoinInfo(
-        final ImmutableList<AliasedDataSource> joinedSources,
+        final AliasedDataSource leftSource,
         final Expression leftJoinExpression,
+        final AliasedDataSource rightSource,
         final Expression rightJoinExpression,
         final JoinType type,
         final Optional<WithinExpression> withinExpression
 
     ) {
-      this.joinedSources = requireNonNull(joinedSources, "joinedSources");
+      this.leftSource = requireNonNull(leftSource, "leftSource");
+      this.rightSource = requireNonNull(rightSource, "rightSource");
       this.leftJoinExpression = requireNonNull(leftJoinExpression, "leftJoinExpression");
       this.rightJoinExpression = requireNonNull(rightJoinExpression, "rightJoinExpression");
       this.type = requireNonNull(type, "type");
       this.withinExpression = requireNonNull(withinExpression, "withinExpression");
     }
 
-    public ImmutableList<AliasedDataSource> getJoinedSources() {
-      return joinedSources;
+    public AliasedDataSource getLeftSource() {
+      return leftSource;
+    }
+
+    public AliasedDataSource getRightSource() {
+      return rightSource;
     }
 
     public Expression getLeftJoinExpression() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -333,8 +333,9 @@ class Analyzer {
       // all (e.g. SELECT * FROM a JOIN b ON a.id = b.id JOIN c ON b.id = c.id)
       final boolean flipped = rightSourceName.equals(analysis.getFrom().getAlias());
       analysis.addJoin(new JoinInfo(
-          ImmutableList.of(left, right),
+          flipped ? right : left,
           flipped ? comparisonExpression.getRight() : comparisonExpression.getLeft(),
+          flipped ? left : right,
           flipped ? comparisonExpression.getLeft() : comparisonExpression.getRight(),
           joinType,
           node.getWithinExpression()

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -332,14 +332,15 @@ class Analyzer {
       // as it is possible that the JOIN will not have the "FROM" source in it at
       // all (e.g. SELECT * FROM a JOIN b ON a.id = b.id JOIN c ON b.id = c.id)
       final boolean flipped = rightSourceName.equals(analysis.getFrom().getAlias());
-      analysis.addJoin(new JoinInfo(
-          flipped ? right : left,
-          flipped ? comparisonExpression.getRight() : comparisonExpression.getLeft(),
-          flipped ? left : right,
-          flipped ? comparisonExpression.getLeft() : comparisonExpression.getRight(),
+      final JoinInfo joinInfo = new JoinInfo(
+          left,
+          comparisonExpression.getLeft(),
+          right,
+          comparisonExpression.getRight(),
           joinType,
           node.getWithinExpression()
-      ));
+      );
+      analysis.addJoin(flipped ? joinInfo.flip() : joinInfo);
 
       return null;
     }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/RewrittenAnalysis.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/RewrittenAnalysis.java
@@ -150,8 +150,9 @@ public class RewrittenAnalysis implements ImmutableAnalysis {
   public List<JoinInfo> getJoin() {
     return original.getJoin().stream().map(
         j -> new JoinInfo(
-            j.getJoinedSources(),
+            j.getLeftSource(),
             rewrite(j.getLeftJoinExpression()),
+            j.getRightSource(),
             rewrite(j.getRightJoinExpression()),
             j.getType(),
             j.getWithinExpression()

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/JoinTree.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/JoinTree.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.planner;
+
+import io.confluent.ksql.analyzer.Analysis.AliasedDataSource;
+import io.confluent.ksql.analyzer.Analysis.JoinInfo;
+import io.confluent.ksql.schema.ksql.FormatOptions;
+import io.confluent.ksql.util.KsqlException;
+import java.util.List;
+import java.util.Objects;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * {@code JoinTree} constructs the logical order for which the
+ * joins should be executed. At the moment, there is no optimization
+ * done and it simply follows the order of execution that the user
+ * indicates.
+ *
+ * <p>The algorithm is simple: the root is the very first source that
+ * we encounter (in the case of a single join, we ensure that the left
+ * root is the FROM source). From then on, any join that happens will
+ * check if either the left or right source is within the join tree and
+ * add the other to the corresponding side of the join tree.</p>
+ *
+ * <p>For example, take the following join statement:
+ * <pre>
+ * {@code
+ *    SELECT * FROM a
+ *      JOIN b ON a.id = b.id
+ *      JOIN c ON a.id = c.id;
+ * }
+ * </pre>
+ * The resulting join tree would look like:
+ * <pre>
+ * {@code
+ *       ⋈
+ *      / \
+ *     ⋈   C
+ *    / \
+ *   A   B
+ * }
+ * </pre>
+ * If the statement was modified so that the final expression was
+ * {@code JOIN c ON c.id = a.id} (note that {@code c.id} has moved
+ * to the left side of the join), then the resulting join tree would
+ * look like:
+ * <pre>
+ * {@code
+ *     ⋈
+ *   /   \
+ *  C    ⋈
+ *      / \
+ *     A   B
+ * }
+ * </pre>
+ * </p>
+ */
+final class JoinTree {
+
+  private JoinTree() {
+  }
+
+  /**
+   * Constructs the join tree given a list of {@code JoinInfo}
+   *
+   * @param joins the joins
+   * @return the tree indicating the order of the join
+   * @see JoinTree
+   */
+  public static Node build(final List<JoinInfo> joins) {
+    Node root = null;
+
+    for (final JoinInfo join : joins) {
+      if (root == null) {
+        root = new Leaf(join.getLeftSource());
+      }
+
+      if (root.containsSource(join.getRightSource()) && root.containsSource(join.getLeftSource())) {
+        throw new KsqlException("Cannot perform circular join - both " + join.getRightSource()
+            + " and " + join.getLeftJoinExpression()
+            + " are already included in the current join tree: " + root.debugString(0));
+      } else if (root.containsSource(join.getLeftSource())) {
+        root = new Join(root, new Leaf(join.getRightSource()), join);
+      } else if (root.containsSource(join.getRightSource())) {
+        root = new Join(new Leaf(join.getLeftSource()), root, join);
+      } else {
+        throw new KsqlException(
+            "Cannot build JOIN tree; neither source in the join is the FROM source or included "
+                + "in a previous JOIN: " + join + ". The current join tree is "
+                + root.debugString(0)
+        );
+      }
+    }
+
+    return root;
+  }
+
+  /**
+   * A node in the {@code JoinTree} that represents either a Leaf node or a Join
+   * node.
+   */
+  interface Node {
+
+    /**
+     * @param dataSource the data source to search for
+     * @return whether or not this node already references the {@code dataSource}
+     */
+    boolean containsSource(AliasedDataSource dataSource);
+
+    /**
+     * @return a debug string that pretty prints the tree
+     */
+    String debugString(int indent);
+  }
+
+  static class Join implements Node {
+
+    private final Node left;
+    private final Node right;
+    private final JoinInfo info;
+
+    Join(final Node left, final Node right, final JoinInfo info) {
+      this.left = left;
+      this.right = right;
+      this.info = info;
+    }
+
+    public JoinInfo getInfo() {
+      return info;
+    }
+
+    public Node getLeft() {
+      return left;
+    }
+
+    public Node getRight() {
+      return right;
+    }
+
+    @Override
+    public boolean containsSource(final AliasedDataSource dataSource) {
+      return left.containsSource(dataSource) || right.containsSource(dataSource);
+    }
+
+    @Override
+    public String debugString(final int indent) {
+      return "⋈\n"
+          + StringUtils.repeat(' ', indent) + "+--"
+          + left.debugString(indent + 3) + "\n"
+          + StringUtils.repeat(' ', indent) + "+--"
+          + right.debugString(indent + 3);
+    }
+
+    @Override
+    public String toString() {
+      return "Join{" + "left=" + left
+          + ", right=" + right
+          + ", info=" + info
+          + '}';
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      final Join that = (Join) o;
+      return Objects.equals(left, that.left)
+          && Objects.equals(right, that.right)
+          && Objects.equals(info, that.info);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(left, right, info);
+    }
+  }
+
+  static class Leaf implements Node {
+    private final AliasedDataSource source;
+
+    Leaf(final AliasedDataSource source) {
+      this.source = source;
+    }
+
+    public AliasedDataSource getSource() {
+      return source;
+    }
+
+    @Override
+    public boolean containsSource(final AliasedDataSource dataSource) {
+      return source.equals(dataSource);
+    }
+
+    @Override
+    public String debugString(final int indent) {
+      return source.getAlias().toString(FormatOptions.noEscape());
+    }
+
+    @Override
+    public String toString() {
+      return "Leaf{" + "source=" + source + '}';
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final Leaf that = (Leaf) o;
+      return Objects.equals(source, that.source);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(source);
+    }
+  }
+
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/JoinTree.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/JoinTree.java
@@ -32,8 +32,7 @@ import org.apache.commons.lang3.StringUtils;
  * <p>The algorithm is simple: the root is the very first source that
  * we encounter (in the case of a single join, we ensure that the left
  * root is the FROM source). From then on, any join that happens will
- * check if either the left or right source is within the join tree and
- * add the other to the corresponding side of the join tree.</p>
+ * happen on the right, creating a left-deep tree.
  *
  * <p>For example, take the following join statement:
  * <pre>
@@ -51,19 +50,6 @@ import org.apache.commons.lang3.StringUtils;
  *     ⋈   C
  *    / \
  *   A   B
- * }
- * </pre>
- * If the statement was modified so that the final expression was
- * {@code JOIN c ON c.id = a.id} (note that {@code c.id} has moved
- * to the left side of the join), then the resulting join tree would
- * look like:
- * <pre>
- * {@code
- *     ⋈
- *   /   \
- *  C    ⋈
- *      / \
- *     A   B
  * }
  * </pre>
  * </p>
@@ -95,7 +81,7 @@ final class JoinTree {
       } else if (root.containsSource(join.getLeftSource())) {
         root = new Join(root, new Leaf(join.getRightSource()), join);
       } else if (root.containsSource(join.getRightSource())) {
-        root = new Join(new Leaf(join.getLeftSource()), root, join);
+        root = new Join(root, new Leaf(join.getLeftSource()), join.flip());
       } else {
         throw new KsqlException(
             "Cannot build JOIN tree; neither source in the join is the FROM source or included "

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/JoinTreeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/JoinTreeTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
@@ -104,6 +105,7 @@ public class JoinTreeTest {
     when(j1.getRightSource()).thenReturn(b);
     when(j2.getLeftSource()).thenReturn(c);
     when(j2.getRightSource()).thenReturn(a);
+    when(j2.flip()).thenReturn(j2);
     final List<JoinInfo> joins = ImmutableList.of(j1, j2);
 
     // When:
@@ -113,10 +115,10 @@ public class JoinTreeTest {
     assertThat(root, instanceOf(Join.class));
     assertThat(root, is(
         new Join(
-            new Leaf(c),
             new Join(
                 new Leaf(a), new Leaf(b), j1
             ),
+            new Leaf(c),
             j2
         )
     ));

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/JoinTreeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/JoinTreeTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.planner;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.analyzer.Analysis.AliasedDataSource;
+import io.confluent.ksql.analyzer.Analysis.JoinInfo;
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.planner.JoinTree.Join;
+import io.confluent.ksql.planner.JoinTree.Leaf;
+import io.confluent.ksql.planner.JoinTree.Node;
+import io.confluent.ksql.util.KsqlException;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class JoinTreeTest {
+
+  @Mock(name = "a") private AliasedDataSource a;
+  @Mock(name = "b") private AliasedDataSource b;
+  @Mock(name = "c") private AliasedDataSource c;
+  @Mock(name = "d") private AliasedDataSource d;
+
+  @Mock private JoinInfo j1;
+  @Mock private JoinInfo j2;
+
+  @Before
+  public void setUp() {
+    when(a.getAlias()).thenReturn(SourceName.of("a"));
+    when(b.getAlias()).thenReturn(SourceName.of("b"));
+    when(c.getAlias()).thenReturn(SourceName.of("c"));
+  }
+
+  @Test
+  public void handlesBasicTwoWayJoin() {
+    // Given:
+    when(j1.getLeftSource()).thenReturn(a);
+    when(j1.getRightSource()).thenReturn(b);
+    final List<JoinInfo> joins = ImmutableList.of(j1);
+
+    // When:
+    final Node root = JoinTree.build(joins);
+
+    // Then:
+    assertThat(root, instanceOf(Join.class));
+    assertThat(((Join) root).getLeft(), is(new JoinTree.Leaf(a)));
+    assertThat(((Join) root).getRight(), is(new JoinTree.Leaf(b)));
+    assertThat(((Join) root).getInfo(), is(j1));
+  }
+
+  @Test
+  public void handlesLeftThreeWayJoin() {
+    // Given:
+    when(j1.getLeftSource()).thenReturn(a);
+    when(j1.getRightSource()).thenReturn(b);
+    when(j2.getLeftSource()).thenReturn(a);
+    when(j2.getRightSource()).thenReturn(c);
+    final List<JoinInfo> joins = ImmutableList.of(j1, j2);
+
+    // When:
+    final Node root = JoinTree.build(joins);
+
+    // Then:
+    assertThat(root, instanceOf(Join.class));
+    assertThat(root, is(
+        new Join(
+            new Join(
+                new Leaf(a), new Leaf(b), j1
+            ),
+            new Leaf(c),
+            j2
+        )
+    ));
+  }
+
+  @Test
+  public void handlesRightThreeWayJoin() {
+    // Given:
+    when(j1.getLeftSource()).thenReturn(a);
+    when(j1.getRightSource()).thenReturn(b);
+    when(j2.getLeftSource()).thenReturn(c);
+    when(j2.getRightSource()).thenReturn(a);
+    final List<JoinInfo> joins = ImmutableList.of(j1, j2);
+
+    // When:
+    final Node root = JoinTree.build(joins);
+
+    // Then:
+    assertThat(root, instanceOf(Join.class));
+    assertThat(root, is(
+        new Join(
+            new Leaf(c),
+            new Join(
+                new Leaf(a), new Leaf(b), j1
+            ),
+            j2
+        )
+    ));
+  }
+
+  @Test
+  public void outputsCorrectJoinTreeString() {
+    // Given:
+    when(j1.getLeftSource()).thenReturn(a);
+    when(j1.getRightSource()).thenReturn(b);
+    when(j2.getLeftSource()).thenReturn(a);
+    when(j2.getRightSource()).thenReturn(c);
+    final List<JoinInfo> joins = ImmutableList.of(j1, j2);
+
+    // When:
+    final Node root = JoinTree.build(joins);
+
+    // Then:
+    assertThat(root.debugString(0), is(
+        "⋈\n"
+            + "+--⋈\n"
+            + "   +--a\n"
+            + "   +--b\n"
+            + "+--c"
+    ));
+  }
+
+  @Test
+  public void shouldThrowOnSelfJoin() {
+    // Given:
+    when(j1.getLeftSource()).thenReturn(a);
+    when(j1.getRightSource()).thenReturn(a);
+    final List<JoinInfo> joins = ImmutableList.of(j1);
+
+    // When:
+    final KsqlException e = assertThrows(KsqlException.class, () -> JoinTree.build(joins));
+
+    // Then:
+    assertThat(e.getMessage(), containsString("Cannot perform circular join"));
+  }
+
+  @Test
+  public void shouldThrowOnCircularJoin() {
+    // Given:
+    when(j1.getLeftSource()).thenReturn(a);
+    when(j1.getRightSource()).thenReturn(b);
+    when(j2.getLeftSource()).thenReturn(a);
+    when(j2.getRightSource()).thenReturn(b);
+    final List<JoinInfo> joins = ImmutableList.of(j1, j2);
+
+    // When:
+    final KsqlException e = assertThrows(KsqlException.class, () -> JoinTree.build(joins));
+
+    // Then:
+    assertThat(e.getMessage(), containsString("Cannot perform circular join"));
+  }
+
+  @Test
+  public void shouldThrowOnMissingSource() {
+    // Given:
+    when(j1.getLeftSource()).thenReturn(a);
+    when(j1.getRightSource()).thenReturn(b);
+    when(j2.getLeftSource()).thenReturn(c);
+    when(j2.getRightSource()).thenReturn(d);
+    final List<JoinInfo> joins = ImmutableList.of(j1, j2);
+
+    // When:
+    final KsqlException e = assertThrows(KsqlException.class, () -> JoinTree.build(joins));
+
+    // Then:
+    assertThat(e.getMessage(), containsString("neither source in the join is the FROM source"));
+  }
+
+}


### PR DESCRIPTION
### Description 

Introduces the `JoinTree` class, which contains the algorithm for constructing a join tree from a list of join information. This PR does not enable any new behaviors.

### Testing done 

Unit testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

