### PR TITLE
fix: Move Cors handler in front of /chc handlers

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -100,14 +100,14 @@ public class ServerVerticle extends AbstractVerticle {
   private Router setupRouter() {
     final Router router = Router.router(vertx);
 
-    // /chc endpoints need to be first because they need to be accessible even before
-    // preconditions have been satisfied
+    KsqlCorsHandler.setupCorsHandler(server, router);
+
+    // /chc endpoints need to be before server state handler but before CORS handler as they
+    // need to be usable from browser with cross origin policy
     router.route(HttpMethod.GET, "/chc/ready").handler(ServerVerticle::chcHandler);
     router.route(HttpMethod.GET, "/chc/live").handler(ServerVerticle::chcHandler);
 
     PortedEndpoints.setupFailureHandler(router);
-
-    KsqlCorsHandler.setupCorsHandler(server, router);
 
     router.route().failureHandler(ServerVerticle::failureHandler);
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -102,7 +102,7 @@ public class ServerVerticle extends AbstractVerticle {
 
     KsqlCorsHandler.setupCorsHandler(server, router);
 
-    // /chc endpoints need to be before server state handler but before CORS handler as they
+    // /chc endpoints need to be before server state handler but after CORS handler as they
     // need to be usable from browser with cross origin policy
     router.route(HttpMethod.GET, "/chc/ready").handler(ServerVerticle::chcHandler);
     router.route(HttpMethod.GET, "/chc/live").handler(ServerVerticle::chcHandler);


### PR DESCRIPTION
### Description 

/chc/* endpoints need to be accessible from a browser which will enforce the cross origin policy, so we need cors handler in front of it to provide the cors headers.

### Testing done 

Manual testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

