### PR TITLE
feat: transient queries added to show queries output

### DIFF
--- a/docs/developer-guide/ksqldb-reference/show-queries.md
+++ b/docs/developer-guide/ksqldb-reference/show-queries.md
@@ -30,6 +30,12 @@ Query Status
 * `ERROR`: the query has entered an error state.
 * `UNRESPONSIVE`: the host running the query returned an error when requesting the query status.
 
+Query Type
+-----------
+
+* `Push`: these queries run on every single node in the cluster.
+* `Transient`: these queries run on a single node.
+
 Example
 -------
 

--- a/docs/developer-guide/ksqldb-reference/show-queries.md
+++ b/docs/developer-guide/ksqldb-reference/show-queries.md
@@ -42,9 +42,9 @@ Example
 ```sql
 ksql> show queries;
 
- Query ID    | Status    | Sink Name | Sink Kafka Topic | Query String                                                                                                                                
+ Query ID    | Query Type | Status    | Sink Name | Sink Kafka Topic | Query String                                                                                                                                
 ------------------------------------------------------------------------------------------------------------
- CSAS_TEST_0 | RUNNING:2 | TEST      | TEST             | CREATE STREAM TEST WITH (KAFKA_TOPIC='TEST', PARTITIONS=1, REPLICAS=1) AS SELECT *FROM KSQL_PROCESSING_LOG KSQL_PROCESSING_LOG EMIT CHANGES; 
+ CSAS_TEST_0 | PUSH       | RUNNING:2 | TEST      | TEST             | CREATE STREAM TEST WITH (KAFKA_TOPIC='TEST', PARTITIONS=1, REPLICAS=1) AS SELECT *FROM KSQL_PROCESSING_LOG KSQL_PROCESSING_LOG EMIT CHANGES; 
 ------------------------------------------------------------------------------------------------------------
 For detailed information on a Query run: EXPLAIN <Query ID>;
 ```
@@ -54,6 +54,7 @@ For detailed information on a Query run: EXPLAIN <Query ID>;
 ksql> show queries extended;
 
 ID                   : CSAS_TEST_0
+Query Type           : PUSH
 SQL                  : CREATE STREAM TEST WITH (KAFKA_TOPIC='TEST', PARTITIONS=1, REPLICAS=1) AS SELECT *
 FROM KSQL_PROCESSING_LOG KSQL_PROCESSING_LOG
 EMIT CHANGES;

--- a/docs/developer-guide/ksqldb-reference/show-queries.md
+++ b/docs/developer-guide/ksqldb-reference/show-queries.md
@@ -33,8 +33,8 @@ Query Status
 Query Type
 -----------
 
-* `Push`: these queries run on every single node in the cluster.
-* `Transient`: these queries run on a single node.
+* `PERSISTENT`: these queries run on every node and materialize new state.
+* `PUSH`: these queries are owned by the client and are terminated when the session ends.
 
 Example
 -------
@@ -44,7 +44,7 @@ ksql> show queries;
 
  Query ID    | Query Type | Status    | Sink Name | Sink Kafka Topic | Query String                                                                                                                                
 ------------------------------------------------------------------------------------------------------------
- CSAS_TEST_0 | PUSH       | RUNNING:2 | TEST      | TEST             | CREATE STREAM TEST WITH (KAFKA_TOPIC='TEST', PARTITIONS=1, REPLICAS=1) AS SELECT *FROM KSQL_PROCESSING_LOG KSQL_PROCESSING_LOG EMIT CHANGES; 
+ CSAS_TEST_0 | PERSISTENT       | RUNNING:2 | TEST      | TEST             | CREATE STREAM TEST WITH (KAFKA_TOPIC='TEST', PARTITIONS=1, REPLICAS=1) AS SELECT *FROM KSQL_PROCESSING_LOG KSQL_PROCESSING_LOG EMIT CHANGES; 
 ------------------------------------------------------------------------------------------------------------
 For detailed information on a Query run: EXPLAIN <Query ID>;
 ```
@@ -54,7 +54,7 @@ For detailed information on a Query run: EXPLAIN <Query ID>;
 ksql> show queries extended;
 
 ID                   : CSAS_TEST_0
-Query Type           : PUSH
+Query Type           : PERSISTENT
 SQL                  : CREATE STREAM TEST WITH (KAFKA_TOPIC='TEST', PARTITIONS=1, REPLICAS=1) AS SELECT *
 FROM KSQL_PROCESSING_LOG KSQL_PROCESSING_LOG
 EMIT CHANGES;

--- a/docs/developer-guide/ksqldb-reference/show-queries.md
+++ b/docs/developer-guide/ksqldb-reference/show-queries.md
@@ -42,7 +42,7 @@ Example
 ```sql
 ksql> show queries;
 
