### PR TITLE
docs: remove confusing statement about key requirement in CREATE TABLE (MINOR)

### DIFF
--- a/docs-md/developer-guide/ksqldb-reference/create-table.md
+++ b/docs-md/developer-guide/ksqldb-reference/create-table.md
@@ -25,10 +25,6 @@ ksqlDB adds the implicit columns `ROWTIME` and `ROWKEY` to every stream
 and table, which represent the corresponding Kafka message timestamp and
 message key, respectively. The timestamp has milliseconds accuracy.
 
-When creating a table from a Kafka topic, ksqlDB requries the message key
-to be a `VARCHAR` aka `STRING`. If the message key is not of this type
-follow the instructions in [Key Requirements](../syntax-reference.md#key-requirements).
-
 The WITH clause supports the following properties:
 
 |        Property         |                                            Description                                            |


### PR DESCRIPTION
### Description 

As of KSQL 5.4 and ksqlDB 0.6.0, the old requirement that `CREATE TABLE` statements had to specify the `KEY` property was dropped (see https://github.com/confluentinc/ksql/pull/2746), and the relevant docs were updated accordingly, except this statement which remains in the docs for `CREATE TABLE`:
```
When creating a table from a Kafka topic, ksqlDB requries the message key	
to be a `VARCHAR` aka `STRING`. If the message key is not of this type	
follow the instructions in "Key Requirements".
```
which misleading makes it sound as if the `KEY` property is still required for tables.

This PR removes the confusing statement.

@JimGalasyn could you help cherry-pick this to older branches? It's not needed on master since it's already been removed on master as part of https://github.com/confluentinc/ksql/pull/4986. 

### Testing done 

Docs-only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

