### PR TITLE
refactor: Migrate server metadata endpoints

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/endpoints/KsqlServerEndpoints.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/endpoints/KsqlServerEndpoints.java
@@ -33,6 +33,7 @@ import io.confluent.ksql.rest.server.resources.HeartbeatResource;
 import io.confluent.ksql.rest.server.resources.KsqlResource;
 import io.confluent.ksql.rest.server.resources.LagReportingResource;
 import io.confluent.ksql.rest.server.resources.ServerInfoResource;
+import io.confluent.ksql.rest.server.resources.ServerMetadataResource;
 import io.confluent.ksql.rest.server.resources.StatusResource;
 import io.confluent.ksql.rest.server.resources.streaming.StreamedQueryResource;
 import io.confluent.ksql.security.KsqlSecurityContext;
@@ -68,6 +69,7 @@ public class KsqlServerEndpoints implements Endpoints {
   private final StatusResource statusResource;
   private final Optional<LagReportingResource> lagReportingResource;
   private final HealthCheckResource healthCheckResource;
+  private final ServerMetadataResource serverMetadataResource;
 
   // CHECKSTYLE_RULES.OFF: ParameterNumber
   public KsqlServerEndpoints(
@@ -82,7 +84,8 @@ public class KsqlServerEndpoints implements Endpoints {
       final Optional<ClusterStatusResource> clusterStatusResource,
       final StatusResource statusResource,
       final Optional<LagReportingResource> lagReportingResource,
-      final HealthCheckResource healthCheckResource) {
+      final HealthCheckResource healthCheckResource,
+      final ServerMetadataResource serverMetadataResource) {
 
     // CHECKSTYLE_RULES.ON: ParameterNumber
     this.ksqlEngine = Objects.requireNonNull(ksqlEngine);
@@ -99,6 +102,7 @@ public class KsqlServerEndpoints implements Endpoints {
     this.statusResource = Objects.requireNonNull(statusResource);
     this.lagReportingResource = Objects.requireNonNull(lagReportingResource);
     this.healthCheckResource = Objects.requireNonNull(healthCheckResource);
+    this.serverMetadataResource = Objects.requireNonNull(serverMetadataResource);
   }
 
   @Override
@@ -219,6 +223,20 @@ public class KsqlServerEndpoints implements Endpoints {
       final ApiSecurityContext apiSecurityContext) {
     return CompletableFuture
         .completedFuture(EndpointResponse.create(healthCheckResource.checkHealth()));
+  }
+
+  @Override
+  public CompletableFuture<EndpointResponse> executeServerMetadata(
+      final ApiSecurityContext apiSecurityContext) {
+    return CompletableFuture
+        .completedFuture(EndpointResponse.create(serverMetadataResource.getServerMetadata()));
+  }
+
+  @Override
+  public CompletableFuture<EndpointResponse> executeServerMetadataClusterId(
+      final ApiSecurityContext apiSecurityContext) {
+    return CompletableFuture
+        .completedFuture(EndpointResponse.create(serverMetadataResource.getServerClusterId()));
   }
 
   private <R> CompletableFuture<R> executeOnWorker(final Supplier<R> supplier,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/PortedEndpoints.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/PortedEndpoints.java
@@ -59,7 +59,8 @@ class PortedEndpoints {
 
   private static final Set<String> PORTED_ENDPOINTS = ImmutableSet
       .of("/ksql", "/ksql/terminate", "/query", "/info", "/heartbeat", "/clusterStatus",
-          "/status/:type/:entity/:action", "/status", "/lag", "/healthcheck");
+          "/status/:type/:entity/:action", "/status", "/lag", "/healthcheck", "/v1/metadata",
+          "/v1/metadata/id");
 
   private static final String CONTENT_TYPE_HEADER = HttpHeaders.CONTENT_TYPE.toString();
   private static final String JSON_CONTENT_TYPE = "application/json";
@@ -123,6 +124,14 @@ class PortedEndpoints {
         .produces(Versions.KSQL_V1_JSON)
         .produces(MediaType.APPLICATION_JSON)
         .handler(new PortedEndpoints(endpoints, server)::handleHealthcheckRequest);
+    router.route(HttpMethod.GET, "/v1/metadata")
+        .produces(Versions.KSQL_V1_JSON)
+        .produces(MediaType.APPLICATION_JSON)
+        .handler(new PortedEndpoints(endpoints, server)::handleServerMetadataRequest);
+    router.route(HttpMethod.GET, "/v1/metadata/id")
+        .produces(Versions.KSQL_V1_JSON)
+        .produces(MediaType.APPLICATION_JSON)
+        .handler(new PortedEndpoints(endpoints, server)::handleServerMetadataClusterIdRequest);
   }
 
   static void setupFailureHandler(final Router router) {
@@ -213,6 +222,21 @@ class PortedEndpoints {
     handlePortedOldApiRequest(server, routingContext, null,
         (request, apiSecurityContext) ->
             endpoints.executeCheckHealth(DefaultApiSecurityContext.create(routingContext))
+    );
+  }
+
+  void handleServerMetadataRequest(final RoutingContext routingContext) {
+    handlePortedOldApiRequest(server, routingContext, null,
+        (request, apiSecurityContext) ->
+            endpoints.executeServerMetadata(DefaultApiSecurityContext.create(routingContext))
+    );
+  }
+
+  void handleServerMetadataClusterIdRequest(final RoutingContext routingContext) {
+    handlePortedOldApiRequest(server, routingContext, null,
+        (request, apiSecurityContext) ->
+            endpoints
+                .executeServerMetadataClusterId(DefaultApiSecurityContext.create(routingContext))
     );
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -57,7 +57,8 @@ public class ServerVerticle extends AbstractVerticle {
   public static final Set<String> NON_PROXIED_ENDPOINTS = ImmutableSet
       .of("/query-stream", "/inserts-stream", "/close-query",
           "/ksql", "/ksql/terminate", "/query", "/info", "/heartbeat", "/clusterStatus",
-          "/status/:type/:entity/:action", "/status", "/lag", "/healthcheck");
+          "/status/:type/:entity/:action", "/status", "/lag", "/healthcheck", "/v1/metadata",
+          "/v1/metadata/id");
 
   private final Endpoints endpoints;
   private final HttpServerOptions httpServerOptions;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/spi/Endpoints.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/spi/Endpoints.java
@@ -64,6 +64,10 @@ public interface Endpoints {
       Subscriber<InsertResult> acksSubscriber, Context context, WorkerExecutor workerExecutor,
       ApiSecurityContext apiSecurityContext);
 
+  /*
+  The ported old API endpoints now follow
+   */
+
   CompletableFuture<EndpointResponse> executeKsqlRequest(KsqlRequest request,
       WorkerExecutor workerExecutor, ApiSecurityContext apiSecurityContext);
 
@@ -90,5 +94,10 @@ public interface Endpoints {
       ApiSecurityContext apiSecurityContext);
 
   CompletableFuture<EndpointResponse> executeCheckHealth(ApiSecurityContext apiSecurityContext);
+
+  CompletableFuture<EndpointResponse> executeServerMetadata(ApiSecurityContext apiSecurityContext);
+
+  CompletableFuture<EndpointResponse> executeServerMetadataClusterId(
+      ApiSecurityContext apiSecurityContext);
 
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -191,6 +191,7 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
   private final Optional<ClusterStatusResource> clusterStatusResource;
   private final Optional<LagReportingResource> lagReportingResource;
   private final HealthCheckResource healthCheckResource;
+  private volatile ServerMetadataResource serverMetadataResource;
 
   // We embed this in here for now
   private Vertx vertx = null;
@@ -368,7 +369,8 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
   public void setupResources(final Configurable<?> config, final KsqlRestConfig appConfig) {
     config.register(rootDocument);
     config.register(serverInfoResource);
-    config.register(ServerMetadataResource.create(serviceContext, ksqlConfigNoPort));
+    this.serverMetadataResource = ServerMetadataResource.create(serviceContext, ksqlConfigNoPort);
+    config.register(serverMetadataResource);
     config.register(statusResource);
     config.register(ksqlResource);
     config.register(streamedQueryResource);
@@ -434,7 +436,8 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
         clusterStatusResource,
         statusResource,
         lagReportingResource,
-        healthCheckResource
+        healthCheckResource,
+        serverMetadataResource
     );
     apiServerConfig = new ApiServerConfig(ksqlConfigWithPort.originals());
     apiServer = new Server(vertx, apiServerConfig, endpoints, true, securityExtension,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/ServerMetadataResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/ServerMetadataResource.java
@@ -17,20 +17,13 @@ package io.confluent.ksql.rest.server.resources;
 
 import io.confluent.ksql.rest.entity.ServerClusterId;
 import io.confluent.ksql.rest.entity.ServerMetadata;
-import io.confluent.ksql.rest.entity.Versions;
 import io.confluent.ksql.services.KafkaClusterUtil;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.Version;
 import java.util.Objects;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-@Path("/v1/metadata")
-@Produces({Versions.KSQL_V1_JSON, MediaType.APPLICATION_JSON})
 public final class ServerMetadataResource {
   private final ServerMetadata serverMetadata;
 
@@ -38,13 +31,10 @@ public final class ServerMetadataResource {
     this.serverMetadata = Objects.requireNonNull(serverMetadata, "serverMetadata");
   }
 
-  @GET
   public Response getServerMetadata() {
     return Response.ok(serverMetadata).build();
   }
 
-  @GET
-  @Path("/id")
   public Response getServerClusterId() {
     return Response.ok(serverMetadata.getClusterId()).build();
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TestEndpoints.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TestEndpoints.java
@@ -163,6 +163,18 @@ public class TestEndpoints implements Endpoints {
     return null;
   }
 
+  @Override
+  public CompletableFuture<EndpointResponse> executeServerMetadata(
+      ApiSecurityContext apiSecurityContext) {
+    return null;
+  }
+
+  @Override
+  public CompletableFuture<EndpointResponse> executeServerMetadataClusterId(
+      ApiSecurityContext apiSecurityContext) {
+    return null;
+  }
+
   public synchronized void setRowGeneratorFactory(
       final Supplier<RowGenerator> rowGeneratorFactory) {
     this.rowGeneratorFactory = rowGeneratorFactory;

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/InsertsStreamRunner.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/InsertsStreamRunner.java
@@ -231,6 +231,18 @@ public class InsertsStreamRunner extends BasePerfRunner {
         ApiSecurityContext apiSecurityContext) {
       return null;
     }
+
+    @Override
+    public CompletableFuture<EndpointResponse> executeServerMetadata(
+        ApiSecurityContext apiSecurityContext) {
+      return null;
+    }
+
+    @Override
+    public CompletableFuture<EndpointResponse> executeServerMetadataClusterId(
+        ApiSecurityContext apiSecurityContext) {
+      return null;
+    }
   }
 
   private class InsertsSubscriber extends BaseSubscriber<JsonObject> implements

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/PullQueryRunner.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/PullQueryRunner.java
@@ -189,6 +189,18 @@ public class PullQueryRunner extends BasePerfRunner {
       return null;
     }
 
+    @Override
+    public CompletableFuture<EndpointResponse> executeServerMetadata(
+        ApiSecurityContext apiSecurityContext) {
+      return null;
+    }
+
+    @Override
+    public CompletableFuture<EndpointResponse> executeServerMetadataClusterId(
+        ApiSecurityContext apiSecurityContext) {
+      return null;
+    }
+
     synchronized void closePublishers() {
       for (PullQueryPublisher publisher : publishers) {
         publisher.close();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/QueryStreamRunner.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/QueryStreamRunner.java
@@ -172,6 +172,18 @@ public class QueryStreamRunner extends BasePerfRunner {
       return null;
     }
 
+    @Override
+    public CompletableFuture<EndpointResponse> executeServerMetadata(
+        ApiSecurityContext apiSecurityContext) {
+      return null;
+    }
+
+    @Override
+    public CompletableFuture<EndpointResponse> executeServerMetadataClusterId(
+        ApiSecurityContext apiSecurityContext) {
+      return null;
+    }
+
     synchronized void closePublishers() {
       for (QueryStreamPublisher publisher : publishers) {
         publisher.close();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
@@ -29,7 +29,9 @@ import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlErrorMessage;
 import io.confluent.ksql.rest.entity.KsqlRequest;
+import io.confluent.ksql.rest.entity.ServerClusterId;
 import io.confluent.ksql.rest.entity.ServerInfo;
+import io.confluent.ksql.rest.entity.ServerMetadata;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
 import io.confluent.ksql.test.util.secure.Credentials;
@@ -116,6 +118,28 @@ public final class RestIntegrationTestUtil {
     try (final KsqlRestClient restClient = restApp.buildKsqlClient(Optional.empty())) {
 
       final RestResponse<CommandStatuses> res = restClient.getAllStatuses();
+
+      throwOnError(res);
+
+      return res.getResponse();
+    }
+  }
+
+  static ServerMetadata makeServerMetadataRequest(final TestKsqlRestApp restApp) {
+    try (final KsqlRestClient restClient = restApp.buildKsqlClient(Optional.empty())) {
+
+      final RestResponse<ServerMetadata> res = restClient.getServerMetadata();
+
+      throwOnError(res);
+
+      return res.getResponse();
+    }
+  }
+
+  static ServerClusterId makeServerMetadataIdRequest(final TestKsqlRestApp restApp) {
+    try (final KsqlRestClient restClient = restApp.buildKsqlClient(Optional.empty())) {
+
+      final RestResponse<ServerClusterId> res = restClient.getServerMetadataId();
 
       throwOnError(res);
 

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -29,7 +29,9 @@ import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlHostInfoEntity;
 import io.confluent.ksql.rest.entity.LagReportingMessage;
 import io.confluent.ksql.rest.entity.LagReportingResponse;
+import io.confluent.ksql.rest.entity.ServerClusterId;
 import io.confluent.ksql.rest.entity.ServerInfo;
+import io.confluent.ksql.rest.entity.ServerMetadata;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import io.vertx.core.http.HttpClientOptions;
 import java.io.Closeable;
@@ -122,6 +124,14 @@ public final class KsqlRestClient implements Closeable {
 
   public RestResponse<CommandStatuses> getAllStatuses() {
     return target().getStatuses();
+  }
+
+  public RestResponse<ServerMetadata> getServerMetadata() {
+    return target().getServerMetadata();
+  }
+
+  public RestResponse<ServerClusterId> getServerMetadataId() {
+    return target().getServerMetadataId();
   }
 
   public RestResponse<HealthCheckResponse> getServerHealth() {

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
@@ -31,7 +31,9 @@ import io.confluent.ksql.rest.entity.KsqlHostInfoEntity;
 import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.entity.LagReportingMessage;
 import io.confluent.ksql.rest.entity.LagReportingResponse;
+import io.confluent.ksql.rest.entity.ServerClusterId;
 import io.confluent.ksql.rest.entity.ServerInfo;
+import io.confluent.ksql.rest.entity.ServerMetadata;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.util.VertxCompletableFuture;
 import io.vertx.core.Vertx;
@@ -64,6 +66,8 @@ public final class KsqlTarget {
   private static final String HEARTBEAT_PATH = "/heartbeat";
   private static final String CLUSTERSTATUS_PATH = "/clusterStatus";
   private static final String LAG_REPORT_PATH = "/lag";
+  private static final String SERVER_METADATA_PATH = "/v1/metadata";
+  private static final String SERVER_METADATA_ID_PATH = "/v1/metadata/id";
 
   private final HttpClient httpClient;
   private final SocketAddress socketAddress;
@@ -134,6 +138,14 @@ public final class KsqlTarget {
 
   public RestResponse<CommandStatus> getStatus(final String commandId) {
     return get(STATUS_PATH + "/" + commandId, CommandStatus.class);
+  }
+
+  public RestResponse<ServerMetadata> getServerMetadata() {
+    return get(SERVER_METADATA_PATH, ServerMetadata.class);
+  }
+
+  public RestResponse<ServerClusterId> getServerMetadataId() {
+    return get(SERVER_METADATA_ID_PATH, ServerClusterId.class);
   }
 
   public RestResponse<KsqlEntityList> postKsqlRequest(


### PR DESCRIPTION
### Description 

This is a stacked PR, please only review top commit(s).

This PR migrates the server metadata endpoints ( /v1/metadata and /v1/metadata/id )from Jetty to Vert.x.

Also, there were zero integration tests for these endpoints so I added them.

### Testing done 

Non functional change, but I added some new tests.

## Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

