### PR TITLE
docs: update docker README build instructions to new base image tag (MINOR)

### DIFF
--- a/ksqldb-docker/README.md
+++ b/ksqldb-docker/README.md
@@ -13,7 +13,7 @@ To build a new image with local changes:
 
 1. Build docker images from local changes.
     ```
-    > mvn -Pdocker package -DskipTests -Dspotbugs.skip -Dcheckstyle.skip  -Ddockerfile.skip=false -Dskip.docker.build=false -Ddocker.upstream-tag=5.4.1-2-ubi8 -Ddocker.tag=local.build  -Ddocker.upstream-registry=''
+    > mvn -Pdocker package -DskipTests -Dspotbugs.skip -Dcheckstyle.skip  -Ddockerfile.skip=false -Dskip.docker.build=false -Ddocker.upstream-tag=latest-ubi8 -Ddocker.tag=local.build  -Ddocker.upstream-registry=''
     ```
    Change `docker.upstream-tag` if you want to depend on anything other than the latest master upstream, e.g. 5.4.x-latest.
 


### PR DESCRIPTION
### Description 

As a followup to https://github.com/confluentinc/ksql/pull/5061, @elismaga has kindly helped us create a new docker image tag for our base docker images so we can update the tag with new version behind the scenes without needing to update our docs each time. This PR updates our README instructions for building local docker images accordingly.

### Testing done 

Built local docker image with new base image tag.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

