### PR TITLE
BREAKING CHANGE: minor: allow more precise configuration of rocks bounds

### DIFF
--- a/ksqldb-rocksdb-config-setter/src/main/java/io/confluent/ksql/rocksdb/KsqlBoundedMemoryRocksDBConfig.java
+++ b/ksqldb-rocksdb-config-setter/src/main/java/io/confluent/ksql/rocksdb/KsqlBoundedMemoryRocksDBConfig.java
@@ -25,10 +25,24 @@ public class KsqlBoundedMemoryRocksDBConfig extends AbstractConfig {
 
   private static final String CONFIG_PREFIX = "ksql.plugins.rocksdb.";
 
-  public static final String TOTAL_OFF_HEAP_MEMORY_CONFIG = CONFIG_PREFIX + "total.memory";
+  public static final String BLOCK_CACHE_SIZE = CONFIG_PREFIX + "cache.size";
   private static final String TOTAL_OFF_HEAP_MEMORY_DOC =
       "All RocksDB instances across all KSQL queries (i.e., all Kafka Streams applications) "
-      + "will be limited to sharing this much memory (in bytes).";
+      + "will be limited to sharing this much memory (in bytes) for block cache.";
+
+  public static final String WRITE_BUFFER_LIMIT = CONFIG_PREFIX + "write.buffer.size";
+  private static final String WRITE_BUFFER_LIMIT_DOC =
+      "All RocksDB instances across all KSQL queries (i.e. all Kafka Streams applications) "
+          + "will be limited to sharing this much write buffer memory.";
+  private static final int WRITE_BUFFER_LIMIT_DEFAULT = -1;
+
+  public static final String STRICT_CACHE_LIMIT = CONFIG_PREFIX + "cache.limit.strict";
+  private static final String STRICT_CACHE_LIMIT_DOC = "Apply a strict limit to the cache size";
+
+  public static final String ACCOUNT_WRITE_BUFFER_AGAINST_CACHE
+      = CONFIG_PREFIX + "write.buffer.cache.use";
+  private static final String ACCOUNT_WRITE_BUFFER_AGAINST_CACHE_DOC =
+      "Account write buffer usage against the block cache";
 
   public static final String N_BACKGROUND_THREADS_CONFIG =
       CONFIG_PREFIX + "num.background.threads";
@@ -44,11 +58,29 @@ public class KsqlBoundedMemoryRocksDBConfig extends AbstractConfig {
 
   private static final ConfigDef CONFIG_DEF = new ConfigDef()
       .define(
-          TOTAL_OFF_HEAP_MEMORY_CONFIG,
+          BLOCK_CACHE_SIZE,
           Type.LONG,
           ConfigDef.NO_DEFAULT_VALUE,
           Importance.HIGH,
           TOTAL_OFF_HEAP_MEMORY_DOC)
+      .define(
+          WRITE_BUFFER_LIMIT,
+          Type.LONG,
+          WRITE_BUFFER_LIMIT_DEFAULT,
+          Importance.HIGH,
+          WRITE_BUFFER_LIMIT_DOC)
+      .define(
+          ACCOUNT_WRITE_BUFFER_AGAINST_CACHE,
+          Type.BOOLEAN,
+          false,
+          Importance.MEDIUM,
+          ACCOUNT_WRITE_BUFFER_AGAINST_CACHE_DOC)
+      .define(
+          STRICT_CACHE_LIMIT,
+          Type.BOOLEAN,
+          false,
+          Importance.MEDIUM,
+          STRICT_CACHE_LIMIT_DOC)
       .define(
           N_BACKGROUND_THREADS_CONFIG,
           Type.INT,

--- a/ksqldb-rocksdb-config-setter/src/test/java/io/confluent/ksql/rocksdb/KsqlBoundedMemoryRocksDBConfigSetterTest.java
+++ b/ksqldb-rocksdb-config-setter/src/test/java/io/confluent/ksql/rocksdb/KsqlBoundedMemoryRocksDBConfigSetterTest.java
@@ -21,11 +21,20 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.rocksdb.KsqlBoundedMemoryRocksDBConfigSetter.LruCacheFactory;
+import io.confluent.ksql.rocksdb.KsqlBoundedMemoryRocksDBConfigSetter.WriteBufferManagerFactory;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,18 +46,24 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.Cache;
 import org.rocksdb.Env;
+import org.rocksdb.LRUCache;
 import org.rocksdb.Options;
 import org.rocksdb.WriteBufferManager;
 
 @RunWith(MockitoJUnitRunner.class)
 public class KsqlBoundedMemoryRocksDBConfigSetterTest {
 
-  private static final long TOTAL_OFF_HEAP_MEMORY = 16 * 1024 * 1024 * 1024L;
+  private static final long CACHE_SIZE = 16 * 1024 * 1024 * 1024L;
+  private static final long WRITE_BUFFER_SIZE = 8 * 1024 * 1024 * 1024L;
   private static final int NUM_BACKGROUND_THREADS = 4;
 
-  private static final Map<String, Object> CONFIG_PROPS = ImmutableMap.of(
-      "ksql.plugins.rocksdb.total.memory", TOTAL_OFF_HEAP_MEMORY,
-      "ksql.plugins.rocksdb.num.background.threads", NUM_BACKGROUND_THREADS);
+  private static final Map<String, Object> CONFIG_PROPS = new HashMap<>(ImmutableMap.of(
+      "ksql.plugins.rocksdb.cache.size", CACHE_SIZE,
+      "ksql.plugins.rocksdb.write.buffer.size", WRITE_BUFFER_SIZE,
+      "ksql.plugins.rocksdb.write.buffer.cache.use", true,
+      "ksql.plugns.rocksdb.cache.limit.strict", false,
+      "ksql.plugins.rocksdb.num.background.threads", NUM_BACKGROUND_THREADS)
+  );
 
   @Mock
   private Options rocksOptions;
@@ -60,6 +75,16 @@ public class KsqlBoundedMemoryRocksDBConfigSetterTest {
   private BlockBasedTableConfig secondTableConfig;
   @Mock
   private Env env;
+  @Mock
+  private LruCacheFactory cacheFactory;
+  @Mock
+  private WriteBufferManagerFactory bufferManagerFactory;
+  @Mock
+  private LRUCache blockCache;
+  @Mock
+  private LRUCache writeCache;
+  @Mock
+  private WriteBufferManager bufferManager;
   @Captor
   private ArgumentCaptor<WriteBufferManager> writeBufferManagerCaptor;
   @Captor
@@ -82,6 +107,11 @@ public class KsqlBoundedMemoryRocksDBConfigSetterTest {
     when(rocksOptions.tableFormatConfig()).thenReturn(tableConfig);
     when(secondRocksOptions.tableFormatConfig()).thenReturn(secondTableConfig);
     when(rocksOptions.getEnv()).thenReturn(env);
+    when(bufferManagerFactory.create(anyLong(), any())).thenReturn(bufferManager);
+    when(cacheFactory.create(anyLong(), anyInt(), anyBoolean(), anyDouble()))
+        .thenReturn(blockCache)
+        .thenReturn(writeCache)
+        .thenThrow(new IllegalStateException());
   }
 
   @Test
@@ -132,17 +162,17 @@ public class KsqlBoundedMemoryRocksDBConfigSetterTest {
   @Test
   public void shouldSetConfig() {
     // Given:
-    rocksDBConfig.configure(CONFIG_PROPS);
+    rocksDBConfig.configure(CONFIG_PROPS, rocksOptions, cacheFactory, bufferManagerFactory);
 
     // When:
     rocksDBConfig.setConfig("store_name", rocksOptions, Collections.emptyMap());
 
     // Then:
-    verify(rocksOptions).setWriteBufferManager(any());
+    verify(rocksOptions).setWriteBufferManager(bufferManager);
     verify(rocksOptions).setStatsDumpPeriodSec(0);
     verify(rocksOptions).setTableFormatConfig(tableConfig);
 
-    verify(tableConfig).setBlockCache(any());
+    verify(tableConfig).setBlockCache(blockCache);
     verify(tableConfig).setCacheIndexAndFilterBlocks(true);
     verify(tableConfig).setCacheIndexAndFilterBlocksWithHighPriority(true);
     verify(tableConfig).setPinTopLevelIndexAndFilter(true);
@@ -183,9 +213,100 @@ public class KsqlBoundedMemoryRocksDBConfigSetterTest {
   @Test
   public void shouldSetNumThreads() {
     // When:
-    KsqlBoundedMemoryRocksDBConfigSetter.configure(CONFIG_PROPS, rocksOptions);
+    KsqlBoundedMemoryRocksDBConfigSetter.configure(
+        CONFIG_PROPS,
+        rocksOptions,
+        cacheFactory,
+        bufferManagerFactory
+    );
 
     // Then:
     verify(env).setBackgroundThreads(NUM_BACKGROUND_THREADS);
+  }
+
+  @Test
+  public void shouldUseCacheForWriteBufferIfConfigured() {
+    // When:
+    CONFIG_PROPS.put(KsqlBoundedMemoryRocksDBConfig.ACCOUNT_WRITE_BUFFER_AGAINST_CACHE, true);
+    KsqlBoundedMemoryRocksDBConfigSetter.configure(
+        CONFIG_PROPS,
+        rocksOptions,
+        cacheFactory,
+        bufferManagerFactory
+    );
+
+    // Then:
+    verify(bufferManagerFactory).create(anyLong(), same(blockCache));
+  }
+
+  @Test
+  public void shouldNotUseCacheForWriteBufferIfNotConfigured() {
+    // When:
+    CONFIG_PROPS.put(KsqlBoundedMemoryRocksDBConfig.ACCOUNT_WRITE_BUFFER_AGAINST_CACHE, false);
+    KsqlBoundedMemoryRocksDBConfigSetter.configure(
+        CONFIG_PROPS,
+        rocksOptions,
+        cacheFactory,
+        bufferManagerFactory
+    );
+
+    // Then:
+    verify(bufferManagerFactory).create(anyLong(), same(writeCache));
+  }
+
+  @Test
+  public void shouldUseStrictCacheIfConfigured() {
+    // When:
+    CONFIG_PROPS.put(KsqlBoundedMemoryRocksDBConfig.STRICT_CACHE_LIMIT, true);
+    KsqlBoundedMemoryRocksDBConfigSetter.configure(
+        CONFIG_PROPS,
+        rocksOptions,
+        cacheFactory,
+        bufferManagerFactory
+    );
+
+    // Then:
+    verify(cacheFactory).create(anyLong(), anyInt(), eq(true), anyDouble());
+  }
+
+  @Test
+  public void shouldNotUseStrictCacheIfNotConfigured() {
+    // When:
+    CONFIG_PROPS.put(KsqlBoundedMemoryRocksDBConfig.STRICT_CACHE_LIMIT, false);
+    KsqlBoundedMemoryRocksDBConfigSetter.configure(
+        CONFIG_PROPS,
+        rocksOptions,
+        cacheFactory,
+        bufferManagerFactory
+    );
+
+    // Then:
+    verify(cacheFactory).create(anyLong(), anyInt(), eq(false), anyDouble());
+  }
+
+  @Test
+  public void shouldUseConfiguredBlockCacheSize() {
+    KsqlBoundedMemoryRocksDBConfigSetter.configure(
+        CONFIG_PROPS,
+        rocksOptions,
+        cacheFactory,
+        bufferManagerFactory
+    );
+
+    // Then:
+    verify(cacheFactory).create(eq(16 * 1024 * 1024 * 1024L), anyInt(), anyBoolean(), anyDouble());
+  }
+
+  @Test
+  public void shouldUseConfiguredWriteBufferSize() {
+    KsqlBoundedMemoryRocksDBConfigSetter.configure(
+        CONFIG_PROPS,
+        rocksOptions,
+        cacheFactory,
+        bufferManagerFactory
+    );
+
+    // Then:
+    verify(bufferManagerFactory).create(eq(8 * 1024 * 1024 * 1024L), any());
   }
 }

--- a/ksqldb-rocksdb-config-setter/src/test/java/io/confluent/ksql/rocksdb/KsqlBoundedMemoryRocksDBConfigTest.java
+++ b/ksqldb-rocksdb-config-setter/src/test/java/io/confluent/ksql/rocksdb/KsqlBoundedMemoryRocksDBConfigTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 
 public class KsqlBoundedMemoryRocksDBConfigTest {
 
-  private static final long TOTAL_OFF_HEAP_MEMORY = 16 * 1024 * 1024 * 1024L;
+  private static final long CACHE_SIZE = 16 * 1024 * 1024 * 1024L;
   private static final int NUM_BACKGROUND_THREADS = 4;
   private static final double INDEX_FILTER_BLOCK_RATIO = 0.1;
 
@@ -36,7 +36,7 @@ public class KsqlBoundedMemoryRocksDBConfigTest {
   public void shouldCreateConfig() {
     // Given:
     final Map<String, Object> configs = ImmutableMap.of(
-        "ksql.plugins.rocksdb.total.memory", TOTAL_OFF_HEAP_MEMORY,
+        "ksql.plugins.rocksdb.cache.size", CACHE_SIZE,
         "ksql.plugins.rocksdb.num.background.threads", NUM_BACKGROUND_THREADS,
         "ksql.plugins.rocksdb.index.filter.block.ratio", INDEX_FILTER_BLOCK_RATIO
     );
@@ -46,8 +46,8 @@ public class KsqlBoundedMemoryRocksDBConfigTest {
 
     // Then:
     assertThat(
-        pluginConfig.getLong(KsqlBoundedMemoryRocksDBConfig.TOTAL_OFF_HEAP_MEMORY_CONFIG),
-        is(TOTAL_OFF_HEAP_MEMORY));
+        pluginConfig.getLong(KsqlBoundedMemoryRocksDBConfig.BLOCK_CACHE_SIZE),
+        is(CACHE_SIZE));
     assertThat(
         pluginConfig.getInt(KsqlBoundedMemoryRocksDBConfig.N_BACKGROUND_THREADS_CONFIG),
         is(NUM_BACKGROUND_THREADS));
@@ -63,7 +63,6 @@ public class KsqlBoundedMemoryRocksDBConfigTest {
         "ksql.plugins.rocksdb.num.background.threads", NUM_BACKGROUND_THREADS
     );
 
-    // Expect:
     // When:
     final Exception e = assertThrows(
         ConfigException.class,
@@ -72,7 +71,7 @@ public class KsqlBoundedMemoryRocksDBConfigTest {
 
     // Then:
     assertThat(e.getMessage(), containsString(
-        "Missing required configuration \"ksql.plugins.rocksdb.total.memory\" "
+        "Missing required configuration \"ksql.plugins.rocksdb.cache.size\" "
             + "which has no default value."));
   }
 
@@ -80,7 +79,7 @@ public class KsqlBoundedMemoryRocksDBConfigTest {
   public void shouldDefaultNumThreadsConfig() {
     // Given:
     final Map<String, Object> configs = ImmutableMap.of(
-        "ksql.plugins.rocksdb.total.memory", TOTAL_OFF_HEAP_MEMORY
+        "ksql.plugins.rocksdb.cache.size", CACHE_SIZE
     );
 
     // When:
@@ -96,7 +95,7 @@ public class KsqlBoundedMemoryRocksDBConfigTest {
   public void shouldDefaultIndexFilterBlockRatioConfig() {
     // Given:
     final Map<String, Object> configs = ImmutableMap.of(
-        "ksql.plugins.rocksdb.total.memory", TOTAL_OFF_HEAP_MEMORY
+        "ksql.plugins.rocksdb.cache.size", CACHE_SIZE
     );
 
     // When:


### PR DESCRIPTION
### Description 

Allows more precise configuration of rocks bounds. Rather than a general
bound config, allow configuring the sizes of cache and memtables, and
allow configuring whether memtable usage is charged to cache.
