### PR TITLE
fix: use schema in annotation as schema provider if present

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/FunctionLoaderUtils.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/FunctionLoaderUtils.java
@@ -17,10 +17,10 @@ package io.confluent.ksql.function;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.execution.function.UdfUtil;
-import io.confluent.ksql.function.types.DecimalType;
 import io.confluent.ksql.function.types.GenericType;
 import io.confluent.ksql.function.types.ParamType;
 import io.confluent.ksql.function.types.ParamTypes;
+import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.function.udf.UdfSchemaProvider;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
@@ -180,17 +180,27 @@ public final class FunctionLoaderUtils {
   static SchemaProvider handleUdfReturnSchema(
       final Class theClass,
       final ParamType javaReturnSchema,
+      final String annotationSchema,
+      final SqlTypeParser parser,
       final String schemaProviderFunctionName,
       final String functionName,
       final boolean isVariadic
   ) {
     final Function<List<SqlType>, SqlType> schemaProvider;
-    if (!schemaProviderFunctionName.equals("")) {
+    if (!Udf.NO_SCHEMA_PROVIDER.equals(schemaProviderFunctionName)) {
       schemaProvider = handleUdfSchemaProviderAnnotation(
           schemaProviderFunctionName, theClass, functionName);
-    } else if (javaReturnSchema instanceof DecimalType) {
-      throw new KsqlException(String.format("Cannot load UDF %s. BigDecimal return type "
-          + "is not supported without a schema provider method.", functionName));
+    } else if (!Udf.NO_SCHEMA.equals(annotationSchema)) {
+      schemaProvider = args -> parser.parse(annotationSchema).getSqlType();
+    } else if (!GenericsUtil.hasGenerics(javaReturnSchema)) {
+      final SqlType sqlType;
+      try {
+        sqlType = SchemaConverters.functionToSqlConverter().toSqlType(javaReturnSchema);
+      } catch (final Exception e) {
+        throw new KsqlException("Cannot load UDF " + functionName + ". "
+            + javaReturnSchema + " return type is not supported without a schema annotation.");
+      }
+      schemaProvider = args -> sqlType;
     } else {
       schemaProvider = null;
     }
@@ -208,10 +218,6 @@ public final class FunctionLoaderUtils {
           ));
         }
         return returnType;
-      }
-
-      if (!GenericsUtil.hasGenerics(javaReturnSchema)) {
-        return SchemaConverters.functionToSqlConverter().toSqlType(javaReturnSchema);
       }
 
       final Map<GenericType, SqlType> genericMapping = new HashMap<>();
@@ -283,5 +289,4 @@ public final class FunctionLoaderUtils {
       ), e);
     }
   }
-
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
@@ -151,6 +151,8 @@ public class UdfLoader {
         .handleUdfReturnSchema(
             theClass,
             javaReturnSchema,
+            udfAnnotation.schema(),
+            typeParser,
             udfAnnotation.schemaProvider(),
             udfDescriptionAnnotation.name(),
             method.isVarArgs()

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdtfLoader.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdtfLoader.java
@@ -142,6 +142,8 @@ public class UdtfLoader {
         .handleUdfReturnSchema(
             method.getDeclaringClass(),
             outputType,
+            udtfAnnotation.schema(),
+            typeParser,
             udtfAnnotation.schemaProvider(),
             functionName.text(),
             method.isVarArgs());

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
@@ -317,7 +317,7 @@ public class UdfLoaderTest {
     // Then:
     assertThat(e.getMessage(), containsString(
         "Cannot load UDF MissingAnnotation. DECIMAL return type is " +
-            "not supported without a schema annotation."));
+            "not supported without an explicit schema"));
 
   }
 
@@ -376,7 +376,7 @@ public class UdfLoaderTest {
     // Then:
     assertThat(e.getMessage(), containsString(
         "Cannot load UDF ReturnDecimalWithoutSchemaProvider. DECIMAL return type is not " +
-            "supported without a schema annotation."));
+            "supported without an explicit schema"));
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdtfLoaderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdtfLoaderTest.java
@@ -287,7 +287,7 @@ public class UdtfLoaderTest {
 
     // Then:
     assertThat(e.getMessage(), containsString(
-        "Cannot load UDF bigDecimalNoSchemaProvider. BigDecimal return type is not supported without a schema provider method."));
+        "Cannot load UDF bigDecimalNoSchemaProvider. DECIMAL return type is not supported without a schema annotation"));
   }
 
   @UdtfDescription(name = "badReturnUdtf", description = "whatever")

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdtfLoaderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdtfLoaderTest.java
@@ -287,7 +287,7 @@ public class UdtfLoaderTest {
 
     // Then:
     assertThat(e.getMessage(), containsString(
-        "Cannot load UDF bigDecimalNoSchemaProvider. DECIMAL return type is not supported without a schema annotation"));
+        "Cannot load UDF bigDecimalNoSchemaProvider. DECIMAL return type is not supported without an explicit schema"));
   }
 
   @UdtfDescription(name = "badReturnUdtf", description = "whatever")

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/function/udf/Udf.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/function/udf/Udf.java
@@ -29,6 +29,9 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 public @interface Udf {
 
+  String NO_SCHEMA = "";
+  String NO_SCHEMA_PROVIDER = "";
+
   /**
    * The function description.
    *
@@ -45,11 +48,11 @@ public @interface Udf {
    * the return value itself. For complex return types (e.g. {@code Struct} types),
    * this is required and will fail if not supplied.
    */
-  String schema() default "";
+  String schema() default NO_SCHEMA;
 
   /**
    * The name of the method that provides the return type of the UDF.
    * @return the name of the other method
    */
-  String schemaProvider() default "";
+  String schemaProvider() default NO_SCHEMA_PROVIDER;
 }


### PR DESCRIPTION
fixes #5164
replaces #5190 

### Description 

This change (1) eagerly resolves the return type if possible to fail early if a function cannot be loaded and (2) skips resolving the java type to a sql type if the udf annotation contains the `schema` field.

Thanks @stevenpyzhang for exploring the issue!

### Testing done 

Lots of new unit tests and end-to-end testing with the UDF linked in the ticket.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

