### PR TITLE
fix: Make sure internal client is configured for TLS

### DIFF
--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslClientAuthFunctionalTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslClientAuthFunctionalTest.java
@@ -27,7 +27,6 @@ import com.google.common.net.UrlEscapers;
 import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.integration.IntegrationTestHarness;
 import io.confluent.ksql.integration.Retry;
-import io.confluent.ksql.rest.client.KsqlClient;
 import io.confluent.ksql.rest.client.KsqlRestClient;
 import io.confluent.ksql.rest.client.KsqlRestClientException;
 import io.confluent.ksql.rest.client.RestResponse;
@@ -108,7 +107,7 @@ public class SslClientAuthFunctionalTest {
 
   @Before
   public void setUp() {
-    clientProps = ImmutableMap.of(KsqlClient.DISABLE_HOSTNAME_VERIFICATION_PROP_NAME, "true");
+    clientProps = ImmutableMap.of();
     sslContextFactory = new Server();
   }
 
@@ -174,7 +173,6 @@ public class SslClientAuthFunctionalTest {
         .putAll(ClientTrustStore.trustStoreProps())
         .put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, clientCertPath)
         .put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, clientCertPassword)
-        .put(KsqlClient.DISABLE_HOSTNAME_VERIFICATION_PROP_NAME, "true")
         .build();
 
     // WS:
