### PR TITLE
 test: add test coverage to create-type

### DIFF
--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/RegisterTypeCommand.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/RegisterTypeCommand.java
@@ -47,8 +47,14 @@ public class RegisterTypeCommand implements DdlCommand {
 
   @Override
   public boolean equals(final Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
     final RegisterTypeCommand that = (RegisterTypeCommand) o;
     return Objects.equals(type, that.type)
         && Objects.equals(typeName, that.typeName);

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/RegisterTypeCommand.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/RegisterTypeCommand.java
@@ -44,4 +44,18 @@ public class RegisterTypeCommand implements DdlCommand {
   public String getTypeName() {
     return typeName;
   }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final RegisterTypeCommand that = (RegisterTypeCommand) o;
+    return Objects.equals(type, that.type)
+        && Objects.equals(typeName, that.typeName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, typeName);
+  }
 }

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestCaseBuilderUtil.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestCaseBuilderUtil.java
@@ -18,10 +18,7 @@ package io.confluent.ksql.test.tools;
 import static com.google.common.io.Files.getNameWithoutExtension;
 
 import com.google.common.collect.Streams;
-import com.google.gson.internal.$Gson$Preconditions;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
-import io.confluent.ksql.ddl.commands.DdlCommandExec;
-import io.confluent.ksql.execution.ddl.commands.DdlCommand;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.metastore.MetaStore;
@@ -50,7 +47,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
@@ -118,7 +114,7 @@ public final class TestCaseBuilderUtil {
     // Infer topics if not added already:
     final MutableMetaStore metaStore = new MetaStoreImpl(functionRegistry);
     for (String sql : statements) {
-      Topic topicFromStatement = createTopicFromStatement(sql, metaStore);
+      final Topic topicFromStatement = createTopicFromStatement(sql, metaStore);
       if (topicFromStatement != null) {
         allTopics.putIfAbsent(topicFromStatement.getName(), topicFromStatement);
       }

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/create-type_-_create_nested_type/6.0.0_1588107644049/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/create-type_-_create_nested_type/6.0.0_1588107644049/plan.json
@@ -1,0 +1,141 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TYPE ADDRESS AS STRUCT<NUMBER INTEGER, STREET STRING, CITY STRING>;",
+    "ddlCommand" : {
+      "@type" : "registerTypeV1",
+      "type" : "STRUCT<`NUMBER` INTEGER, `STREET` STRING, `CITY` STRING>",
+      "typeName" : "ADDRESS"
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TYPE PERSON AS STRUCT<NAME STRING, ADDRESS STRUCT<NUMBER INTEGER, STREET STRING, CITY STRING>>;",
+    "ddlCommand" : {
+      "@type" : "registerTypeV1",
+      "type" : "STRUCT<`NAME` STRING, `ADDRESS` STRUCT<`NUMBER` INTEGER, `STREET` STRING, `CITY` STRING>>",
+      "typeName" : "PERSON"
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE PEOPLE (PERSON STRUCT<NAME STRING, ADDRESS STRUCT<NUMBER INTEGER, STREET STRING, CITY STRING>>) WITH (KAFKA_TOPIC='test', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "PEOPLE",
+      "schema" : "`ROWKEY` STRING KEY, `PERSON` STRUCT<`NAME` STRING, `ADDRESS` STRUCT<`NUMBER` INTEGER, `STREET` STRING, `CITY` STRING>>",
+      "topicName" : "test",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE COPY AS SELECT *\nFROM PEOPLE PEOPLE\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "COPY",
+      "schema" : "`ROWKEY` STRING KEY, `PERSON` STRUCT<`NAME` STRING, `ADDRESS` STRUCT<`NUMBER` INTEGER, `STREET` STRING, `CITY` STRING>>",
+      "topicName" : "COPY",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "PEOPLE" ],
+      "sink" : "COPY",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "COPY"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ROWKEY` STRING KEY, `PERSON` STRUCT<`NAME` STRING, `ADDRESS` STRUCT<`NUMBER` INTEGER, `STREET` STRING, `CITY` STRING>>"
+          },
+          "selectExpressions" : [ "PERSON AS PERSON" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "COPY"
+      },
+      "queryId" : "CTAS_COPY_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/create-type_-_create_nested_type/6.0.0_1588107644049/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/create-type_-_create_nested_type/6.0.0_1588107644049/spec.json
@@ -1,0 +1,77 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1588107644049,
+  "path" : "query-validation-tests/create-type.json",
+  "schemas" : {
+    "CTAS_COPY_0.KsqlTopic.Source" : "STRUCT<PERSON STRUCT<NAME VARCHAR, ADDRESS STRUCT<NUMBER INT, STREET VARCHAR, CITY VARCHAR>>> NOT NULL",
+    "CTAS_COPY_0.COPY" : "STRUCT<PERSON STRUCT<NAME VARCHAR, ADDRESS STRUCT<NUMBER INT, STREET VARCHAR, CITY VARCHAR>>> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "create nested type",
+    "inputs" : [ {
+      "topic" : "test",
+      "key" : "",
+      "value" : {
+        "person" : {
+          "name" : "jay",
+          "address" : {
+            "number" : 899,
+            "street" : "W. Evelyn",
+            "city" : "Mountain View"
+          }
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "COPY",
+      "key" : "",
+      "value" : {
+        "PERSON" : {
+          "NAME" : "jay",
+          "ADDRESS" : {
+            "NUMBER" : 899,
+            "STREET" : "W. Evelyn",
+            "CITY" : "Mountain View"
+          }
+        }
+      }
+    } ],
+    "topics" : [ {
+      "name" : "test",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "COPY",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE TYPE ADDRESS AS STRUCT<number INTEGER, street VARCHAR, city VARCHAR>;", "CREATE TYPE PERSON AS STRUCT<name VARCHAR, address ADDRESS>;", "CREATE TABLE people (person PERSON) WITH (kafka_topic='test', value_format='JSON');", "CREATE TABLE copy AS SELECT * FROM people;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "COPY",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "test",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/create-type_-_create_nested_type/6.0.0_1588107644049/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/create-type_-_create_nested_type/6.0.0_1588107644049/topology
@@ -1,0 +1,19 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Project
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-TOSTREAM-0000000004 (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- Project
+    Sink: KSTREAM-SINK-0000000005 (topic: COPY)
+      <-- KTABLE-TOSTREAM-0000000004
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/create-type_-_create_simple_type/6.0.0_1588107643993/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/create-type_-_create_simple_type/6.0.0_1588107643993/plan.json
@@ -1,0 +1,133 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TYPE ADDRESS AS STRUCT<NUMBER INTEGER, STREET STRING, CITY STRING>;",
+    "ddlCommand" : {
+      "@type" : "registerTypeV1",
+      "type" : "STRUCT<`NUMBER` INTEGER, `STREET` STRING, `CITY` STRING>",
+      "typeName" : "ADDRESS"
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE ADDRESSES (ADDRESS STRUCT<NUMBER INTEGER, STREET STRING, CITY STRING>) WITH (KAFKA_TOPIC='test', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "ADDRESSES",
+      "schema" : "`ROWKEY` STRING KEY, `ADDRESS` STRUCT<`NUMBER` INTEGER, `STREET` STRING, `CITY` STRING>",
+      "topicName" : "test",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE COPY AS SELECT *\nFROM ADDRESSES ADDRESSES\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "COPY",
+      "schema" : "`ROWKEY` STRING KEY, `ADDRESS` STRUCT<`NUMBER` INTEGER, `STREET` STRING, `CITY` STRING>",
+      "topicName" : "COPY",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "ADDRESSES" ],
+      "sink" : "COPY",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "COPY"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ROWKEY` STRING KEY, `ADDRESS` STRUCT<`NUMBER` INTEGER, `STREET` STRING, `CITY` STRING>"
+          },
+          "selectExpressions" : [ "ADDRESS AS ADDRESS" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "COPY"
+      },
+      "queryId" : "CTAS_COPY_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/create-type_-_create_simple_type/6.0.0_1588107643993/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/create-type_-_create_simple_type/6.0.0_1588107643993/spec.json
@@ -1,0 +1,71 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1588107643993,
+  "path" : "query-validation-tests/create-type.json",
+  "schemas" : {
+    "CTAS_COPY_0.KsqlTopic.Source" : "STRUCT<ADDRESS STRUCT<NUMBER INT, STREET VARCHAR, CITY VARCHAR>> NOT NULL",
+    "CTAS_COPY_0.COPY" : "STRUCT<ADDRESS STRUCT<NUMBER INT, STREET VARCHAR, CITY VARCHAR>> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "create simple type",
+    "inputs" : [ {
+      "topic" : "test",
+      "key" : "",
+      "value" : {
+        "address" : {
+          "number" : 899,
+          "street" : "W. Evelyn",
+          "city" : "Mountain View"
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "COPY",
+      "key" : "",
+      "value" : {
+        "ADDRESS" : {
+          "NUMBER" : 899,
+          "STREET" : "W. Evelyn",
+          "CITY" : "Mountain View"
+        }
+      }
+    } ],
+    "topics" : [ {
+      "name" : "test",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "COPY",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE TYPE ADDRESS AS STRUCT<number INTEGER, street VARCHAR, city VARCHAR>;", "CREATE TABLE addresses (address ADDRESS) WITH (kafka_topic='test', value_format='JSON');", "CREATE TABLE copy AS SELECT * FROM addresses;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "COPY",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "test",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/create-type_-_create_simple_type/6.0.0_1588107643993/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/create-type_-_create_simple_type/6.0.0_1588107643993/topology
@@ -1,0 +1,19 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KTABLE-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000001 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KTABLE-TRANSFORMVALUES-0000000002 (stores: [])
+      --> Project
+      <-- KTABLE-SOURCE-0000000001
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000004
+      <-- KTABLE-TRANSFORMVALUES-0000000002
+    Processor: KTABLE-TOSTREAM-0000000004 (stores: [])
+      --> KSTREAM-SINK-0000000005
+      <-- Project
+    Sink: KSTREAM-SINK-0000000005 (topic: COPY)
+      <-- KTABLE-TOSTREAM-0000000004
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/create-type.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/create-type.json
@@ -1,0 +1,36 @@
+{
+  "comments": [
+    "Tests covering CREATE_TYPE functionality"
+  ],
+  "tests": [
+    {
+      "name": "create simple type",
+      "statements": [
+        "CREATE TYPE ADDRESS AS STRUCT<number INTEGER, street VARCHAR, city VARCHAR>;",
+        "CREATE TABLE addresses (address ADDRESS) WITH (kafka_topic='test', value_format='JSON');",
+        "CREATE TABLE copy AS SELECT * FROM addresses;"
+      ],
+      "inputs": [
+        {"topic": "test", "value": {"address": {"number": 899, "street": "W. Evelyn", "city": "Mountain View"}}}
+      ],
+      "outputs": [
+        {"topic": "COPY", "value": {"ADDRESS": {"NUMBER": 899, "STREET": "W. Evelyn", "CITY": "Mountain View"}}}
+      ]
+    },
+    {
+      "name": "create nested type",
+      "statements": [
+        "CREATE TYPE ADDRESS AS STRUCT<number INTEGER, street VARCHAR, city VARCHAR>;",
+        "CREATE TYPE PERSON AS STRUCT<name VARCHAR, address ADDRESS>;",
+        "CREATE TABLE people (person PERSON) WITH (kafka_topic='test', value_format='JSON');",
+        "CREATE TABLE copy AS SELECT * FROM people;"
+      ],
+      "inputs": [
+        {"topic": "test", "value": {"person":  {"name": "jay", "address": {"number": 899, "street": "W. Evelyn", "city": "Mountain View"}}}}
+      ],
+      "outputs": [
+        {"topic": "COPY", "value": {"PERSON": {"NAME": "jay", "ADDRESS": {"NUMBER": 899, "STREET": "W. Evelyn", "CITY": "Mountain View"}}}}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Description 

Add QTT tests to the `CREATE TYPE` commands. In order to do that, however, we needed to modify the test util to run these commands when creating the test topics.

### Testing done 

Ran the tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

