### PR TITLE
refactor: Drop meta columns from logical schema

### DIFF
--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -700,7 +700,6 @@ public class CliTest {
 
     final PhysicalSchema resultSchema = PhysicalSchema.from(
         LogicalSchema.builder()
-            .withRowTime()
             .keyColumns(ORDER_DATA_PROVIDER.schema().logicalSchema().key())
             .valueColumn(ColumnName.of("ITEMID"), SqlTypes.STRING)
             .valueColumn(ColumnName.of("COL1"), SqlTypes.DOUBLE)

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -110,7 +110,6 @@ public class ConsoleTest {
   private static final String AGGREGATE_STATUS = "ERROR";
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(ColumnName.of("foo"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("bar"), SqlTypes.STRING)
       .build();
@@ -1510,7 +1509,6 @@ public class ConsoleTest {
 
   private static List<FieldInfo> buildTestSchema(final SqlType... fieldTypes) {
     final Builder schemaBuilder = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING);
 
     for (int idx = 0; idx < fieldTypes.length; idx++) {

--- a/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/Column.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/Column.java
@@ -29,8 +29,7 @@ public final class Column implements SimpleColumn {
   // The order of the enum defines the order of precedence of {@code LogicalScheam.findColumn}.
   public enum Namespace {
     KEY,
-    VALUE,
-    META
+    VALUE
   }
 
   private final ColumnName name;

--- a/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
@@ -15,6 +15,10 @@
 
 package io.confluent.ksql.schema.ksql;
 
+import static io.confluent.ksql.schema.ksql.Column.Namespace.KEY;
+import static io.confluent.ksql.schema.ksql.Column.Namespace.VALUE;
+import static io.confluent.ksql.util.SchemaUtil.ROWTIME_NAME;
+import static io.confluent.ksql.util.SchemaUtil.ROWTIME_TYPE;
 import static io.confluent.ksql.util.SchemaUtil.WINDOWBOUND_TYPE;
 import static io.confluent.ksql.util.SchemaUtil.WINDOWEND_NAME;
 import static io.confluent.ksql.util.SchemaUtil.WINDOWSTART_NAME;
@@ -25,7 +29,6 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.Column.Namespace;
 import io.confluent.ksql.schema.ksql.SchemaConverters.SqlToConnectTypeConverter;
 import io.confluent.ksql.schema.ksql.types.SqlType;
-import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.SchemaUtil;
 import java.util.Arrays;
@@ -48,17 +51,18 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 @Immutable
 public final class LogicalSchema {
 
-  private static final Column IMPLICIT_TIME_COLUMN = Column
-      .of(SchemaUtil.ROWTIME_NAME, SqlTypes.BIGINT, Column.Namespace.META, 0);
-
   private final ImmutableList<Column> columns;
 
   public static Builder builder() {
-    return new Builder();
+    return new Builder(ImmutableList.of());
   }
 
   private LogicalSchema(final ImmutableList<Column> columns) {
     this.columns = Objects.requireNonNull(columns, "columns");
+  }
+
+  public Builder asBuilder() {
+    return new Builder(columns);
   }
 
   public ConnectSchema keyConnectSchema() {
@@ -67,14 +71,6 @@ public final class LogicalSchema {
 
   public ConnectSchema valueConnectSchema() {
     return toConnectSchema(value());
-  }
-
-  /**
-   * @return the schema of the metadata.
-   */
-  public List<Column> metadata() {
-    return byNamespace()
-        .get(Namespace.META);
   }
 
   /**
@@ -90,7 +86,7 @@ public final class LogicalSchema {
    */
   public List<Column> value() {
     return byNamespace()
-        .get(Namespace.VALUE);
+        .get(VALUE);
   }
 
   /**
@@ -107,7 +103,7 @@ public final class LogicalSchema {
    * @return the column if found, else {@code Optional.empty()}.
    */
   public Optional<Column> findColumn(final ColumnName columnName) {
-    return findColumnMatching(withRef(columnName));
+    return findColumnMatching(withName(columnName));
   }
 
   /**
@@ -117,7 +113,7 @@ public final class LogicalSchema {
    * @return the value column if found, else {@code Optional.empty()}.
    */
   public Optional<Column> findValueColumn(final ColumnName columnName) {
-    return findColumnMatching(withNamespace(Namespace.VALUE).and(withRef(columnName)));
+    return findColumnMatching(withNamespace(VALUE).and(withName(columnName)));
   }
 
   /**
@@ -133,7 +129,7 @@ public final class LogicalSchema {
   }
 
   /**
-   * Copies metadata and key columns to the value schema.
+   * Copies pseudo and key columns to the value schema.
    *
    * <p>If the columns already exist in the value schema the function returns the same schema.
    *
@@ -141,26 +137,17 @@ public final class LogicalSchema {
    * WINDOWEND} columns will added to the value schema to represent the window bounds.
    * @return the new schema.
    */
-  public LogicalSchema withMetaAndKeyColsInValue(final boolean windowed) {
+  public LogicalSchema withPseudoAndKeyColsInValue(final boolean windowed) {
     return rebuild(true, windowed);
   }
 
   /**
-   * Remove metadata and key columns from the value schema.
+   * Remove pseudo and key columns from the value schema.
    *
    * @return the new schema with the columns removed.
    */
-  public LogicalSchema withoutMetaAndKeyColsInValue() {
+  public LogicalSchema withoutPseudoAndKeyColsInValue() {
     return rebuild(false, false);
-  }
-
-  /**
-   * @param columnName the column name to check
-   * @return {@code true} if the column matches the name of any metadata column.
-   */
-  public boolean isMetaColumn(final ColumnName columnName) {
-    return findColumnMatching(withNamespace(Namespace.META).and(withName(columnName)))
-        .isPresent();
   }
 
   /**
@@ -195,18 +182,15 @@ public final class LogicalSchema {
   }
 
   public String toString(final FormatOptions formatOptions) {
-    // Meta columns deliberately excluded.
-
     return columns.stream()
-        .filter(withNamespace(Namespace.META).negate())
         .map(c -> c.toString(formatOptions))
         .collect(Collectors.joining(", "));
   }
 
   private Optional<Column> findColumnMatching(final Predicate<Column> predicate) {
     // At the moment, it's possible for some column names to have multiple matches, e.g.
-    // ROWKEY and ROWTIME. Order of preference on namespace is KEY, VALUE then META,
-    // as per Namespace enum ordinal.
+    // ROWKEY and ROWTIME. Order of preference on namespace is KEY then VALUE, as per Namespace
+    // enum ordinal.
 
     return columns.stream()
         .filter(predicate)
@@ -224,59 +208,47 @@ public final class LogicalSchema {
   }
 
   private LogicalSchema rebuild(
-      final boolean withMetaAndKeyColsInValue,
+      final boolean withPseudoAndKeyColsInValue,
       final boolean windowedKey
   ) {
     final Map<Namespace, List<Column>> byNamespace = byNamespace();
 
-    final List<Column> metadata = byNamespace.get(Namespace.META);
     final List<Column> key = byNamespace.get(Namespace.KEY);
-    final List<Column> value = byNamespace.get(Namespace.VALUE);
+    final List<Column> value = byNamespace.get(VALUE);
 
     final ImmutableList.Builder<Column> builder = ImmutableList.builder();
 
-    builder.addAll(metadata);
     builder.addAll(key);
 
     int valueIndex = 0;
     for (final Column c : value) {
-      if (c.name().equals(WINDOWSTART_NAME)
-          || c.name().equals(WINDOWEND_NAME)
-      ) {
+      if (SchemaUtil.isSystemColumn(c.name())) {
         continue;
       }
 
-      if (findColumnMatching(
-          (withNamespace(Namespace.META).or(withNamespace(Namespace.KEY)).and(withRef(c.name()))
-          )).isPresent()) {
+      if (findColumnMatching(withNamespace(Namespace.KEY).and(withName(c.name()))).isPresent()) {
         continue;
       }
 
-      builder.add(Column.of(c.name(), c.type(), Namespace.VALUE, valueIndex++));
+      builder.add(Column.of(c.name(), c.type(), VALUE, valueIndex++));
     }
 
-    if (withMetaAndKeyColsInValue) {
-      for (final Column c : metadata) {
-        builder.add(Column.of(c.name(), c.type(), Namespace.VALUE, valueIndex++));
-      }
+    if (withPseudoAndKeyColsInValue) {
+      builder.add(Column.of(ROWTIME_NAME, ROWTIME_TYPE, VALUE, valueIndex++));
 
       for (final Column c : key) {
-        builder.add(Column.of(c.name(), c.type(), Namespace.VALUE, valueIndex++));
+        builder.add(Column.of(c.name(), c.type(), VALUE, valueIndex++));
       }
 
       if (windowedKey) {
         builder.add(
-            Column.of(WINDOWSTART_NAME, WINDOWBOUND_TYPE, Namespace.VALUE, valueIndex++));
+            Column.of(WINDOWSTART_NAME, WINDOWBOUND_TYPE, VALUE, valueIndex++));
         builder.add(
-            Column.of(WINDOWEND_NAME, WINDOWBOUND_TYPE, Namespace.VALUE, valueIndex));
+            Column.of(WINDOWEND_NAME, WINDOWBOUND_TYPE, VALUE, valueIndex));
       }
     }
 
     return new LogicalSchema(builder.build());
-  }
-
-  private static Predicate<Column> withRef(final ColumnName ref) {
-    return c -> c.name().equals(ref);
   }
 
   private static Predicate<Column> withName(final ColumnName name) {
@@ -301,15 +273,20 @@ public final class LogicalSchema {
     return (ConnectSchema) builder.build();
   }
 
-  public static class Builder {
+  public static final class Builder {
 
     private final ImmutableList.Builder<Column> columns = ImmutableList.builder();
     private final Set<ColumnName> seenKeys = new HashSet<>();
     private final Set<ColumnName> seenValues = new HashSet<>();
 
-    public Builder withRowTime() {
-      columns.add(IMPLICIT_TIME_COLUMN);
-      return this;
+    private Builder(final ImmutableList<Column> columns) {
+      columns.forEach(col -> {
+        if (col.namespace() == KEY) {
+          keyColumn(col.name(), col.type());
+        } else {
+          valueColumn(col.name(), col.type());
+        }
+      });
     }
 
     public Builder keyColumns(final Iterable<? extends SimpleColumn> columns) {
@@ -336,7 +313,7 @@ public final class LogicalSchema {
     }
 
     public Builder valueColumn(final ColumnName name, final SqlType type) {
-      addColumn(Column.of(name, type, Column.Namespace.VALUE, seenValues.size()));
+      addColumn(Column.of(name, type, VALUE, seenValues.size()));
       return this;
     }
 
@@ -359,7 +336,7 @@ public final class LogicalSchema {
           break;
 
         default:
-          break;
+          throw new UnsupportedOperationException("Unsupported column type: " + column);
       }
 
       columns.add(column);

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
@@ -47,6 +47,7 @@ public final class SchemaUtil {
 
   public static final ColumnName ROWKEY_NAME = ColumnName.of("ROWKEY");
   public static final ColumnName ROWTIME_NAME = ColumnName.of("ROWTIME");
+  public static final SqlType ROWTIME_TYPE = SqlTypes.BIGINT;
   public static final ColumnName WINDOWSTART_NAME = ColumnName.of("WINDOWSTART");
   public static final ColumnName WINDOWEND_NAME = ColumnName.of("WINDOWEND");
   public static final SqlType WINDOWBOUND_TYPE = SqlTypes.BIGINT;
@@ -56,8 +57,12 @@ public final class SchemaUtil {
       WINDOWEND_NAME
   );
 
+  private static final Set<ColumnName> PSEUDO_COLUMN_NAMES = ImmutableSet.of(
+      ROWTIME_NAME
+  );
+
   private static final Set<ColumnName> SYSTEM_COLUMN_NAMES = ImmutableSet.<ColumnName>builder()
-      .add(ROWTIME_NAME)
+      .addAll(PSEUDO_COLUMN_NAMES)
       .addAll(WINDOW_BOUNDS_COLUMN_NAMES)
       .build();
 
@@ -81,6 +86,14 @@ public final class SchemaUtil {
 
   public static Set<ColumnName> windowBoundsColumnNames() {
     return WINDOW_BOUNDS_COLUMN_NAMES;
+  }
+
+  public static boolean isPseudoColumn(final ColumnName columnName) {
+    return pseudoColumnNames().contains(columnName);
+  }
+
+  public static Set<ColumnName> pseudoColumnNames() {
+    return PSEUDO_COLUMN_NAMES;
   }
 
   public static boolean isSystemColumn(final ColumnName columnName) {

--- a/ksqldb-common/src/test/java/io/confluent/ksql/json/LogicalSchemaSerializerTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/json/LogicalSchemaSerializerTest.java
@@ -40,7 +40,6 @@ public class LogicalSchemaSerializerTest {
   public void shouldSerializeSchemaWithImplicitColumns() throws Exception {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("v0"), SqlTypes.INTEGER)
         .build();

--- a/ksqldb-common/src/test/java/io/confluent/ksql/schema/ksql/ColumnMatchers.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/schema/ksql/ColumnMatchers.java
@@ -42,29 +42,6 @@ public final class ColumnMatchers {
     );
   }
 
-  public static Matcher<Column> metaColumn(
-      final ColumnName name,
-      final SqlType type
-  ) {
-    return allOf(
-        hasName(name),
-        hasType(type),
-        hasNamespace(Namespace.META)
-    );
-  }
-
-  public static Matcher<Column> metaColumn(
-      final SourceName source,
-      final ColumnName name,
-      final SqlType type
-  ) {
-    return allOf(
-        hasName(name),
-        hasType(type),
-        hasNamespace(Namespace.META)
-    );
-  }
-
   public static Matcher<Column> keyColumn(
       final ColumnName name,
       final SqlType type

--- a/ksqldb-common/src/test/java/io/confluent/ksql/schema/ksql/ColumnTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/schema/ksql/ColumnTest.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.schema.ksql;
 
 import static io.confluent.ksql.schema.ksql.Column.Namespace.KEY;
-import static io.confluent.ksql.schema.ksql.Column.Namespace.META;
 import static io.confluent.ksql.schema.ksql.Column.Namespace.VALUE;
 import static io.confluent.ksql.schema.ksql.types.SqlTypes.BIGINT;
 import static io.confluent.ksql.schema.ksql.types.SqlTypes.BOOLEAN;
@@ -29,7 +28,6 @@ import static org.hamcrest.Matchers.is;
 import com.google.common.testing.EqualsTester;
 import com.google.common.testing.NullPointerTester;
 import io.confluent.ksql.name.ColumnName;
-import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import org.junit.Test;
 
@@ -81,7 +79,7 @@ public class ColumnTest {
 
   @Test
   public void shouldReturnType() {
-    assertThat(Column.of(SOME_NAME, BOOLEAN, META, 1).type(), is(BOOLEAN));
+    assertThat(Column.of(SOME_NAME, BOOLEAN, KEY, 1).type(), is(BOOLEAN));
   }
 
   @Test
@@ -103,9 +101,6 @@ public class ColumnTest {
 
     assertThat(Column.of(SOME_NAME, INTEGER, KEY, 10).toString(),
         is("`SomeName` INTEGER KEY"));
-
-    assertThat(Column.of(SOME_NAME, INTEGER, META, 10).toString(),
-        is("`SomeName` INTEGER META"));
   }
 
   @Test

--- a/ksqldb-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.schema.ksql;
 
 import static io.confluent.ksql.schema.ksql.ColumnMatchers.keyColumn;
-import static io.confluent.ksql.schema.ksql.ColumnMatchers.metaColumn;
 import static io.confluent.ksql.schema.ksql.ColumnMatchers.valueColumn;
 import static io.confluent.ksql.schema.ksql.types.SqlTypes.BIGINT;
 import static io.confluent.ksql.schema.ksql.types.SqlTypes.BOOLEAN;
@@ -29,7 +28,6 @@ import static io.confluent.ksql.util.SchemaUtil.WINDOWSTART_NAME;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThrows;
@@ -41,6 +39,7 @@ import io.confluent.ksql.schema.ksql.Column.Namespace;
 import io.confluent.ksql.schema.ksql.LogicalSchema.Builder;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.SchemaUtil;
 import java.util.List;
 import java.util.Optional;
 import org.apache.kafka.connect.data.ConnectSchema;
@@ -60,7 +59,6 @@ public class LogicalSchemaTest {
   private static final ColumnName VALUE = ColumnName.of("value");
 
   private static final LogicalSchema SOME_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .valueColumn(F0, STRING)
       .keyColumn(K0, BIGINT)
       .valueColumn(F1, BIGINT)
@@ -106,27 +104,20 @@ public class LogicalSchemaTest {
                 .build()
         )
         .addEqualityGroup(
-            LogicalSchema.builder()
-                .withRowTime()
-                .keyColumn(K0, BIGINT)
-                .valueColumn(V0, STRING)
-                .build()
-        )
-        .addEqualityGroup(
             aSchema,
             aSchema
-                .withMetaAndKeyColsInValue(false)
-                .withoutMetaAndKeyColsInValue(),
+                .withPseudoAndKeyColsInValue(false)
+                .withoutPseudoAndKeyColsInValue(),
 
             aSchema
-                .withMetaAndKeyColsInValue(true)
-                .withoutMetaAndKeyColsInValue()
+                .withPseudoAndKeyColsInValue(true)
+                .withoutPseudoAndKeyColsInValue()
         )
         .addEqualityGroup(
-            aSchema.withMetaAndKeyColsInValue(true)
+            aSchema.withPseudoAndKeyColsInValue(true)
         )
         .addEqualityGroup(
-            aSchema.withMetaAndKeyColsInValue(false)
+            aSchema.withPseudoAndKeyColsInValue(false)
         )
         .testEquals();
   }
@@ -135,7 +126,6 @@ public class LogicalSchemaTest {
   public void shouldExposeColumnIndexWithinValueNamespace() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .withRowTime()
         .valueColumn(F0, STRING)
         .keyColumn(K0, BIGINT)
         .valueColumn(F1, BIGINT)
@@ -147,7 +137,6 @@ public class LogicalSchemaTest {
 
     // Then:
     assertThat(result, contains(
-        Column.of(ROWTIME_NAME, BIGINT, Namespace.META, 0),
         Column.of(F0, STRING, Namespace.VALUE, 0),
         Column.of(K0, BIGINT, Namespace.KEY, 0),
         Column.of(F1, BIGINT, Namespace.VALUE, 1),
@@ -188,7 +177,7 @@ public class LogicalSchemaTest {
   @Test
   public void shouldGetMetaColumnFromValueIfAdded() {
     // Given:
-    final LogicalSchema schema = SOME_SCHEMA.withMetaAndKeyColsInValue(false);
+    final LogicalSchema schema = SOME_SCHEMA.withPseudoAndKeyColsInValue(false);
 
     // Then:
     assertThat(schema.findValueColumn(ROWTIME_NAME),
@@ -198,18 +187,11 @@ public class LogicalSchemaTest {
   @Test
   public void shouldGetKeyColumnFromValueIfAdded() {
     // Given:
-    final LogicalSchema schema = SOME_SCHEMA.withMetaAndKeyColsInValue(false);
+    final LogicalSchema schema = SOME_SCHEMA.withPseudoAndKeyColsInValue(false);
 
     // Then:
     assertThat(schema.findValueColumn(K0),
         is(not(Optional.empty())));
-  }
-
-  @Test
-  public void shouldGetMetaFields() {
-    assertThat(SOME_SCHEMA.findColumn(ROWTIME_NAME), is(Optional.of(
-        Column.of(ROWTIME_NAME, BIGINT, Namespace.META, 0)
-    )));
   }
 
   @Test
@@ -246,7 +228,6 @@ public class LogicalSchemaTest {
   public void shouldPreferValueOverMetaColumns() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(K0, INTEGER)
         .valueColumn(ROWTIME_NAME, BIGINT)
         .build();
@@ -256,13 +237,6 @@ public class LogicalSchemaTest {
         schema.findColumn(ROWTIME_NAME).map(Column::namespace),
         is(Optional.of(Namespace.VALUE))
     );
-  }
-
-  @Test
-  public void shouldExposeMetaColumns() {
-    assertThat(SOME_SCHEMA.metadata(), contains(
-        metaColumn(ROWTIME_NAME, BIGINT)
-    ));
   }
 
   @Test
@@ -276,16 +250,6 @@ public class LogicalSchemaTest {
   public void shouldExposeValueColumns() {
     assertThat(SOME_SCHEMA.value(), contains(
         valueColumn(F0, STRING),
-        valueColumn(F1, BIGINT)
-    ));
-  }
-
-  @Test
-  public void shouldExposeAllColumns() {
-    assertThat(SOME_SCHEMA.columns(), contains(
-        metaColumn(ROWTIME_NAME, BIGINT),
-        valueColumn(F0, STRING),
-        keyColumn(K0, BIGINT),
         valueColumn(F1, BIGINT)
     ));
   }
@@ -396,7 +360,6 @@ public class LogicalSchemaTest {
   public void shouldAddMetaAndKeyColumnsToValue() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(K0, INTEGER)
         .keyColumn(K1, STRING)
         .valueColumn(F0, STRING)
@@ -404,11 +367,10 @@ public class LogicalSchemaTest {
         .build();
 
     // When:
-    final LogicalSchema result = schema.withMetaAndKeyColsInValue(false);
+    final LogicalSchema result = schema.withPseudoAndKeyColsInValue(false);
 
     // Then:
     assertThat(result, is(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(K0, INTEGER)
         .keyColumn(K1, STRING)
         .valueColumn(F0, STRING)
@@ -424,7 +386,6 @@ public class LogicalSchemaTest {
   public void shouldAddWindowedMetaAndKeyColumnsToValue() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(K0, INTEGER)
         .keyColumn(K1, STRING)
         .valueColumn(F0, STRING)
@@ -433,11 +394,10 @@ public class LogicalSchemaTest {
 
     // When:
     final LogicalSchema result = schema
-        .withMetaAndKeyColsInValue(true);
+        .withPseudoAndKeyColsInValue(true);
 
     // Then:
     assertThat(result, is(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(K0, INTEGER)
         .keyColumn(K1, STRING)
         .valueColumn(F0, STRING)
@@ -459,10 +419,10 @@ public class LogicalSchemaTest {
         .keyColumn(K0, INTEGER)
         .valueColumn(F1, BIGINT)
         .build()
-        .withMetaAndKeyColsInValue(false);
+        .withPseudoAndKeyColsInValue(false);
 
     // When:
-    final LogicalSchema result = schema.withMetaAndKeyColsInValue(false);
+    final LogicalSchema result = schema.withPseudoAndKeyColsInValue(false);
 
     // Then:
     assertThat(result, is(schema));
@@ -472,7 +432,6 @@ public class LogicalSchemaTest {
   public void shouldRemoveOthersWhenAddingMetasAndKeyColumns() {
     // Given:
     final LogicalSchema ksqlSchema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(K0, INTEGER)
         .valueColumn(F0, BIGINT)
         .valueColumn(K0, DOUBLE)
@@ -481,11 +440,10 @@ public class LogicalSchemaTest {
         .build();
 
     // When:
-    final LogicalSchema result = ksqlSchema.withMetaAndKeyColsInValue(false);
+    final LogicalSchema result = ksqlSchema.withPseudoAndKeyColsInValue(false);
 
     // Then:
     assertThat(result, is(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(K0, INTEGER)
         .valueColumn(F0, BIGINT)
         .valueColumn(F1, BIGINT)
@@ -503,10 +461,10 @@ public class LogicalSchemaTest {
         .valueColumn(F0, BIGINT)
         .valueColumn(F1, BIGINT)
         .build()
-        .withMetaAndKeyColsInValue(false);
+        .withPseudoAndKeyColsInValue(false);
 
     // When
-    final LogicalSchema result = schema.withoutMetaAndKeyColsInValue();
+    final LogicalSchema result = schema.withoutPseudoAndKeyColsInValue();
 
     // Then:
     assertThat(result, is(LogicalSchema.builder()
@@ -525,10 +483,10 @@ public class LogicalSchemaTest {
         .valueColumn(F0, BIGINT)
         .valueColumn(F1, BIGINT)
         .build()
-        .withMetaAndKeyColsInValue(true);
+        .withPseudoAndKeyColsInValue(true);
 
     // When
-    final LogicalSchema result = schema.withoutMetaAndKeyColsInValue();
+    final LogicalSchema result = schema.withoutPseudoAndKeyColsInValue();
 
     // Then:
     assertThat(result, is(LogicalSchema.builder()
@@ -543,7 +501,6 @@ public class LogicalSchemaTest {
   public void shouldRemoveMetaColumnsWhereEverTheyAre() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(K0, INTEGER)
         .valueColumn(F0, BIGINT)
         .valueColumn(F1, BIGINT)
@@ -551,11 +508,10 @@ public class LogicalSchemaTest {
         .build();
 
     // When
-    final LogicalSchema result = schema.withoutMetaAndKeyColsInValue();
+    final LogicalSchema result = schema.withoutPseudoAndKeyColsInValue();
 
     // Then:
     assertThat(result, is(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(K0, INTEGER)
         .valueColumn(F0, BIGINT)
         .valueColumn(F1, BIGINT)
@@ -574,7 +530,7 @@ public class LogicalSchemaTest {
         .build();
 
     // When
-    final LogicalSchema result = schema.withoutMetaAndKeyColsInValue();
+    final LogicalSchema result = schema.withoutPseudoAndKeyColsInValue();
 
     // Then:
     assertThat(result, is(LogicalSchema.builder()
@@ -587,13 +543,13 @@ public class LogicalSchemaTest {
 
   @Test
   public void shouldMatchMetaColumnName() {
-    assertThat(SOME_SCHEMA.isMetaColumn(ROWTIME_NAME), is(true));
+    assertThat(SchemaUtil.isPseudoColumn(ROWTIME_NAME), is(true));
     assertThat(SOME_SCHEMA.isKeyColumn(ROWTIME_NAME), is(false));
   }
 
   @Test
   public void shouldMatchKeyColumnName() {
-    assertThat(SOME_SCHEMA.isMetaColumn(K0), is(false));
+    assertThat(SchemaUtil.isPseudoColumn(K0), is(false));
     assertThat(SOME_SCHEMA.isKeyColumn(K0), is(true));
   }
 
@@ -601,14 +557,14 @@ public class LogicalSchemaTest {
   public void shouldNotMatchValueColumnsAsBeingMetaOrKeyColumns() {
     SOME_SCHEMA.value().forEach(column ->
     {
-      assertThat(SOME_SCHEMA.isMetaColumn(column.name()), is(false));
+      assertThat(SchemaUtil.isPseudoColumn(column.name()), is(false));
       assertThat(SOME_SCHEMA.isKeyColumn(column.name()), is(false));
     });
   }
 
   @Test
   public void shouldNotMatchRandomColumnNameAsBeingMetaOrKeyColumns() {
-    assertThat(SOME_SCHEMA.isMetaColumn(ColumnName.of("well_this_ain't_in_the_schema")), is(false));
+    assertThat(SchemaUtil.isPseudoColumn(ColumnName.of("well_this_ain't_in_the_schema")), is(false));
     assertThat(SOME_SCHEMA.isKeyColumn(ColumnName.of("well_this_ain't_in_the_schema")), is(false));
   }
 
@@ -683,29 +639,10 @@ public class LogicalSchemaTest {
   }
 
   @Test
-  public void shouldBuildSchemaWithNoMetaColumns() {
-    // When:
-    final LogicalSchema schema = LogicalSchema.builder()
-        .keyColumn(K0, DOUBLE)
-        .valueColumn(F0, BIGINT)
-        .build();
-
-    // Then:
-    assertThat(schema.metadata(), is(empty()));
-    assertThat(schema.key(), contains(
-        keyColumn(K0, DOUBLE)
-    ));
-    assertThat(schema.value(), contains(
-        valueColumn(F0, BIGINT)
-    ));
-  }
-
-  @Test
   public void shouldSupportCopyingColumnsFromOtherSchemas() {
     // When:
     final LogicalSchema schema = LogicalSchema.builder()
         .keyColumns(SOME_SCHEMA.value())
-        .valueColumns(SOME_SCHEMA.metadata())
         .valueColumns(SOME_SCHEMA.key())
         .build();
 
@@ -713,7 +650,6 @@ public class LogicalSchemaTest {
     assertThat(schema.columns(), contains(
         keyColumn(F0, STRING),
         keyColumn(F1, BIGINT),
-        valueColumn(ROWTIME_NAME, BIGINT),
         valueColumn(K0, BIGINT)
     ));
   }
@@ -743,6 +679,63 @@ public class LogicalSchemaTest {
 
     // Then:
     assertThat(schema.valueContainsAny(ImmutableSet.of(K0, V0, ROWTIME_NAME)), is(false));
+  }
+
+  @Test
+  public void shouldDuplicateViaAsBuilder() {
+    // Given:
+    final Builder builder = SOME_SCHEMA.asBuilder();
+
+    // When:
+    final LogicalSchema clone = builder.build();
+
+    // Then:
+    assertThat(clone, is(SOME_SCHEMA));
+  }
+
+  @Test
+  public void shouldAddColumnsViaAsBuilder() {
+    // Given:
+    final Builder builder = SOME_SCHEMA.asBuilder();
+
+    // When:
+    final LogicalSchema clone = builder
+        .keyColumn(K1, INTEGER)
+        .valueColumn(V1, STRING)
+        .build();
+
+    // Then:
+    assertThat(clone, is(LogicalSchema.builder()
+        .valueColumn(F0, STRING)
+        .keyColumn(K0, BIGINT)
+        .valueColumn(F1, BIGINT)
+        .keyColumn(K1, INTEGER)
+        .valueColumn(V1, STRING)
+        .build()));
+  }
+
+  @Test
+  public void shouldDetectDuplicateKeysViaAsBuilder() {
+    // Given:
+    final Builder builder = SOME_SCHEMA.asBuilder();
+
+    // When:
+    assertThrows(
+        KsqlException.class,
+        () -> builder.keyColumn(K0, STRING)
+    );
+  }
+
+  @Test
+  public void shouldDetectDuplicateValuesViaAsBuilder() {
+    // Given:
+    final Builder builder = SOME_SCHEMA.asBuilder();
+
+    // When:
+    assertThrows(
+        KsqlException.class,
+        () -> builder.valueColumn(F0, STRING)
+    );
   }
 
   private static org.apache.kafka.connect.data.Field connectField(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analysis.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analysis.java
@@ -265,7 +265,7 @@ public class Analysis implements ImmutableAnalysis {
 
     return ds.getDataSource()
         .getSchema()
-        .withMetaAndKeyColsInValue(windowedSource || windowedGroupBy);
+        .withPseudoAndKeyColsInValue(windowedSource || windowedGroupBy);
   }
 
   @Immutable

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/SourceSchemas.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/SourceSchemas.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.util.SchemaUtil;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -93,8 +94,7 @@ public final class SourceSchemas {
   boolean matchesNonValueField(final Optional<SourceName> source, final ColumnName column) {
     if (!source.isPresent()) {
       return sourceSchemas.values().stream()
-          .anyMatch(schema ->
-              schema.isMetaColumn(column) || schema.isKeyColumn(column));
+          .anyMatch(schema -> SchemaUtil.isPseudoColumn(column) || schema.isKeyColumn(column));
     }
 
     final SourceName sourceName = source.get();
@@ -103,6 +103,6 @@ public final class SourceSchemas {
       throw new IllegalArgumentException("Unknown source: " + sourceName);
     }
 
-    return sourceSchema.isKeyColumn(column) || sourceSchema.isMetaColumn(column);
+    return sourceSchema.isKeyColumn(column) || SchemaUtil.isPseudoColumn(column);
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/AstSanitizer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/AstSanitizer.java
@@ -145,8 +145,7 @@ public final class AstSanitizer {
       if (expression instanceof QualifiedColumnReferenceExp) {
         final SourceName source = ((QualifiedColumnReferenceExp) expression).getQualifier();
         final ColumnName name = ((QualifiedColumnReferenceExp) expression).getColumnName();
-        if (dataSourceExtractor.isJoin()
-            && dataSourceExtractor.getClashingColumnNames().contains(name)) {
+        if (dataSourceExtractor.isClashingColumnName(name)) {
           alias = ColumnNames.generatedJoinColumnAlias(source, name);
         } else {
           alias = name;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/DataSourceExtractor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/DataSourceExtractor.java
@@ -31,7 +31,7 @@ import io.confluent.ksql.parser.tree.Relation;
 import io.confluent.ksql.parser.tree.Table;
 import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.util.KsqlException;
-import java.util.Collections;
+import io.confluent.ksql.util.SchemaUtil;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -61,14 +61,19 @@ class DataSourceExtractor {
   }
 
   /**
-   * @return the set of column names that existing in more than one source.
+   * @param name the column name to test.
+   * @return {@code true} if the name exists in more than one source.
    */
-  public Set<ColumnName> getClashingColumnNames() {
-    return Collections.unmodifiableSet(clashingColumns);
-  }
+  public boolean isClashingColumnName(final ColumnName name) {
+    if (!isJoin) {
+      return false;
+    }
 
-  public boolean isJoin() {
-    return isJoin;
+    if (SchemaUtil.isPseudoColumn(name)) {
+      return true;
+    }
+
+    return clashingColumns.contains(name);
   }
 
   public SourceName getAliasFor(final ColumnName columnName) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -562,8 +562,7 @@ public class LogicalPlanner {
         functionRegistry
     );
 
-    final Builder builder = LogicalSchema.builder()
-        .withRowTime();
+    final Builder builder = LogicalSchema.builder();
 
     builder.keyColumns(schema.key());
 
@@ -586,7 +585,7 @@ public class LogicalPlanner {
 
     final LogicalSchema projectionSchema = buildProjectionSchema(
         sourceSchema
-            .withMetaAndKeyColsInValue(analysis.getWindowExpression().isPresent()),
+            .withPseudoAndKeyColsInValue(analysis.getWindowExpression().isPresent()),
         projectionExpressions
     );
 
@@ -630,7 +629,6 @@ public class LogicalPlanner {
     }
 
     return LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(keyName, keyType)
         .valueColumns(projectionSchema.value())
         .build();
@@ -650,7 +648,6 @@ public class LogicalPlanner {
           .getExpressionSqlType(partitionBy.getExpression());
 
       return LogicalSchema.builder()
-          .withRowTime()
           .keyColumn(SchemaUtil.ROWKEY_NAME, keyType)
           .valueColumns(sourceSchema.value())
           .build();

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/DataSourceNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/DataSourceNode.java
@@ -127,7 +127,7 @@ public class DataSourceNode extends PlanNode {
     }
 
     return valueOnly
-        ? getSchema().withoutMetaAndKeyColsInValue().value().stream().map(Column::name)
+        ? getSchema().withoutPseudoAndKeyColsInValue().value().stream().map(Column::name)
         : orderColumns(getSchema().value(), getSchema());
   }
 
@@ -136,7 +136,7 @@ public class DataSourceNode extends PlanNode {
     // It users a KS valueMapper to add the key fields
     // and a KS transformValues to add the implicit fields
     return dataSource.getSchema()
-        .withMetaAndKeyColsInValue(dataSource.getKsqlTopic().getKeyFormat().isWindowed());
+        .withPseudoAndKeyColsInValue(dataSource.getKsqlTopic().getKeyFormat().isWindowed());
   }
 
   @SuppressWarnings("UnstableApiUsage")
@@ -155,8 +155,8 @@ public class DataSourceNode extends PlanNode {
 
     final Stream<Column> values = columns.stream()
         .filter(c -> !SchemaUtil.isWindowBound(c.name()))
-        .filter(c -> !schema.isKeyColumn(c.name()))
-        .filter(c -> !schema.isMetaColumn(c.name()));
+        .filter(c -> !SchemaUtil.isPseudoColumn(c.name()))
+        .filter(c -> !schema.isKeyColumn(c.name()));
 
     return Streams.concat(keys, windowBounds, values).map(Column::name);
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
@@ -68,7 +68,7 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
         // This is done by DataSourceNode
         // Hence, they must be removed again here if they are still in the sink schema.
         // This leads to strange behaviour, but changing it is a breaking change.
-        schema.withoutMetaAndKeyColsInValue(),
+        schema.withoutPseudoAndKeyColsInValue(),
         limit,
         timestampColumn
     );

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/RepartitionNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/RepartitionNode.java
@@ -97,7 +97,7 @@ public class RepartitionNode extends PlanNode {
     final boolean sourceNameMatches = !sourceName.isPresent() || sourceName.equals(getSourceName());
     if (sourceNameMatches && valueOnly) {
       // Override set of value columns to take into account the repartition:
-      return getSchema().withoutMetaAndKeyColsInValue().value().stream().map(Column::name);
+      return getSchema().withoutPseudoAndKeyColsInValue().value().stream().map(Column::name);
     }
 
     // Set of all columns not changed by a repartition:

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjector.java
@@ -113,7 +113,7 @@ public class SchemaRegisterInjector implements Injector {
       try {
         serviceContext.getSchemaRegistryClient().register(
             topic + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX,
-            format.toParsedSchema(schema.withoutMetaAndKeyColsInValue().value(), formatInfo)
+            format.toParsedSchema(schema.withoutPseudoAndKeyColsInValue().value(), formatInfo)
         );
       } catch (IOException | RestClientException e) {
         throw new KsqlStatementException("Could not register schema for topic.", statementText, e);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -359,7 +359,7 @@ public class SchemaKStream<K> {
 
     final ColumnName columnName = ((UnqualifiedColumnReferenceExp) expression).getColumnName();
     final KeyField newKeyField = isKeyColumn(columnName) ? keyField : KeyField.of(columnName);
-    return getSchema().isMetaColumn(columnName) ? KeyField.none() : newKeyField;
+    return SchemaUtil.isPseudoColumn(columnName) ? KeyField.none() : newKeyField;
   }
 
   boolean repartitionNotNeeded(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
@@ -68,7 +68,7 @@ public class TransientQueryMetadata extends QueryMetadata {
     );
     this.rowQueue = Objects.requireNonNull(rowQueue, "rowQueue");
 
-    if (!logicalSchema.metadata().isEmpty() || !logicalSchema.key().isEmpty()) {
+    if (!logicalSchema.key().isEmpty()) {
       throw new IllegalArgumentException("Transient queries only support value columns");
     }
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/AnalysisTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/AnalysisTest.java
@@ -50,7 +50,6 @@ public class AnalysisTest {
   private static final WindowInfo A_WINDOW = WindowInfo.of(WindowType.SESSION, Optional.empty());
 
   private static final LogicalSchema SOURCE_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("bob"), SqlTypes.BIGINT)
       .build();
@@ -86,7 +85,7 @@ public class AnalysisTest {
     // Then:
     verify(sourceSchemasFactory).apply(ImmutableMap.of(
         ALIAS,
-        SOURCE_SCHEMA.withMetaAndKeyColsInValue(false)
+        SOURCE_SCHEMA.withPseudoAndKeyColsInValue(false)
     ));
   }
 
@@ -103,7 +102,7 @@ public class AnalysisTest {
     // Then:
     verify(sourceSchemasFactory).apply(ImmutableMap.of(
         ALIAS,
-        SOURCE_SCHEMA.withMetaAndKeyColsInValue(true)
+        SOURCE_SCHEMA.withPseudoAndKeyColsInValue(true)
     ));
   }
 
@@ -121,7 +120,7 @@ public class AnalysisTest {
     // Then:
     verify(sourceSchemasFactory).apply(ImmutableMap.of(
         ALIAS,
-        SOURCE_SCHEMA.withMetaAndKeyColsInValue(false)
+        SOURCE_SCHEMA.withPseudoAndKeyColsInValue(false)
     ));
   }
 
@@ -138,7 +137,7 @@ public class AnalysisTest {
     // Then:
     verify(sourceSchemasFactory).apply(ImmutableMap.of(
         ALIAS,
-        SOURCE_SCHEMA.withMetaAndKeyColsInValue(false)
+        SOURCE_SCHEMA.withPseudoAndKeyColsInValue(false)
     ));
   }
 
@@ -155,7 +154,7 @@ public class AnalysisTest {
     // Then:
     verify(sourceSchemasFactory).apply(ImmutableMap.of(
         ALIAS,
-        SOURCE_SCHEMA.withMetaAndKeyColsInValue(true)
+        SOURCE_SCHEMA.withPseudoAndKeyColsInValue(true)
     ));
   }
 
@@ -173,7 +172,7 @@ public class AnalysisTest {
     // Then:
     verify(sourceSchemasFactory).apply(ImmutableMap.of(
         ALIAS,
-        SOURCE_SCHEMA.withMetaAndKeyColsInValue(true)
+        SOURCE_SCHEMA.withPseudoAndKeyColsInValue(true)
     ));
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerFunctionalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerFunctionalTest.java
@@ -171,7 +171,6 @@ public class AnalyzerFunctionalTest {
     );
 
     final LogicalSchema schema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("FIELD1"), SqlTypes.BIGINT)
         .build();
@@ -380,7 +379,6 @@ public class AnalyzerFunctionalTest {
 
   private void registerKafkaSource() {
     final LogicalSchema schema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(COL0, SqlTypes.BIGINT)
         .build();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/SourceSchemasTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/SourceSchemasTest.java
@@ -44,7 +44,6 @@ public class SourceSchemasTest {
   private static final ColumnName V2 = ColumnName.of("V2");
 
   private static final LogicalSchema SCHEMA_1 = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .keyColumn(K0, SqlTypes.INTEGER)
       .valueColumn(COMMON_VALUE_FIELD_NAME, SqlTypes.STRING)
@@ -52,7 +51,6 @@ public class SourceSchemasTest {
       .build();
 
   private static final LogicalSchema SCHEMA_2 = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .keyColumn(K1, SqlTypes.STRING)
       .valueColumn(COMMON_VALUE_FIELD_NAME, SqlTypes.STRING)

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceFactoryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceFactoryTest.java
@@ -115,7 +115,6 @@ public class CreateSourceFactoryTest {
       TableElements.of(EXPLICIT_KEY, ELEMENT1, ELEMENT2);
 
   private static final LogicalSchema EXPECTED_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(ROWKEY_NAME, SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("bob"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("hojjat"), BIGINT)
@@ -460,7 +459,6 @@ public class CreateSourceFactoryTest {
     givenCommandFactoriesWithMocks();
     final CreateStream statement = new CreateStream(SOME_NAME, ONE_ELEMENTS, true, withProperties);
     final LogicalSchema schema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("bob"), SqlTypes.STRING)
         .build();
@@ -597,7 +595,6 @@ public class CreateSourceFactoryTest {
 
     // Then:
     assertThat(result.getSchema(), is(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("bob"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("hojjat"), BIGINT)

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/DdlCommandExecTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/DdlCommandExecTest.java
@@ -42,7 +42,7 @@ public class DdlCommandExecTest {
   private static final SourceName STREAM_NAME = SourceName.of("s1");
   private static final SourceName TABLE_NAME = SourceName.of("t1");
   private static final String TOPIC_NAME = "topic";
-  private static final LogicalSchema SCHEMA = new LogicalSchema.Builder()
+  private static final LogicalSchema SCHEMA = LogicalSchema.builder()
       .keyColumn(ColumnName.of("K0"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("F1"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("F2"), SqlTypes.STRING)

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
@@ -120,7 +120,6 @@ public class JsonFormatTest {
     TEST_HARNESS.produceRows(inputTopic, orderDataProvider, JSON);
 
     final LogicalSchema messageSchema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("MESSAGE"), SqlTypes.STRING)
         .build();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
@@ -699,7 +699,6 @@ public class KsMaterializationFunctionalTest {
       final SqlType columnType0
   ) {
     return LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of(columnName0), columnType0)
         .build();
@@ -711,7 +710,6 @@ public class KsMaterializationFunctionalTest {
       final String columnName1, final SqlType columnType1
   ) {
     return LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of(columnName0), columnType0)
         .valueColumn(ColumnName.of(columnName1), columnType1)
@@ -725,7 +723,6 @@ public class KsMaterializationFunctionalTest {
       final String columnName2, final SqlType columnType2
   ) {
     return LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of(columnName0), columnType0)
         .valueColumn(ColumnName.of(columnName1), columnType1)

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -163,7 +163,6 @@ public class PhysicalPlanBuilderTest {
 
     // Then:
     assertThat(queryMetadata.getLogicalSchema(), is(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("COL0"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("COL2"), SqlTypes.DOUBLE)

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
@@ -95,7 +95,6 @@ public class DataSourceNodeTest {
   private static final ColumnName KEY = ColumnName.of("key");
 
   private static final LogicalSchema REAL_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(K0, SqlTypes.INTEGER)
       .valueColumn(FIELD1, SqlTypes.INTEGER)
       .valueColumn(FIELD2, SqlTypes.STRING)
@@ -268,7 +267,7 @@ public class DataSourceNodeTest {
     final LogicalSchema schema = node.getSchema();
 
     // Then:
-    assertThat(schema, is(REAL_SCHEMA.withMetaAndKeyColsInValue(false)));
+    assertThat(schema, is(REAL_SCHEMA.withPseudoAndKeyColsInValue(false)));
   }
 
   @Test
@@ -281,7 +280,7 @@ public class DataSourceNodeTest {
     final LogicalSchema schema = node.getSchema();
 
     // Then:
-    assertThat(schema, is(REAL_SCHEMA.withMetaAndKeyColsInValue(true)));
+    assertThat(schema, is(REAL_SCHEMA.withPseudoAndKeyColsInValue(true)));
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
@@ -89,21 +89,18 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class JoinNodeTest {
 
   private static final LogicalSchema LEFT_SOURCE_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(ColumnName.of("leftKey"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("C0"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("L1"), SqlTypes.STRING)
       .build();
 
   private static final LogicalSchema RIGHT_SOURCE_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(ColumnName.of("rightKey"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("C0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("R1"), SqlTypes.BIGINT)
       .build();
 
   private static final LogicalSchema RIGHT2_SOURCE_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(ColumnName.of("right2Key"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("C0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("R2"), SqlTypes.BIGINT)
@@ -114,15 +111,15 @@ public class JoinNodeTest {
   private static final SourceName RIGHT2_ALIAS = SourceName.of("right2");
 
   private static final LogicalSchema LEFT_NODE_SCHEMA = prependAlias(
-      LEFT_ALIAS, LEFT_SOURCE_SCHEMA.withMetaAndKeyColsInValue(false)
+      LEFT_ALIAS, LEFT_SOURCE_SCHEMA.withPseudoAndKeyColsInValue(false)
   );
 
   private static final LogicalSchema RIGHT_NODE_SCHEMA = prependAlias(
-      RIGHT_ALIAS, RIGHT_SOURCE_SCHEMA.withMetaAndKeyColsInValue(false)
+      RIGHT_ALIAS, RIGHT_SOURCE_SCHEMA.withPseudoAndKeyColsInValue(false)
   );
 
   private static final LogicalSchema RIGHT2_NODE_SCHEMA = prependAlias(
-      RIGHT2_ALIAS, RIGHT2_SOURCE_SCHEMA.withMetaAndKeyColsInValue(false)
+      RIGHT2_ALIAS, RIGHT2_SOURCE_SCHEMA.withPseudoAndKeyColsInValue(false)
   );
 
   private static final ValueFormat VALUE_FORMAT = ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name()));
@@ -646,7 +643,6 @@ public class JoinNodeTest {
 
     // When:
     assertThat(joinNode.getSchema(), is(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(ColumnName.of("leftKey"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of(LEFT_ALIAS.text() + "_C0"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of(LEFT_ALIAS.text() + "_L1"), SqlTypes.STRING)
@@ -695,7 +691,6 @@ public class JoinNodeTest {
 
     // Then:
     assertThat(joinNode.getSchema(), is(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(ColumnName.of("leftKey"), SqlTypes.BIGINT)
         .valueColumns(LEFT_NODE_SCHEMA.value())
         .valueColumns(RIGHT_NODE_SCHEMA.value())
@@ -931,8 +926,7 @@ public class JoinNodeTest {
   }
 
   private static LogicalSchema prependAlias(final SourceName alias, final LogicalSchema schema) {
-    final LogicalSchema.Builder builder = LogicalSchema.builder()
-        .withRowTime();
+    final LogicalSchema.Builder builder = LogicalSchema.builder();
     builder.keyColumns(schema.key());
     for (final Column c : schema.value()) {
       builder.valueColumn(ColumnNames.generatedJoinColumnAlias(alias, c.name()), c.type());

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -66,7 +66,6 @@ public class KsqlStructuredDataOutputNodeTest {
   private static final String SINK_KAFKA_TOPIC_NAME = "output_kafka";
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("field1"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("field2"), SqlTypes.STRING)

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/ProjectNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/ProjectNodeTest.java
@@ -71,7 +71,6 @@ public class ProjectNodeTest {
   private static final String KEY_FIELD_NAME = "col0";
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(COL_0, SqlTypes.STRING)
       .valueColumn(COL_1, SqlTypes.STRING)

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/RepartitionNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/RepartitionNodeTest.java
@@ -56,7 +56,6 @@ public class RepartitionNodeTest {
       Optional.of(ColumnName.of("SomeAlias"));
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(K0, SqlTypes.DOUBLE)
       .valueColumn(V0, SqlTypes.DOUBLE)
       .valueColumn(V1, SqlTypes.DOUBLE)

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
@@ -92,7 +92,6 @@ public class QueryExecutorTest {
   private static final Map<String, Object> OVERRIDES = Collections.emptyMap();
 
   private static final LogicalSchema SINK_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("col0"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("col1"), SqlTypes.STRING)

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorTest.java
@@ -81,7 +81,6 @@ public class DefaultSchemaInjectorTest {
   private static final String SQL_TEXT = "Some SQL";
 
   private static final List<? extends SimpleColumn> SUPPORTED_SCHEMAS = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("intField"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("bigIntField"), SqlTypes.BIGINT)

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjectorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjectorTest.java
@@ -73,7 +73,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class SchemaRegisterInjectorTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("F1"), SqlTypes.STRING)
       .build();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/security/KsqlAuthorizationValidatorImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/security/KsqlAuthorizationValidatorImplTest.java
@@ -55,7 +55,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class KsqlAuthorizationValidatorImplTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("F1"), SqlTypes.STRING)
       .build();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/serde/SerdeOptionsTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/serde/SerdeOptionsTest.java
@@ -47,13 +47,11 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class SerdeOptionsTest {
 
   private static final LogicalSchema SINGLE_FIELD_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("f0"), SqlTypes.BIGINT)
       .build();
 
   private static final LogicalSchema MULTI_FIELD_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("f0"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("f1"), SqlTypes.DOUBLE)

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedStreamTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedStreamTest.java
@@ -60,14 +60,12 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class SchemaKGroupedStreamTest {
 
   private static final LogicalSchema IN_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("IN0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("IN1"), SqlTypes.INTEGER)
       .build();
 
   private static final LogicalSchema OUT_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("IN0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("KSQL_AGG_VARIABLE_0"), SqlTypes.INTEGER)

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
@@ -55,14 +55,12 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class SchemaKGroupedTableTest {
 
   private static final LogicalSchema IN_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("IN0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("IN1"), SqlTypes.INTEGER)
       .build();
 
   private static final LogicalSchema OUT_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("IN0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("KSQL_AGG_VARIABLE_0"), SqlTypes.INTEGER)

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKSourceFactoryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKSourceFactoryTest.java
@@ -61,7 +61,6 @@ public class SchemaKSourceFactoryTest {
   private static final KeyField KEY_FIELD = KeyField.none();
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("FOO"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("BAR"), SqlTypes.STRING)

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/topic/SourceTopicsExtractorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/topic/SourceTopicsExtractorTest.java
@@ -57,7 +57,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class SourceTopicsExtractorTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("F1"), SqlTypes.STRING)
       .build();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
@@ -73,7 +73,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class TopicCreateInjectorTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("F1"), SqlTypes.STRING)
       .build();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/AvroUtilTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/AvroUtilTest.java
@@ -94,7 +94,6 @@ public class AvroUtilTest {
       toKsqlSchema(SINGLE_FIELD_AVRO_SCHEMA_STRING);
 
   private static final LogicalSchema SCHEMA_WITH_MAPS = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("notmap"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("mapcol"), SqlTypes.map(SqlTypes.INTEGER))
@@ -320,7 +319,6 @@ public class AvroUtilTest {
         .connectToSqlConverter();
 
     final Builder builder = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING);
 
     connectSchema.fields()

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/ItemDataProvider.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/ItemDataProvider.java
@@ -29,7 +29,6 @@ import java.util.Map;
 public class ItemDataProvider extends TestDataProvider<String> {
 
   private static final LogicalSchema LOGICAL_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("ID"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("DESCRIPTION"), SqlTypes.STRING)

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/OrderDataProvider.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/OrderDataProvider.java
@@ -30,7 +30,6 @@ import java.util.Map;
 public class OrderDataProvider extends TestDataProvider<Long> {
 
   private static final LogicalSchema LOGICAL_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("ORDERTIME"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("ORDERID"), SqlTypes.STRING)

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/PageViewDataProvider.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/PageViewDataProvider.java
@@ -28,7 +28,6 @@ import java.util.Map;
 public class PageViewDataProvider extends TestDataProvider<Long> {
 
   private static final LogicalSchema LOGICAL_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("VIEWTIME"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("USERID"), SqlTypes.STRING)

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/PlanSummaryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/PlanSummaryTest.java
@@ -47,7 +47,6 @@ public class PlanSummaryTest {
   private static final QueryId QUERY_ID = new QueryId("QID");
 
   private static final LogicalSchema SOURCE_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("L0"), SqlTypes.INTEGER)
       .build();
@@ -79,7 +78,6 @@ public class PlanSummaryTest {
   public void shouldSummarizeWithSource() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("L1"), SqlTypes.STRING)
         .build();
@@ -100,13 +98,11 @@ public class PlanSummaryTest {
   public void shouldSummarizePlanWithMultipleSources() {
     // Given:
     final LogicalSchema sourceSchema2 = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("L0_2"), SqlTypes.STRING)
         .build();
 
     final LogicalSchema schema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("L1"), SqlTypes.STRING)
         .build();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
@@ -51,7 +51,6 @@ public class QueryMetadataTest {
   private static final String QUERY_APPLICATION_ID = "Query1";
   private static final QueryId QUERY_ID = new QueryId("queryId");
   private static final LogicalSchema SOME_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("f0"), SqlTypes.STRING)
       .build();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/TestDataProvider.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/TestDataProvider.java
@@ -49,7 +49,6 @@ public abstract class TestDataProvider<K> {
 
   public String ksqlSchemaString(final boolean asTable) {
     return schema.logicalSchema().columns().stream()
-        .filter(col -> col.namespace() != Namespace.META)
         .map(col -> col.name() + " " + col.type() + namespace(col.namespace(), asTable))
         .collect(Collectors.joining(", "));
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/UserDataProvider.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/UserDataProvider.java
@@ -28,7 +28,6 @@ import java.util.Map;
 public class UserDataProvider extends TestDataProvider<String> {
 
   private static final LogicalSchema LOGICAL_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("REGISTERTIME"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("GENDER"), SqlTypes.STRING)

--- a/ksqldb-examples/src/main/java/io/confluent/ksql/datagen/RowGenerator.java
+++ b/ksqldb-examples/src/main/java/io/confluent/ksql/datagen/RowGenerator.java
@@ -276,8 +276,7 @@ public class RowGenerator {
       throw new IllegalArgumentException("key field does not exist in schema: " + keyFieldName);
     }
 
-    final Builder schemaBuilder = LogicalSchema.builder()
-        .withRowTime();
+    final Builder schemaBuilder = LogicalSchema.builder();
 
     final ConnectToSqlTypeConverter converter = SchemaConverters.connectToSqlConverter();
 

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/transform/select/Selection.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/transform/select/Selection.java
@@ -51,8 +51,7 @@ public final class Selection<K> {
       final LogicalSchema sourceSchema,
       final SelectValueMapper<?> mapper
   ) {
-    final LogicalSchema.Builder schemaBuilder = LogicalSchema.builder()
-        .withRowTime();
+    final LogicalSchema.Builder schemaBuilder = LogicalSchema.builder();
 
     final List<Column> keyCols = sourceSchema.key();
 

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/builder/KsqlQueryBuilderTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/builder/KsqlQueryBuilderTest.java
@@ -66,7 +66,6 @@ public class KsqlQueryBuilderTest {
 
   private static final PhysicalSchema SOME_SCHEMA = PhysicalSchema.from(
       LogicalSchema.builder()
-          .withRowTime()
           .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
           .valueColumn(ColumnName.of("f0"), SqlTypes.BOOLEAN)
           .build(),

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/ddl/commands/CreateSourceCommandTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/ddl/commands/CreateSourceCommandTest.java
@@ -46,7 +46,6 @@ public class CreateSourceCommandTest {
   public void shouldThrowOnMultipleKeyColumns() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .keyColumn(K0, SqlTypes.STRING)
         .keyColumn(K1, SqlTypes.STRING)

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/function/UdafUtilTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/function/UdafUtilTest.java
@@ -45,7 +45,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class UdafUtilTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("FOO"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("BAR"), SqlTypes.BIGINT)

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/testutil/TestExpressions.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/testutil/TestExpressions.java
@@ -23,7 +23,6 @@ public final class TestExpressions {
       .build();
 
   public final static LogicalSchema SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("COL0"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("COL1"), SqlTypes.STRING)

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/transform/select/SelectionTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/transform/select/SelectionTest.java
@@ -46,12 +46,11 @@ import org.mockito.junit.MockitoRule;
 public class SelectionTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(ColumnName.of("K0"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("GIRAFFE"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("MANATEE"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("RACCOON"), SqlTypes.BIGINT)
-      .build().withMetaAndKeyColsInValue(false);
+      .build().withPseudoAndKeyColsInValue(false);
 
   private static final Expression EXPRESSION1 =
       new UnqualifiedColumnReferenceExp(ColumnName.of("GIRAFFE"));
@@ -116,7 +115,6 @@ public class SelectionTest {
 
     // Then:
     assertThat(resultSchema, equalTo(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(ColumnName.of("K0"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("FOO"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("BAR"), SqlTypes.BIGINT)

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
@@ -520,7 +520,6 @@ public class ExpressionTypeManagerTest {
   public void shouldEvaluateTypeForStructExpression() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(COL0, SqlTypes.array(SqlTypes.INTEGER))
         .build();
@@ -551,7 +550,6 @@ public class ExpressionTypeManagerTest {
     final SqlStruct inner = SqlTypes.struct().field("IN0", SqlTypes.INTEGER).build();
 
     final LogicalSchema schema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(COL0, SqlTypes.array(inner))
         .build();
@@ -580,7 +578,6 @@ public class ExpressionTypeManagerTest {
         .build();
 
     final LogicalSchema schema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(COL0, inner)
         .build();

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/util/StructKeyUtilTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/util/StructKeyUtilTest.java
@@ -32,7 +32,6 @@ import org.junit.Test;
 public class StructKeyUtilTest {
 
   private static final LogicalSchema LOGICAL_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(ColumnName.of("Bob"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("DOES_NOT_MATTER"), SqlTypes.STRING)
       .build();

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutorTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutorTest.java
@@ -15,6 +15,14 @@
 
 package io.confluent.ksql.test.rest;
 
+import static com.google.common.collect.ImmutableList.of;
+import static io.confluent.ksql.GenericRow.genericRow;
+import static io.confluent.ksql.rest.entity.StreamedRow.header;
+import static io.confluent.ksql.rest.entity.StreamedRow.row;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThrows;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.GenericRow;
@@ -28,18 +36,9 @@ import io.confluent.ksql.util.SchemaUtil;
 import java.math.BigDecimal;
 import org.junit.Test;
 
-import static com.google.common.collect.ImmutableList.of;
-import static io.confluent.ksql.GenericRow.genericRow;
-import static io.confluent.ksql.rest.entity.StreamedRow.header;
-import static io.confluent.ksql.rest.entity.StreamedRow.row;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertThrows;
-
 public class RestTestExecutorTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("col0"), SqlTypes.STRING)
       .build();

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorTest.java
@@ -70,7 +70,6 @@ public class TestExecutorTest {
   private static final String SINK_TOPIC_NAME = "sink_topic";
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("v0"), SqlTypes.INTEGER)
       .build();
@@ -323,7 +322,6 @@ public class TestExecutorTest {
     when(testCase.getOutputRecords()).thenReturn(ImmutableList.of(expected_0, expected_1));
 
     final LogicalSchema schema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(ColumnName.of("key"), SqlTypes.INTEGER)
         .valueColumn(ColumnName.of("v0"), SqlTypes.STRING)
         .build();

--- a/ksqldb-metastore/src/test/java/io/confluent/ksql/metastore/model/MetaStoreModelTest.java
+++ b/ksqldb-metastore/src/test/java/io/confluent/ksql/metastore/model/MetaStoreModelTest.java
@@ -68,7 +68,6 @@ public class MetaStoreModelTest {
       .put(Column.class, Column.of(ColumnName.of("someField"), SqlTypes.INTEGER, Namespace.VALUE, 1))
       .put(SqlType.class, SqlTypes.INTEGER)
       .put(LogicalSchema.class, LogicalSchema.builder()
-          .withRowTime()
           .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
           .valueColumn(ColumnName.of("f0"), SqlTypes.BIGINT)
           .build())

--- a/ksqldb-metastore/src/test/java/io/confluent/ksql/metastore/model/StructuredDataSourceTest.java
+++ b/ksqldb-metastore/src/test/java/io/confluent/ksql/metastore/model/StructuredDataSourceTest.java
@@ -35,7 +35,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class StructuredDataSourceTest {
 
   private static final LogicalSchema SOME_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(ColumnName.of("k0"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("f0"), SqlTypes.BIGINT)
       .build();
@@ -59,7 +58,6 @@ public class StructuredDataSourceTest {
   public void shouldThrowIfSchemaContainsRowTime() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(ColumnName.of("k0"), SqlTypes.INTEGER)
         .valueColumn(SchemaUtil.ROWTIME_NAME, SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("f0"), SqlTypes.BIGINT)
@@ -92,7 +90,6 @@ public class StructuredDataSourceTest {
   public void shouldThrowIfSchemaContainsWindowStart() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(ColumnName.of("k0"), SqlTypes.INTEGER)
         .valueColumn(SchemaUtil.WINDOWSTART_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("f0"), SqlTypes.BIGINT)
@@ -109,7 +106,6 @@ public class StructuredDataSourceTest {
   public void shouldThrowIfSchemaContainsWindowEnd() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(ColumnName.of("k0"), SqlTypes.INTEGER)
         .valueColumn(SchemaUtil.WINDOWEND_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("f0"), SqlTypes.BIGINT)

--- a/ksqldb-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
+++ b/ksqldb-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
@@ -52,7 +52,6 @@ public final class MetaStoreFixture {
     final KeyFormat keyFormat = KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name()));
 
     final LogicalSchema test1Schema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("COL0"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("COL1"), SqlTypes.STRING)
@@ -102,7 +101,6 @@ public final class MetaStoreFixture {
     metaStore.putSource(ksqlStream1);
 
     final LogicalSchema test2Schema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("COL0"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("COL1"), SqlTypes.STRING)
@@ -150,7 +148,6 @@ public final class MetaStoreFixture {
         .build();
 
     final LogicalSchema ordersSchema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("ORDERTIME"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("ORDERID"), SqlTypes.BIGINT)
@@ -182,7 +179,6 @@ public final class MetaStoreFixture {
     metaStore.putSource(ksqlStreamOrders);
 
     final LogicalSchema testTable3 = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("COL0"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("COL1"), SqlTypes.STRING)
@@ -222,7 +218,6 @@ public final class MetaStoreFixture {
         .build();
 
     final LogicalSchema nestedArrayStructMapSchema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("ARRAYCOL"), SqlTypes.array(itemInfoSchema))
         .valueColumn(ColumnName.of("MAPCOL"), SqlTypes.map(itemInfoSchema))
@@ -269,7 +264,6 @@ public final class MetaStoreFixture {
     metaStore.putSource(ksqlStream4);
 
     final LogicalSchema sensorReadingsSchema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("ID"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("SENSOR_NAME"), SqlTypes.STRING)

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/TableElements.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/TableElements.java
@@ -88,7 +88,6 @@ public final class TableElements implements Iterable<TableElement> {
     final Builder builder = LogicalSchema.builder();
 
     if (withImplicitColumns) {
-      builder.withRowTime();
 
       final boolean noKey = elements.stream().noneMatch(e -> e.getNamespace().isKey());
       if (noKey) {

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
@@ -115,7 +115,6 @@ public class SqlFormatterTest {
       .build();
 
   private static final LogicalSchema TABLE_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(ColumnName.of("K0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("TABLE"), SqlTypes.STRING)
       .build();

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/json/LogicalSchemaDeserializerTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/json/LogicalSchemaDeserializerTest.java
@@ -93,7 +93,6 @@ public class LogicalSchemaDeserializerTest {
 
     // Then:
     assertThat(schema, is(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("v0"), SqlTypes.INTEGER)
         .build()));

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/TableElementsTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/TableElementsTest.java
@@ -233,7 +233,6 @@ public class TableElementsTest {
 
     // Then:
     assertThat(schema, is(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("v0"), SqlTypes.INTEGER)
         .build()
@@ -253,7 +252,6 @@ public class TableElementsTest {
 
     // Then:
     assertThat(schema, is(LogicalSchema.builder()
-        .withRowTime()
         .valueColumn(ColumnName.of("v0"), SqlTypes.INTEGER)
         .keyColumn(ColumnName.of("k0"), SqlTypes.INTEGER)
         .build()
@@ -273,7 +271,6 @@ public class TableElementsTest {
 
     // Then:
     assertThat(schema, is(LogicalSchema.builder()
-        .withRowTime()
         .valueColumn(ColumnName.of("v0"), SqlTypes.INTEGER)
         .keyColumn(ColumnName.of("k0"), SqlTypes.INTEGER)
         .build()

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PullQueryExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PullQueryExecutor.java
@@ -114,6 +114,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
+@SuppressWarnings("UnstableApiUsage")
 public final class PullQueryExecutor {
   // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
 
@@ -843,7 +844,7 @@ public final class PullQueryExecutor {
       final boolean windowed = windowType.isPresent();
 
       intermediateSchema = input.schema
-          .withMetaAndKeyColsInValue(windowed);
+          .withPseudoAndKeyColsInValue(windowed);
 
       preSelectTransform = row -> {
         final Struct key = row.key();
@@ -932,7 +933,7 @@ public final class PullQueryExecutor {
 
     // Copy meta & key columns into the value schema as SelectValueMapper expects it:
     final LogicalSchema schema = input.schema
-        .withMetaAndKeyColsInValue(windowType.isPresent());
+        .withPseudoAndKeyColsInValue(windowType.isPresent());
 
     final ExpressionTypeManager expressionTypeManager =
         new ExpressionTypeManager(schema, executionContext.getMetaStore());

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/EntityUtil.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/EntityUtil.java
@@ -40,7 +40,6 @@ public final class EntityUtil {
 
   public static List<FieldInfo> buildSourceSchemaEntity(final LogicalSchema schema) {
     final List<FieldInfo> allFields = schema.columns().stream()
-        .filter(f -> f.namespace() != Namespace.META)
         .map(EntityUtil::toFieldInfo)
         .collect(Collectors.toList());
 
@@ -93,14 +92,9 @@ public final class EntityUtil {
     }
 
     private static Optional<FieldType> toFieldType(final Column.Namespace ns) {
-      switch (ns) {
-        case KEY:
-          return Optional.of(FieldType.KEY);
-        case META:
-          throw new IllegalArgumentException("pseudo columns should not be exposed");
-        default:
-          return Optional.empty();
-      }
+      return ns == Namespace.KEY
+          ? Optional.of(FieldType.KEY)
+          : Optional.empty();
     }
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
@@ -70,7 +70,6 @@ public class QueryDescriptionFactoryTest {
       .build();
 
   private static final LogicalSchema PERSISTENT_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("field1"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("field2"), SqlTypes.STRING)

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionFactoryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionFactoryTest.java
@@ -72,7 +72,6 @@ public class SourceDescriptionFactoryTest {
       final String kafkaTopicName,
       final Optional<TimestampColumn> timestampColumn) {
     final LogicalSchema schema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("field0"), SqlTypes.INTEGER)
         .build();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/entity/TableRowsEntityFactoryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/entity/TableRowsEntityFactoryTest.java
@@ -46,13 +46,11 @@ public class TableRowsEntityFactoryTest {
       .keyBuilder(K0, SqlTypes.STRING);
 
   private static final LogicalSchema SIMPLE_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(K0, SqlTypes.STRING)
       .valueColumn(ColumnName.of("v0"), SqlTypes.BOOLEAN)
       .build();
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(K0, SqlTypes.STRING)
       .keyColumn(ColumnName.of("k1"), SqlTypes.BOOLEAN)
       .valueColumn(ColumnName.of("v0"), SqlTypes.INTEGER)
@@ -60,7 +58,6 @@ public class TableRowsEntityFactoryTest {
       .build();
 
   private static final LogicalSchema SCHEMA_NULL = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(K0, SqlTypes.STRING)
       .valueColumn(ColumnName.of("v0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("v1"), SqlTypes.INTEGER)

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/KsqlResourceFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/KsqlResourceFunctionalTest.java
@@ -154,7 +154,6 @@ public class KsqlResourceFunctionalTest {
     // Given:
     final PhysicalSchema schema = PhysicalSchema.from(
         LogicalSchema.builder()
-            .withRowTime()
             .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
             .valueColumn(ColumnName.of("AUTHOR"), SqlTypes.STRING)
             .valueColumn(ColumnName.of("TITLE"), SqlTypes.STRING)

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryFunctionalTest.java
@@ -103,7 +103,6 @@ public class PullQueryFunctionalTest {
 
   private static final PhysicalSchema AGGREGATE_SCHEMA = PhysicalSchema.from(
       LogicalSchema.builder()
-          .withRowTime()
           .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
           .valueColumn(ColumnName.of("COUNT"), SqlTypes.BIGINT)
           .build(),

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
@@ -124,7 +124,6 @@ public class PullQueryRoutingFunctionalTest {
 
   private static final PhysicalSchema AGGREGATE_SCHEMA = PhysicalSchema.from(
       LogicalSchema.builder()
-          .withRowTime()
           .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
           .valueColumn(ColumnName.of("COUNT"), SqlTypes.BIGINT)
           .build(),

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorFunctionalTest.java
@@ -151,7 +151,6 @@ public class StandaloneExecutorFunctionalTest {
 
     final PhysicalSchema dataSchema = PhysicalSchema.from(
         LogicalSchema.builder()
-            .withRowTime()
             .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
             .valueColumn(ColumnName.of("ORDERTIME"), SqlTypes.BIGINT)
             .build(),
@@ -194,7 +193,6 @@ public class StandaloneExecutorFunctionalTest {
 
     final PhysicalSchema dataSchema = PhysicalSchema.from(
         LogicalSchema.builder()
-            .withRowTime()
             .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
             .valueColumn(ColumnName.of("ORDERTIME"), SqlTypes.BIGINT)
             .build(),
@@ -299,7 +297,6 @@ public class StandaloneExecutorFunctionalTest {
 
   private static void givenIncompatibleSchemaExists(final String topicName) {
     final LogicalSchema logical = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("ORDERID"), SqlTypes.struct()
             .field("fred", SqlTypes.INTEGER)

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
@@ -61,7 +61,6 @@ import org.junit.rules.ExternalResource;
 public class TemporaryEngine extends ExternalResource {
 
   public static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("val"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("val2"), SqlTypes.decimal(2, 1))

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutorTest.java
@@ -135,7 +135,6 @@ public class DescribeConnectorExecutorTest {
     );
     when(source.getSchema()).thenReturn(
         LogicalSchema.builder()
-            .withRowTime()
             .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
             .valueColumn(ColumnName.of("foo"), SqlPrimitiveType.of( SqlBaseType.STRING))
             .build());

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -209,7 +209,6 @@ public class KsqlResourceTest {
       0L);
 
   private static final LogicalSchema SINGLE_FIELD_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("val"), SqlTypes.STRING)
       .build();
@@ -252,7 +251,6 @@ public class KsqlResourceTest {
   );
 
   private static final LogicalSchema SOME_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("f1"), SqlTypes.STRING)
       .build();
@@ -470,7 +468,6 @@ public class KsqlResourceTest {
   public void shouldShowStreamsExtended() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("FIELD1"), SqlTypes.BOOLEAN)
         .valueColumn(ColumnName.of("FIELD2"), SqlTypes.STRING)
@@ -501,7 +498,6 @@ public class KsqlResourceTest {
   public void shouldShowTablesExtended() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("FIELD1"), SqlTypes.BOOLEAN)
         .valueColumn(ColumnName.of("FIELD2"), SqlTypes.STRING)
@@ -2176,7 +2172,6 @@ public class KsqlResourceTest {
 
   private void addTestTopicAndSources() {
     final LogicalSchema schema1 = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("S1_F1"), SqlTypes.BOOLEAN)
         .build();
@@ -2186,7 +2181,6 @@ public class KsqlResourceTest {
         "TEST_TABLE", "KAFKA_TOPIC_1", schema1);
 
     final LogicalSchema schema2 = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("S2_F1"), SqlTypes.STRING)
         .build();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriterTest.java
@@ -95,7 +95,6 @@ public class QueryStreamWriterTest {
     limitHandlerCapture = newCapture();
 
     final LogicalSchema schema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("col1"), SqlTypes.STRING)
         .build();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/EntityUtilTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/EntityUtilTest.java
@@ -161,7 +161,6 @@ public class EntityUtilTest {
   public void shouldNotExposeMetaColumns() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .withRowTime()
         .valueColumn(ColumnName.of("bob"), SqlTypes.STRING)
         .build();
 

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/GenericRowSerDe.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/GenericRowSerDe.java
@@ -48,7 +48,7 @@ public final class GenericRowSerDe implements ValueSerdeFactory {
    * Additional capacity added to each created `GenericRow` in an attempt to avoid later resizes,
    * and associated array copies, when the row has additional elements appended to the end during
    * processing, e.g. to match columns added by
-   * {@link io.confluent.ksql.schema.ksql.LogicalSchema#withMetaAndKeyColsInValue(boolean)}
+   * {@link io.confluent.ksql.schema.ksql.LogicalSchema#withPseudoAndKeyColsInValue(boolean)}
    *
    * <p>The number is optimised for a single key column, as this is the most common case.
    *

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/schema/ksql/PhysicalSchemaTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/schema/ksql/PhysicalSchemaTest.java
@@ -33,14 +33,12 @@ import org.junit.Test;
 public class PhysicalSchemaTest {
 
   private static final LogicalSchema SCHEMA_WITH_MULTIPLE_FIELDS = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("f0"), SqlTypes.BOOLEAN)
       .valueColumn(ColumnName.of("f1"), SqlTypes.BOOLEAN)
       .build();
 
   private static final LogicalSchema SCHEMA_WITH_SINGLE_FIELD = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("f0"), SqlTypes.BOOLEAN)
       .build();

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/kafka/KafkaSerdeFactoryTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/kafka/KafkaSerdeFactoryTest.java
@@ -59,7 +59,6 @@ public class KafkaSerdeFactoryTest {
   public void shouldThrowOnValidateIfMultipleFields() {
     // Given:
     final PersistenceSchema schema = getPersistenceSchema(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("f0"), SqlTypes.INTEGER)
         .valueColumn(ColumnName.of("f1"), SqlTypes.BIGINT)
@@ -228,7 +227,6 @@ public class KafkaSerdeFactoryTest {
 
   private static PersistenceSchema schemaWithFieldOfType(final SqlType fieldSchema) {
     final LogicalSchema logical = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("f0"), fieldSchema)
         .build();

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/AggregateParamsFactory.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/AggregateParamsFactory.java
@@ -152,8 +152,7 @@ public class AggregateParamsFactory {
       final boolean useAggregate,
       final boolean addWindowBounds
   ) {
-    final LogicalSchema.Builder schemaBuilder = LogicalSchema.builder()
-        .withRowTime();
+    final LogicalSchema.Builder schemaBuilder = LogicalSchema.builder();
 
     schemaBuilder.keyColumns(schema.key());
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/GroupByParamsFactory.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/GroupByParamsFactory.java
@@ -102,7 +102,6 @@ final class GroupByParamsFactory {
       final SqlType keyType
   ) {
     return LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(keyName, keyType)
         .valueColumns(sourceSchema.value())
         .build();

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/JoinParamsFactory.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/JoinParamsFactory.java
@@ -40,7 +40,6 @@ public final class JoinParamsFactory {
     throwOnKeyMismatch(leftSchema, rightSchema);
 
     return LogicalSchema.builder()
-        .withRowTime()
         .keyColumns(leftSchema.key())
         .valueColumns(leftSchema.value())
         .valueColumns(rightSchema.value())

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/PartitionByParamsFactory.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/PartitionByParamsFactory.java
@@ -125,7 +125,6 @@ public final class PartitionByParamsFactory {
         );
 
     final Builder builder = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(newKeyName, keyType)
         .valueColumns(sourceSchema.value());
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
@@ -251,7 +251,7 @@ public final class SourceBuilder {
   ) {
     return source
         .getSourceSchema()
-        .withMetaAndKeyColsInValue(windowed);
+        .withPseudoAndKeyColsInValue(windowed);
   }
 
   private static Serde<GenericRow> getValueSerde(

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StepSchemaResolver.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StepSchemaResolver.java
@@ -222,7 +222,6 @@ public final class StepSchemaResolver {
         .getExpressionSqlType(step.getKeyExpression());
 
     return LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, keyType)
         .valueColumns(sourceSchema.value())
         .build();
@@ -280,7 +279,7 @@ public final class StepSchemaResolver {
       final boolean windowed
   ) {
     return schema
-        .withMetaAndKeyColsInValue(windowed);
+        .withPseudoAndKeyColsInValue(windowed);
   }
 
   private LogicalSchema buildSelectSchema(

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFlatMapBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFlatMapBuilder.java
@@ -105,8 +105,7 @@ public final class StreamFlatMapBuilder {
       final List<FunctionCall> tableFunctions,
       final FunctionRegistry functionRegistry
   ) {
-    final LogicalSchema.Builder schemaBuilder = LogicalSchema.builder()
-        .withRowTime();
+    final LogicalSchema.Builder schemaBuilder = LogicalSchema.builder();
 
     final List<Column> cols = inputSchema.value();
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/TableRowValidation.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/TableRowValidation.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.execution.streams.materialization;
 
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
-import io.confluent.ksql.util.SchemaUtil;
 import org.apache.kafka.connect.data.Struct;
 
 final class TableRowValidation {
@@ -39,16 +38,6 @@ final class TableRowValidation {
       final Struct key,
       final GenericRow value
   ) {
-    if (schema.metadata().size() != 1) {
-      throw new IllegalArgumentException(
-          "expected only " + SchemaUtil.ROWTIME_NAME + " meta columns, got: " + schema.metadata());
-    }
-
-    if (!schema.metadata().get(0).name().equals(SchemaUtil.ROWTIME_NAME)) {
-      throw new IllegalArgumentException(
-          "expected " + SchemaUtil.ROWTIME_NAME + ", got: " + schema.metadata().get(0));
-    }
-
     final int expectedKeyCount = schema.key().size();
     final int actualKeyCount = key.schema().fields().size();
     if (actualKeyCount != expectedKeyCount) {

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/AggregateParamsFactoryTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/AggregateParamsFactoryTest.java
@@ -39,7 +39,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class AggregateParamsFactoryTest {
 
   private static final LogicalSchema INPUT_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(ColumnName.of("k0"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("REQUIRED0"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("ARGUMENT0"), SqlTypes.INTEGER)
@@ -195,7 +194,6 @@ public class AggregateParamsFactoryTest {
         schema,
         equalTo(
             LogicalSchema.builder()
-                .withRowTime()
                 .keyColumns(INPUT_SCHEMA.key())
                 .valueColumn(ColumnName.of("REQUIRED0"), SqlTypes.BIGINT)
                 .valueColumn(ColumnName.of("REQUIRED1"), SqlTypes.STRING)
@@ -216,7 +214,6 @@ public class AggregateParamsFactoryTest {
         schema,
         equalTo(
             LogicalSchema.builder()
-                .withRowTime()
                 .keyColumns(INPUT_SCHEMA.key())
                 .valueColumn(ColumnName.of("REQUIRED0"), SqlTypes.BIGINT)
                 .valueColumn(ColumnName.of("REQUIRED1"), SqlTypes.STRING)
@@ -246,7 +243,6 @@ public class AggregateParamsFactoryTest {
         schema,
         equalTo(
             LogicalSchema.builder()
-                .withRowTime()
                 .keyColumns(INPUT_SCHEMA.key())
                 .valueColumn(ColumnName.of("REQUIRED0"), SqlTypes.BIGINT)
                 .valueColumn(ColumnName.of("REQUIRED1"), SqlTypes.STRING)

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/GroupByParamsFactoryTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/GroupByParamsFactoryTest.java
@@ -335,7 +335,6 @@ public class GroupByParamsFactoryTest {
         : SchemaUtil.ROWKEY_NAME;
 
     assertThat(schema, is(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(expectedKeyColName, SqlTypes.INTEGER)
         .valueColumns(SOURCE_SCHEMA.value())
         .build()));
@@ -360,7 +359,6 @@ public class GroupByParamsFactoryTest {
         : SchemaUtil.ROWKEY_NAME;
 
     assertThat(schema, is(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(expectedKeyColName, SqlTypes.INTEGER)
         .valueColumns(SOURCE_SCHEMA.value())
         .build()));
@@ -388,7 +386,6 @@ public class GroupByParamsFactoryTest {
         : SchemaUtil.ROWKEY_NAME;
 
     assertThat(schema, is(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(expectedKeyColName, SqlTypes.INTEGER)
         .valueColumns(SOURCE_SCHEMA.value())
         .build()));
@@ -410,7 +407,6 @@ public class GroupByParamsFactoryTest {
         : SchemaUtil.ROWKEY_NAME;
 
     assertThat(schema, is(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(expectedKeyColName, SqlTypes.INTEGER)
         .valueColumns(SOURCE_SCHEMA.value())
         .build()));
@@ -432,7 +428,6 @@ public class GroupByParamsFactoryTest {
         : SchemaUtil.ROWKEY_NAME;
 
     assertThat(schema, is(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(expectedKeyColName, SqlTypes.STRING)
         .valueColumns(SOURCE_SCHEMA.value())
         .build()));
@@ -452,7 +447,6 @@ public class GroupByParamsFactoryTest {
 
     // Then:
     assertThat(schema, is(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(keyAlias, SqlTypes.STRING)
         .valueColumns(SOURCE_SCHEMA.value())
         .build()));

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/JoinParamsFactoryTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/JoinParamsFactoryTest.java
@@ -36,7 +36,6 @@ public class JoinParamsFactoryTest {
 
     // Then:
     assertThat(joinParams.getSchema(), is(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(ColumnName.of("LK"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("BLUE"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("GREEN"), SqlTypes.INTEGER)
@@ -54,7 +53,7 @@ public class JoinParamsFactoryTest {
         .valueColumn(ColumnName.of("BLUE"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("GREEN"), SqlTypes.INTEGER)
         .build()
-        .withMetaAndKeyColsInValue(false);
+        .withPseudoAndKeyColsInValue(false);
 
     // When:
     final Exception e = assertThrows(

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/PartitionByParamsFactoryTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/PartitionByParamsFactoryTest.java
@@ -144,7 +144,6 @@ public class PartitionByParamsFactoryTest {
 
     // Then:
     assertThat(resultSchema, is(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(COL1, SqlTypes.INTEGER)
         .valueColumn(COL1, SqlTypes.INTEGER)
         .valueColumn(COL2, SqlTypes.INTEGER)
@@ -173,7 +172,6 @@ public class PartitionByParamsFactoryTest {
 
     // Then:
     assertThat(resultSchema, is(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(ColumnName.of("someField"), SqlTypes.BIGINT)
         .valueColumn(COL1, SqlTypes.INTEGER)
         .valueColumn(COL2, SqlTypes.INTEGER)
@@ -202,7 +200,6 @@ public class PartitionByParamsFactoryTest {
 
     // Then:
     assertThat(resultSchema, is(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(ColumnName.of("KSQL_COL_0"), SqlTypes.INTEGER)
         .valueColumn(COL1, SqlTypes.INTEGER)
         .valueColumn(COL2, SqlTypes.INTEGER)
@@ -229,7 +226,6 @@ public class PartitionByParamsFactoryTest {
 
     // Then:
     assertThat(resultSchema, is(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(newKeyName, SqlTypes.INTEGER)
         .valueColumn(COL1, SqlTypes.INTEGER)
         .valueColumn(COL2, SqlTypes.INTEGER)

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/SinkBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/SinkBuilderTest.java
@@ -76,7 +76,7 @@ public class SinkBuilderTest {
   private static final FormatInfo KEY_FORMAT = FormatInfo.of(FormatFactory.KAFKA.name());
   private static final FormatInfo VALUE_FORMAT = FormatInfo.of(FormatFactory.JSON.name());
   private static final PhysicalSchema PHYSICAL_SCHEMA =
-      PhysicalSchema.from(SCHEMA.withoutMetaAndKeyColsInValue(), SerdeOption.none());
+      PhysicalSchema.from(SCHEMA.withoutPseudoAndKeyColsInValue(), SerdeOption.none());
 
   @Mock
   private KsqlQueryBuilder queryBuilder;

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/SourceBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/SourceBuilderTest.java
@@ -111,10 +111,10 @@ public class SourceBuilderTest {
       .put(K0.text(), A_KEY);
 
   private static final LogicalSchema SCHEMA = SOURCE_SCHEMA
-      .withMetaAndKeyColsInValue(false);
+      .withPseudoAndKeyColsInValue(false);
 
   private static final LogicalSchema WINDOWED_SCHEMA = SOURCE_SCHEMA
-      .withMetaAndKeyColsInValue(true);
+      .withPseudoAndKeyColsInValue(true);
 
   private static final KsqlConfig KSQL_CONFIG = new KsqlConfig(ImmutableMap.of());
 

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StepSchemaResolverTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StepSchemaResolverTest.java
@@ -84,7 +84,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class StepSchemaResolverTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(ColumnName.of("K0"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("ORANGE"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("APPLE"), SqlTypes.BIGINT)
@@ -137,7 +136,6 @@ public class StepSchemaResolverTest {
     // Then:
     assertThat(result, is(
         LogicalSchema.builder()
-            .withRowTime()
             .keyColumn(ColumnName.of("K0"), SqlTypes.INTEGER)
             .valueColumn(ColumnName.of("ORANGE"), SqlTypes.INTEGER)
             .valueColumn(ColumnNames.aggregateColumn(0), SqlTypes.BIGINT)
@@ -164,7 +162,6 @@ public class StepSchemaResolverTest {
     // Then:
     assertThat(result, is(
         LogicalSchema.builder()
-            .withRowTime()
             .keyColumn(ColumnName.of("K0"), SqlTypes.INTEGER)
             .valueColumn(ColumnName.of("ORANGE"), SqlTypes.INTEGER)
             .valueColumn(ColumnNames.aggregateColumn(0), SqlTypes.BIGINT)
@@ -192,7 +189,6 @@ public class StepSchemaResolverTest {
     // Then:
     assertThat(result, is(
         LogicalSchema.builder()
-            .withRowTime()
             .keyColumn(ColumnName.of("K0"), SqlTypes.INTEGER)
             .valueColumn(ColumnName.of("JUICE"), SqlTypes.BIGINT)
             .valueColumn(ColumnName.of("PLANTAIN"), SqlTypes.STRING)
@@ -217,7 +213,6 @@ public class StepSchemaResolverTest {
     // Then:
     assertThat(result, is(
         LogicalSchema.builder()
-            .withRowTime()
             .keyColumn(ColumnName.of("K0"), SqlTypes.INTEGER)
             .valueColumn(ColumnName.of("ORANGE"), SqlTypes.INTEGER)
             .valueColumn(ColumnName.of("APPLE"), SqlTypes.BIGINT)
@@ -259,7 +254,6 @@ public class StepSchemaResolverTest {
 
     // Then:
     assertThat(result, is(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.INTEGER)
         .valueColumns(SCHEMA.value())
         .build()));
@@ -283,7 +277,6 @@ public class StepSchemaResolverTest {
 
     // Then:
     assertThat(result, is(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(ORANGE_COL, SqlTypes.INTEGER)
         .valueColumns(SCHEMA.value())
         .build()));
@@ -307,7 +300,6 @@ public class StepSchemaResolverTest {
 
     // Then:
     assertThat(result, is(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(ColumnName.of("NEW_KEY"), SqlTypes.INTEGER)
         .valueColumns(SCHEMA.value())
         .build()));
@@ -346,7 +338,6 @@ public class StepSchemaResolverTest {
 
     // Then:
     assertThat(result, is(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.INTEGER)
         .valueColumns(SCHEMA.value())
         .build()
@@ -371,7 +362,6 @@ public class StepSchemaResolverTest {
 
     // Then:
     assertThat(result, is(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(keyExpression.getColumnName(), SqlTypes.INTEGER)
         .valueColumns(SCHEMA.value())
         .build()
@@ -396,7 +386,6 @@ public class StepSchemaResolverTest {
 
     // Then:
     assertThat(result, is(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(ColumnName.of("RED"), SqlTypes.INTEGER)
         .valueColumns(SCHEMA.value())
         .build()
@@ -417,7 +406,7 @@ public class StepSchemaResolverTest {
     final LogicalSchema result = resolver.resolve(step, SCHEMA);
 
     // Then:
-    assertThat(result, is(SCHEMA.withMetaAndKeyColsInValue(false)));
+    assertThat(result, is(SCHEMA.withPseudoAndKeyColsInValue(false)));
   }
 
   @Test
@@ -435,7 +424,7 @@ public class StepSchemaResolverTest {
     final LogicalSchema result = resolver.resolve(step, SCHEMA);
 
     // Then:
-    assertThat(result, is(SCHEMA.withMetaAndKeyColsInValue(true)));
+    assertThat(result, is(SCHEMA.withPseudoAndKeyColsInValue(true)));
   }
 
   @Test
@@ -456,7 +445,6 @@ public class StepSchemaResolverTest {
     // Then:
     assertThat(result, is(
         LogicalSchema.builder()
-            .withRowTime()
             .keyColumn(ColumnName.of("K0"), SqlTypes.INTEGER)
             .valueColumn(ColumnName.of("ORANGE"), SqlTypes.INTEGER)
             .valueColumn(ColumnNames.aggregateColumn(0), SqlTypes.BIGINT)
@@ -480,7 +468,6 @@ public class StepSchemaResolverTest {
 
     // Then:
     assertThat(result, is(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.INTEGER)
         .valueColumns(SCHEMA.value())
         .build()));
@@ -504,7 +491,6 @@ public class StepSchemaResolverTest {
 
     // Then:
     assertThat(result, is(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(ORANGE_COL, SqlTypes.INTEGER)
         .valueColumns(SCHEMA.value())
         .build()));
@@ -528,7 +514,6 @@ public class StepSchemaResolverTest {
 
     // Then:
     assertThat(result, is(LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(ColumnName.of("NEW_KEY"), SqlTypes.INTEGER)
         .valueColumns(SCHEMA.value())
         .build()));
@@ -552,7 +537,6 @@ public class StepSchemaResolverTest {
     // Then:
     assertThat(result, is(
         LogicalSchema.builder()
-            .withRowTime()
             .keyColumn(ColumnName.of("K0"), SqlTypes.INTEGER)
             .valueColumn(ColumnName.of("JUICE"), SqlTypes.BIGINT)
             .valueColumn(ColumnName.of("PLANTAIN"), SqlTypes.STRING)
@@ -592,7 +576,7 @@ public class StepSchemaResolverTest {
     final LogicalSchema result = resolver.resolve(step, SCHEMA);
 
     // Then:
-    assertThat(result, is(SCHEMA.withMetaAndKeyColsInValue(false)));
+    assertThat(result, is(SCHEMA.withPseudoAndKeyColsInValue(false)));
   }
 
   @Test
@@ -611,7 +595,7 @@ public class StepSchemaResolverTest {
     final LogicalSchema result = resolver.resolve(step, SCHEMA);
 
     // Then:
-    assertThat(result, is(SCHEMA.withMetaAndKeyColsInValue(true)));
+    assertThat(result, is(SCHEMA.withPseudoAndKeyColsInValue(true)));
   }
 
   private void givenTableFunction(final String name, final SqlType returnType) {

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderTest.java
@@ -61,15 +61,13 @@ public class StreamGroupByBuilderTest {
   private static final KeyBuilder STRING_KEY_BUILDER = StructKeyUtil
       .keyBuilder(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING);
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(ColumnName.of("K0"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("PAC"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("MAN"), SqlTypes.STRING)
       .build()
-      .withMetaAndKeyColsInValue(false);
+      .withPseudoAndKeyColsInValue(false);
 
   private static final LogicalSchema REKEYED_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumns(SCHEMA.value())
       .build();

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectBuilderTest.java
@@ -62,13 +62,12 @@ import org.mockito.junit.MockitoRule;
 @SuppressWarnings("unchecked")
 public class StreamSelectBuilderTest {
 
-  private static final LogicalSchema SCHEMA = new LogicalSchema.Builder()
-      .withRowTime()
+  private static final LogicalSchema SCHEMA = LogicalSchema.builder()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("foo"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("bar"), SqlTypes.BIGINT)
       .build()
-      .withMetaAndKeyColsInValue(false);
+      .withPseudoAndKeyColsInValue(false);
 
   private static final Expression EXPRESSION1 = new StringLiteral("baz");
   private static final Expression EXPRESSION2 = new IntegerLiteral(123);
@@ -170,7 +169,6 @@ public class StreamSelectBuilderTest {
     assertThat(
         result.getSchema(),
         is(LogicalSchema.builder()
-            .withRowTime()
             .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
             .valueColumn(ColumnName.of("expr1"), SqlTypes.STRING)
             .valueColumn(ColumnName.of("expr2"), SqlTypes.INTEGER)

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderTest.java
@@ -63,18 +63,16 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class StreamSelectKeyBuilderTest {
 
   private static final LogicalSchema SOURCE_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(ColumnName.of("k0"), SqlTypes.DOUBLE)
       .valueColumn(ColumnName.of("BIG"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("BOI"), SqlTypes.BIGINT)
       .build()
-      .withMetaAndKeyColsInValue(false);
+      .withPseudoAndKeyColsInValue(false);
 
   private static final UnqualifiedColumnReferenceExp KEY =
       new UnqualifiedColumnReferenceExp(ColumnName.of("BOI"));
 
   private static final LogicalSchema RESULT_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(ColumnName.of("BOI"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("BIG"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("BOI"), SqlTypes.BIGINT)

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderV1Test.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderV1Test.java
@@ -63,18 +63,16 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class StreamSelectKeyBuilderV1Test {
 
   private static final LogicalSchema SOURCE_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(ColumnName.of("k0"), SqlTypes.DOUBLE)
       .valueColumn(ColumnName.of("BIG"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("BOI"), SqlTypes.BIGINT)
       .build()
-      .withMetaAndKeyColsInValue(false);
+      .withPseudoAndKeyColsInValue(false);
 
   private static final UnqualifiedColumnReferenceExp KEY =
       new UnqualifiedColumnReferenceExp(ColumnName.of("BOI"));
 
   private static final LogicalSchema RESULT_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("BIG"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("BOI"), SqlTypes.BIGINT)

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilderTest.java
@@ -46,14 +46,12 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class StreamStreamJoinBuilderTest {
 
   private static final LogicalSchema LEFT_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("BLUE"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("GREEN"), SqlTypes.INTEGER)
       .build();
 
   private static final LogicalSchema RIGHT_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("RED"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("ORANGE"), SqlTypes.DOUBLE)

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilderTest.java
@@ -45,14 +45,12 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class StreamTableJoinBuilderTest {
 
   private static final LogicalSchema LEFT_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("BLUE"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("GREEN"), SqlTypes.INTEGER)
       .build();
 
   private static final LogicalSchema RIGHT_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("RED"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("ORANGE"), SqlTypes.DOUBLE)

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableGroupByBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableGroupByBuilderTest.java
@@ -56,15 +56,13 @@ import org.mockito.junit.MockitoRule;
 public class TableGroupByBuilderTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(ColumnName.of("k0"), SqlTypes.DOUBLE)
       .valueColumn(ColumnName.of("PAC"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("MAN"), SqlTypes.STRING)
       .build()
-      .withMetaAndKeyColsInValue(false);
+      .withPseudoAndKeyColsInValue(false);
 
   private static final LogicalSchema REKEYED_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumns(SCHEMA.value())
       .build();

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableTableJoinBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableTableJoinBuilderTest.java
@@ -36,14 +36,12 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class TableTableJoinBuilderTest {
 
   private static final LogicalSchema LEFT_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("BLUE"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("GREEN"), SqlTypes.INTEGER)
       .build();
 
   private static final LogicalSchema RIGHT_SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
       .valueColumn(ColumnName.of("RED"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("ORANGE"), SqlTypes.DOUBLE)

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/KsqlMaterializationTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/KsqlMaterializationTest.java
@@ -59,7 +59,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class KsqlMaterializationTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("v0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("v1"), SqlTypes.STRING)

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/RowTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/RowTest.java
@@ -39,7 +39,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class RowTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
       .keyColumn(ColumnName.of("k1"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("v0"), SqlTypes.STRING)
@@ -75,7 +74,6 @@ public class RowTest {
   @Test
   public void shouldImplementEquals() {
     final LogicalSchema differentSchema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
         .keyColumn(ColumnName.of("k1"), SqlTypes.INTEGER)
         .valueColumn(ColumnName.of("diff0"), SqlTypes.STRING)

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/TableRowValidationTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/TableRowValidationTest.java
@@ -27,7 +27,6 @@ import org.junit.Test;
 public class TableRowValidationTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
       .keyColumn(ColumnName.of("k1"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("v0"), SqlTypes.STRING)
@@ -71,17 +70,5 @@ public class TableRowValidationTest {
   @Test
   public void shouldNotThrowOnMatching() {
     TableRowValidation.validate(SCHEMA, A_KEY, A_VALUE);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldThrowOnNoMetaColumnsInSchema() {
-    // Given:
-    final LogicalSchema noMetaColumns = LogicalSchema.builder()
-        .keyColumns(SCHEMA.key())
-        .valueColumns(SCHEMA.value())
-        .build();
-
-    // When:
-    TableRowValidation.validate(noMetaColumns, A_KEY, A_VALUE);
   }
 }

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/WindowedRowTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/WindowedRowTest.java
@@ -42,7 +42,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class WindowedRowTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
       .keyColumn(ColumnName.of("k1"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("v0"), SqlTypes.STRING)
@@ -82,7 +81,6 @@ public class WindowedRowTest {
   @Test
   public void shouldImplementEquals() {
     final LogicalSchema differentSchema = LogicalSchema.builder()
-        .withRowTime()
         .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
         .keyColumn(ColumnName.of("k1"), SqlTypes.INTEGER)
         .valueColumn(ColumnName.of("diff0"), SqlTypes.STRING)

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedSessionTableTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedSessionTableTest.java
@@ -58,7 +58,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class KsMaterializedSessionTableTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("v0"), SqlTypes.STRING)
       .build();

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedTableTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedTableTest.java
@@ -51,7 +51,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class KsMaterializedTableTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(ColumnName.of("K0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("v0"), SqlTypes.STRING)
       .build();

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedWindowTableTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedWindowTableTest.java
@@ -62,7 +62,6 @@ public class KsMaterializedWindowTableTest {
   private static final Duration WINDOW_SIZE = Duration.ofMinutes(1);
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .withRowTime()
       .keyColumn(ColumnName.of("K0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("v0"), SqlTypes.STRING)
       .build();


### PR DESCRIPTION
### Description 

Refactor to remove the concept of meta columns from the `LogicalSchema`. This simplifies the schemas in ksql.

The pseudo column `ROWTIME` is still added to the value columns of a source during processing. All that's changed is that now a logical schema doesn't track meta columns, because... they weren't needed!

### Reviewing notes:

Commits are:

1. The core production code changes - review `LogicalSchema` first, then the rest.
2. The core test code changes relating to the first commit - skim review.
3. Other production code changes pertaining to `rowTime()` being removed and some function renames - boring stuff, skim if you want.
4. Other test code changes pertaining to the same - really boring, skim if you have nothing better to do.

### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

