### PR TITLE
fix: /query-stream endpoint should serialize Struct (MINOR)

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ErrorCodes.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ErrorCodes.java
@@ -24,7 +24,6 @@ public final class ErrorCodes {
   }
 
   public static final int ERROR_CODE_MISSING_PARAM = 1;
-  public static final int ERROR_CODE_UNKNOWN_PARAM = 2;
   public static final int ERROR_CODE_UNKNOWN_QUERY_ID = 3;
   public static final int ERROR_CODE_MALFORMED_REQUEST = 4;
   public static final int ERROR_CODE_INVALID_QUERY = 5;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerUtils.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerUtils.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.api.server;
 
 import static io.confluent.ksql.api.server.ErrorCodes.ERROR_CODE_MALFORMED_REQUEST;
 import static io.confluent.ksql.api.server.ErrorCodes.ERROR_CODE_MISSING_PARAM;
-import static io.confluent.ksql.api.server.ErrorCodes.ERROR_CODE_UNKNOWN_PARAM;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 
 import io.confluent.ksql.api.server.protocol.PojoCodec;
@@ -80,13 +79,6 @@ public final class ServerUtils {
       routingContext
           .fail(BAD_REQUEST.code(), new KsqlApiException("No " + paramName + " in arguments",
               ERROR_CODE_MISSING_PARAM));
-    }
-
-    @Override
-    public void onExtraParam(final String paramName) {
-      routingContext
-          .fail(BAD_REQUEST.code(), new KsqlApiException("Unknown arg " + paramName,
-              ERROR_CODE_UNKNOWN_PARAM));
     }
 
     @Override

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/protocol/PojoCodec.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/protocol/PojoCodec.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
-import io.confluent.ksql.json.JsonMapper;
+import io.confluent.ksql.rest.ApiJsonMapper;
 import io.vertx.core.buffer.Buffer;
 import java.io.IOException;
 import java.util.Optional;
