### PR TITLE
test: have QTT report test name when exception thrown

### DIFF
--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/EndToEndEngineTestUtil.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/EndToEndEngineTestUtil.java
@@ -39,7 +39,7 @@ final class EndToEndEngineTestUtil {
   static void shouldBuildAndExecuteQuery(final TestCase testCase) {
     try (final TestExecutor testExecutor = TestExecutor.create()) {
       testExecutor.buildAndExecuteQuery(testCase, TestExecutionListener.noOp());
-    } catch (final AssertionError e) {
+    } catch (final AssertionError | Exception e) {
       throw new AssertionError(e.getMessage()
           + System.lineSeparator()
           + "failed test: " + testCase.getName()

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/TestCasePlanLoader.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/TestCasePlanLoader.java
@@ -258,7 +258,7 @@ public final class TestCasePlanLoader {
       final TestInfoGatherer listener = new TestInfoGatherer();
       testExecutor.buildAndExecuteQuery(testCase, listener);
       return listener;
-    } catch (final AssertionError e) {
+    } catch (final AssertionError | Exception e) {
       throw new AssertionError("Failed to run test case: " + e.getMessage()
           + System.lineSeparator()
           + "failed test: " + testCase.getName()

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
@@ -108,7 +108,7 @@ public class RestQueryTranslationTest {
   public void shouldBuildAndExecuteQueries() {
     try (RestTestExecutor testExecutor = testExecutor()) {
       testExecutor.buildAndExecuteQuery(testCase);
-    } catch (final AssertionError e) {
+    } catch (final AssertionError | Exception e) {
       throw new AssertionError(e.getMessage()
           + System.lineSeparator()
           + "failed test: " + testCase.getName()


### PR DESCRIPTION
### Description 

QTT tests normally output the test name that failed, (making it easy to copy and search for it). However, tests that throw exceptions when building do not.  This commit fixes this.


### Testing done 

test only change,

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

