### PR TITLE
docs: cherry-pick bump CP version in ksqlDB Standalone docs (DOCS-4152)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -190,10 +190,10 @@ extra:
 
         # Build-related string tokens
         kafkaversion: 2.4
-        kafkarelease: 5.4.1-ccs
+        kafkarelease: 5.5.0-ccs
         ksqldbversion: 0.8.1
         release: 0.8.1
-        cprelease: 5.4.1
-        releasepostbranch: 5.4.1-post
+        cprelease: 5.5.0
+        releasepostbranch: 5.5.0-post
         scalaversion: 2.12
         version: 5.4


### PR DESCRIPTION
From https://github.com/confluentinc/ksql/pull/5156.