### PR TITLE
chore: add configurable metrics reporter to headless mode and unit tests

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -258,6 +258,7 @@ public final class KsqlRestApplication implements Executable {
         serviceContext,
         this.restConfig,
         this.ksqlConfigNoPort);
+    MetricCollectors.addConfigurableReporter(ksqlConfig);
     log.debug("ksqlDB API server instance created");
   }
 
@@ -562,8 +563,6 @@ public final class KsqlRestApplication implements Executable {
     final String ksqlInstallDir = restConfig.getString(KsqlRestConfig.INSTALL_DIR_CONFIG);
 
     final KsqlConfig ksqlConfig = new KsqlConfig(restConfig.getKsqlConfigProperties());
-
-    MetricCollectors.addConfigurableReporter(ksqlConfig);
 
     final ProcessingLogConfig processingLogConfig
         = new ProcessingLogConfig(restConfig.getOriginals());

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
@@ -25,6 +25,7 @@ import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.function.UserFunctionLoader;
 import io.confluent.ksql.logging.processing.ProcessingLogConfig;
 import io.confluent.ksql.logging.processing.ProcessingLogServerUtils;
+import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.CreateSource;
@@ -103,6 +104,7 @@ public class StandaloneExecutor implements Executable {
     this.failOnNoQueries = failOnNoQueries;
     this.versionChecker = requireNonNull(versionChecker, "versionChecker");
     this.injectorFactory = requireNonNull(injectorFactory, "injectorFactory");
+    MetricCollectors.addConfigurableReporter(ksqlConfig);
   }
 
   public void startAsync() {


### PR DESCRIPTION
### Description 
https://github.com/confluentinc/ksql/pull/3490

Previously, we were only adding configurable metrics reporters to interactive mode, this makes it so that headless mode will also add the metrics reporters.

### Testing done 
Unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