@@ -31,7 +31,7 @@ import java.util.Optional;
  */
 public final class PojoCodec {
 
-  private static final ObjectMapper OBJECT_MAPPER = JsonMapper.INSTANCE.mapper;
+  private static final ObjectMapper OBJECT_MAPPER = ApiJsonMapper.INSTANCE.get();
 
   private PojoCodec() {
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/protocol/PojoCodec.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/protocol/PojoCodec.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
-import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import io.confluent.ksql.rest.ApiJsonMapper;
 import io.vertx.core.buffer.Buffer;
 import java.io.IOException;
@@ -41,9 +40,6 @@ public final class PojoCodec {
       final Class<T> clazz) {
     try {
       return Optional.of(OBJECT_MAPPER.readValue(buffer.getBytes(), clazz));
-    } catch (UnrecognizedPropertyException e) {
-      errorHandler.onExtraParam(e.getPropertyName());
-      return Optional.empty();
     } catch (MismatchedInputException e) {
       // This is super ugly but I can't see how else to extract the property name
       final int startIndex = e.getMessage().indexOf('\'');

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/protocol/PojoCodec.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/protocol/PojoCodec.java
@@ -20,8 +20,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import io.confluent.ksql.json.JsonMapper;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.json.jackson.DatabindCodec;
 import java.io.IOException;
 import java.util.Optional;
 
@@ -31,15 +31,16 @@ import java.util.Optional;
  */
 public final class PojoCodec {
 
+  private static final ObjectMapper OBJECT_MAPPER = JsonMapper.INSTANCE.mapper;
+
   private PojoCodec() {
   }
 
   public static <T> Optional<T> deserialiseObject(final Buffer buffer,
       final PojoDeserializerErrorHandler errorHandler,
       final Class<T> clazz) {
-    final ObjectMapper objectMapper = DatabindCodec.mapper();
     try {
-      return Optional.of(objectMapper.readValue(buffer.getBytes(), clazz));
+      return Optional.of(OBJECT_MAPPER.readValue(buffer.getBytes(), clazz));
     } catch (UnrecognizedPropertyException e) {
       errorHandler.onExtraParam(e.getPropertyName());
       return Optional.empty();
@@ -59,9 +60,8 @@ public final class PojoCodec {
   }
 
   public static <T> Buffer serializeObject(final T t) {
-    final ObjectMapper objectMapper = DatabindCodec.mapper();
     try {
-      final byte[] bytes = objectMapper.writeValueAsBytes(t);
+      final byte[] bytes = OBJECT_MAPPER.writeValueAsBytes(t);
       return Buffer.buffer(bytes);
     } catch (JsonProcessingException e) {
       throw new RuntimeException("Failed to serialize buffer", e);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/protocol/PojoDeserializerErrorHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/protocol/PojoDeserializerErrorHandler.java
@@ -29,13 +29,6 @@ public interface PojoDeserializerErrorHandler {
   void onMissingParam(String paramName);
 
   /**
-   * Called when a POJO fails to deserialise because the JSON contains an extra (unknown) param
-   *
-   * @param paramName the name of the param
-   */
-  void onExtraParam(String paramName);
-
-  /**
    * Called when a POJO fails to deserialise because the JSON is not well formed
    */
   void onInvalidJson();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
@@ -19,7 +19,6 @@ import static io.confluent.ksql.api.server.ErrorCodes.ERROR_CODE_INTERNAL_ERROR;
 import static io.confluent.ksql.api.server.ErrorCodes.ERROR_CODE_INVALID_QUERY;
 import static io.confluent.ksql.api.server.ErrorCodes.ERROR_CODE_MALFORMED_REQUEST;
 import static io.confluent.ksql.api.server.ErrorCodes.ERROR_CODE_MISSING_PARAM;
-import static io.confluent.ksql.api.server.ErrorCodes.ERROR_CODE_UNKNOWN_PARAM;
 import static io.confluent.ksql.api.server.ErrorCodes.ERROR_CODE_UNKNOWN_QUERY_ID;
 import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 import static org.hamcrest.CoreMatchers.hasItem;
@@ -233,26 +232,6 @@ public class ApiTest extends BaseApiTest {
   }
 
   @Test
-  public void shouldHandleExtraArgInQuery() throws Exception {
-
-    // Given
-    JsonObject requestBody = new JsonObject().put("sql", DEFAULT_PULL_QUERY)
-        .put("badarg", 213);
-
-    // When
-    HttpResponse<Buffer> response = sendRequest("/query-stream",
-        requestBody.toBuffer().appendString("\n"));
-
-    // Then
-    assertThat(response.statusCode(), is(400));
-    assertThat(response.statusMessage(), is("Bad Request"));
-
-    QueryResponse queryResponse = new QueryResponse(response.bodyAsString());
-    validateError(ERROR_CODE_UNKNOWN_PARAM, "Unknown arg badarg",
-        queryResponse.responseObject);
-  }
-
-  @Test
   public void shouldHandleErrorInProcessingQuery() throws Exception {
 
     // Given
@@ -365,26 +344,6 @@ public class ApiTest extends BaseApiTest {
 
     QueryResponse queryResponse = new QueryResponse(response.bodyAsString());
     validateError(ERROR_CODE_MISSING_PARAM, "No queryId in arguments",
-        queryResponse.responseObject);
-  }
-
-  @Test
-  public void shouldHandleExtraArgInCloseQuery() throws Exception {
-
-    // Given
-    JsonObject requestBody = new JsonObject().put("queryId", "qwydguygwd")
-        .put("badarg", 213);
-
-    // When
-    HttpResponse<Buffer> response = sendRequest("/close-query",
-        requestBody.toBuffer().appendString("\n"));
-
-    // Then
-    assertThat(response.statusCode(), is(400));
-    assertThat(response.statusMessage(), is("Bad Request"));
-
-    QueryResponse queryResponse = new QueryResponse(response.bodyAsString());
-    validateError(ERROR_CODE_UNKNOWN_PARAM, "Unknown arg badarg",
         queryResponse.responseObject);
   }
 
@@ -513,26 +472,6 @@ public class ApiTest extends BaseApiTest {
 
     QueryResponse queryResponse = new QueryResponse(response.bodyAsString());
     validateError(ERROR_CODE_MISSING_PARAM, "No target in arguments", queryResponse.responseObject);
-  }
-
-  @Test
-  public void shouldHandleExtraArgInInserts() throws Exception {
-
-    // Given
-    JsonObject requestBody = new JsonObject().put("target", "some-stream")
-        .put("badarg", 213);
-
-    // When
-    HttpResponse<Buffer> response = sendRequest("/inserts-stream",
-        requestBody.toBuffer().appendString("\n"));
-
-    // Then
-    assertThat(response.statusCode(), is(400));
-    assertThat(response.statusMessage(), is("Bad Request"));
-
-    QueryResponse queryResponse = new QueryResponse(response.bodyAsString());
-    validateError(ERROR_CODE_UNKNOWN_PARAM, "Unknown arg badarg",
-        queryResponse.responseObject);
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/PojoCodecTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/PojoCodecTest.java
@@ -26,6 +26,9 @@ import io.confluent.ksql.api.server.protocol.PojoDeserializerErrorHandler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import java.util.Optional;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -33,6 +36,13 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PojoCodecTest {
+
+  private static final Schema STRUCT_SCHEMA = SchemaBuilder.struct()
+      .field("foo", Schema.OPTIONAL_INT32_SCHEMA)
+      .field("bar", Schema.OPTIONAL_STRING_SCHEMA)
+      .optional()
+      .build();
+  private static final Struct STRUCT = new Struct(STRUCT_SCHEMA);
 
   @Mock
   private PojoDeserializerErrorHandler errorHandler;
@@ -72,6 +82,11 @@ public class PojoCodecTest {
     Optional<TestPojo> testPojo = PojoCodec.deserialiseObject(buff, errorHandler, TestPojo.class);
     assertThat(testPojo.isPresent(), is(false));
     verify(errorHandler).onExtraParam("blah");
+  }
+
+  @Test
+  public void shouldSerializeStruct() {
+    PojoCodec.serializeObject(STRUCT);
   }
 
   public static class TestPojo {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/PojoCodecTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/PojoCodecTest.java
@@ -48,7 +48,7 @@ public class PojoCodecTest {
   private PojoDeserializerErrorHandler errorHandler;
 
   @Test
-  public void testDeserializePojo() {
+  public void shouldDeserializePojo() {
     JsonObject jsonObject = new JsonObject().put("field1", 123)
         .put("field2", "foobar")
         .put("field3", true);
@@ -61,7 +61,7 @@ public class PojoCodecTest {
   }
 
   @Test
-  public void testDeserializeInvalidJson() {
+  public void shouldFailToDeserializeInvalidJson() {
     Buffer buff = Buffer.buffer("{\"foo\":123");
     Optional<TestPojo> testPojo = PojoCodec.deserialiseObject(buff, errorHandler, TestPojo.class);
     assertThat(testPojo.isPresent(), is(false));
@@ -69,7 +69,7 @@ public class PojoCodecTest {
   }
 
   @Test
-  public void testDeserializeMissingField() {
+  public void shouldFailToDeserializeMissingField() {
     Buffer buff = Buffer.buffer("{\"field1\":123,\"field2\":\"foo\"}");
     Optional<TestPojo> testPojo = PojoCodec.deserialiseObject(buff, errorHandler, TestPojo.class);
     assertThat(testPojo.isPresent(), is(false));
@@ -77,11 +77,13 @@ public class PojoCodecTest {
   }
 
   @Test
-  public void testDeserializeUnknownField() {
+  public void shouldDeserializeWithUnknownField() {
     Buffer buff = Buffer.buffer("{\"field1\":123,\"field2\":\"foo\",\"field3\":true,\"blah\":432}");
     Optional<TestPojo> testPojo = PojoCodec.deserialiseObject(buff, errorHandler, TestPojo.class);
-    assertThat(testPojo.isPresent(), is(false));
-    verify(errorHandler).onExtraParam("blah");
+    assertThat(testPojo.isPresent(), is(true));
+    assertThat(testPojo.get().field1, is(123));
+    assertThat(testPojo.get().field2, is("foo"));
+    assertThat(testPojo.get().field3, is(true));
   }
 
   @Test


### PR DESCRIPTION
### Description 

Fixes https://github.com/confluentinc/ksql/issues/4996

^ by switching from `DatabindCodec.mapper` to the JSON mapper used for the existing APIs. This also means we no longer fail to deserialize on unknown properties, which is nice to have for forward compatibility (in case we evolve the API to add additional properties in the future). The relevant unit test was updated accordingly.

### Testing done 

Added unit test.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