- Query ID    | Query Type | Status    | Sink Name | Sink Kafka Topic | Query String                                                                                                                                
+ Query ID    | Query Type       | Status    | Sink Name | Sink Kafka Topic | Query String                                                                                                                                
 ------------------------------------------------------------------------------------------------------------
  CSAS_TEST_0 | PERSISTENT       | RUNNING:2 | TEST      | TEST             | CREATE STREAM TEST WITH (KAFKA_TOPIC='TEST', PARTITIONS=1, REPLICAS=1) AS SELECT *FROM KSQL_PROCESSING_LOG KSQL_PROCESSING_LOG EMIT CHANGES; 
 ------------------------------------------------------------------------------------------------------------

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -661,6 +661,7 @@ public class Console implements Closeable {
 
   private void printQueryDescription(final QueryDescription query) {
     writer().println(String.format("%-20s : %s", "ID", query.getId()));
+    writer().println(String.format("%-20s : %s", "Query Type", query.getQueryType()));
     if (query.getStatementText().length() > 0) {
       writer().println(String.format("%-20s : %s", "SQL", query.getStatementText()));
     }

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/QueriesTableBuilder.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/QueriesTableBuilder.java
@@ -25,13 +25,20 @@ import java.util.stream.Stream;
 public class QueriesTableBuilder implements TableBuilder<Queries> {
 
   private static final List<String> HEADERS =
-      ImmutableList.of("Query ID", "Status", "Sink Name", "Sink Kafka Topic", "Query String");
+      ImmutableList.of(
+          "Query ID",
+          "Query Type",
+          "Status",
+          "Sink Name",
+          "Sink Kafka Topic",
+          "Query String");
 
   @Override
   public Table buildTable(final Queries entity) {
     final Stream<List<String>> rows = entity.getQueries().stream()
         .map(r -> ImmutableList.of(
             r.getId().toString(),
+            r.getQueryType().toString(),
             r.getStatusCount().toString(),
             String.join(",", r.getSinks()),
             String.join(",", r.getSinkKafkaTopics()),

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -312,7 +312,7 @@ public class ConsoleTest {
     final List<RunningQuery> queries = new ArrayList<>();
     queries.add(
         new RunningQuery(
-            "select * from t1 emit changes", Collections.singleton("Test"), Collections.singleton("Test topic"), new QueryId("0"), queryStatusCount, KsqlConstants.KsqlQueryType.TRANSIENT));
+            "select * from t1 emit changes", Collections.singleton("Test"), Collections.singleton("Test topic"), new QueryId("0"), queryStatusCount, KsqlConstants.KsqlQueryType.PUSH));
 
     final KsqlEntityList entityList = new KsqlEntityList(ImmutableList.of(
         new Queries("e", queries)
@@ -336,7 +336,7 @@ public class ConsoleTest {
           + "      \"RUNNING\" : 1," + NEWLINE
           + "      \"ERROR\" : 2" + NEWLINE
           + "    }," + NEWLINE
-          + "    \"queryType\" : \"TRANSIENT\"," + NEWLINE
+          + "    \"queryType\" : \"PUSH\"," + NEWLINE
           + "    \"state\" : \"" + AGGREGATE_STATUS +"\"" + NEWLINE
           + "  } ]," + NEWLINE
           + "  \"warnings\" : [ ]" + NEWLINE
@@ -345,7 +345,7 @@ public class ConsoleTest {
       assertThat(output, is("" + NEWLINE
           + " Query ID | Query Type | Status            | Sink Name | Sink Kafka Topic | Query String                  " + NEWLINE
           + "----------------------------------------------------------------------------------------------------" + NEWLINE
-          + " 0        | TRANSIENT  | " + STATUS_COUNT_STRING + " | Test      | Test topic       | select * from t1 emit changes " + NEWLINE
+          + " 0        | PUSH       | " + STATUS_COUNT_STRING + " | Test      | Test topic       | select * from t1 emit changes " + NEWLINE
           + "----------------------------------------------------------------------------------------------------" + NEWLINE
           + "For detailed information on a Query run: EXPLAIN <Query ID>;" + NEWLINE));
     }
@@ -368,10 +368,10 @@ public class ConsoleTest {
     );
 
     final List<RunningQuery> readQueries = ImmutableList.of(
-        new RunningQuery("read query", ImmutableSet.of("sink1"), ImmutableSet.of("sink1 topic"), new QueryId("readId"), queryStatusCount, KsqlConstants.KsqlQueryType.PUSH)
+        new RunningQuery("read query", ImmutableSet.of("sink1"), ImmutableSet.of("sink1 topic"), new QueryId("readId"), queryStatusCount, KsqlConstants.KsqlQueryType.PERSISTENT)
     );
     final List<RunningQuery> writeQueries = ImmutableList.of(
-        new RunningQuery("write query", ImmutableSet.of("sink2"), ImmutableSet.of("sink2 topic"), new QueryId("writeId"), queryStatusCount, KsqlConstants.KsqlQueryType.PUSH)
+        new RunningQuery("write query", ImmutableSet.of("sink2"), ImmutableSet.of("sink2 topic"), new QueryId("writeId"), queryStatusCount, KsqlConstants.KsqlQueryType.PERSISTENT)
     );
 
     final KsqlEntityList entityList = new KsqlEntityList(ImmutableList.of(
@@ -421,7 +421,7 @@ public class ConsoleTest {
           + "        \"RUNNING\" : 1," + NEWLINE
           + "        \"ERROR\" : 2" + NEWLINE
           + "      }," + NEWLINE
-          + "      \"queryType\" : \"PUSH\"," + NEWLINE
+          + "      \"queryType\" : \"PERSISTENT\"," + NEWLINE
           + "      \"state\" : \"" + AGGREGATE_STATUS +"\"" + NEWLINE
           + "    } ]," + NEWLINE
           + "    \"writeQueries\" : [ {" + NEWLINE
@@ -433,7 +433,7 @@ public class ConsoleTest {
           + "        \"RUNNING\" : 1," + NEWLINE
           + "        \"ERROR\" : 2" + NEWLINE
           + "      }," + NEWLINE
-          + "      \"queryType\" : \"PUSH\"," + NEWLINE
+          + "      \"queryType\" : \"PERSISTENT\"," + NEWLINE
           + "      \"state\" : \"" + AGGREGATE_STATUS +"\"" + NEWLINE
           + "    } ]," + NEWLINE
           + "    \"fields\" : [ {" + NEWLINE
@@ -1038,10 +1038,10 @@ public class ConsoleTest {
   public void shouldPrintTopicDescribeExtended() {
     // Given:
     final List<RunningQuery> readQueries = ImmutableList.of(
-        new RunningQuery("read query", ImmutableSet.of("sink1"), ImmutableSet.of("sink1 topic"), new QueryId("readId"), queryStatusCount, KsqlConstants.KsqlQueryType.PUSH)
+        new RunningQuery("read query", ImmutableSet.of("sink1"), ImmutableSet.of("sink1 topic"), new QueryId("readId"), queryStatusCount, KsqlConstants.KsqlQueryType.PERSISTENT)
     );
     final List<RunningQuery> writeQueries = ImmutableList.of(
-        new RunningQuery("write query", ImmutableSet.of("sink2"), ImmutableSet.of("sink2 topic"), new QueryId("writeId"), queryStatusCount, KsqlConstants.KsqlQueryType.PUSH)
+        new RunningQuery("write query", ImmutableSet.of("sink2"), ImmutableSet.of("sink2 topic"), new QueryId("writeId"), queryStatusCount, KsqlConstants.KsqlQueryType.PERSISTENT)
     );
 
     final KsqlEntityList entityList = new KsqlEntityList(ImmutableList.of(
@@ -1090,7 +1090,7 @@ public class ConsoleTest {
           + "        \"RUNNING\" : 1," + NEWLINE
           + "        \"ERROR\" : 2" + NEWLINE
           + "      }," + NEWLINE
-          + "      \"queryType\" : \"PUSH\"," + NEWLINE
+          + "      \"queryType\" : \"PERSISTENT\"," + NEWLINE
           + "      \"state\" : \"" + AGGREGATE_STATUS +"\"" + NEWLINE
           + "    } ]," + NEWLINE
           + "    \"writeQueries\" : [ {" + NEWLINE
@@ -1102,7 +1102,7 @@ public class ConsoleTest {
           + "        \"RUNNING\" : 1," + NEWLINE
           + "        \"ERROR\" : 2" + NEWLINE
           + "      }," + NEWLINE
-          + "      \"queryType\" : \"PUSH\"," + NEWLINE
+          + "      \"queryType\" : \"PERSISTENT\"," + NEWLINE
           + "      \"state\" : \"" + AGGREGATE_STATUS +"\"" + NEWLINE
           + "    } ]," + NEWLINE
           + "    \"fields\" : [ {" + NEWLINE

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -76,6 +76,7 @@ import io.confluent.ksql.schema.ksql.LogicalSchema.Builder;
 import io.confluent.ksql.schema.ksql.SqlBaseType;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlConstants.KsqlQueryStatus;
 import io.confluent.ksql.util.SchemaUtil;
 import java.io.IOException;
@@ -311,7 +312,7 @@ public class ConsoleTest {
     final List<RunningQuery> queries = new ArrayList<>();
     queries.add(
         new RunningQuery(
-            "select * from t1", Collections.singleton("Test"), Collections.singleton("Test topic"), new QueryId("0"), queryStatusCount));
+            "select * from t1 emit changes", Collections.singleton("Test"), Collections.singleton("Test topic"), new QueryId("0"), queryStatusCount, KsqlConstants.KsqlQueryType.TRANSIENT));
 
     final KsqlEntityList entityList = new KsqlEntityList(ImmutableList.of(
         new Queries("e", queries)
@@ -327,7 +328,7 @@ public class ConsoleTest {
           + "  \"@type\" : \"queries\"," + NEWLINE
           + "  \"statementText\" : \"e\"," + NEWLINE
           + "  \"queries\" : [ {" + NEWLINE
-          + "    \"queryString\" : \"select * from t1\"," + NEWLINE
+          + "    \"queryString\" : \"select * from t1 emit changes\"," + NEWLINE
           + "    \"sinks\" : [ \"Test\" ]," + NEWLINE
           + "    \"sinkKafkaTopics\" : [ \"Test topic\" ]," + NEWLINE
           + "    \"id\" : \"0\"," + NEWLINE
@@ -335,16 +336,17 @@ public class ConsoleTest {
           + "      \"RUNNING\" : 1," + NEWLINE
           + "      \"ERROR\" : 2" + NEWLINE
           + "    }," + NEWLINE
+          + "    \"queryType\" : \"TRANSIENT\"," + NEWLINE
           + "    \"state\" : \"" + AGGREGATE_STATUS +"\"" + NEWLINE
           + "  } ]," + NEWLINE
           + "  \"warnings\" : [ ]" + NEWLINE
           + "} ]" + NEWLINE));
     } else {
       assertThat(output, is("" + NEWLINE
-          + " Query ID | Status            | Sink Name | Sink Kafka Topic | Query String     " + NEWLINE
-          + "--------------------------------------------------------------------------------" + NEWLINE
-          + " 0        | " + STATUS_COUNT_STRING + " | Test      | Test topic       | select * from t1 " + NEWLINE
-          + "--------------------------------------------------------------------------------" + NEWLINE
+          + " Query ID | Query Type | Status            | Sink Name | Sink Kafka Topic | Query String                  " + NEWLINE
+          + "----------------------------------------------------------------------------------------------------" + NEWLINE
+          + " 0        | TRANSIENT  | " + STATUS_COUNT_STRING + " | Test      | Test topic       | select * from t1 emit changes " + NEWLINE
+          + "----------------------------------------------------------------------------------------------------" + NEWLINE
           + "For detailed information on a Query run: EXPLAIN <Query ID>;" + NEWLINE));
     }
   }
@@ -366,10 +368,10 @@ public class ConsoleTest {
     );
 
     final List<RunningQuery> readQueries = ImmutableList.of(
-        new RunningQuery("read query", ImmutableSet.of("sink1"), ImmutableSet.of("sink1 topic"), new QueryId("readId"), queryStatusCount)
+        new RunningQuery("read query", ImmutableSet.of("sink1"), ImmutableSet.of("sink1 topic"), new QueryId("readId"), queryStatusCount, KsqlConstants.KsqlQueryType.PUSH)
     );
     final List<RunningQuery> writeQueries = ImmutableList.of(
-        new RunningQuery("write query", ImmutableSet.of("sink2"), ImmutableSet.of("sink2 topic"), new QueryId("writeId"), queryStatusCount)
+        new RunningQuery("write query", ImmutableSet.of("sink2"), ImmutableSet.of("sink2 topic"), new QueryId("writeId"), queryStatusCount, KsqlConstants.KsqlQueryType.PUSH)
     );
 
     final KsqlEntityList entityList = new KsqlEntityList(ImmutableList.of(
@@ -419,6 +421,7 @@ public class ConsoleTest {
           + "        \"RUNNING\" : 1," + NEWLINE
           + "        \"ERROR\" : 2" + NEWLINE
           + "      }," + NEWLINE
+          + "      \"queryType\" : \"PUSH\"," + NEWLINE
           + "      \"state\" : \"" + AGGREGATE_STATUS +"\"" + NEWLINE
           + "    } ]," + NEWLINE
           + "    \"writeQueries\" : [ {" + NEWLINE
@@ -430,6 +433,7 @@ public class ConsoleTest {
           + "        \"RUNNING\" : 1," + NEWLINE
           + "        \"ERROR\" : 2" + NEWLINE
           + "      }," + NEWLINE
+          + "      \"queryType\" : \"PUSH\"," + NEWLINE
           + "      \"state\" : \"" + AGGREGATE_STATUS +"\"" + NEWLINE
           + "    } ]," + NEWLINE
           + "    \"fields\" : [ {" + NEWLINE
@@ -1034,10 +1038,10 @@ public class ConsoleTest {
   public void shouldPrintTopicDescribeExtended() {
     // Given:
     final List<RunningQuery> readQueries = ImmutableList.of(
-        new RunningQuery("read query", ImmutableSet.of("sink1"), ImmutableSet.of("sink1 topic"), new QueryId("readId"), queryStatusCount)
+        new RunningQuery("read query", ImmutableSet.of("sink1"), ImmutableSet.of("sink1 topic"), new QueryId("readId"), queryStatusCount, KsqlConstants.KsqlQueryType.PUSH)
     );
     final List<RunningQuery> writeQueries = ImmutableList.of(
-        new RunningQuery("write query", ImmutableSet.of("sink2"), ImmutableSet.of("sink2 topic"), new QueryId("writeId"), queryStatusCount)
+        new RunningQuery("write query", ImmutableSet.of("sink2"), ImmutableSet.of("sink2 topic"), new QueryId("writeId"), queryStatusCount, KsqlConstants.KsqlQueryType.PUSH)
     );
 
     final KsqlEntityList entityList = new KsqlEntityList(ImmutableList.of(
@@ -1086,6 +1090,7 @@ public class ConsoleTest {
           + "        \"RUNNING\" : 1," + NEWLINE
           + "        \"ERROR\" : 2" + NEWLINE
           + "      }," + NEWLINE
+          + "      \"queryType\" : \"PUSH\"," + NEWLINE
           + "      \"state\" : \"" + AGGREGATE_STATUS +"\"" + NEWLINE
           + "    } ]," + NEWLINE
           + "    \"writeQueries\" : [ {" + NEWLINE
@@ -1097,6 +1102,7 @@ public class ConsoleTest {
           + "        \"RUNNING\" : 1," + NEWLINE
           + "        \"ERROR\" : 2" + NEWLINE
           + "      }," + NEWLINE
+          + "      \"queryType\" : \"PUSH\"," + NEWLINE
           + "      \"state\" : \"" + AGGREGATE_STATUS +"\"" + NEWLINE
           + "    } ]," + NEWLINE
           + "    \"fields\" : [ {" + NEWLINE

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/table/builder/QueriesTableBuilderTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/table/builder/QueriesTableBuilderTest.java
@@ -14,6 +14,7 @@ import io.confluent.ksql.rest.entity.RunningQuery;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.confluent.ksql.util.KsqlConstants;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,21 +36,22 @@ public class QueriesTableBuilderTest {
   @Test
   public void shouldBuildQueriesTable() {
     // Given:
+    final String exampleQuery = "select * from test_stream emit changes";
     final RunningQuery query = new RunningQuery(
-        "EXAMPLE QUERY;",
+            exampleQuery,
         ImmutableSet.of("SINK"),
         ImmutableSet.of("SINK"),
         new QueryId("0"),
-        queryStatusCount
-    );
+        queryStatusCount,
+        KsqlConstants.KsqlQueryType.TRANSIENT);
 
     // When:
     final Table table = buildTableWithSingleQuery(query);
 
     // Then:
-    assertThat(table.headers(), contains("Query ID", "Status", "Sink Name", "Sink Kafka Topic", "Query String"));
+    assertThat(table.headers(), contains("Query ID", "Query Type", "Status", "Sink Name", "Sink Kafka Topic", "Query String"));
     assertThat(table.rows(), hasSize(1));
-    assertThat(table.rows().get(0), contains("0", STATUS, "SINK", "SINK", "EXAMPLE QUERY;"));
+    assertThat(table.rows().get(0), contains("0", "TRANSIENT", STATUS, "SINK", "SINK", exampleQuery));
   }
 
   @Test
@@ -60,17 +62,17 @@ public class QueriesTableBuilderTest {
         ImmutableSet.of("S2"),
         ImmutableSet.of("S2"),
         new QueryId("CSAS_S2_0"),
-        queryStatusCount
-    );
+        queryStatusCount,
+        KsqlConstants.KsqlQueryType.PUSH);
 
 
     // When:
     final Table table = buildTableWithSingleQuery(query);
 
     // Then:
-    assertThat(table.headers(), contains("Query ID", "Status", "Sink Name", "Sink Kafka Topic", "Query String"));
+    assertThat(table.headers(), contains("Query ID", "Query Type", "Status", "Sink Name", "Sink Kafka Topic", "Query String"));
     assertThat(table.rows(), hasSize(1));
-    assertThat(table.rows().get(0), contains("CSAS_S2_0", STATUS, "S2", "S2", "CREATE STREAM S2 AS SELECT * FROM S1 EMIT CHANGES;"));
+    assertThat(table.rows().get(0), contains("CSAS_S2_0", "PUSH", STATUS, "S2", "S2", "CREATE STREAM S2 AS SELECT * FROM S1 EMIT CHANGES;"));
   }
 
   private Table buildTableWithSingleQuery(RunningQuery query) {

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/table/builder/QueriesTableBuilderTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/table/builder/QueriesTableBuilderTest.java
@@ -38,7 +38,7 @@ public class QueriesTableBuilderTest {
     // Given:
     final String exampleQuery = "select * from test_stream emit changes";
     final RunningQuery query = new RunningQuery(
-            exampleQuery,
+        exampleQuery,
         ImmutableSet.of("SINK"),
         ImmutableSet.of("SINK"),
         new QueryId("0"),

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/table/builder/QueriesTableBuilderTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/table/builder/QueriesTableBuilderTest.java
@@ -43,7 +43,7 @@ public class QueriesTableBuilderTest {
         ImmutableSet.of("SINK"),
         new QueryId("0"),
         queryStatusCount,
-        KsqlConstants.KsqlQueryType.TRANSIENT);
+        KsqlConstants.KsqlQueryType.PUSH);
 
     // When:
     final Table table = buildTableWithSingleQuery(query);
@@ -51,7 +51,7 @@ public class QueriesTableBuilderTest {
     // Then:
     assertThat(table.headers(), contains("Query ID", "Query Type", "Status", "Sink Name", "Sink Kafka Topic", "Query String"));
     assertThat(table.rows(), hasSize(1));
-    assertThat(table.rows().get(0), contains("0", "TRANSIENT", STATUS, "SINK", "SINK", exampleQuery));
+    assertThat(table.rows().get(0), contains("0", KsqlConstants.KsqlQueryType.PUSH.toString(), STATUS, "SINK", "SINK", exampleQuery));
   }
 
   @Test
@@ -63,7 +63,7 @@ public class QueriesTableBuilderTest {
         ImmutableSet.of("S2"),
         new QueryId("CSAS_S2_0"),
         queryStatusCount,
-        KsqlConstants.KsqlQueryType.PUSH);
+        KsqlConstants.KsqlQueryType.PERSISTENT);
 
 
     // When:
@@ -72,7 +72,7 @@ public class QueriesTableBuilderTest {
     // Then:
     assertThat(table.headers(), contains("Query ID", "Query Type", "Status", "Sink Name", "Sink Kafka Topic", "Query String"));
     assertThat(table.rows(), hasSize(1));
-    assertThat(table.rows().get(0), contains("CSAS_S2_0", "PUSH", STATUS, "S2", "S2", "CREATE STREAM S2 AS SELECT * FROM S1 EMIT CHANGES;"));
+    assertThat(table.rows().get(0), contains("CSAS_S2_0", KsqlConstants.KsqlQueryType.PERSISTENT.toString(), STATUS, "S2", "S2", "CREATE STREAM S2 AS SELECT * FROM S1 EMIT CHANGES;"));
   }
 
   private Table buildTableWithSingleQuery(RunningQuery query) {

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
@@ -47,8 +47,8 @@ public final class KsqlConstants {
       AVRO_SCHEMA_NAMESPACE + "." + AVRO_SCHEMA_NAME;
 
   public enum KsqlQueryType {
-    PUSH,
-    TRANSIENT
+    PERSISTENT,
+    PUSH
   }
 
   public enum KsqlQueryStatus {

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
@@ -46,6 +46,11 @@ public final class KsqlConstants {
   public static final String DEFAULT_AVRO_SCHEMA_FULL_NAME =
       AVRO_SCHEMA_NAMESPACE + "." + AVRO_SCHEMA_NAME;
 
+  public enum KsqlQueryType {
+    PUSH,
+    TRANSIENT
+  }
+
   public enum KsqlQueryStatus {
     RUNNING,
     ERROR,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/KsqlExecutionContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/KsqlExecutionContext.java
@@ -79,6 +79,13 @@ public interface KsqlExecutionContext {
   List<PersistentQueryMetadata> getPersistentQueries();
 
   /**
+   * Retrieves the list of all running queries.
+   *
+   * @return the list of all queries
+   */
+  List<QueryMetadata> getAllLiveQueries();
+
+  /**
    * Parse the statement(s) in supplied {@code sql}.
    *
    * <p>Note: the state of the execution context will not be changed.

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -44,6 +44,7 @@ import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import java.io.Closeable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -54,6 +55,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -128,8 +130,14 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
     return primaryContext.getPersistentQuery(queryId);
   }
 
+  @Override
   public List<PersistentQueryMetadata> getPersistentQueries() {
     return ImmutableList.copyOf(primaryContext.getPersistentQueries().values());
+  }
+
+  @Override
+  public List<QueryMetadata> getAllLiveQueries() {
+    return ImmutableList.copyOf(new ArrayList<>(allLiveQueries));
   }
 
   public boolean hasActiveQueries() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -137,7 +137,7 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
 
   @Override
   public List<QueryMetadata> getAllLiveQueries() {
-    return ImmutableList.copyOf(new ArrayList<>(allLiveQueries));
+    return ImmutableList.copyOf(allLiveQueries);
   }
 
   public boolean hasActiveQueries() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -44,7 +44,6 @@ import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import java.io.Closeable;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
@@ -83,6 +83,11 @@ final class SandboxedExecutionContext implements KsqlExecutionContext {
   }
 
   @Override
+  public List<QueryMetadata> getAllLiveQueries() {
+    return ImmutableList.of();
+  }
+
+  @Override
   public List<ParsedStatement> parse(final String sql) {
     return engineContext.parse(sql);
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -235,7 +235,8 @@ public final class QueryExecutor {
         streamsProperties,
         overrides,
         queryCloseCallback,
-        ksqlConfig.getLong(KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG)
+        ksqlConfig.getLong(KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG),
+        new QueryId(applicationId)
     ) {
       @Override
       public void stop() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -38,7 +38,6 @@ import org.apache.kafka.streams.Topology;
  */
 public class PersistentQueryMetadata extends QueryMetadata {
 
-  private final QueryId id;
   private final KsqlTopic resultTopic;
   private final SourceName sinkName;
   private final QuerySchemas schemas;
@@ -77,9 +76,9 @@ public class PersistentQueryMetadata extends QueryMetadata {
         streamsProperties,
         overriddenProperties,
         closeCallback,
-        closeTimeout);
+        closeTimeout,
+        id);
 
-    this.id = requireNonNull(id, "id");
     this.resultTopic = requireNonNull(resultTopic, "resultTopic");
     this.sinkName = Objects.requireNonNull(sinkName, "sinkName");
     this.schemas = requireNonNull(schemas, "schemas");
@@ -94,7 +93,6 @@ public class PersistentQueryMetadata extends QueryMetadata {
       final Consumer<QueryMetadata> closeCallback
   ) {
     super(other, closeCallback);
-    this.id = other.id;
     this.resultTopic = other.resultTopic;
     this.sinkName = other.sinkName;
     this.schemas = other.schemas;
@@ -109,10 +107,6 @@ public class PersistentQueryMetadata extends QueryMetadata {
 
   public DataSourceType getDataSourceType() {
     return dataSourceType;
-  }
-
-  public QueryId getQueryId() {
-    return id;
   }
 
   public KsqlTopic getResultTopic() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -19,7 +19,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.internal.QueryStateListener;
 import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.util.KsqlConstants.KsqlQueryType;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.time.Duration;
 import java.util.Collection;
@@ -51,6 +53,7 @@ public abstract class QueryMetadata {
   private final Set<SourceName> sourceNames;
   private final LogicalSchema logicalSchema;
   private final Long closeTimeout;
+  private final QueryId queryId;
 
   private Optional<QueryStateListener> queryStateListener = Optional.empty();
   private boolean everStarted = false;
@@ -67,7 +70,8 @@ public abstract class QueryMetadata {
       final Map<String, Object> streamsProperties,
       final Map<String, Object> overriddenProperties,
       final Consumer<QueryMetadata> closeCallback,
-      final long closeTimeout
+      final long closeTimeout,
+      final QueryId queryId
   ) {
     // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     this.statementString = Objects.requireNonNull(statementString, "statementString");
@@ -85,6 +89,7 @@ public abstract class QueryMetadata {
     this.sourceNames = Objects.requireNonNull(sourceNames, "sourceNames");
     this.logicalSchema = Objects.requireNonNull(logicalSchema, "logicalSchema");
     this.closeTimeout = closeTimeout;
+    this.queryId = Objects.requireNonNull(queryId, "queryId");
   }
 
   protected QueryMetadata(final QueryMetadata other, final Consumer<QueryMetadata> closeCallback) {
@@ -99,6 +104,7 @@ public abstract class QueryMetadata {
     this.logicalSchema = other.logicalSchema;
     this.closeCallback = Objects.requireNonNull(closeCallback, "closeCallback");
     this.closeTimeout = other.closeTimeout;
+    this.queryId = other.queryId;
   }
 
   public void registerQueryStateListener(final QueryStateListener queryStateListener) {
@@ -168,6 +174,13 @@ public abstract class QueryMetadata {
     return everStarted;
   }
 
+  public QueryId getQueryId() {
+    return queryId;
+  }
+
+  public KsqlQueryType getQueryType() {
+    return KsqlQueryType.PUSH;
+  }
 
   /**
    * Stops the query without cleaning up the external resources

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -179,7 +179,7 @@ public abstract class QueryMetadata {
   }
 
   public KsqlQueryType getQueryType() {
-    return KsqlQueryType.PUSH;
+    return KsqlQueryType.PERSISTENT;
   }
 
   /**

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
@@ -18,7 +18,9 @@ package io.confluent.ksql.util;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.BlockingRowQueue;
 import io.confluent.ksql.query.LimitHandler;
+import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.util.KsqlConstants.KsqlQueryType;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -61,7 +63,8 @@ public class TransientQueryMetadata extends QueryMetadata {
         streamsProperties,
         overriddenProperties,
         closeCallback,
-        closeTimeout
+        closeTimeout,
+        new QueryId(queryApplicationId)
     );
     this.rowQueue = Objects.requireNonNull(rowQueue, "rowQueue");
 
@@ -76,6 +79,11 @@ public class TransientQueryMetadata extends QueryMetadata {
 
   public BlockingRowQueue getRowQueue() {
     return rowQueue;
+  }
+  
+  @Override
+  public KsqlQueryType getQueryType() {
+    return KsqlQueryType.TRANSIENT;
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
@@ -83,7 +83,7 @@ public class TransientQueryMetadata extends QueryMetadata {
   
   @Override
   public KsqlQueryType getQueryType() {
-    return KsqlQueryType.TRANSIENT;
+    return KsqlQueryType.PUSH;
   }
 
   @Override

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
@@ -213,7 +213,7 @@ public class QueryMetadataTest {
   }
 
   @Test
-  public void shouldReturnPushQueryTypeByDefault() {
-    assertThat(query.getQueryType(), is(KsqlQueryType.PUSH));
+  public void shouldReturnPersistentQueryTypeByDefault() {
+    assertThat(query.getQueryType(), is(KsqlQueryType.PERSISTENT));
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
@@ -27,8 +27,10 @@ import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.internal.QueryStateListener;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.util.KsqlConstants.KsqlQueryType;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Set;
@@ -47,6 +49,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class QueryMetadataTest {
 
   private static final String QUERY_APPLICATION_ID = "Query1";
+  private static final QueryId QUERY_ID = new QueryId("queryId");
   private static final LogicalSchema SOME_SCHEMA = LogicalSchema.builder()
       .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
@@ -81,7 +84,8 @@ public class QueryMetadataTest {
         Collections.emptyMap(),
         Collections.emptyMap(),
         closeCallback,
-        closeTimeout) {
+        closeTimeout,
+        QUERY_ID) {
       @Override
       public void stop() {
         doClose(cleanUp);
@@ -206,5 +210,10 @@ public class QueryMetadataTest {
   @Test
   public void shouldReturnSchema() {
     assertThat(query.getLogicalSchema(), is(SOME_SCHEMA));
+  }
+
+  @Test
+  public void shouldReturnPushQueryTypeByDefault() {
+    assertThat(query.getQueryType(), is(KsqlQueryType.PUSH));
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/TransientQueryMetadataTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/TransientQueryMetadataTest.java
@@ -106,6 +106,6 @@ public class TransientQueryMetadataTest {
 
   @Test
   public void shouldReturnPushQueryTypeByDefault() {
-    assertThat(query.getQueryType(), is(KsqlQueryType.TRANSIENT));
+    assertThat(query.getQueryType(), is(KsqlQueryType.PUSH));
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/TransientQueryMetadataTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/TransientQueryMetadataTest.java
@@ -15,12 +15,15 @@
 
 package io.confluent.ksql.util;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.inOrder;
 
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.BlockingRowQueue;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.util.KsqlConstants.KsqlQueryType;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -99,5 +102,10 @@ public class TransientQueryMetadataTest {
     inOrder.verify(kafkaStreams).close(any());
     inOrder.verify(kafkaStreams).cleanUp();
     inOrder.verify(closeCallback).accept(query);
+  }
+
+  @Test
+  public void shouldReturnPushQueryTypeByDefault() {
+    assertThat(query.getQueryType(), is(KsqlQueryType.TRANSIENT));
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescriptionFactory.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescriptionFactory.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.rest.entity;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.model.WindowType;
 import io.confluent.ksql.name.SourceName;
-import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.util.EntityUtil;
 import io.confluent.ksql.util.KsqlConstants.KsqlQueryStatus;
 import io.confluent.ksql.util.PersistentQueryMetadata;
@@ -41,7 +40,6 @@ public final class QueryDescriptionFactory {
     if (queryMetadata instanceof PersistentQueryMetadata) {
       final PersistentQueryMetadata persistentQuery = (PersistentQueryMetadata) queryMetadata;
       return create(
-          persistentQuery.getQueryId(),
           persistentQuery,
           persistentQuery.getResultTopic().getKeyFormat().getWindowType(),
           ImmutableSet.of(persistentQuery.getSinkName()),
@@ -50,23 +48,21 @@ public final class QueryDescriptionFactory {
     }
 
     return create(
-        new QueryId(""),
         queryMetadata,
         Optional.empty(),
         Collections.emptySet(),
-        Collections.emptyMap()
+        ksqlHostQueryStatus
     );
   }
 
   private static QueryDescription create(
-      final QueryId id,
       final QueryMetadata queryMetadata,
       final Optional<WindowType> windowType,
       final Set<SourceName> sinks,
       final Map<KsqlHostInfoEntity, KsqlQueryStatus> ksqlHostQueryStatus
   ) {
     return new QueryDescription(
-        id,
+        queryMetadata.getQueryId(),
         queryMetadata.getStatementString(),
         windowType,
         EntityUtil.buildSourceSchemaEntity(queryMetadata.getLogicalSchema()),
@@ -75,7 +71,8 @@ public final class QueryDescriptionFactory {
         queryMetadata.getTopologyDescription(),
         queryMetadata.getExecutionPlan(),
         queryMetadata.getOverriddenProperties(),
-        ksqlHostQueryStatus
+        ksqlHostQueryStatus,
+        queryMetadata.getQueryType()
     );
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutor.java
@@ -107,7 +107,7 @@ public final class ListQueriesExecutor {
             QueryMetadata::getQueryId,
             q -> {
               if (q instanceof PersistentQueryMetadata) {
-                System.out.println("getting local");
+
                 final PersistentQueryMetadata persistentQuery = (PersistentQueryMetadata) q;
                 return new RunningQuery(
                     q.getStatementString(),
@@ -118,7 +118,7 @@ public final class ListQueriesExecutor {
                         Collections.singletonMap(KafkaStreams.State.valueOf(q.getState()), 1)),
                     q.getQueryType());
               }
-              System.out.println("what is being returned");
+
               return new RunningQuery(
                   q.getStatementString(),
                   ImmutableSet.of(),
@@ -145,7 +145,7 @@ public final class ListQueriesExecutor {
     
     for (RunningQuery q : remoteRunningQueries) {
       final QueryId queryId = q.getId();
-      System.out.println(q.getId());
+
       // If the query has already been discovered, update the QueryStatusCount object
       if (allResults.containsKey(queryId)) {
         for (Map.Entry<KsqlQueryStatus, Integer> entry :

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutor.java
@@ -100,7 +100,7 @@ public final class ListQueriesExecutor {
   private static Map<QueryId, RunningQuery> getLocalSimple(
       final KsqlExecutionContext executionContext
   ) {
-    return executionContext
+    final Map<QueryId, RunningQuery> persistentQueries =  executionContext
         .getPersistentQueries()
         .stream()
         .collect(Collectors.toMap(
@@ -111,8 +111,10 @@ public final class ListQueriesExecutor {
                 ImmutableSet.of(q.getResultTopic().getKafkaTopicName()),
                 q.getQueryId(),
                 QueryStatusCount.fromStreamsStateCounts(
-                    Collections.singletonMap(KafkaStreams.State.valueOf(q.getState()), 1)))
+                    Collections.singletonMap(KafkaStreams.State.valueOf(q.getState()), 1)),
+                q.getQueryType())
         ));
+    return persistentQueries;
   }
 
   private static void mergeSimple(

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
@@ -232,7 +232,7 @@ public final class ListSourceExecutor {
             QueryStatusCount.fromStreamsStateCounts(
                 Collections.singletonMap(
                     KafkaStreams.State.valueOf(q.getState()), 1)),
-            KsqlConstants.KsqlQueryType.PUSH)).collect(Collectors.toList());
+            KsqlConstants.KsqlQueryType.PERSISTENT)).collect(Collectors.toList());
   }
 
   private static Stream sourceSteam(final KsqlStream<?> dataSource) {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
@@ -41,6 +41,7 @@ import io.confluent.ksql.rest.entity.TablesList;
 import io.confluent.ksql.rest.server.KsqlRestApplication;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
+import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 
@@ -230,7 +231,7 @@ public final class ListSourceExecutor {
             q.getQueryId(),
             QueryStatusCount.fromStreamsStateCounts(
                 Collections.singletonMap(
-                    KafkaStreams.State.valueOf(q.getState()), 1)))).collect(Collectors.toList());
+                    KafkaStreams.State.valueOf(q.getState()), 1)), KsqlConstants.KsqlQueryType.PUSH)).collect(Collectors.toList());
   }
 
   private static Stream sourceSteam(final KsqlStream<?> dataSource) {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
@@ -231,7 +231,8 @@ public final class ListSourceExecutor {
             q.getQueryId(),
             QueryStatusCount.fromStreamsStateCounts(
                 Collections.singletonMap(
-                    KafkaStreams.State.valueOf(q.getState()), 1)), KsqlConstants.KsqlQueryType.PUSH)).collect(Collectors.toList());
+                    KafkaStreams.State.valueOf(q.getState()), 1)),
+            KsqlConstants.KsqlQueryType.PUSH)).collect(Collectors.toList());
   }
 
   private static Stream sourceSteam(final KsqlStream<?> dataSource) {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
@@ -37,7 +37,6 @@ import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlConstants.KsqlQueryStatus;
 import io.confluent.ksql.util.KsqlConstants.KsqlQueryType;
 import io.confluent.ksql.util.PersistentQueryMetadata;
@@ -220,13 +219,13 @@ public class QueryDescriptionFactoryTest {
   }
 
   @Test
-  public void shouldHavePushQueryTypePersistentQuery() {
-    assertThat(persistentQueryDescription.getQueryType(), is(KsqlQueryType.PUSH));
+  public void shouldHavePersistentQueryTypePersistentQueryDescription() {
+    assertThat(persistentQueryDescription.getQueryType(), is(KsqlQueryType.PERSISTENT));
   }
 
   @Test
-  public void shouldHaveTransientQueryTypeTransientQuery() {
-    assertThat(transientQueryDescription.getQueryType(), is(KsqlQueryType.TRANSIENT));
+  public void shouldHavePushQueryTypeTransientQueryDescription() {
+    assertThat(transientQueryDescription.getQueryType(), is(KsqlQueryType.PUSH));
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.rest.entity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isEmptyString;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableSet;
@@ -38,7 +37,9 @@ import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlConstants.KsqlQueryStatus;
+import io.confluent.ksql.util.KsqlConstants.KsqlQueryType;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.QuerySchemas;
@@ -78,7 +79,8 @@ public class QueryDescriptionFactoryTest {
 
   private static final Map<String, Object> STREAMS_PROPS = Collections.singletonMap("k1", "v1");
   private static final Map<String, Object> PROP_OVERRIDES = Collections.singletonMap("k2", "v2");
-  private static final QueryId QUERY_ID = new QueryId("query_id");
+  private static final String APPLICATION_ID = "app id";
+  private static final QueryId QUERY_ID = new QueryId(APPLICATION_ID);
   private static final ImmutableSet<SourceName> SOURCE_NAMES = ImmutableSet.of(SourceName.of("s1"), SourceName.of("s2"));
   private static final String SQL_TEXT = "test statement";
   private static final String TOPOLOGY_TEXT = "Topology Text";
@@ -114,7 +116,7 @@ public class QueryDescriptionFactoryTest {
         SOURCE_NAMES,
         "execution plan",
         queryQueue,
-        "app id",
+        APPLICATION_ID,
         topology,
         STREAMS_PROPS,
         PROP_OVERRIDES,
@@ -133,7 +135,7 @@ public class QueryDescriptionFactoryTest {
         QUERY_ID,
         DataSourceType.KSTREAM,
         Optional.empty(),
-        "app id",
+        APPLICATION_ID,
         sinkTopic,
         topology,
         QuerySchemas.of(new LinkedHashMap<>()),
@@ -146,8 +148,8 @@ public class QueryDescriptionFactoryTest {
   }
 
   @Test
-  public void shouldHaveEmptyQueryIdFromTransientQuery() {
-    assertThat(transientQueryDescription.getId().toString(), is(isEmptyString()));
+  public void shouldHaveApplicationIdAsQueryIdFromTransientQuery() {
+    assertThat(transientQueryDescription.getId().toString(), is(APPLICATION_ID));
   }
 
   @Test
@@ -215,6 +217,16 @@ public class QueryDescriptionFactoryTest {
   @Test
   public void shouldNotReportTransientQueriesStatus() {
     assertThat(transientQueryDescription.getState(), is(Optional.empty()));
+  }
+
+  @Test
+  public void shouldHavePushQueryTypePersistentQuery() {
+    assertThat(persistentQueryDescription.getQueryType(), is(KsqlQueryType.PUSH));
+  }
+
+  @Test
+  public void shouldHaveTransientQueryTypeTransientQuery() {
+    assertThat(transientQueryDescription.getQueryType(), is(KsqlQueryType.TRANSIENT));
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -330,7 +330,7 @@ public class TestKsqlRestApp extends ExternalResource {
 
     final Queries queries = (Queries) response.getResponse().get(0);
     return queries.getQueries().stream()
-        .filter(query -> query.getQueryType() == KsqlConstants.KsqlQueryType.PUSH)
+        .filter(query -> query.getQueryType() == KsqlConstants.KsqlQueryType.PERSISTENT)
         .map(RunningQuery::getId)
         .map(QueryId::toString)
         .collect(Collectors.toSet());

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -50,6 +50,7 @@ import io.confluent.ksql.services.ServiceContextFactory;
 import io.confluent.ksql.services.SimpleKsqlClient;
 import io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.ReservedInternalTopics;
 import io.confluent.ksql.version.metrics.VersionCheckerAgent;
 import io.confluent.rest.ApplicationServer;
@@ -329,6 +330,7 @@ public class TestKsqlRestApp extends ExternalResource {
 
     final Queries queries = (Queries) response.getResponse().get(0);
     return queries.getQueries().stream()
+        .filter(query -> query.getQueryType() == KsqlConstants.KsqlQueryType.PUSH)
         .map(RunningQuery::getId)
         .map(QueryId::toString)
         .collect(Collectors.toSet());

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ExplainExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ExplainExecutorTest.java
@@ -37,6 +37,7 @@ import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.statement.ConfiguredStatement;
+import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlConstants.KsqlQueryStatus;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlHostInfo;
@@ -183,6 +184,7 @@ public class ExplainExecutorTest {
     when(metadata.getTopologyDescription()).thenReturn("topology");
     when(metadata.getExecutionPlan()).thenReturn("plan");
     when(metadata.getStatementString()).thenReturn("sql");
+    when(metadata.getQueryType()).thenReturn(KsqlConstants.KsqlQueryType.PUSH);
 
     final KsqlTopic sinkTopic = mock(KsqlTopic.class);
     when(sinkTopic.getKeyFormat()).thenReturn(KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())));

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ExplainExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ExplainExecutorTest.java
@@ -46,7 +46,6 @@ import io.confluent.ksql.util.PersistentQueryMetadata;
 import java.util.Collections;
 import java.util.Optional;
 
-import org.apache.kafka.streams.KafkaStreams;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -184,7 +183,7 @@ public class ExplainExecutorTest {
     when(metadata.getTopologyDescription()).thenReturn("topology");
     when(metadata.getExecutionPlan()).thenReturn("plan");
     when(metadata.getStatementString()).thenReturn("sql");
-    when(metadata.getQueryType()).thenReturn(KsqlConstants.KsqlQueryType.PUSH);
+    when(metadata.getQueryType()).thenReturn(KsqlConstants.KsqlQueryType.PERSISTENT);
 
     final KsqlTopic sinkTopic = mock(KsqlTopic.class);
     when(sinkTopic.getKeyFormat()).thenReturn(KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())));

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
@@ -472,6 +472,6 @@ public class ListQueriesExecutorTest {
         ImmutableSet.of(md.getSinkName().text()),
         ImmutableSet.of(md.getResultTopic().getKafkaTopicName()),
         md.getQueryId(),
-        queryStatusCount);
+        queryStatusCount, KsqlConstants.KsqlQueryType.PUSH);
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
@@ -220,8 +220,7 @@ public class ListQueriesExecutorTest {
         engine,
         serviceContext
     ).orElseThrow(IllegalStateException::new);
-
-    System.out.println(queries.getQueries().get(0).getId());
+    
     // Then
     assertThat(queries.getQueries(),
         containsInAnyOrder(

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
@@ -450,7 +450,7 @@ public class ListQueriesExecutorTest {
   ) {
     final PersistentQueryMetadata metadata = mock(PersistentQueryMetadata.class);
     mockQuery(id, state, metadata);
-    when(metadata.getQueryType()).thenReturn(KsqlConstants.KsqlQueryType.PUSH);
+    when(metadata.getQueryType()).thenReturn(KsqlConstants.KsqlQueryType.PERSISTENT);
     when(metadata.getSinkName()).thenReturn(SourceName.of(id));
     final KsqlTopic sinkTopic = mock(KsqlTopic.class);
     when(sinkTopic.getKeyFormat()).thenReturn(KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())));
@@ -466,7 +466,7 @@ public class ListQueriesExecutorTest {
   ) {
     final TransientQueryMetadata metadata = mock(TransientQueryMetadata.class);
     mockQuery(id, state, metadata);
-    when(metadata.getQueryType()).thenReturn(KsqlConstants.KsqlQueryType.TRANSIENT);
+    when(metadata.getQueryType()).thenReturn(KsqlConstants.KsqlQueryType.PUSH);
 
     return metadata;
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
@@ -267,7 +267,7 @@ public class ListSourceExecutorTest {
                 ImmutableSet.of(metadata.getSinkName().toString(FormatOptions.noEscape())),
                 ImmutableSet.of(metadata.getResultTopic().getKafkaTopicName()),
                 metadata.getQueryId(),
-                queryStatusCount, KsqlConstants.KsqlQueryType.PUSH)),
+                queryStatusCount, KsqlConstants.KsqlQueryType.PERSISTENT)),
             Optional.empty())));
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
@@ -55,6 +55,7 @@ import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.TestServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
+import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import java.util.Arrays;
@@ -266,7 +267,7 @@ public class ListSourceExecutorTest {
                 ImmutableSet.of(metadata.getSinkName().toString(FormatOptions.noEscape())),
                 ImmutableSet.of(metadata.getResultTopic().getKafkaTopicName()),
                 metadata.getQueryId(),
-                queryStatusCount)),
+                queryStatusCount, KsqlConstants.KsqlQueryType.PUSH)),
             Optional.empty())));
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -1993,7 +1993,7 @@ public class KsqlResourceTest {
             ImmutableSet.of(md.getResultTopic().getKafkaTopicName()),
             md.getQueryId(),
             QueryStatusCount.fromStreamsStateCounts(
-                Collections.singletonMap(KafkaStreams.State.valueOf(md.getState()), 1)))
+                Collections.singletonMap(KafkaStreams.State.valueOf(md.getState()), 1)), KsqlConstants.KsqlQueryType.PUSH)
     ).collect(Collectors.toList());
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -1993,7 +1993,7 @@ public class KsqlResourceTest {
             ImmutableSet.of(md.getResultTopic().getKafkaTopicName()),
             md.getQueryId(),
             QueryStatusCount.fromStreamsStateCounts(
-                Collections.singletonMap(KafkaStreams.State.valueOf(md.getState()), 1)), KsqlConstants.KsqlQueryType.PUSH)
+                Collections.singletonMap(KafkaStreams.State.valueOf(md.getState()), 1)), KsqlConstants.KsqlQueryType.PERSISTENT)
     ).collect(Collectors.toList());
   }
 

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryDescription.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryDescription.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.model.WindowType;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.util.KsqlConstants.KsqlQueryStatus;
+import io.confluent.ksql.util.KsqlConstants.KsqlQueryType;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -46,6 +47,7 @@ public class QueryDescription {
   private final String executionPlan;
   private final Map<String, Object> overriddenProperties;
   private final Map<KsqlHostInfoEntity, KsqlQueryStatus> ksqlHostQueryStatus;
+  private final KsqlQueryType queryType;
 
   // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
   @SuppressWarnings("WeakerAccess") // Invoked via reflection
@@ -61,7 +63,8 @@ public class QueryDescription {
       @JsonProperty("executionPlan") final String executionPlan,
       @JsonProperty("overriddenProperties") final Map<String, Object> overriddenProperties,
       @JsonProperty("ksqlHostQueryStatus") final Map<KsqlHostInfoEntity, KsqlQueryStatus>
-          ksqlHostQueryStatus
+          ksqlHostQueryStatus,
+      @JsonProperty("queryType") final KsqlQueryType queryType
   ) {
     this.id = Objects.requireNonNull(id, "id");
     this.statementText = Objects.requireNonNull(statementText, "statementText");
@@ -75,6 +78,7 @@ public class QueryDescription {
         .requireNonNull(overriddenProperties, "overriddenProperties"));
     this.ksqlHostQueryStatus =
         new HashMap<>(Objects.requireNonNull(ksqlHostQueryStatus, "ksqlHostQueryStatus"));
+    this.queryType = Objects.requireNonNull(queryType, "queryType");
   }
 
   public QueryId getId() {
@@ -135,6 +139,10 @@ public class QueryDescription {
     return Collections.unmodifiableMap(ksqlHostQueryStatus);
   }
 
+  public KsqlQueryType getQueryType() {
+    return queryType;
+  }
+
   // CHECKSTYLE_RULES.OFF: CyclomaticComplexity
   @Override
   public boolean equals(final Object o) {
@@ -155,7 +163,8 @@ public class QueryDescription {
         && Objects.equals(sources, that.sources)
         && Objects.equals(sinks, that.sinks)
         && Objects.equals(overriddenProperties, that.overriddenProperties)
-        && Objects.equals(ksqlHostQueryStatus, that.ksqlHostQueryStatus);
+        && Objects.equals(ksqlHostQueryStatus, that.ksqlHostQueryStatus)
+        && Objects.equals(queryType, that.queryType);
   }
 
   @Override
@@ -170,7 +179,8 @@ public class QueryDescription {
         sources,
         sinks,
         overriddenProperties,
-        ksqlHostQueryStatus
+        ksqlHostQueryStatus,
+        queryType
     );
   }
 }

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/RunningQuery.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/RunningQuery.java
@@ -20,6 +20,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.util.KsqlConstants;
+import io.confluent.ksql.util.KsqlConstants.KsqlQueryType;
+
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -32,6 +35,7 @@ public class RunningQuery {
   private final Set<String> sinkKafkaTopics;
   private final QueryId id;
   private final QueryStatusCount statusCount;
+  private final KsqlConstants.KsqlQueryType queryType;
 
   @JsonCreator
   public RunningQuery(
@@ -39,13 +43,15 @@ public class RunningQuery {
       @JsonProperty("sinks") final Set<String> sinks,
       @JsonProperty("sinkKafkaTopics") final Set<String> sinkKafkaTopics,
       @JsonProperty("id") final QueryId id,
-      @JsonProperty("statusCount") final QueryStatusCount statusCount
+      @JsonProperty("statusCount") final QueryStatusCount statusCount,
+      @JsonProperty("queryType") final KsqlQueryType queryType
   ) {
     this.queryString = Objects.requireNonNull(queryString, "queryString");
     this.sinkKafkaTopics = Objects.requireNonNull(sinkKafkaTopics, "sinkKafkaTopics");
     this.sinks = Objects.requireNonNull(sinks, "sinks");
     this.id = Objects.requireNonNull(id, "id");
     this.statusCount = Objects.requireNonNull(statusCount, "statusCount");
+    this.queryType = Objects.requireNonNull(queryType, "queryType");
   }
 
   public String getQueryString() {
@@ -77,6 +83,10 @@ public class RunningQuery {
 
   public QueryStatusCount getStatusCount() {
     return statusCount;
+  }
+
+  public KsqlQueryType getQueryType() {
+    return queryType;
   }
 
   @Override


### PR DESCRIPTION
### Description 
Addresses https://github.com/confluentinc/ksql/issues/4308

There's a known issue where if no persistent queries are running in a multi node environment and a transient query is running on node A, that transient query won't show up in `Show queries` executed to other nodes.
https://github.com/confluentinc/ksql/issues/4910

### Testing done 
```
 Query ID                                                            | Query Type | Status    | Sink Name | Sink Kafka Topic | Query String                                                                                                                                  
---------------------------------------------------------------------------------------------------------------------------------------------
 CSAS_TEST_0                                                         | PUSH       | RUNNING:2 | TEST      | TEST             | CREATE STREAM TEST WITH (KAFKA_TOPIC='TEST', PARTITIONS=1, REPLICAS=1) AS SELECT * FROM KSQL_PROCESSING_LOG KSQL_PROCESSING_LOG EMIT CHANGES; 
 _confluent-ksql-default_transient_4363766092250723780_1587488499684 | TRANSIENT  | RUNNING:1 |           |                  | select * from test emit changes;                                                                                                              
---------------------------------------------------------------------------------------------------------------------------------------------
```

```
ID                   : _confluent-ksql-default_transient_4363766092250723780_1587488499684
Query Type           : TRANSIENT
SQL                  : select * from test emit changes;
Host Query Status    : {192.168.1.6:8089=RUNNING}

 Field   | Type                                                                                                                                                                                                                                                                                                                                    
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 ROWTIME | BIGINT                                                                                                                                                                                                                                                                                                                                  
 ROWKEY  | VARCHAR(STRING)                                                                                                                                                                                                                                                                                                                         
 LOGGER  | VARCHAR(STRING)                                                                                                                                                                                                                                                                                                                         
 LEVEL   | VARCHAR(STRING)                                                                                                                                                                                                                                                                                                                         
 TIME    | BIGINT                                                                                                                                                                                                                                                                                                                                  
 MESSAGE | STRUCT<TYPE INTEGER, DESERIALIZATIONERROR STRUCT<ERRORMESSAGE VARCHAR(STRING), RECORDB64 VARCHAR(STRING), CAUSE ARRAY<VARCHAR(STRING)>, topic VARCHAR(STRING)>, RECORDPROCESSINGERROR STRUCT<ERRORMESSAGE VARCHAR(STRING), RECORD VARCHAR(STRING), CAUSE ARRAY<VARCHAR(STRING)>>, PRODUCTIONERROR STRUCT<ERRORMESSAGE VARCHAR(STRING)>> 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Sources that this query reads from: 
-----------------------------------
TEST

For source description please run: DESCRIBE [EXTENDED] <SourceId>

Execution plan      
--------------      
 > [ PROJECT ] | Schema: ROWKEY STRING KEY, ROWTIME BIGINT, ROWKEY STRING, LOGGER STRING, LEVEL STRING, TIME BIGINT, MESSAGE STRUCT<TYPE INTEGER, DESERIALIZATIONERROR STRUCT<ERRORMESSAGE STRING, RECORDB64 STRING, CAUSE ARRAY<STRING>, `topic` STRING>, RECORDPROCESSINGERROR STRUCT<ERRORMESSAGE STRING, RECORD STRING, CAUSE ARRAY<STRING>>, PRODUCTIONERROR STRUCT<ERRORMESSAGE STRING>> | Logger: 4363766092250723780.Project
                 > [ SOURCE ] | Schema: ROWKEY STRING KEY, LOGGER STRING, LEVEL STRING, TIME BIGINT, MESSAGE STRUCT<TYPE INTEGER, DESERIALIZATIONERROR STRUCT<ERRORMESSAGE STRING, RECORDB64 STRING, CAUSE ARRAY<STRING>, `topic` STRING>, RECORDPROCESSINGERROR STRUCT<ERRORMESSAGE STRING, RECORD STRING, CAUSE ARRAY<STRING>>, PRODUCTIONERROR STRUCT<ERRORMESSAGE STRING>>, ROWTIME BIGINT, ROWKEY STRING | Logger: 4363766092250723780.KsqlTopic.Source


Processing topology 
------------------- 
Topologies:
   Sub-topology: 0
    Source: KSTREAM-SOURCE-0000000000 (topics: [TEST])
      --> KSTREAM-TRANSFORMVALUES-0000000001
    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
      --> Project
      <-- KSTREAM-SOURCE-0000000000
    Processor: Project (stores: [])
      --> KSTREAM-FOREACH-0000000003
      <-- KSTREAM-TRANSFORMVALUES-0000000001
    Processor: KSTREAM-FOREACH-0000000003 (stores: [])
      --> none
      <-- Project
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

