### PR TITLE
chore: fix outer join handling in multi-way joins

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/JoinTree.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/JoinTree.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Sets;
 import io.confluent.ksql.analyzer.Analysis.AliasedDataSource;
 import io.confluent.ksql.analyzer.Analysis.JoinInfo;
 import io.confluent.ksql.execution.expression.tree.Expression;
+import io.confluent.ksql.planner.plan.JoinNode.JoinType;
 import io.confluent.ksql.schema.ksql.FormatOptions;
 import io.confluent.ksql.util.KsqlException;
 import java.util.List;
@@ -198,6 +199,13 @@ final class JoinTree {
       //
       // We always include both sides of the current join in the output set,
       // since we know the key will be the equivalence of those
+
+      if (info.getType() == JoinType.OUTER) {
+        // The key column of OUTER joins are not equivalent to either join
+        // expression, (as either can be null), and hence return an empty equivalence
+        // set.
+        return ImmutableSet.of();
+      }
 
       final Set<Expression> keys = ImmutableSet.of(
           info.getLeftJoinExpression(),

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/multi-joins.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/multi-joins.json
@@ -583,16 +583,19 @@
         {"topic": "right", "key": 0, "value": {"V0": 6}, "timestamp": 100001}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": null, "S2_V0": 2, "T3_V0": 3}, "timestamp":  11},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition", "key": null, "value": {"S1_V0": null, "S1_ROWTIME": null, "S1_ID": null, "S2_V0": 2, "S2_ROWTIME": 11, "S2_ID": 0}, "timestamp":  11},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition", "key": 0, "value": {"S1_V0": 1, "S1_ROWTIME": 12, "S1_ID": 0, "S2_V0": 2, "S2_ROWTIME": 11, "S2_ID": 0}, "timestamp":  12},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition", "key": 0, "value": {"S1_V0": 1, "S1_ROWTIME": 12, "S1_ID": 0, "S2_V0": 4, "S2_ROWTIME": 13, "S2_ID": 0}, "timestamp":  13},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition", "key": 0, "value": {"S1_V0": 5, "S1_ROWTIME": 100000, "S1_ID": 0, "S2_V0": null, "S2_ROWTIME": null, "S2_ID": null}, "timestamp":  100000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition", "key": 0, "value": {"S1_V0": 5, "S1_ROWTIME": 100000, "S1_ID": 0, "S2_V0": 6, "S2_ROWTIME": 100001, "S2_ID": 0}, "timestamp":  100001},
         {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 2, "T3_V0": 3}, "timestamp":  12},
         {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 4, "T3_V0": 3}, "timestamp":  13},
         {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 5, "S2_V0": null, "T3_V0": 3}, "timestamp":  100000},
         {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 5, "S2_V0": 6, "T3_V0": 3}, "timestamp":  100001}
       ],
       "post": {
-        "topics": {"blacklist": ".*-repartition"},
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, S1_V0 BIGINT, S2_V0 BIGINT, T3_V0 BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "S1_ID INT KEY, S1_V0 BIGINT, S2_V0 BIGINT, T3_V0 BIGINT"}
         ]
       }
     },


### PR DESCRIPTION
### Description 

fixes: https://github.com/confluentinc/ksql/issues/5202

This change ensures the appropriate repartition step is added when an outer join is combined with a later join type in the same query.

### Testing done 

Usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

