### PR TITLE
docs: fix version picker for previous versions

### DIFF
--- a/docs/js/extra.js
+++ b/docs/js/extra.js
@@ -31,11 +31,29 @@
     var nav = document.querySelector('nav');
     var select = document.createElement('select');
 
+    var segs = window.location.pathname.split('/');
+    var currVersion = segs.reduce(function(acc, seg) {
+      if (LANGS.indexOf(acc.prev) > -1) {
+        acc.version = seg;
+      }
+      acc.prev = seg;
+      return acc;
+    }, {prev: '', version: null}).version;
+
+    if (!currVersion) {
+      console.warn('Version selector could not infer the current version. Are you running in a local development environment?');
+      return;
+    }
+
+    if (currVersion === 'latest') {
+      currVersion = config.defaultVersion;
+    }
+
     config.versions.forEach(function(v) {
       var option = document.createElement('option');
       option.value = v;
       option.innerText = v;
-      option.selected = v === config.defaultVersion;
+      option.selected = v === currVersion;
 
       select.append(option);
     });


### PR DESCRIPTION
### Description 
The docs version picker does not select the current version when on the 0.7.1-ksqldb url. This fixes the logic to choose the dropdown's default selection based on the url.

### Testing done 
Tested locally with dummy pages under `/en/0.7.1-ksqldb/`, `/en/0.8.1-ksqldb/`, `/en/latest/` to mimic the deployed docs.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

