### PR TITLE
docs: cherry-pick: update link to old KSQL changelog (DOCS-4220)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,5 +245,6 @@ This change splits "SHOW TOPICS" into two commands:
 
 ## Earlier releases
 
-Note: Release notes for releases prior to ksqlDB v0.6.0 can be found at [docs/changelog.rst](docs/changelog.rst).
+Release notes for KSQL releases prior to ksqlDB v0.6.0 can be found at
+[docs/changelog.rst](https://github.com/confluentinc/ksql/blob/5.4.1-post/docs/changelog.rst).
 


### PR DESCRIPTION
From https://github.com/confluentinc/ksql/pull/5240.