### PR TITLE
fix: json creator for QueryStatusCount should match getter (MINOR)

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutor.java
@@ -110,7 +110,7 @@ public final class ListQueriesExecutor {
                 ImmutableSet.of(q.getSinkName().text()),
                 ImmutableSet.of(q.getResultTopic().getKafkaTopicName()),
                 q.getQueryId(),
-                new QueryStatusCount(
+                QueryStatusCount.fromStreamsStateCounts(
                     Collections.singletonMap(KafkaStreams.State.valueOf(q.getState()), 1)))
         ));
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
@@ -228,7 +228,7 @@ public final class ListSourceExecutor {
             ImmutableSet.of(q.getSinkName().text()),
             ImmutableSet.of(q.getResultTopic().getKafkaTopicName()),
             q.getQueryId(),
-            new QueryStatusCount(
+            QueryStatusCount.fromStreamsStateCounts(
                 Collections.singletonMap(
                     KafkaStreams.State.valueOf(q.getState()), 1)))).collect(Collectors.toList());
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
@@ -167,7 +167,7 @@ public class ListQueriesExecutorTest {
     
     final List<RunningQuery> remoteRunningQueries = Collections.singletonList(queryMetaDataToRunningQuery(
         remoteMetadata,
-        new QueryStatusCount(Collections.singletonMap(ERROR_QUERY_STATE, 1))));
+        QueryStatusCount.fromStreamsStateCounts(Collections.singletonMap(ERROR_QUERY_STATE, 1))));
     when(remoteQueries.getQueries()).thenReturn(remoteRunningQueries);
     when(ksqlEntityList.get(anyInt())).thenReturn(remoteQueries);
     when(response.getResponse()).thenReturn(ksqlEntityList);
@@ -200,7 +200,7 @@ public class ListQueriesExecutorTest {
     
     final List<RunningQuery> remoteRunningQueries = Collections.singletonList(queryMetaDataToRunningQuery(
         remoteMetadata,
-        new QueryStatusCount(Collections.singletonMap(RUNNING_QUERY_STATE, 1))));
+        QueryStatusCount.fromStreamsStateCounts(Collections.singletonMap(RUNNING_QUERY_STATE, 1))));
     when(remoteQueries.getQueries()).thenReturn(remoteRunningQueries);
     when(ksqlEntityList.get(anyInt())).thenReturn(remoteQueries);
     when(response.getResponse()).thenReturn(ksqlEntityList);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
@@ -253,7 +253,7 @@ public class ListSourceExecutorTest {
         ).orElseThrow(IllegalStateException::new);
 
     // Then:
