### PR TITLE
chore: update base docker image tag to be UBI (MINOR)

### DIFF
--- a/ksqldb-docker/README.md
+++ b/ksqldb-docker/README.md
@@ -13,7 +13,7 @@ To build a new image with local changes:
 
 1. Build docker images from local changes.
     ```
-    > mvn -Pdocker package -DskipTests -Dspotbugs.skip -Dcheckstyle.skip  -Ddockerfile.skip=false -Dskip.docker.build=false -Ddocker.upstream-tag=latest -Ddocker.tag=local.build  -Ddocker.upstream-registry=''
+    > mvn -Pdocker package -DskipTests -Dspotbugs.skip -Dcheckstyle.skip  -Ddockerfile.skip=false -Dskip.docker.build=false -Ddocker.upstream-tag=5.4.1-2-ubi8 -Ddocker.tag=local.build  -Ddocker.upstream-registry=''
     ```
    Change `docker.upstream-tag` if you want to depend on anything other than the latest master upstream, e.g. 5.4.x-latest.
 


### PR DESCRIPTION
### Description 

After the Dockerfile update to support UBI base images (https://github.com/confluentinc/ksql/pull/5025) the local Docker build instructions started failing with
```
[ERROR] Failed to execute goal com.spotify:dockerfile-maven-plugin:1.4.13:build (package) on project ksqldb-docker: Could not build image: unable to convert uid/gid chown string to host mapping: can't find uid for user appuser: no such user: appuser
```
because the base image specified in the README was still on Debian. This PR updates the README to use a UBI base image to avoid the failure.

There are plans in the works for creating a new upstream image/tag to one that will always have the latest base image (e.g., `confluentinc/cp-base-new:ubi-latest` or `confluentinc/ksqldb-base:latest`). This is a temporary fix to unblock community builds until the new base image/tag has been created.

### Testing done 

Build local docker image.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

