### PR TITLE
feat: add multi-join expression support

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/RewrittenAnalysis.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/RewrittenAnalysis.java
@@ -59,10 +59,6 @@ public class RewrittenAnalysis implements ImmutableAnalysis {
     this.rewriter = Objects.requireNonNull(rewriter, "rewriter");
   }
 
-  public ImmutableAnalysis getOriginal() {
-    return original;
-  }
-
   @Override
   public List<FunctionCall> getTableFunctions() {
     return rewriteList(original.getTableFunctions());
@@ -148,16 +144,7 @@ public class RewrittenAnalysis implements ImmutableAnalysis {
 
   @Override
   public List<JoinInfo> getJoin() {
-    return original.getJoin().stream().map(
-        j -> new JoinInfo(
-            j.getLeftSource(),
-            rewrite(j.getLeftJoinExpression()),
-            j.getRightSource(),
-            rewrite(j.getRightJoinExpression()),
-            j.getType(),
-            j.getWithinExpression()
-        )
-    ).collect(Collectors.toList());
+    return original.getJoin();
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -431,12 +431,37 @@ public class LogicalPlanner {
     );
   }
 
+  private PlanNode buildSourceForJoin(
+      final Join join,
+      final PlanNode joinedSource,
+      final String side,
+      final Expression joinExpression
+  ) {
+    // we do not need to repartition if the joinExpression
+    // is already part of the join equivalence set
+    if (join.joinEquivalenceSet().contains(joinExpression)) {
+      return joinedSource;
+    }
+
+    return buildRepartitionNode(
+        side + "SourceKeyed",
+        joinedSource,
+        new PartitionBy(
+            Optional.empty(),
+            // We need to repartition on the original join expression, and we need to drop
+            // all qualifiers.
+            ExpressionTreeRewriter.rewriteWith(refRewriter::process, joinExpression),
+            Optional.empty()
+        )
+    );
+  }
+
   private PlanNode buildSourceNode() {
     if (!analysis.isJoin()) {
       return buildNonJoinNode(analysis.getFrom());
     }
 
-    final List<JoinInfo> joinInfo = analysis.getOriginal().getJoin();
+    final List<JoinInfo> joinInfo = analysis.getJoin();
     final JoinTree.Node tree = JoinTree.build(joinInfo);
     if (tree instanceof JoinTree.Leaf) {
       throw new IllegalStateException("Expected more than one source:"
@@ -454,7 +479,12 @@ public class LogicalPlanner {
   private PlanNode buildJoin(final Join root, final String prefix) {
     final PlanNode left;
     if (root.getLeft() instanceof JoinTree.Join) {
-      left = buildJoin((Join) root.getLeft(), prefix + "L_");
+      left = buildSourceForJoin(
+          (JoinTree.Join) root.getLeft(),
+          buildJoin((Join) root.getLeft(), prefix + "L_"),
+          prefix + "Left",
+          root.getInfo().getLeftJoinExpression()
+      );
     } else {
       final JoinTree.Leaf leaf = (Leaf) root.getLeft();
       left = buildSourceForJoin(
@@ -463,7 +493,12 @@ public class LogicalPlanner {
 
     final PlanNode right;
     if (root.getRight() instanceof JoinTree.Join) {
-      right = buildJoin((Join) root.getRight(), prefix + "R_");
+      right = buildSourceForJoin(
+          (JoinTree.Join) root.getRight(),
+          buildJoin((Join) root.getRight(), prefix + "R_"),
+          prefix + "Right",
+          root.getInfo().getRightJoinExpression()
+      );
     } else {
       final JoinTree.Leaf leaf = (Leaf) root.getRight();
       right = buildSourceForJoin(

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/multi-joins.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/multi-joins.json
@@ -145,28 +145,53 @@
       }
     },
     {
-      "name": "stream-table-table - inner-inner - rekey with expression",
+      "name": "stream-table-table - inner-inner - rekey with different expression",
       "statements": [
         "CREATE STREAM S1 (ROWKEY INT KEY, K INT, ID bigint) WITH (kafka_topic='left', value_format='JSON');",
         "CREATE TABLE T2 (ROWKEY INT PRIMARY KEY, ID bigint) WITH (kafka_topic='right', value_format='JSON');",
         "CREATE TABLE T3 (ROWKEY INT PRIMARY KEY, ID bigint) WITH (kafka_topic='right2', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT s1.ID, t2.ID, t3.ID FROM S1 JOIN T2 ON S1.K + 1 = T2.ROWKEY JOIN T3 ON S1.K + 1 = T3.ROWKEY;"
+        "CREATE STREAM OUTPUT as SELECT s1.ID, t2.ID, t3.ID FROM S1 JOIN T2 ON S1.K - 1 = T2.ROWKEY JOIN T3 ON S1.K + 1 = T3.ROWKEY;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
       },
       "inputs": [
-        {"topic": "right2", "key": 1, "value": {"id": 3}, "timestamp": 10},
+        {"topic": "right2", "key": 3, "value": {"id": 3}, "timestamp": 10},
         {"topic": "right", "key": 1, "value": {"id": 2}, "timestamp": 11},
-        {"topic": "left", "key": 0, "value": {"k": 0, "id": 1}, "timestamp": 12}
+        {"topic": "left", "key": 0, "value": {"k": 2, "id": 1}, "timestamp": 12}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-L_Join-repartition", "key": 1, "value": {"S1_K": 0, "S1_ID": 1, "S1_ROWTIME": 12, "S1_ROWKEY": 0, "S1_KSQL_COL_0": 1}, "timestamp": 12},
-        {"topic": "OUTPUT", "key": 1, "value": {"S1_ID": 1, "T2_ID": 2, "T3_ID": 3}, "timestamp":  12}
+        {"topic": "OUTPUT", "key": 3, "value": {"S1_ID": 1, "T2_ID": 2, "T3_ID": 3}, "timestamp":  12}
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "KSQL_COL_0 INT KEY, S1_ID BIGINT, T2_ID BIGINT, T3_ID BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "KSQL_COL_1 INT KEY, S1_ID BIGINT, T2_ID BIGINT, T3_ID BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "stream-table-table - inner-inner - rekey on different field",
+      "comments": ["https://github.com/confluentinc/ksql/issues/5062"],
+      "statements": [
+        "CREATE STREAM S1 (ROWKEY INT KEY, K INT, ID int) WITH (kafka_topic='left', value_format='JSON');",
+        "CREATE TABLE T2 (ROWKEY INT PRIMARY KEY, ID int) WITH (kafka_topic='right', value_format='JSON');",
+        "CREATE TABLE T3 (ROWKEY INT PRIMARY KEY, ID int) WITH (kafka_topic='right2', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT s1.ID, t2.ID, t3.ID FROM S1 JOIN T2 ON S1.ID = T2.ROWKEY JOIN T3 ON S1.K = T3.ROWKEY;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "right2", "key": 2, "value": {"id": 3}, "timestamp": 10},
+        {"topic": "right", "key": 1, "value": {"id": 2}, "timestamp": 11},
+        {"topic": "left", "key": 0, "value": {"k": 2, "id": 1}, "timestamp": 12}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 2, "value": {"S1_ID": 1, "T2_ID": 2, "T3_ID": 3}, "timestamp":  12}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "S1_K INT KEY, S1_ID INT, T2_ID INT, T3_ID INT"}
         ]
       }
     },
@@ -728,7 +753,7 @@
       }
     },
     {
-      "name": "TTS - Invalid",
+      "name": "table-table-stream - Invalid",
       "statements": [
         "CREATE STREAM S1 (ROWKEY INT KEY, ID bigint) WITH (kafka_topic='left_topic', value_format='JSON');",
         "CREATE TABLE T2 (ROWKEY INT PRIMARY KEY, ID bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
@@ -738,40 +763,6 @@
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlException",
         "message": "Join between invalid operands requested: left type: KTABLE, right type: KSTREAM"
-      }
-    },
-    {
-      "name": "stream-table-table - inner-inner - rekey on different field",
-      "comments": ["https://github.com/confluentinc/ksql/issues/5062"],
-      "statements": [
-        "CREATE STREAM S1 (ROWKEY INT KEY, K INT, ID bigint) WITH (kafka_topic='left', value_format='JSON');",
-        "CREATE TABLE T2 (ROWKEY INT PRIMARY KEY, ID bigint) WITH (kafka_topic='right', value_format='JSON');",
-        "CREATE TABLE T3 (ROWKEY INT PRIMARY KEY, ID bigint) WITH (kafka_topic='right2', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT s1.ID, t2.ID, t3.ID FROM S1 JOIN T2 ON S1.ID = T2.ROWKEY JOIN T3 ON S1.K = T3.ROWKEY;"
-      ],
-      "properties": {
-        "ksql.any.key.name.enabled": true
-      },
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlException",
-        "message": "KSQL does not yet support multi-joins with different expressions. A join for `S1` already exists with the condition `S1.ID` - cannot additionally join on `S1.K`"
-      }
-    },
-    {
-      "name": "stream-table-table - inner-inner - rekey on different expression",
-      "comments": ["https://github.com/confluentinc/ksql/issues/5062"],
-      "statements": [
-        "CREATE STREAM S1 (ROWKEY INT KEY, K INT, ID bigint) WITH (kafka_topic='left', value_format='JSON');",
-        "CREATE TABLE T2 (ROWKEY INT PRIMARY KEY, ID bigint) WITH (kafka_topic='right', value_format='JSON');",
-        "CREATE TABLE T3 (ROWKEY INT PRIMARY KEY, ID bigint) WITH (kafka_topic='right2', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT s1.ID, t2.ID, t3.ID FROM S1 JOIN T2 ON S1.K - 1 = T2.ROWKEY JOIN T3 ON S1.K = T3.ROWKEY;"
-      ],
-      "properties": {
-        "ksql.any.key.name.enabled": true
-      },
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlException",
-        "message": "KSQL does not yet support multi-joins with different expressions. A join for `S1` already exists with the condition `(S1.K - 1)` - cannot additionally join on `S1.K`"
       }
     }
   ]


### PR DESCRIPTION
fixes #5062 

### Description 

This change uses the `JoinTree` to track the equivalence of the join criteria across the different join stages, then uses that information to decide whether or not a repartition is necessary. This opens the door to using different expressions (and non-matching expressions) on different parts of the join.

### Testing done 

- unit testing
- QTT tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

