### PR TITLE
feat: Do not allow access to new streaming endpoints using HTTP1.x

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/CloseQueryHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/CloseQueryHandler.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.api.server;
 
 import static io.confluent.ksql.api.server.ErrorCodes.ERROR_CODE_UNKNOWN_QUERY_ID;
+import static io.confluent.ksql.api.server.ServerUtils.checkHttp2;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 
 import io.confluent.ksql.api.server.protocol.CloseQueryArgs;
@@ -37,6 +38,11 @@ public class CloseQueryHandler implements Handler<RoutingContext> {
 
   @Override
   public void handle(final RoutingContext routingContext) {
+
+    if (!checkHttp2(routingContext)) {
+      return;
+    }
+
     final Optional<CloseQueryArgs> closeQueryArgs = ServerUtils
         .deserialiseObject(routingContext.getBody(), routingContext, CloseQueryArgs.class);
     if (!closeQueryArgs.isPresent()) {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/CloseQueryHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/CloseQueryHandler.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.api.server;
 
 import static io.confluent.ksql.api.server.ErrorCodes.ERROR_CODE_UNKNOWN_QUERY_ID;
-import static io.confluent.ksql.api.server.ServerUtils.checkHttp2;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 
 import io.confluent.ksql.api.server.protocol.CloseQueryArgs;
@@ -38,10 +37,6 @@ public class CloseQueryHandler implements Handler<RoutingContext> {
 
   @Override
   public void handle(final RoutingContext routingContext) {
-
-    if (!checkHttp2(routingContext)) {
-      return;
-    }
 
     final Optional<CloseQueryArgs> closeQueryArgs = ServerUtils
         .deserialiseObject(routingContext.getBody(), routingContext, CloseQueryArgs.class);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ErrorCodes.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ErrorCodes.java
@@ -33,6 +33,7 @@ public final class ErrorCodes {
   public static final int ERROR_MAX_PUSH_QUERIES_EXCEEDED = 8;
   public static final int ERROR_FAILED_AUTHENTICATION = 9;
   public static final int ERROR_FAILED_AUTHORIZATION = 10;
+  public static final int ERROR_HTTP2_ONLY = 11;
 
   public static final int ERROR_CODE_INTERNAL_ERROR = 100;
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/InsertsStreamHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/InsertsStreamHandler.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.api.server;
 
 import static io.confluent.ksql.api.server.QueryStreamHandler.DELIMITED_CONTENT_TYPE;
+import static io.confluent.ksql.api.server.ServerUtils.checkHttp2;
 import static io.confluent.ksql.api.server.ServerUtils.deserialiseObject;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 
@@ -64,6 +65,11 @@ public class InsertsStreamHandler implements Handler<RoutingContext> {
 
   @Override
   public void handle(final RoutingContext routingContext) {
+
+    if (!checkHttp2(routingContext)) {
+      return;
+    }
+
     // The record parser takes in potentially fragmented buffers from the request and spits
     // out the chunks delimited by newline
     final RecordParser recordParser = RecordParser.newDelimited("\n", routingContext.request());

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/QueryStreamHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/QueryStreamHandler.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.api.server;
 
+import static io.confluent.ksql.api.server.ServerUtils.checkHttp2;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 
@@ -56,8 +57,13 @@ public class QueryStreamHandler implements Handler<RoutingContext> {
     this.server = Objects.requireNonNull(server);
   }
 
+
   @Override
   public void handle(final RoutingContext routingContext) {
+
+    if (!checkHttp2(routingContext)) {
+      return;
+    }
 
     final String contentType = routingContext.getAcceptableContentType();
     final QueryStreamResponseWriter queryStreamResponseWriter;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerUtils.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerUtils.java
@@ -23,6 +23,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import io.confluent.ksql.api.server.protocol.PojoCodec;
 import io.confluent.ksql.api.server.protocol.PojoDeserializerErrorHandler;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpVersion;
 import io.vertx.ext.web.RoutingContext;
 import java.util.Objects;
 import java.util.Optional;
@@ -65,6 +66,17 @@ public final class ServerUtils {
       }
     }
     return out.toString();
+  }
+
+  public static boolean checkHttp2(final RoutingContext routingContext) {
+    if (routingContext.request().version() != HttpVersion.HTTP_2) {
+      routingContext.fail(BAD_REQUEST.code(),
+          new KsqlApiException("This endpoint is only available when using HTTP2",
+              ErrorCodes.ERROR_HTTP2_ONLY));
+      return false;
+    } else {
+      return true;
+    }
   }
 
   private static class HttpResponseErrorHandler implements PojoDeserializerErrorHandler {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
@@ -804,17 +804,6 @@ public class ApiTest extends BaseApiTest {
 
   @Test
   @CoreApiTest
-  public void shouldRejectCloseQueryUsingHttp11() throws Exception {
-
-    // Given:
-    JsonObject requestBody = new JsonObject().put("queryId", "query12345");
-
-    // Then:
-    shouldRejectRequestUsingHttp11("/close-query", requestBody);
-  }
-
-  @Test
-  @CoreApiTest
   public void shouldRejectInsertsUsingHttp11() throws Exception {
 
     // Given:

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
@@ -60,27 +60,6 @@ public class ApiTest extends BaseApiTest {
 
   @Test
   @CoreApiTest
-  public void shouldRejectInsertsStreamUsingHttp11() throws Exception {
-
-    client.close();
-    httpVersion = HttpVersion.HTTP_1_1;
-    client = createClient();
-
-    // Given
-    JsonObject closeQueryRequestBody = new JsonObject().put("queryId", "query12345");
-
-    // When
-    HttpResponse<Buffer> response = sendRequest("/query-stream", closeQueryRequestBody.toBuffer());
-
-    // Then
-    assertThat(response.statusCode(), is(400));
-    QueryResponse queryResponse = new QueryResponse(response.bodyAsString());
-    validateError(ERROR_HTTP2_ONLY, "This endpoint is only available when using HTTP2",
-        queryResponse.responseObject);
-  }
-
-  @Test
-  @CoreApiTest
   public void shouldExecutePullQuery() throws Exception {
 
     // Given

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/BaseApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/BaseApiTest.java
@@ -71,7 +71,6 @@ public class BaseApiTest {
   protected Server server;
   protected TestEndpoints testEndpoints;
   protected ServerState serverState;
-  protected HttpVersion httpVersion = HttpVersion.HTTP_2;
 
   @Before
   public void setUp() {
@@ -130,16 +129,11 @@ public class BaseApiTest {
   }
 
   protected WebClientOptions createClientOptions() {
-    WebClientOptions webClientOptions = new WebClientOptions()
+    return new WebClientOptions()
         .setProtocolVersion(HttpVersion.HTTP_2).setHttp2ClearTextUpgrade(false)
         .setDefaultHost("localhost")
         .setDefaultPort(server.getListeners().get(0).getPort())
         .setReusePort(true);
-    webClientOptions.setProtocolVersion(httpVersion);
-    if (httpVersion == HttpVersion.HTTP_2) {
-      webClientOptions.setHttp2ClearTextUpgrade(false);
-    }
-    return webClientOptions;
   }
 
   protected WebClient createClient() {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/BaseApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/BaseApiTest.java
@@ -71,6 +71,7 @@ public class BaseApiTest {
   protected Server server;
   protected TestEndpoints testEndpoints;
   protected ServerState serverState;
+  protected HttpVersion httpVersion = HttpVersion.HTTP_2;
 
   @Before
   public void setUp() {
@@ -129,11 +130,16 @@ public class BaseApiTest {
   }
 
   protected WebClientOptions createClientOptions() {
-    return new WebClientOptions()
+    WebClientOptions webClientOptions = new WebClientOptions()
         .setProtocolVersion(HttpVersion.HTTP_2).setHttp2ClearTextUpgrade(false)
         .setDefaultHost("localhost")
         .setDefaultPort(server.getListeners().get(0).getPort())
         .setReusePort(true);
+    webClientOptions.setProtocolVersion(httpVersion);
+    if (httpVersion == HttpVersion.HTTP_2) {
+      webClientOptions.setHttp2ClearTextUpgrade(false);
+    }
+    return webClientOptions;
   }
 
   protected WebClient createClient() {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/Http2OnlyStreamTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/Http2OnlyStreamTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api;
+
+import static io.confluent.ksql.api.server.ErrorCodes.ERROR_HTTP2_ONLY;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import io.confluent.ksql.api.utils.QueryResponse;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClientOptions;
+import org.junit.Test;
+
+public class Http2OnlyStreamTest extends BaseApiTest {
+
+  protected WebClientOptions createClientOptions() {
+    return new WebClientOptions()
+        .setDefaultHost("localhost")
+        .setDefaultPort(server.getListeners().get(0).getPort())
+        .setReusePort(true);
+  }
+
+  @Test
+  public void shouldRejectQueryUsingHttp11() throws Exception {
+
+    // Given:
+    JsonObject requestBody = new JsonObject().put("sql", DEFAULT_PULL_QUERY);
+    JsonObject properties = new JsonObject().put("prop1", "val1").put("prop2", 23);
+    requestBody.put("properties", properties);
+
+    // Then
+    shouldRejectRequestUsingHttp11("/query-stream", requestBody);
+  }
+
+  @Test
+  public void shouldRejectInsertsUsingHttp11() throws Exception {
+
+    // Given:
+    JsonObject requestBody = new JsonObject().put("target", "test-stream");
+
+    // Then:
+    shouldRejectRequestUsingHttp11("/inserts-stream", requestBody);
+  }
+
+  private void shouldRejectRequestUsingHttp11(final String uri, final JsonObject request)
+      throws Exception {
+    // When
+    HttpResponse<Buffer> response = sendRequest(uri, request.toBuffer());
+
+    // Then
+    assertThat(response.statusCode(), is(400));
+    QueryResponse queryResponse = new QueryResponse(response.bodyAsString());
+    validateError(ERROR_HTTP2_ONLY, "This endpoint is only available when using HTTP2",
+        queryResponse.responseObject);
+  }
+
+
+}


### PR DESCRIPTION
### Description 

Implements: https://github.com/confluentinc/ksql/issues/4604

Reject access to the new streaming endpoints when attempted using HTTP1.1.

### Testing done 

Added new tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

