### PR TITLE
build: pin streams to 5.5.0 instead of 5.5.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,9 +124,9 @@
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <skip.docker.build>true</skip.docker.build>
         <skip.docker.test>true</skip.docker.test>
-        <kafka.version>5.5.0-ccs-SNAPSHOT</kafka.version>
-        <ce.kafka.version>5.5.0-ce-SNAPSHOT</ce.kafka.version>
-        <confluent.version>5.5.0-SNAPSHOT</confluent.version>
+        <kafka.version>5.5.0-ccs</kafka.version>
+        <ce.kafka.version>5.5.0-ce</ce.kafka.version>
+        <confluent.version>5.5.0</confluent.version>
         <compile.warnings-flag>-Werror</compile.warnings-flag>
         <!-- Only used to provide login module implementation for tests -->
         <jetty.version>9.4.28.v20200408</jetty.version>


### PR DESCRIPTION
### Description 

Now that 5.5 is released we shouldn't be pinning to snapshots.

### Testing done 
local build

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

