### PR TITLE
fix: do not allow implicit casting in UDAF function lookup

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/TableFunctionFactory.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/TableFunctionFactory.java
@@ -31,7 +31,7 @@ public class TableFunctionFactory {
 
   public TableFunctionFactory(final UdfMetadata metadata) {
     this.metadata = Objects.requireNonNull(metadata, "metadata");
-    this.udtfIndex = new UdfIndex<>(metadata.getName());
+    this.udtfIndex = new UdfIndex<>(metadata.getName(), true);
   }
 
   public UdfMetadata getMetadata() {

--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/UdfFactory.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/UdfFactory.java
@@ -33,7 +33,7 @@ public class UdfFactory {
              final UdfMetadata metadata) {
     this.udfClass = Objects.requireNonNull(udfClass, "udfClass can't be null");
     this.metadata = Objects.requireNonNull(metadata, "metadata can't be null");
-    this.udfIndex = new UdfIndex<>(metadata.getName());
+    this.udfIndex = new UdfIndex<>(metadata.getName(), true);
   }
 
   synchronized void addFunction(final KsqlScalarFunction ksqlFunction) {

--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
@@ -92,10 +92,12 @@ public class UdfIndex<T extends FunctionSignature> {
   private final String udfName;
   private final Node root = new Node();
   private final Map<List<ParamType>, T> allFunctions;
+  private final boolean supportsImplicitCasts;
 
-  UdfIndex(final String udfName) {
+  UdfIndex(final String udfName, final boolean supportsImplicitCasts) {
     this.udfName = Objects.requireNonNull(udfName, "udfName");
-    allFunctions = new HashMap<>();
+    this.allFunctions = new HashMap<>();
+    this.supportsImplicitCasts = supportsImplicitCasts;
   }
 
   void addFunction(final T function) {
@@ -152,6 +154,8 @@ public class UdfIndex<T extends FunctionSignature> {
 
     if (fun.isPresent()) {
       return fun.get();
+    } else if (!supportsImplicitCasts) {
+      throw createNoMatchingFunctionException(arguments);
     }
 
     // if none were found (candidates is empty) try again with

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafAggregateFunctionFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafAggregateFunctionFactory.java
@@ -32,7 +32,7 @@ public class UdafAggregateFunctionFactory extends AggregateFunctionFactory {
       final List<UdafFactoryInvoker> factoryList
   ) {
     super(metadata);
-    udfIndex = new UdfIndex<>(metadata.getName());
+    udfIndex = new UdfIndex<>(metadata.getName(), false);
     factoryList.forEach(udfIndex::addFunction);
   }
 


### PR DESCRIPTION
### Description 

fixes #5129 

ensures that lookups for UDAFs in the UdfIndex do not support implicit casting. Previously, the UDF index would find a match but it would fail later on with a cryptic error message.

### Testing done 

Unit testing and end to end testing:
```sql
ksql> SELECT COLLECT_LIST(amount) FROM transactions GROUP BY rowkey EMIT CHANGES;
Function 'collect_list' does not accept parameters (DECIMAL(12, 2)).
Valid alternatives are:
collect_list(BOOLEAN val)
collect_list(DOUBLE val)
collect_list(INT val)
collect_list(BIGINT val)
collect_list(VARCHAR val)
For detailed information on a function run: DESCRIBE FUNCTION <Function-Name>;
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

