### PR TITLE
refactor: Migrate /heartbeat and /clusterStatus endpoints

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/PortedEndpoints.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/PortedEndpoints.java
@@ -32,6 +32,7 @@ import io.confluent.ksql.rest.entity.HeartbeatMessage;
 import io.confluent.ksql.rest.entity.KsqlErrorMessage;
 import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.entity.Versions;
+import io.confluent.ksql.rest.server.resources.KsqlExceptionMapper;
 import io.confluent.ksql.util.VertxCompletableFuture;
 import io.vertx.core.WorkerExecutor;
 import io.vertx.core.buffer.Buffer;
@@ -46,14 +47,16 @@ import java.io.BufferedOutputStream;
 import java.io.OutputStream;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.function.BiFunction;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import org.apache.http.HttpStatus;
 
 class PortedEndpoints {
 
   private static final Set<String> PORTED_ENDPOINTS = ImmutableSet
-      .of("/ksql", "/ksql/terminate", "/query", "/info", "/heartbeat");
+      .of("/ksql", "/ksql/terminate", "/query", "/info", "/heartbeat", "/clusterStatus");
 
   private static final String CONTENT_TYPE_HEADER = HttpHeaders.CONTENT_TYPE.toString();
   private static final String JSON_CONTENT_TYPE = "application/json";
@@ -92,9 +95,14 @@ class PortedEndpoints {
         .produces(MediaType.APPLICATION_JSON)
         .handler(new PortedEndpoints(endpoints, server)::handleInfoRequest);
     router.route(HttpMethod.POST, "/heartbeat")
+        .handler(BodyHandler.create())
         .produces(Versions.KSQL_V1_JSON)
         .produces(MediaType.APPLICATION_JSON)
         .handler(new PortedEndpoints(endpoints, server)::handleHeartbeatRequest);
+    router.route(HttpMethod.GET, "/clusterStatus")
+        .produces(Versions.KSQL_V1_JSON)
+        .produces(MediaType.APPLICATION_JSON)
+        .handler(new PortedEndpoints(endpoints, server)::handleClusterStatusRequest);
   }
 
   static void setupFailureHandler(final Router router) {
@@ -141,6 +149,13 @@ class PortedEndpoints {
     );
   }
 
+  void handleClusterStatusRequest(final RoutingContext routingContext) {
+    handlePortedOldApiRequest(server, routingContext, null,
+        (request, apiSecurityContext) ->
+            endpoints.executeClusterStatus(DefaultApiSecurityContext.create(routingContext))
+    );
+  }
+
 
   void handleHeartbeatRequest(final RoutingContext routingContext) {
     handlePortedOldApiRequest(server, routingContext, HeartbeatMessage.class,
@@ -169,29 +184,40 @@ class PortedEndpoints {
     final CompletableFuture<EndpointResponse> completableFuture = requestor
         .apply(requestObject, DefaultApiSecurityContext.create(routingContext));
     completableFuture.thenAccept(endpointResponse -> {
+      handleOldApiResponse(server, routingContext, response, endpointResponse);
+    }).exceptionally(t -> {
+      if (t instanceof CompletionException) {
+        t = t.getCause();
+      }
+      final Response errResponse = new KsqlExceptionMapper().toResponse(t);
+      handleOldApiResponse(server, routingContext, response, EndpointResponse.create(errResponse));
+      return null;
+    });
+  }
 
-      response.putHeader(CONTENT_TYPE_HEADER, JSON_CONTENT_TYPE);
+  private static void handleOldApiResponse(final Server server, final RoutingContext routingContext,
+      final HttpServerResponse response,
+      final EndpointResponse endpointResponse) {
+    response.putHeader(CONTENT_TYPE_HEADER, JSON_CONTENT_TYPE);
 
-      response.setStatusCode(endpointResponse.getStatusCode())
-          .setStatusMessage(endpointResponse.getStatusMessage());
+    response.setStatusCode(endpointResponse.getStatusCode())
+        .setStatusMessage(endpointResponse.getStatusMessage());
 
-      if (endpointResponse.getResponseBody() == null) {
-        response.end();
+    // What the old API returns in it's response is something of a mishmash - sometimes it's
+    // a plain String, other times it's an object that needs to be JSON encoded, other times
+    // it represents a stream.
+    if (endpointResponse instanceof StreamedEndpointResponse) {
+      if (routingContext.request().version() == HttpVersion.HTTP_2) {
+        // The old /query endpoint uses chunked encoding which is not supported in HTTP2
+        routingContext.response().setStatusCode(HttpStatus.SC_METHOD_NOT_ALLOWED)
+            .setStatusMessage("The /query endpoint is not available using HTTP2").end();
         return;
       }
-
-      // What the old API returns in it's response is something of a mishmash - sometimes it's
-      // a plain String, other times it's an object that needs to be JSON encoded, other times
-      // it represents a stream.
-      if (endpointResponse instanceof StreamedEndpointResponse) {
-        if (routingContext.request().version() == HttpVersion.HTTP_2) {
-          // The old /query endpoint uses chunked encoding which is not supported in HTTP2
-          routingContext.response().setStatusCode(HttpStatus.SC_METHOD_NOT_ALLOWED)
-              .setStatusMessage("The /query endpoint is not available using HTTP2").end();
-          return;
-        }
-        response.putHeader(TRANSFER_ENCODING, CHUNKED_ENCODING);
-        streamEndpointResponse(server, response, (StreamedEndpointResponse) endpointResponse);
+      response.putHeader(TRANSFER_ENCODING, CHUNKED_ENCODING);
+      streamEndpointResponse(server, response, (StreamedEndpointResponse) endpointResponse);
+    } else {
+      if (endpointResponse.getResponseBody() == null) {
+        response.end();
       } else {
         final Buffer responseBody;
         if (endpointResponse.getResponseBody() instanceof String) {
@@ -209,10 +235,7 @@ class PortedEndpoints {
         }
         response.end(responseBody);
       }
-    }).exceptionally(t -> {
-      routingContext.fail(HttpStatus.SC_INTERNAL_SERVER_ERROR, t);
-      return null;
-    });
+    }
   }
 
   private static void streamEndpointResponse(final Server server, final HttpServerResponse response,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/Server.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/Server.java
@@ -68,7 +68,7 @@ public class Server {
   private final Optional<AuthenticationPlugin> authenticationPlugin;
   private final ServerState serverState;
   private WorkerExecutor workerExecutor;
-  private int jettyPort = -1;
+  private volatile int jettyPort = -1;
   private List<URI> listeners = new ArrayList<>();
 
   public Server(final Vertx vertx, final ApiServerConfig config, final Endpoints endpoints,
@@ -172,7 +172,7 @@ public class Server {
     return workerExecutor;
   }
 
-  synchronized SocketAddress getProxyTarget() {
+  SocketAddress getProxyTarget() {
     if (jettyPort == -1) {
       throw new IllegalStateException("jetty port not set");
     }
@@ -236,7 +236,7 @@ public class Server {
     return ImmutableList.copyOf(listeners);
   }
 
-  public synchronized void setJettyPort(final int jettyPort) {
+  public void setJettyPort(final int jettyPort) {
     this.jettyPort = jettyPort;
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -56,7 +56,7 @@ public class ServerVerticle extends AbstractVerticle {
 
   public static final Set<String> NON_PROXIED_ENDPOINTS = ImmutableSet
       .of("/query-stream", "/inserts-stream", "/close-query",
-          "/ksql", "/ksql/terminate", "/query", "/info");
+          "/ksql", "/ksql/terminate", "/query", "/info", "/heartbeat");
 
   // Quick switch so we can easily revert to not serving ported endpoints directly
   private static final boolean SERVE_PORTED_ENDPOINTS = true;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -56,10 +56,7 @@ public class ServerVerticle extends AbstractVerticle {
 
   public static final Set<String> NON_PROXIED_ENDPOINTS = ImmutableSet
       .of("/query-stream", "/inserts-stream", "/close-query",
-          "/ksql", "/ksql/terminate", "/query", "/info", "/heartbeat");
-
-  // Quick switch so we can easily revert to not serving ported endpoints directly
-  private static final boolean SERVE_PORTED_ENDPOINTS = true;
+          "/ksql", "/ksql/terminate", "/query", "/info", "/heartbeat", "/clusterStatus");
 
   private final Endpoints endpoints;
   private final HttpServerOptions httpServerOptions;
@@ -115,9 +112,7 @@ public class ServerVerticle extends AbstractVerticle {
   private Router setupRouter() {
     final Router router = Router.router(vertx);
 
-    if (SERVE_PORTED_ENDPOINTS) {
-      PortedEndpoints.setupFailureHandler(router);
-    }
+    PortedEndpoints.setupFailureHandler(router);
 
     KsqlCorsHandler.setupCorsHandler(server, router);
 
@@ -140,9 +135,7 @@ public class ServerVerticle extends AbstractVerticle {
         .handler(BodyHandler.create())
         .handler(new CloseQueryHandler(server));
 
-    if (SERVE_PORTED_ENDPOINTS) {
-      PortedEndpoints.setupEndpoints(endpoints, server, router);
-    }
+    PortedEndpoints.setupEndpoints(endpoints, server, router);
 
     if (proxyHandler != null) {
       proxyHandler.setupRoutes(router);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/spi/Endpoints.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/spi/Endpoints.java
@@ -19,6 +19,7 @@ import io.confluent.ksql.api.auth.ApiSecurityContext;
 import io.confluent.ksql.api.server.InsertResult;
 import io.confluent.ksql.api.server.InsertsStreamSubscriber;
 import io.confluent.ksql.rest.entity.ClusterTerminateRequest;
+import io.confluent.ksql.rest.entity.HeartbeatMessage;
 import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.vertx.core.Context;
 import io.vertx.core.WorkerExecutor;
@@ -73,5 +74,8 @@ public interface Endpoints {
       ApiSecurityContext apiSecurityContext);
 
   CompletableFuture<EndpointResponse> executeInfo(ApiSecurityContext apiSecurityContext);
+
+  CompletableFuture<EndpointResponse> executeHeartbeat(HeartbeatMessage heartbeatMessage,
+      ApiSecurityContext apiSecurityContext);
 
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/spi/Endpoints.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/spi/Endpoints.java
@@ -78,4 +78,6 @@ public interface Endpoints {
   CompletableFuture<EndpointResponse> executeHeartbeat(HeartbeatMessage heartbeatMessage,
       ApiSecurityContext apiSecurityContext);
 
+  CompletableFuture<EndpointResponse> executeClusterStatus(ApiSecurityContext apiSecurityContext);
+
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -423,7 +423,8 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
         ksqlResource,
         streamedQueryResource,
         serverInfoResource,
-        heartbeatResource
+        heartbeatResource,
+        clusterStatusResource
     );
     apiServerConfig = new ApiServerConfig(ksqlConfigWithPort.originals());
     apiServer = new Server(vertx, apiServerConfig, endpoints, true, securityExtension,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -187,6 +187,8 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
   private final PullQueryExecutor pullQueryExecutor;
   private final AtomicBoolean shuttingDown = new AtomicBoolean(false);
   private final ServerInfoResource serverInfoResource;
+  private final Optional<HeartbeatResource> heartbeatResource;
+  private final Optional<ClusterStatusResource> clusterStatusResource;
 
   // We embed this in here for now
   private Vertx vertx = null;
@@ -336,7 +338,16 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
     this.lagReportingAgent = requireNonNull(lagReportingAgent, "lagReportingAgent");
     this.routingFilterFactory = initializeRoutingFilterFactory(
         ksqlConfigNoPort, heartbeatAgent, lagReportingAgent);
+
     this.serverInfoResource = new ServerInfoResource(serviceContext, ksqlConfigNoPort);
+    if (heartbeatAgent.isPresent()) {
+      this.heartbeatResource = Optional.of(new HeartbeatResource(heartbeatAgent.get()));
+      this.clusterStatusResource = Optional.of(new ClusterStatusResource(
+          ksqlEngine, heartbeatAgent.get(), lagReportingAgent));
+    } else {
+      this.heartbeatResource = Optional.empty();
+      this.clusterStatusResource = Optional.empty();
+    }
 
     sanityCheckPluginConfig(ksqlConfig.originals());
   }
@@ -356,10 +367,9 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
         this.ksqlConfigNoPort)
     );
 
-    if (heartbeatAgent.isPresent()) {
-      config.register(new HeartbeatResource(heartbeatAgent.get()));
-      config.register(new ClusterStatusResource(
-          ksqlEngine, heartbeatAgent.get(), lagReportingAgent));
+    if (heartbeatResource.isPresent()) {
+      config.register(heartbeatResource.get());
+      config.register(clusterStatusResource.get());
     }
     if (lagReportingAgent.isPresent()) {
       config.register(new LagReportingResource(lagReportingAgent.get()));
@@ -412,7 +422,8 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
         ksqlSecurityContextProvider,
         ksqlResource,
         streamedQueryResource,
-        serverInfoResource
+        serverInfoResource,
+        heartbeatResource
     );
     apiServerConfig = new ApiServerConfig(ksqlConfigWithPort.originals());
     apiServer = new Server(vertx, apiServerConfig, endpoints, true, securityExtension,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/ClusterStatusResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/ClusterStatusResource.java
@@ -25,7 +25,6 @@ import io.confluent.ksql.rest.entity.HostStatusEntity;
 import io.confluent.ksql.rest.entity.HostStoreLags;
 import io.confluent.ksql.rest.entity.KsqlHostInfoEntity;
 import io.confluent.ksql.rest.entity.TopicPartitionEntity;
-import io.confluent.ksql.rest.entity.Versions;
 import io.confluent.ksql.rest.server.HeartbeatAgent;
 import io.confluent.ksql.rest.server.LagReportingAgent;
 import io.confluent.ksql.util.HostStatus;
@@ -36,10 +35,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.kafka.streams.state.HostInfo;
 import org.apache.kafka.streams.state.StreamsMetadata;
@@ -50,8 +45,6 @@ import org.apache.kafka.streams.state.StreamsMetadata;
  * status such as whether it is alive or dead and the last time its status got updated.
  */
 
-@Path("/clusterStatus")
-@Produces({Versions.KSQL_V1_JSON, MediaType.APPLICATION_JSON})
 public class ClusterStatusResource {
 
   private final KsqlEngine engine;
@@ -69,7 +62,6 @@ public class ClusterStatusResource {
     this.lagReportingAgent = requireNonNull(lagReportingAgent, "lagReportingAgent");
   }
 
-  @GET
   public Response checkClusterStatus() {
     final ClusterStatusResponse response = getResponse();
     return Response.ok(response).build();

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/HeartbeatResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/HeartbeatResource.java
@@ -18,13 +18,8 @@ package io.confluent.ksql.rest.server.resources;
 import io.confluent.ksql.rest.entity.HeartbeatMessage;
 import io.confluent.ksql.rest.entity.HeartbeatResponse;
 import io.confluent.ksql.rest.entity.KsqlHostInfoEntity;
-import io.confluent.ksql.rest.entity.Versions;
 import io.confluent.ksql.rest.server.HeartbeatAgent;
 import io.confluent.ksql.util.KsqlHostInfo;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 /**
@@ -32,8 +27,6 @@ import javax.ws.rs.core.Response;
  * to determine the status of the remote servers, i.e. whether they are alive or dead.
  */
 
-@Path("/heartbeat")
-@Produces({Versions.KSQL_V1_JSON, MediaType.APPLICATION_JSON})
 public class HeartbeatResource {
 
   private final HeartbeatAgent heartbeatAgent;
@@ -42,7 +35,6 @@ public class HeartbeatResource {
     this.heartbeatAgent = heartbeatAgent;
   }
 
-  @POST
   public Response registerHeartbeat(final HeartbeatMessage request) {
     handleHeartbeat(request);
     return Response.ok(new HeartbeatResponse(true)).build();

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -34,7 +34,6 @@ import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.ClusterTerminateRequest;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlRequest;
-import io.confluent.ksql.rest.entity.Versions;
 import io.confluent.ksql.rest.server.ServerUtil;
 import io.confluent.ksql.rest.server.computation.CommandQueue;
 import io.confluent.ksql.rest.server.computation.DistributingExecutor;
@@ -66,12 +65,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.regex.PatternSyntaxException;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.state.HostInfo;
@@ -79,9 +73,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
-@Path("/ksql")
-@Consumes({Versions.KSQL_V1_JSON, MediaType.APPLICATION_JSON})
-@Produces({Versions.KSQL_V1_JSON, MediaType.APPLICATION_JSON})
 public class KsqlResource implements KsqlConfigurable {
   // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
 
@@ -111,7 +102,6 @@ public class KsqlResource implements KsqlConfigurable {
   private final Errors errorHandler;
   private KsqlHostInfo localHost;
   private URL localUrl;
-
 
   public KsqlResource(
       final KsqlEngine ksqlEngine,
@@ -200,8 +190,6 @@ public class KsqlResource implements KsqlConfigurable {
     );
   }
 
-  @POST
-  @Path("/terminate")
   public Response terminateCluster(
       @Context final KsqlSecurityContext securityContext,
       final ClusterTerminateRequest request
@@ -229,7 +217,6 @@ public class KsqlResource implements KsqlConfigurable {
     }
   }
 
-  @POST
   public Response handleKsqlStatements(
       @Context final KsqlSecurityContext securityContext,
       final KsqlRequest request

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/ServerInfoResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/ServerInfoResource.java
@@ -22,7 +22,6 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.Version;
 import java.util.function.Supplier;
-import javax.ws.rs.GET;
 import javax.ws.rs.core.Response;
 
 public class ServerInfoResource {
@@ -39,7 +38,6 @@ public class ServerInfoResource {
     )::get;
   }
 
-  @GET
   public Response get() {
     return Response.ok(serverInfo.get()).build();
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TestEndpoints.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TestEndpoints.java
@@ -132,6 +132,12 @@ public class TestEndpoints implements Endpoints {
     return null;
   }
 
+  @Override
+  public CompletableFuture<EndpointResponse> executeClusterStatus(
+      ApiSecurityContext apiSecurityContext) {
+    return null;
+  }
+
   public synchronized void setRowGeneratorFactory(
       final Supplier<RowGenerator> rowGeneratorFactory) {
     this.rowGeneratorFactory = rowGeneratorFactory;

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TestEndpoints.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TestEndpoints.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.api.spi.QueryPublisher;
 import io.confluent.ksql.api.utils.RowGenerator;
 import io.confluent.ksql.reactive.BufferedPublisher;
 import io.confluent.ksql.rest.entity.ClusterTerminateRequest;
+import io.confluent.ksql.rest.entity.HeartbeatMessage;
 import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.entity.StreamsList;
 import io.vertx.core.Context;
@@ -122,6 +123,12 @@ public class TestEndpoints implements Endpoints {
 
   @Override
   public CompletableFuture<EndpointResponse> executeInfo(ApiSecurityContext apiSecurityContext) {
+    return null;
+  }
+
+  @Override
+  public CompletableFuture<EndpointResponse> executeHeartbeat(HeartbeatMessage heartbeatMessage,
+      ApiSecurityContext apiSecurityContext) {
     return null;
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/InsertsStreamRunner.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/InsertsStreamRunner.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.api.spi.QueryPublisher;
 import io.confluent.ksql.reactive.BaseSubscriber;
 import io.confluent.ksql.reactive.BufferedPublisher;
 import io.confluent.ksql.rest.entity.ClusterTerminateRequest;
+import io.confluent.ksql.rest.entity.HeartbeatMessage;
 import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.Context;
@@ -191,6 +192,12 @@ public class InsertsStreamRunner extends BasePerfRunner {
 
     @Override
     public CompletableFuture<EndpointResponse> executeInfo(ApiSecurityContext apiSecurityContext) {
+      return null;
+    }
+
+    @Override
+    public CompletableFuture<EndpointResponse> executeHeartbeat(HeartbeatMessage heartbeatMessage,
+        ApiSecurityContext apiSecurityContext) {
       return null;
     }
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/InsertsStreamRunner.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/InsertsStreamRunner.java
@@ -200,6 +200,12 @@ public class InsertsStreamRunner extends BasePerfRunner {
         ApiSecurityContext apiSecurityContext) {
       return null;
     }
+
+    @Override
+    public CompletableFuture<EndpointResponse> executeClusterStatus(
+        ApiSecurityContext apiSecurityContext) {
+      return null;
+    }
   }
 
   private class InsertsSubscriber extends BaseSubscriber<JsonObject> implements

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/PullQueryRunner.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/PullQueryRunner.java
@@ -158,6 +158,12 @@ public class PullQueryRunner extends BasePerfRunner {
       return null;
     }
 
+    @Override
+    public CompletableFuture<EndpointResponse> executeClusterStatus(
+        ApiSecurityContext apiSecurityContext) {
+      return null;
+    }
+
     synchronized void closePublishers() {
       for (PullQueryPublisher publisher : publishers) {
         publisher.close();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/PullQueryRunner.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/PullQueryRunner.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.api.spi.Endpoints;
 import io.confluent.ksql.api.spi.QueryPublisher;
 import io.confluent.ksql.reactive.BufferedPublisher;
 import io.confluent.ksql.rest.entity.ClusterTerminateRequest;
+import io.confluent.ksql.rest.entity.HeartbeatMessage;
 import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.util.VertxCompletableFuture;
 import io.vertx.core.Context;
@@ -148,6 +149,12 @@ public class PullQueryRunner extends BasePerfRunner {
 
     @Override
     public CompletableFuture<EndpointResponse> executeInfo(ApiSecurityContext apiSecurityContext) {
+      return null;
+    }
+
+    @Override
+    public CompletableFuture<EndpointResponse> executeHeartbeat(HeartbeatMessage heartbeatMessage,
+        ApiSecurityContext apiSecurityContext) {
       return null;
     }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/QueryStreamRunner.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/QueryStreamRunner.java
@@ -141,6 +141,12 @@ public class QueryStreamRunner extends BasePerfRunner {
       return null;
     }
 
+    @Override
+    public CompletableFuture<EndpointResponse> executeClusterStatus(
+        ApiSecurityContext apiSecurityContext) {
+      return null;
+    }
+
     synchronized void closePublishers() {
       for (QueryStreamPublisher publisher : publishers) {
         publisher.close();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/QueryStreamRunner.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/QueryStreamRunner.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.api.spi.EndpointResponse;
 import io.confluent.ksql.api.spi.Endpoints;
 import io.confluent.ksql.api.spi.QueryPublisher;
 import io.confluent.ksql.rest.entity.ClusterTerminateRequest;
+import io.confluent.ksql.rest.entity.HeartbeatMessage;
 import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.vertx.core.Context;
 import io.vertx.core.WorkerExecutor;
@@ -131,6 +132,12 @@ public class QueryStreamRunner extends BasePerfRunner {
 
     @Override
     public CompletableFuture<EndpointResponse> executeInfo(ApiSecurityContext apiSecurityContext) {
+      return null;
+    }
+
+    @Override
+    public CompletableFuture<EndpointResponse> executeHeartbeat(HeartbeatMessage heartbeatMessage,
+        ApiSecurityContext apiSecurityContext) {
       return null;
     }
 


### PR DESCRIPTION
### Description 

This is a stacked PR so please only review the top commit(s).

This PR migrates the /heartbeat and /clusterStatus endpoints to Vert.x

It also removes the JAX-RS annotations from already ported endpoints.

### Testing done 

Non functional change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

