### PR TITLE
fix: Dockerfile to add user appuser

### DIFF
--- a/ksqldb-docker/Dockerfile
+++ b/ksqldb-docker/Dockerfile
@@ -8,6 +8,8 @@ ARG ARTIFACT_ID
 
 USER root
 
+RUN useradd -ms /bin/bash appuser
+
 # target directory must be one of the projects that ksql-run-class sets on the KSQL_CLASSPATH,
 # of which the artifact ID (ksqldb-docker) is not one. thus the workaround of using ksqldb-rest-app
 ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/ksqldb-rest-app/


### PR DESCRIPTION
### Description 
My build was failing for docker when I followed the instructions at [ksqldb-docker/README.md](https://github.com/confluentinc/ksql/blob/master/ksqldb-docker/README.md). It was throwing error: `[ERROR] unable to convert uid/gid chown string to host mapping: can't find uid for user appuser: no such user: appuser`. After this change, the build goes through. 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