@@ -190,7 +188,6 @@ public class SslClientAuthFunctionalTest {
     // HTTP:
     clientProps = ImmutableMap.<String, String>builder()
         .putAll(ClientTrustStore.trustStoreProps())
-        .put(KsqlClient.DISABLE_HOSTNAME_VERIFICATION_PROP_NAME, "true")
         .build();
 
     // WS:

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslFunctionalTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslFunctionalTest.java
@@ -31,7 +31,6 @@ import com.google.common.net.UrlEscapers;
 import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.integration.IntegrationTestHarness;
 import io.confluent.ksql.integration.Retry;
-import io.confluent.ksql.rest.client.KsqlClient;
 import io.confluent.ksql.rest.client.KsqlRestClient;
 import io.confluent.ksql.rest.client.KsqlRestClientException;
 import io.confluent.ksql.rest.client.RestResponse;
@@ -110,7 +109,7 @@ public class SslFunctionalTest {
 
   @Before
   public void setUp() {
-    clientProps = ImmutableMap.of(KsqlClient.DISABLE_HOSTNAME_VERIFICATION_PROP_NAME, "true");
+    clientProps = ImmutableMap.of();
     sslContextFactory = new Server();
   }
 
@@ -174,7 +173,6 @@ public class SslFunctionalTest {
     // HTTP:
     clientProps = ImmutableMap.<String, String>builder()
         .putAll(ClientTrustStore.trustStoreProps())
-        .put(KsqlClient.DISABLE_HOSTNAME_VERIFICATION_PROP_NAME, "true")
         .build();
 
     // WS:
@@ -184,7 +182,7 @@ public class SslFunctionalTest {
   }
 
   private void givenClientConfguredWithoutTruststore() {
-    clientProps = ImmutableMap.of(KsqlClient.DISABLE_HOSTNAME_VERIFICATION_PROP_NAME, "true");
+    clientProps = ImmutableMap.of();
   }
 
   private Code canMakeCliRequest() {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/DefaultKsqlClient.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/DefaultKsqlClient.java
@@ -29,7 +29,6 @@ import io.confluent.ksql.rest.entity.KsqlHostInfoEntity;
 import io.confluent.ksql.rest.entity.LagReportingMessage;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.services.SimpleKsqlClient;
-import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlHostInfo;
 import io.vertx.core.http.HttpClientOptions;
 import java.net.URI;
@@ -47,15 +46,11 @@ final class DefaultKsqlClient implements SimpleKsqlClient {
   private final Optional<String> authHeader;
   private final KsqlClient sharedClient;
 
-  DefaultKsqlClient(final Optional<String> authHeader) {
-    this(authHeader, new KsqlConfig(ImmutableMap.of()));
-  }
-
-  DefaultKsqlClient(final Optional<String> authHeader, final KsqlConfig ksqlConfig) {
+  DefaultKsqlClient(final Optional<String> authHeader, final Map<String, Object> clientProps) {
     this(
         authHeader,
         new KsqlClient(
-            toClientProps(ksqlConfig),
+            toClientProps(clientProps),
             Optional.empty(),
             new LocalProperties(ImmutableMap.of()),
             createClientOptions()
@@ -161,9 +156,9 @@ final class DefaultKsqlClient implements SimpleKsqlClient {
     return new HttpClientOptions().setMaxPoolSize(100);
   }
 
-  private static Map<String, String> toClientProps(final KsqlConfig ksqlConfig) {
+  private static Map<String, String> toClientProps(final Map<String, Object> config) {
     final Map<String, String> clientProps = new HashMap<>();
-    for (Map.Entry<String, Object> entry : ksqlConfig.originals().entrySet()) {
+    for (Map.Entry<String, Object> entry : config.entrySet()) {
       clientProps.put(entry.getKey(), entry.getValue().toString());
     }
     return clientProps;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/DefaultKsqlClient.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/DefaultKsqlClient.java
@@ -164,9 +164,7 @@ final class DefaultKsqlClient implements SimpleKsqlClient {
   private static Map<String, String> toClientProps(final KsqlConfig ksqlConfig) {
     final Map<String, String> clientProps = new HashMap<>();
     for (Map.Entry<String, Object> entry : ksqlConfig.originals().entrySet()) {
-      if (entry.getValue() instanceof String) {
-        clientProps.put(entry.getKey(), (String) entry.getValue());
-      }
+      clientProps.put(entry.getKey(), entry.getValue().toString());
     }
     return clientProps;
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/DefaultKsqlClient.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/DefaultKsqlClient.java
@@ -48,7 +48,7 @@ final class DefaultKsqlClient implements SimpleKsqlClient {
   private final KsqlClient sharedClient;
 
   DefaultKsqlClient(final Optional<String> authHeader) {
-    this(authHeader, (KsqlConfig) null);
+    this(authHeader, new KsqlConfig(ImmutableMap.of()));
   }
 
   DefaultKsqlClient(final Optional<String> authHeader, final KsqlConfig ksqlConfig) {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/RestServiceContextFactory.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/RestServiceContextFactory.java
@@ -73,8 +73,8 @@ public final class RestServiceContextFactory {
         kafkaClientSupplier,
         srClientFactory,
         () -> new DefaultConnectClient(ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY),
-                                       authHeader),
-        () -> new DefaultKsqlClient(authHeader)
+            authHeader),
+        () -> new DefaultKsqlClient(authHeader, ksqlConfig)
     );
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/RestServiceContextFactory.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/RestServiceContextFactory.java
@@ -74,7 +74,9 @@ public final class RestServiceContextFactory {
         srClientFactory,
         () -> new DefaultConnectClient(ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY),
             authHeader),
-        () -> new DefaultKsqlClient(authHeader, ksqlConfig)
+        () -> new DefaultKsqlClient(authHeader, ksqlConfig.originals())
     );
   }
+
+
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
@@ -605,7 +605,7 @@ public class ApiTest extends BaseApiTest {
     validateInsertStreamError(ERROR_CODE_MALFORMED_REQUEST, "Invalid JSON in inserts stream",
         insertsResponse.error, (long) rows.size() - 1);
 
-    assertThat(testEndpoints.getInsertsSubscriber().isCompleted(), is(true));
+    assertThatEventually(() -> testEndpoints.getInsertsSubscriber().isCompleted(), is(true));
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ShowQueriesMultiNodeWithTlsFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ShowQueriesMultiNodeWithTlsFunctionalTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.integration;
+
+import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
+import static org.hamcrest.Matchers.is;
+
+import io.confluent.common.utils.IntegrationTest;
+import io.confluent.ksql.integration.IntegrationTestHarness;
+import io.confluent.ksql.integration.Retry;
+import io.confluent.ksql.rest.entity.KsqlEntity;
+import io.confluent.ksql.rest.entity.Queries;
+import io.confluent.ksql.rest.entity.RunningQuery;
+import io.confluent.ksql.rest.server.KsqlRestConfig;
+import io.confluent.ksql.rest.server.TestKsqlRestApp;
+import io.confluent.ksql.serde.FormatFactory;
+import io.confluent.ksql.test.util.secure.ServerKeyStore;
+import io.confluent.ksql.util.PageViewDataProvider;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import kafka.zookeeper.ZooKeeperClientException;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+
+@Category({IntegrationTest.class})
+public class ShowQueriesMultiNodeWithTlsFunctionalTest {
+
+  private static final PageViewDataProvider PAGE_VIEWS_PROVIDER = new PageViewDataProvider();
+  private static final String PAGE_VIEW_TOPIC = PAGE_VIEWS_PROVIDER.topicName();
+  private static final String PAGE_VIEW_STREAM = PAGE_VIEWS_PROVIDER.kstreamName();
+  private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
+  private static final TestKsqlRestApp REST_APP_0 = TestKsqlRestApp
+      .builder(TEST_HARNESS::kafkaBootstrapServers)
+      .withProperty(KsqlRestConfig.LISTENERS_CONFIG,
+          "http://localhost:8088,https://localhost:8089")
+      .withProperty(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG, "https://localhost:8089")
+      .withProperties(ServerKeyStore.keyStoreProps())
+      .build();
+  private static final TestKsqlRestApp REST_APP_1 = TestKsqlRestApp
+      .builder(TEST_HARNESS::kafkaBootstrapServers)
+      .withProperty(KsqlRestConfig.LISTENERS_CONFIG,
+          "http://localhost:8098,https://localhost:8099")
+      .withProperty(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG, "https://localhost:8099")
+      .withProperties(ServerKeyStore.keyStoreProps())
+      .build();
+
+  @ClassRule
+  public static final RuleChain CHAIN = RuleChain
+      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .around(TEST_HARNESS)
+      .around(REST_APP_0)
+      .around(REST_APP_1);
+
+  @BeforeClass
+  public static void setUpClass() {
+    TEST_HARNESS.ensureTopics(2, PAGE_VIEW_TOPIC);
+    TEST_HARNESS.produceRows(PAGE_VIEW_TOPIC, PAGE_VIEWS_PROVIDER, FormatFactory.JSON);
+    RestIntegrationTestUtil.createStream(REST_APP_0, PAGE_VIEWS_PROVIDER);
+    RestIntegrationTestUtil.makeKsqlRequest(
+        REST_APP_0,
+        "CREATE STREAM S AS SELECT * FROM " + PAGE_VIEW_STREAM + ";"
+    );
+  }
+
+  @Test
+  public void shouldShowAllQueries() {
+    // When:
+    final Supplier<String> app0Response = () -> getShowQueriesResult(REST_APP_0);
+    final Supplier<String> app1Response = () -> getShowQueriesResult(REST_APP_1);
+
+    // Then:
+    assertThatEventually("App0", app0Response, is("RUNNING:2"));
+    assertThatEventually("App1", app1Response, is("RUNNING:2"));
+  }
+
+  private static String getShowQueriesResult(final TestKsqlRestApp restApp) {
+    final List<KsqlEntity> results = RestIntegrationTestUtil.makeKsqlRequest(
+        restApp,
+        "Show Queries;"
+    );
+
+    if (results.size() != 1) {
+      return "Expected 1 response, got " + results.size();
+    }
+
+    final KsqlEntity result = results.get(0);
+
+    if (!(result instanceof Queries)) {
+      return "Expected Queries, got " + result;
+    }
+
+    final List<RunningQuery> runningQueries = ((Queries) result)
+        .getQueries();
+
+    if (runningQueries.size() != 1) {
+      return "Expected 1 running query, got " + runningQueries.size();
+    }
+
+    return runningQueries.get(0).getState().orElse("N/A");
+  }
+
+}

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ShowQueriesMultiNodeWithTlsFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ShowQueriesMultiNodeWithTlsFunctionalTest.java
@@ -52,6 +52,7 @@ public class ShowQueriesMultiNodeWithTlsFunctionalTest {
           "http://localhost:8088,https://localhost:8089")
       .withProperty(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG, "https://localhost:8089")
       .withProperties(ServerKeyStore.keyStoreProps())
+      .withEnabledKsqlClient()
       .build();
   private static final TestKsqlRestApp REST_APP_1 = TestKsqlRestApp
       .builder(TEST_HARNESS::kafkaBootstrapServers)
@@ -59,6 +60,7 @@ public class ShowQueriesMultiNodeWithTlsFunctionalTest {
           "http://localhost:8098,https://localhost:8099")
       .withProperty(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG, "https://localhost:8099")
       .withProperties(ServerKeyStore.keyStoreProps())
+      .withEnabledKsqlClient()
       .build();
 
   @ClassRule

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -482,7 +482,7 @@ public class TestKsqlRestApp extends ExternalResource {
     public Builder withEnabledKsqlClient() {
       this.serviceContext =
           () -> defaultServiceContext(bootstrapServers, buildBaseConfig(additionalProps),
-              TestDefaultKsqlClientFactory::instance);
+              () -> TestDefaultKsqlClientFactory.instance(additionalProps));
       return this;
     }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/services/TestDefaultKsqlClientFactory.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/services/TestDefaultKsqlClientFactory.java
@@ -1,6 +1,7 @@
 package io.confluent.ksql.rest.server.services;
 
 import io.confluent.ksql.services.SimpleKsqlClient;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -10,13 +11,8 @@ import java.util.Optional;
 public class TestDefaultKsqlClientFactory {
 
   // Creates an instance with no auth
-  public static SimpleKsqlClient instance() {
-    return new DefaultKsqlClient(Optional.empty());
-  }
-
-  // Creates an instance with the given auth headers
-  public static SimpleKsqlClient instance(final Optional<String> authHeader) {
-    return new DefaultKsqlClient(authHeader);
+  public static SimpleKsqlClient instance(Map<String, Object> clientProps) {
+    return new DefaultKsqlClient(Optional.empty(), clientProps);
   }
 
 }

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlClient.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlClient.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.rest.client;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.parser.json.KsqlTypesDeserializationModule;
 import io.confluent.ksql.properties.LocalProperties;
 import io.confluent.ksql.rest.ApiJsonMapper;
@@ -40,15 +39,11 @@ public final class KsqlClient implements AutoCloseable {
     ApiJsonMapper.INSTANCE.get().registerModule(new KsqlTypesDeserializationModule(false));
   }
 
-  public static final String DISABLE_HOSTNAME_VERIFICATION_PROP_NAME
-      = "ksql.client.disable.hostname.verification";
-  public static final String TLS_ENABLED_PROP_NAME = "ksql.client.enable.tls";
-
   private final Vertx vertx;
-  private final HttpClient httpClient;
+  private final HttpClient httpNonTlsClient;
+  private final HttpClient httpTlsClient;
   private final LocalProperties localProperties;
   private final Optional<String> basicAuthHeader;
-  private final boolean isTls;
 
   public KsqlClient(
       final Map<String, String> clientProps,
@@ -56,59 +51,30 @@ public final class KsqlClient implements AutoCloseable {
       final LocalProperties localProperties,
       final HttpClientOptions httpClientOptions
   ) {
-    this(Vertx.vertx(), clientProps, credentials, localProperties, httpClientOptions);
-  }
-
-  @VisibleForTesting
-  KsqlClient(
-      final HttpClient httpClient,
-      final boolean isTls,
-      final Optional<BasicCredentials> credentials,
-      final LocalProperties localProperties
-  ) {
-    this(null, httpClient, isTls, credentials, localProperties);
-  }
-
-  private KsqlClient(
-      final Vertx vertx,
-      final HttpClient httpClient,
-      final boolean isTls,
-      final Optional<BasicCredentials> credentials,
-      final LocalProperties localProperties
-  ) {
-    this.vertx = vertx;
-    this.httpClient = Objects.requireNonNull(httpClient, "httpClient");
-    this.isTls = isTls;
+    this.vertx = Vertx.vertx();
     this.basicAuthHeader = createBasicAuthHeader(
         Objects.requireNonNull(credentials, "credentials"));
     this.localProperties = Objects.requireNonNull(localProperties, "localProperties");
-  }
-
-  private KsqlClient(
-      final Vertx vertx,
-      final Map<String, String> clientProps,
-      final Optional<BasicCredentials> credentials,
-      final LocalProperties localProperties,
-      final HttpClientOptions httpClientOptions
-  ) {
-    this(vertx, createHttpClient(vertx, clientProps, httpClientOptions), httpClientOptions.isSsl(),
-        credentials, localProperties);
+    this.httpNonTlsClient = createHttpClient(vertx, clientProps, httpClientOptions, false);
+    this.httpTlsClient = createHttpClient(vertx, clientProps, httpClientOptions, true);
   }
 
   public KsqlTarget target(final URI server) {
     final boolean isUriTls = server.getScheme().equalsIgnoreCase("https");
-    if (isTls != isUriTls) {
-      throw new KsqlRestClientException("Cannot make request with scheme " + server.getScheme()
-          + " as client is configured " + (isTls ? "with" : "without") + " tls");
-    }
-    return new KsqlTarget(httpClient,
+    final HttpClient client = isUriTls ? httpTlsClient : httpNonTlsClient;
+    return new KsqlTarget(client,
         SocketAddress.inetSocketAddress(server.getPort(), server.getHost()), localProperties,
         basicAuthHeader);
   }
 
   public void close() {
     try {
-      httpClient.close();
+      httpTlsClient.close();
+    } catch (Exception ignore) {
+      // Ignore
+    }
+    try {
+      httpNonTlsClient.close();
     } catch (Exception ignore) {
       // Ignore
     }
@@ -127,11 +93,10 @@ public final class KsqlClient implements AutoCloseable {
 
   private static HttpClient createHttpClient(final Vertx vertx,
       final Map<String, String> clientProps,
-      final HttpClientOptions httpClientOptions) {
-    if ("true".equals(clientProps.get(DISABLE_HOSTNAME_VERIFICATION_PROP_NAME))) {
-      httpClientOptions.setVerifyHost(false);
-    }
-    if ("true".equals(clientProps.get(TLS_ENABLED_PROP_NAME))) {
+      final HttpClientOptions httpClientOptions,
+      final boolean tls) {
+    httpClientOptions.setVerifyHost(false);
+    if (tls) {
       httpClientOptions.setSsl(true);
     }
     final String trustStoreLocation = clientProps.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG);

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlClient.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlClient.java
@@ -95,22 +95,22 @@ public final class KsqlClient implements AutoCloseable {
       final Map<String, String> clientProps,
       final HttpClientOptions httpClientOptions,
       final boolean tls) {
-    httpClientOptions.setVerifyHost(false);
     if (tls) {
+      httpClientOptions.setVerifyHost(false);
       httpClientOptions.setSsl(true);
-    }
-    final String trustStoreLocation = clientProps.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG);
-    if (trustStoreLocation != null) {
-      final String suppliedTruststorePassword = clientProps
-          .get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG);
-      httpClientOptions.setTrustStoreOptions(new JksOptions().setPath(trustStoreLocation)
-          .setPassword(suppliedTruststorePassword == null ? "" : suppliedTruststorePassword));
-      final String keyStoreLocation = clientProps.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG);
-      if (keyStoreLocation != null) {
-        final String suppliedKeyStorePassord = clientProps
-            .get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG);
-        httpClientOptions.setKeyStoreOptions(new JksOptions().setPath(keyStoreLocation)
-            .setPassword(suppliedTruststorePassword == null ? "" : suppliedKeyStorePassord));
+      final String trustStoreLocation = clientProps.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG);
+      if (trustStoreLocation != null) {
+        final String suppliedTruststorePassword = clientProps
+            .get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG);
+        httpClientOptions.setTrustStoreOptions(new JksOptions().setPath(trustStoreLocation)
+            .setPassword(suppliedTruststorePassword == null ? "" : suppliedTruststorePassword));
+        final String keyStoreLocation = clientProps.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG);
+        if (keyStoreLocation != null) {
+          final String suppliedKeyStorePassord = clientProps
+              .get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG);
+          httpClientOptions.setKeyStoreOptions(new JksOptions().setPath(keyStoreLocation)
+              .setPassword(suppliedTruststorePassword == null ? "" : suppliedKeyStorePassord));
+        }
       }
     }
     try {

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -19,7 +19,6 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.properties.LocalProperties;
 import io.confluent.ksql.rest.entity.ClusterStatusResponse;
 import io.confluent.ksql.rest.entity.CommandStatus;
@@ -81,8 +80,7 @@ public final class KsqlRestClient implements Closeable {
       final KsqlClientSupplier clientSupplier
   ) {
     final LocalProperties localProperties = new LocalProperties(localProps);
-    final Map<String, String> clientPropsWithTls = maybeConfigureTls(serverAddress, clientProps);
-    final KsqlClient client = clientSupplier.get(clientPropsWithTls, creds, localProperties);
+    final KsqlClient client = clientSupplier.get(clientProps, creds, localProperties);
     return new KsqlRestClient(client, serverAddress, localProperties);
   }
 
@@ -217,17 +215,4 @@ public final class KsqlRestClient implements Closeable {
     }
   }
 
-  private static Map<String, String> maybeConfigureTls(
-      final String serverAddress,
-      final Map<String, String> clientProps
-  ) {
-    if (serverAddress.toLowerCase().startsWith("https:")) {
-      return ImmutableMap.<String, String>builder()
-          .putAll(clientProps)
-          .put(KsqlClient.TLS_ENABLED_PROP_NAME, "true")
-          .build();
-    } else {
-      return clientProps;
-    }
-  }
 }

--- a/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlClientTest.java
+++ b/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlClientTest.java
@@ -515,7 +515,7 @@ public class KsqlClientTest {
     startClientWithTls();
     expectedEx.expect(KsqlRestClientException.class);
     expectedEx
-        .expectMessage("Cannot make request with scheme http as client is configured with tls");
+        .expectMessage("Error issuing POST to KSQL server. path:/ksql");
 
     // When:
     URI uri = URI.create("http://localhost:" + server.getPort());
@@ -529,7 +529,7 @@ public class KsqlClientTest {
     expectedEx.expect(KsqlRestClientException.class);
     expectedEx
         .expectMessage(
-            "Cannot make request with scheme https as client is configured without tls");
+            "Error issuing POST to KSQL server. path:/ksql");
 
     // When:
     URI uri = URI.create("https://localhost:" + server.getPort());
@@ -708,14 +708,12 @@ public class KsqlClientTest {
   private void startClientWithTls() {
     Map<String, String> props = new HashMap<>();
     props.putAll(ClientTrustStore.trustStoreProps());
-    props.put(KsqlClient.TLS_ENABLED_PROP_NAME, "true");
     createClient(props);
   }
 
   private void startClientWithTlsAndTruststorePassword(final String password) {
     Map<String, String> props = new HashMap<>();
     props.putAll(ClientTrustStore.trustStoreProps());
-    props.put(KsqlClient.TLS_ENABLED_PROP_NAME, "true");
     props.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, password);
     createClient(props);
   }


### PR DESCRIPTION
### Description 

Fixes https://github.com/confluentinc/ksql/issues/5055

In a previous non functional change we replaced the Jetty based HTTP client with a Vert.x based one.

However there were no existing integration tests that tested with a TLS configured cluster, so a bug whereby the internal client wasn't being configured with TLS properly wasn't exposed.

This PR fixes things so the internal client works ok with TLS.

### Testing done 

Added a new integration test which tests a cluster configured with TLS.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