-    final QueryStatusCount queryStatusCount = new QueryStatusCount(
+    final QueryStatusCount queryStatusCount = QueryStatusCount.fromStreamsStateCounts(
         Collections.singletonMap(KafkaStreams.State.valueOf(metadata.getState()), 1));
 
     assertThat(sourceDescription.getSourceDescription(),

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -1990,7 +1990,7 @@ public class KsqlResourceTest {
             ImmutableSet.of(md.getSinkName().toString(FormatOptions.noEscape())),
             ImmutableSet.of(md.getResultTopic().getKafkaTopicName()),
             md.getQueryId(),
-            new QueryStatusCount(
+            QueryStatusCount.fromStreamsStateCounts(
                 Collections.singletonMap(KafkaStreams.State.valueOf(md.getState()), 1)))
     ).collect(Collectors.toList());
   }

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryStatusCount.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryStatusCount.java
@@ -39,21 +39,24 @@ public class QueryStatusCount {
   // Use a EnumMap so toString() will always return the same string
   private final EnumMap<KsqlQueryStatus, Integer> statuses;
 
-  public QueryStatusCount() {
-    this.statuses = returnEnumMap();
-  }
-
-  @SuppressWarnings("unused") // Invoked by reflection
-  @JsonCreator
-  public QueryStatusCount(final Map<KafkaStreams.State, Integer> states) {
+  public static QueryStatusCount fromStreamsStateCounts(
+      final Map<KafkaStreams.State, Integer> states) {
     final Map<KsqlQueryStatus, Integer> ksqlQueryStatus = states.entrySet().stream()
         .collect(Collectors.toMap(
             e -> KsqlConstants.fromStreamsState(e.getKey()),
             Map.Entry::getValue));
-    this.statuses = states.isEmpty() ? returnEnumMap() : new EnumMap<>(ksqlQueryStatus);
+    return new QueryStatusCount(ksqlQueryStatus);
   }
 
-  
+  public QueryStatusCount() {
+    this(Collections.emptyMap());
+  }
+
+  @JsonCreator
+  public QueryStatusCount(final Map<KsqlQueryStatus, Integer> states) {
+    this.statuses = states.isEmpty() ? returnEnumMap() : new EnumMap<>(states);
+  }
+
   public void updateStatusCount(final String state, final int change) {
     updateStatusCount(KafkaStreams.State.valueOf(state), change);
   }

--- a/ksqldb-rest-model/src/test/java/io/confluent/ksql/rest/entity/QueryStatusCountTest.java
+++ b/ksqldb-rest-model/src/test/java/io/confluent/ksql/rest/entity/QueryStatusCountTest.java
@@ -79,8 +79,8 @@ public class QueryStatusCountTest {
 
   @Test
   public void shouldImplementHashCodeAndEqualsCorrectly() {
-    final QueryStatusCount queryStatusCount1 = new QueryStatusCount(Collections.singletonMap(KafkaStreams.State.ERROR, 2));
-    final QueryStatusCount queryStatusCount2 = new QueryStatusCount(Collections.singletonMap(KafkaStreams.State.RUNNING, 1));
+    final QueryStatusCount queryStatusCount1 = new QueryStatusCount(Collections.singletonMap(KsqlQueryStatus.ERROR, 2));
+    final QueryStatusCount queryStatusCount2 = new QueryStatusCount(Collections.singletonMap(KsqlQueryStatus.RUNNING, 1));
     queryStatusCount2.updateStatusCount(KafkaStreams.State.ERROR, 2);
     final QueryStatusCount queryStatusCount3 = new QueryStatusCount();
     queryStatusCount3.updateStatusCount(KafkaStreams.State.ERROR, 2);
@@ -106,6 +106,7 @@ public class QueryStatusCountTest {
     // Given:
     queryStatusCount.updateStatusCount(KafkaStreams.State.RUNNING, 2);
     queryStatusCount.updateStatusCount(KafkaStreams.State.ERROR, 10);
+    queryStatusCount.updateStatusCount(KsqlQueryStatus.UNRESPONSIVE, 1);
 
     // When:
     final String json = assertDeserializedToSame(queryStatusCount);
@@ -113,7 +114,8 @@ public class QueryStatusCountTest {
     // Then:
     assertThat(json, is("{"
         + "\"RUNNING\":2,"
-        + "\"ERROR\":10"
+        + "\"ERROR\":10,"
+        + "\"UNRESPONSIVE\":1"
         + "}"));
   }
 


### PR DESCRIPTION
### Description 

The `QueryStatusCount` getter returns `Map<KsqlQueryStatus, Integer>` but the creator expects `Map<KafkaStreams.State, Integer>` which means deserialization fails for `KsqlQueryStatus.UNRESPONSIVE` since that's not a valid `KafkaStreams.State`:
```
Caused by: com.fasterxml.jackson.databind.exc.InvalidFormatException: 
Cannot deserialize Map key of type `org.apache.kafka.streams.KafkaStreams$State` from String "UNRESPONSIVE": not a valid representation, problem: (com.fasterxml.jackson.databind.exc.InvalidFormatException) Cannot deserialize Map key of type `org.apache.kafka.streams.KafkaStreams$State` from String "UNRESPONSIVE": not one of the values accepted for Enum class: [CREATED, NOT_RUNNING, RUNNING, ERROR, REBALANCING, PENDING_SHUTDOWN]
```

This PR updates the creator to match the getter.

### Testing done 

Added unit test.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

