### PR TITLE
chore: allow -Werror to be overridden in compile phase

### DIFF
--- a/ksqldb-benchmark/pom.xml
+++ b/ksqldb-benchmark/pom.xml
@@ -104,7 +104,7 @@ questions.
         <configuration>
           <compilerArgs>
             <arg>-Xlint:all,-serial,-processing</arg>
-            <arg>-Werror</arg>
+            <arg>${compile.warnings-flag}</arg>
           </compilerArgs>
           <showWarnings>true</showWarnings>
           <showDeprecation>true</showDeprecation>

--- a/ksqldb-engine/pom.xml
+++ b/ksqldb-engine/pom.xml
@@ -185,7 +185,7 @@
                             <compilerArgs>
                                 <arg>-Xlint:all,-serial,-options,-path,-rawtypes</arg>
                                 <arg>-parameters</arg>
-                                <arg>-Werror</arg>
+                                <arg>${compile.warnings-flag}</arg>
                             </compilerArgs>
                         </configuration>
                     </execution>

--- a/ksqldb-execution/pom.xml
+++ b/ksqldb-execution/pom.xml
@@ -102,7 +102,7 @@
                         <configuration>
                             <compilerArgs>
                                 <arg>-Xlint:all,-serial,-rawtypes</arg>
-                                <arg>-Werror</arg>
+                                <arg>${compile.warnings-flag}</arg>
                             </compilerArgs>
                         </configuration>
                     </execution>

--- a/ksqldb-parser/pom.xml
+++ b/ksqldb-parser/pom.xml
@@ -96,7 +96,7 @@
                             <compilerArgs>
                                 <arg>-Xlint:all,-serial,-options,-path,-rawtypes</arg>
                                 <arg>-parameters</arg>
-                                <arg>-Werror</arg>
+                                <arg>${compile.warnings-flag}</arg>
                             </compilerArgs>
                         </configuration>
                     </execution>

--- a/ksqldb-streams/pom.xml
+++ b/ksqldb-streams/pom.xml
@@ -86,7 +86,7 @@
                         <configuration>
                             <compilerArgs>
                                 <arg>-Xlint:all,-serial,-rawtypes</arg>
-                                <arg>-Werror</arg>
+                                <arg>${compile.warnings-flag}</arg>
                             </compilerArgs>
                         </configuration>
                     </execution>

--- a/ksqldb-version-metrics-client/pom.xml
+++ b/ksqldb-version-metrics-client/pom.xml
@@ -108,7 +108,7 @@
                         <configuration>
                             <compilerArgs>
                                 <arg>-Xlint:all,-options,-path,-unchecked,-serial,-rawtypes</arg>
-                                <arg>-Werror</arg>
+                                <arg>${compile.warnings-flag}</arg>
                             </compilerArgs>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,7 @@
         <kafka.version>5.5.0-ccs-SNAPSHOT</kafka.version>
         <ce.kafka.version>5.5.0-ce-SNAPSHOT</ce.kafka.version>
         <confluent.version>5.5.0-SNAPSHOT</confluent.version>
+        <compile.warnings-flag>-Werror</compile.warnings-flag>
     </properties>
 
     <dependencyManagement>
@@ -527,7 +528,7 @@
                             <compilerArgs>
                                 <arg>-Xlint:all,-serial,-options,-path</arg>
                                 <arg>-parameters</arg>
-                                <arg>-Werror</arg>
+                                <arg>${compile.warnings-flag}</arg>
                             </compilerArgs>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Use `mvn compile -Dcompile.warnings-flag=""` to disable warnings as errors.