### PR TITLE
fix: replace 'null' in explain plan with correct op type (MINOR)

### DIFF
--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/PlanSummaryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/PlanSummaryTest.java
@@ -15,8 +15,9 @@
 
 package io.confluent.ksql.util;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
@@ -123,6 +124,18 @@ public class PlanSummaryTest {
             + "\n\t\t > [ SOURCE ] | Schema: ROWKEY STRING KEY, L0 INTEGER | Logger: QID.src"
             + "\n\t\t > [ SOURCE ] | Schema: ROWKEY STRING KEY, L0_2 STRING | Logger: QID.src2\n"
     ));
+  }
+
+  @Test
+  public void shouldThrowOnUnsupportedStepType() {
+    // Given:
+    final ExecutionStep<?> step = mock(ExecutionStep.class);
+
+    // When:
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> planSummaryBuilder.summarize(step)
+    );
   }
 
   private <T extends ExecutionStep<?>> T givenStep(


### PR DESCRIPTION
### Description 
 `StreamGroupByKey` steps resulted in a `null` op type, but now resolve correctly to `GROUP_BY`. In the future, unsupported types will result in an exception.

### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

