### PR TITLE
refactor: Migrate /status endpoint to vert.x

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/endpoints/KsqlServerEndpoints.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/endpoints/KsqlServerEndpoints.java
@@ -30,6 +30,7 @@ import io.confluent.ksql.rest.server.resources.ClusterStatusResource;
 import io.confluent.ksql.rest.server.resources.HeartbeatResource;
 import io.confluent.ksql.rest.server.resources.KsqlResource;
 import io.confluent.ksql.rest.server.resources.ServerInfoResource;
+import io.confluent.ksql.rest.server.resources.StatusResource;
 import io.confluent.ksql.rest.server.resources.streaming.StreamedQueryResource;
 import io.confluent.ksql.security.KsqlSecurityContext;
 import io.confluent.ksql.util.KsqlConfig;
@@ -61,6 +62,7 @@ public class KsqlServerEndpoints implements Endpoints {
   private final ServerInfoResource serverInfoResource;
   private final Optional<HeartbeatResource> heartbeatResource;
   private final Optional<ClusterStatusResource> clusterStatusResource;
+  private final StatusResource statusResource;
 
   public KsqlServerEndpoints(
       final KsqlEngine ksqlEngine,
@@ -71,7 +73,8 @@ public class KsqlServerEndpoints implements Endpoints {
       final StreamedQueryResource streamedQueryResource,
       final ServerInfoResource serverInfoResource,
       final Optional<HeartbeatResource> heartbeatResource,
-      final Optional<ClusterStatusResource> clusterStatusResource) {
+      final Optional<ClusterStatusResource> clusterStatusResource,
+      final StatusResource statusResource) {
     this.ksqlEngine = Objects.requireNonNull(ksqlEngine);
     this.ksqlConfig = Objects.requireNonNull(ksqlConfig);
     this.pullQueryExecutor = Objects.requireNonNull(pullQueryExecutor);
@@ -83,6 +86,7 @@ public class KsqlServerEndpoints implements Endpoints {
     this.serverInfoResource = Objects.requireNonNull(serverInfoResource);
     this.heartbeatResource = Objects.requireNonNull(heartbeatResource);
     this.clusterStatusResource = Objects.requireNonNull(clusterStatusResource);
+    this.statusResource = Objects.requireNonNull(statusResource);
   }
 
   @Override
@@ -172,6 +176,20 @@ public class KsqlServerEndpoints implements Endpoints {
             EndpointResponse.create(resource.checkClusterStatus())))
         .orElseGet(() -> CompletableFuture
             .completedFuture(EndpointResponse.create(HttpStatus.SC_NOT_FOUND, "Not found", null)));
+  }
+
+  @Override
+  public CompletableFuture<EndpointResponse> executeStatus(final String type, final String entity,
+      final String action, final ApiSecurityContext apiSecurityContext) {
+    return CompletableFuture
+        .completedFuture(EndpointResponse.create(statusResource.getStatus(type, entity, action)));
+  }
+
+  @Override
+  public CompletableFuture<EndpointResponse> executeAllStatuses(
+      final ApiSecurityContext apiSecurityContext) {
+    return CompletableFuture
+        .completedFuture(EndpointResponse.create(statusResource.getAllStatuses()));
   }
 
   private <R> CompletableFuture<R> executeOnWorker(final Supplier<R> supplier,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -56,7 +56,8 @@ public class ServerVerticle extends AbstractVerticle {
 
   public static final Set<String> NON_PROXIED_ENDPOINTS = ImmutableSet
       .of("/query-stream", "/inserts-stream", "/close-query",
-          "/ksql", "/ksql/terminate", "/query", "/info", "/heartbeat", "/clusterStatus");
+          "/ksql", "/ksql/terminate", "/query", "/info", "/heartbeat", "/clusterStatus",
+          "/status/:type/:entity/:action", "/status");
 
   private final Endpoints endpoints;
   private final HttpServerOptions httpServerOptions;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/spi/Endpoints.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/spi/Endpoints.java
@@ -80,4 +80,9 @@ public interface Endpoints {
 
   CompletableFuture<EndpointResponse> executeClusterStatus(ApiSecurityContext apiSecurityContext);
 
+  CompletableFuture<EndpointResponse> executeStatus(String type, String entity, String action,
+      ApiSecurityContext apiSecurityContext);
+
+  CompletableFuture<EndpointResponse> executeAllStatuses(ApiSecurityContext apiSecurityContext);
+
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -424,7 +424,8 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
         streamedQueryResource,
         serverInfoResource,
         heartbeatResource,
-        clusterStatusResource
+        clusterStatusResource,
+        statusResource
     );
     apiServerConfig = new ApiServerConfig(ksqlConfigWithPort.originals());
     apiServer = new Server(vertx, apiServerConfig, endpoints, true, securityExtension,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/StatusResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/StatusResource.java
@@ -19,18 +19,10 @@ import io.confluent.ksql.rest.Errors;
 import io.confluent.ksql.rest.entity.CommandId;
 import io.confluent.ksql.rest.entity.CommandStatus;
 import io.confluent.ksql.rest.entity.CommandStatuses;
-import io.confluent.ksql.rest.entity.Versions;
 import io.confluent.ksql.rest.server.computation.InteractiveStatementExecutor;
 import java.util.Optional;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-@Path("/status")
-@Produces({Versions.KSQL_V1_JSON, MediaType.APPLICATION_JSON})
 public class StatusResource {
 
   private final InteractiveStatementExecutor statementExecutor;
@@ -39,17 +31,11 @@ public class StatusResource {
     this.statementExecutor = statementExecutor;
   }
 
-  @GET
   public Response getAllStatuses() {
     return Response.ok(CommandStatuses.fromFullStatuses(statementExecutor.getStatuses())).build();
   }
 
-  @GET
-  @Path("/{type}/{entity}/{action}")
-  public Response getStatus(
-      @PathParam("type") final String type,
-      @PathParam("entity") final String entity,
-      @PathParam("action") final String action) {
+  public Response getStatus(final String type, final String entity, final String action) {
     final CommandId commandId = new CommandId(type, entity, action);
 
     final Optional<CommandStatus> commandStatus = statementExecutor.getStatus(commandId);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TestEndpoints.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TestEndpoints.java
@@ -138,6 +138,18 @@ public class TestEndpoints implements Endpoints {
     return null;
   }
 
+  @Override
+  public CompletableFuture<EndpointResponse> executeStatus(String type, String entity,
+      String action, ApiSecurityContext apiSecurityContext) {
+    return null;
+  }
+
+  @Override
+  public CompletableFuture<EndpointResponse> executeAllStatuses(
+      ApiSecurityContext apiSecurityContext) {
+    return null;
+  }
+
   public synchronized void setRowGeneratorFactory(
       final Supplier<RowGenerator> rowGeneratorFactory) {
     this.rowGeneratorFactory = rowGeneratorFactory;

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/InsertsStreamRunner.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/InsertsStreamRunner.java
@@ -206,6 +206,18 @@ public class InsertsStreamRunner extends BasePerfRunner {
         ApiSecurityContext apiSecurityContext) {
       return null;
     }
+
+    @Override
+    public CompletableFuture<EndpointResponse> executeStatus(String type, String entity,
+        String action, ApiSecurityContext apiSecurityContext) {
+      return null;
+    }
+
+    @Override
+    public CompletableFuture<EndpointResponse> executeAllStatuses(
+        ApiSecurityContext apiSecurityContext) {
+      return null;
+    }
   }
 
   private class InsertsSubscriber extends BaseSubscriber<JsonObject> implements

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/PullQueryRunner.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/PullQueryRunner.java
@@ -164,6 +164,18 @@ public class PullQueryRunner extends BasePerfRunner {
       return null;
     }
 
+    @Override
+    public CompletableFuture<EndpointResponse> executeStatus(String type, String entity,
+        String action, ApiSecurityContext apiSecurityContext) {
+      return null;
+    }
+
+    @Override
+    public CompletableFuture<EndpointResponse> executeAllStatuses(
+        ApiSecurityContext apiSecurityContext) {
+      return null;
+    }
+
     synchronized void closePublishers() {
       for (PullQueryPublisher publisher : publishers) {
         publisher.close();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/QueryStreamRunner.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/QueryStreamRunner.java
@@ -147,6 +147,18 @@ public class QueryStreamRunner extends BasePerfRunner {
       return null;
     }
 
+    @Override
+    public CompletableFuture<EndpointResponse> executeStatus(String type, String entity,
+        String action, ApiSecurityContext apiSecurityContext) {
+      return null;
+    }
+
+    @Override
+    public CompletableFuture<EndpointResponse> executeAllStatuses(
+        ApiSecurityContext apiSecurityContext) {
+      return null;
+    }
+
     synchronized void closePublishers() {
       for (QueryStreamPublisher publisher : publishers) {
         publisher.close();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -46,6 +46,12 @@ import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.api.server.ServerVerticle;
 import io.confluent.ksql.integration.IntegrationTestHarness;
 import io.confluent.ksql.rest.ApiJsonMapper;
+import io.confluent.ksql.rest.entity.CommandId;
+import io.confluent.ksql.rest.entity.CommandId.Action;
+import io.confluent.ksql.rest.entity.CommandId.Type;
+import io.confluent.ksql.rest.entity.CommandStatus;
+import io.confluent.ksql.rest.entity.CommandStatus.Status;
+import io.confluent.ksql.rest.entity.CommandStatuses;
 import io.confluent.ksql.rest.entity.ServerInfo;
 import io.confluent.ksql.rest.entity.Versions;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
@@ -236,6 +242,28 @@ public class RestApiTest {
 
     // Then:
     assertThat(response.getVersion(), is(notNullValue()));
+  }
+
+  @Test
+  public void shouldExecuteStatusRequest() {
+
+    // When:
+    String commandId = "stream/`" + PAGE_VIEW_STREAM + "`/create";
+    final CommandStatus response = RestIntegrationTestUtil.makeStatusRequest(REST_APP, commandId);
+
+    // Then:
+    assertThat(response.getStatus(), is(Status.SUCCESS));
+  }
+
+  @Test
+  public void shouldExecuteStatusesRequest() {
+
+    // When:
+    final CommandStatuses response = RestIntegrationTestUtil.makeStatusesRequest(REST_APP);
+
+    // Then:
+    CommandId expected = new CommandId(Type.STREAM, "`" + PAGE_VIEW_STREAM + "`", Action.CREATE);
+    assertThat(response.containsKey(expected), is(true));
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.rest.client.RestResponse;
 import io.confluent.ksql.rest.entity.CommandStatus;
 import io.confluent.ksql.rest.entity.CommandStatus.Status;
 import io.confluent.ksql.rest.entity.CommandStatusEntity;
+import io.confluent.ksql.rest.entity.CommandStatuses;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlErrorMessage;
@@ -93,6 +94,28 @@ public final class RestIntegrationTestUtil {
     try (final KsqlRestClient restClient = restApp.buildKsqlClient(Optional.empty())) {
 
       final RestResponse<ServerInfo> res = restClient.getServerInfo();
+
+      throwOnError(res);
+
+      return res.getResponse();
+    }
+  }
+
+  static CommandStatus makeStatusRequest(final TestKsqlRestApp restApp, final String commandId) {
+    try (final KsqlRestClient restClient = restApp.buildKsqlClient(Optional.empty())) {
+
+      final RestResponse<CommandStatus> res = restClient.getStatus(commandId);
+
+      throwOnError(res);
+
+      return res.getResponse();
+    }
+  }
+
+  static CommandStatuses makeStatusesRequest(final TestKsqlRestApp restApp) {
+    try (final KsqlRestClient restClient = restApp.buildKsqlClient(Optional.empty())) {
+
+      final RestResponse<CommandStatuses> res = restClient.getAllStatuses();
 
       throwOnError(res);
 

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -116,6 +116,14 @@ public final class KsqlRestClient implements Closeable {
     return target().getServerInfo();
   }
 
+  public RestResponse<CommandStatus> getStatus(final String commandId) {
+    return target().getStatus(commandId);
+  }
+
+  public RestResponse<CommandStatuses> getAllStatuses() {
+    return target().getStatuses();
+  }
+
   public RestResponse<HealthCheckResponse> getServerHealth() {
     return target().getServerHealth();
   }


### PR DESCRIPTION
### Description 

This is a stacked PR, please only review the top commit(s).

This PR migrates the /status endpoint from Jetty to Vert.x

### Testing done 

Non functional change

I added a couple of integration test cases because there were no tests for this API!

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

