### PR TITLE
chore: implement new key semantics in queries

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
@@ -325,13 +325,13 @@ public final class LogicalSchema {
       switch (column.namespace()) {
         case KEY:
           if (!seenKeys.add(column.name())) {
-            throw new KsqlException("Duplicate keys found in schema: " + column);
+            throw new KsqlException("Duplicate key columns found in schema: " + column);
           }
           break;
 
         case VALUE:
           if (!seenValues.add(column.name())) {
-            throw new KsqlException("Duplicate values found in schema: " + column);
+            throw new KsqlException("Duplicate value columns found in schema: " + column);
           }
           break;
 

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/GrammaticalJoiner.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/GrammaticalJoiner.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+/**
+ * An object which joins pieces of text, with a separator and additional final word, allowing more
+ * grammatically correct joining, e,g. "a, b, c or d".
+ */
+public final class GrammaticalJoiner {
+
+  private final String separator;
+  private final String lastSeparator;
+
+  /**
+   * @return a joiner with a comma separator and ' or ' as the final separator.
+   */
+  public static GrammaticalJoiner or() {
+    return new GrammaticalJoiner(", ", " or ");
+  }
+
+  /**
+   * @return a joiner with a comma separator and ' and ' as the final separator.
+   */
+  public static GrammaticalJoiner and() {
+    return new GrammaticalJoiner(", ", " and ");
+  }
+
+  private GrammaticalJoiner(final String separator, final String lastSeparator) {
+    this.separator = requireNonNull(separator, "separator");
+    this.lastSeparator = requireNonNull(lastSeparator, "lastSeparator");
+  }
+
+  public String join(final Stream<?> parts) {
+    return join(parts.iterator());
+  }
+
+  public String join(final Iterable<?> parts) {
+    return join(parts.iterator());
+  }
+
+  private String join(final Iterator<?> parts) {
+    if (!parts.hasNext()) {
+      return "";
+    }
+
+    String next = Objects.toString(parts.next());
+
+    final StringBuilder builder = new StringBuilder(next);
+    while (parts.hasNext()) {
+      next = Objects.toString(parts.next());
+
+      builder
+          .append(parts.hasNext() ? separator : lastSeparator)
+          .append(next);
+    }
+
+    return builder.toString();
+  }
+}

--- a/ksqldb-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
@@ -37,8 +37,8 @@ import com.google.common.testing.EqualsTester;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.Column.Namespace;
 import io.confluent.ksql.schema.ksql.LogicalSchema.Builder;
-import io.confluent.ksql.schema.utils.FormatOptions;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.schema.utils.FormatOptions;
 import io.confluent.ksql.util.KsqlException;
 import java.util.List;
 import java.util.Optional;
@@ -581,7 +581,7 @@ public class LogicalSchemaTest {
     );
 
     // Then:
-    assertThat(e.getMessage(), containsString("Duplicate keys found in schema: `key` BIGINT"));
+    assertThat(e.getMessage(), containsString("Duplicate key columns found in schema: `key` BIGINT"));
   }
 
   @Test
@@ -597,7 +597,8 @@ public class LogicalSchemaTest {
     );
 
     // Then:
-    assertThat(e.getMessage(), containsString("Duplicate values found in schema: `value` BIGINT"));
+    assertThat(e.getMessage(),
+        containsString("Duplicate value columns found in schema: `value` BIGINT"));
   }
 
   @Test

--- a/ksqldb-common/src/test/java/io/confluent/ksql/util/GrammaticalJoinerTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/util/GrammaticalJoinerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Arrays;
+import org.junit.Test;
+
+
+public class GrammaticalJoinerTest {
+
+  private final GrammaticalJoiner joiner = GrammaticalJoiner.or();
+
+  @Test
+  public void shouldHandleEmptyList() {
+    assertThat(joiner.join(ImmutableList.of()), is(""));
+  }
+
+  @Test
+  public void shouldHandleSingleItem() {
+    assertThat(joiner.join(ImmutableList.of(1)), is("1"));
+  }
+
+  @Test
+  public void shouldHandleTwoItems() {
+    assertThat(joiner.join(ImmutableList.of(1, 2)), is("1 or 2"));
+  }
+
+  @Test
+  public void shouldHandleThreeItems() {
+    assertThat(joiner.join(ImmutableList.of(1, 2, 3)), is("1, 2 or 3"));
+  }
+
+  @Test
+  public void shouldHandleFourItems() {
+    assertThat(joiner.join(ImmutableList.of(1, 2, 3, 4)), is("1, 2, 3 or 4"));
+  }
+
+  @Test
+  public void shouldHandleNulls() {
+    assertThat(joiner.join(Arrays.asList("a", null, "c")), is("a, null or c"));
+  }
+
+  @Test
+  public void shouldBuildWithAnd() {
+    assertThat(GrammaticalJoiner.and().join(Arrays.asList(1, 2, 3)), is("1, 2 and 3"));
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/RewrittenAnalysis.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/RewrittenAnalysis.java
@@ -59,6 +59,10 @@ public class RewrittenAnalysis implements ImmutableAnalysis {
     this.rewriter = Objects.requireNonNull(rewriter, "rewriter");
   }
 
+  public ImmutableAnalysis original() {
+    return original;
+  }
+
   @Override
   public List<FunctionCall> getTableFunctions() {
     return rewriteList(original.getTableFunctions());

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/AsValue.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/AsValue.java
@@ -15,12 +15,20 @@
 
 package io.confluent.ksql.function.udf;
 
+import io.confluent.ksql.name.FunctionName;
+
 @SuppressWarnings("MethodMayBeStatic")
-@UdfDescription(name = "AS_VALUE", description = AsValue.DESCRIPTION)
+@UdfDescription(name = AsValue.NAME_TEXT, description = AsValue.DESCRIPTION)
 public class AsValue {
+
+  static final String NAME_TEXT = "AS_VALUE";
+
+  public static final FunctionName NAME = FunctionName.of(NAME_TEXT);
+
 
   static final String DESCRIPTION = "Used exclusively in the projection of a query to allow a key"
       + "column to be copied into the value schema. Has no affect if used anywhere else.";
+
 
   @Udf
   public <T> T asValue(final T keyColumn) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/JoinKeyUdf.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/JoinKeyUdf.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf;
+
+import io.confluent.ksql.function.udf.nulls.Coalesce;
+import io.confluent.ksql.name.FunctionName;
+
+@SuppressWarnings("MethodMayBeStatic")
+@UdfDescription(name = JoinKeyUdf.NAME_TEXT, description = JoinKeyUdf.DESCRIPTION)
+public class JoinKeyUdf {
+
+  private static final Coalesce impl = new Coalesce();
+
+  static final String NAME_TEXT = "JOINKEY";
+
+  public static final FunctionName NAME = FunctionName.of(NAME_TEXT);
+
+  static final String DESCRIPTION = "Used to express the synthetic join key created by some joins "
+      + "withing the projection of the query."
+      + "\nOUTER joins or joins where no join criteria is a simple column expression generate a "
+      + "synthetic key column. This column must be included in the projection of persistent "
+      + "queries. " + NAME_TEXT + " can be used within the projection to represent this synthetic "
+      + "key column. For example: "
+      + "\n\tSELECT JOINKEY(ABS(L.ID), ABS(R.ID) AS ID, L.NAME, R.PRICE "
+      + "FROM L JOIN R ON ABS(L.ID) = ABS(R.ID);"
+      + "\nIf used outside of such joins the function returns the same as the "
+      + Coalesce.NAME_TEXT + " function.";
+
+  @Udf
+  public <T> T joinKey(final T left, final T right) {
+    return impl.coalesce(left, right);
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/nulls/Coalesce.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/nulls/Coalesce.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.function.udf.nulls;
 
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.name.FunctionName;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -24,8 +25,11 @@ import java.util.Objects;
  * Returns first non-null element
  */
 @SuppressWarnings("MethodMayBeStatic") // UDF methods can not be static.
-@UdfDescription(name = "COALESCE", description = "Returns first non-null element")
+@UdfDescription(name = Coalesce.NAME_TEXT, description = "Returns first non-null element")
 public class Coalesce {
+
+  public static final String NAME_TEXT = "COALESCE";
+  public static final FunctionName NAME = FunctionName.of(NAME_TEXT);
 
   @SuppressWarnings("varargs")
   @SafeVarargs

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/Projection.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/Projection.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.planner;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.execution.expression.tree.Expression;
+import io.confluent.ksql.execution.expression.tree.QualifiedColumnReferenceExp;
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.parser.tree.AllColumns;
+import io.confluent.ksql.parser.tree.SelectItem;
+import io.confluent.ksql.parser.tree.SingleColumn;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Holds information about in a projection
+ */
+@Immutable
+public final class Projection {
+
+  private final boolean includesAll;
+  private final ImmutableSet<SourceName> includeAllSources;
+  private final ImmutableSet<Expression> singles;
+
+  public static Projection of(final Collection<? extends SelectItem> selectItems) {
+    return new Projection(selectItems);
+  }
+
+  @VisibleForTesting
+  Projection(final Collection<? extends SelectItem> selects) {
+    this.includesAll = selects.stream()
+        .filter(Projection::isAllColumn)
+        .map(AllColumns.class::cast)
+        .anyMatch(si -> !si.getSource().isPresent());
+
+    this.includeAllSources = ImmutableSet.copyOf(selects.stream()
+        .filter(Projection::isAllColumn)
+        .map(AllColumns.class::cast)
+        .map(AllColumns::getSource)
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .collect(Collectors.toSet()));
+
+    this.singles = ImmutableSet.copyOf(selects.stream()
+        .filter(Projection::isSingleColumn)
+        .map(SingleColumn.class::cast)
+        .map(SingleColumn::getExpression)
+        .collect(Collectors.toSet()));
+  }
+
+  /**
+   * Tests is the supplied {@code expression} is contained by the projection.
+   *
+   * <p>The following rules are evaluated to determine if the projection contains
+   * {@code expression}:
+   * <ol>
+   *   <li>
+   *      If any of the projections items are an unqualified {@code *}, then all expressions are
+   *      considered to be contained within the projection.
+   *    </li>
+   *    <li>
+   *      If any of the projection items are a qualified {@code *}, then any column reference with
+   *      the same source name will be considered contained.
+   *    </li>
+   *    <li>
+   *      If any single column within the projection matches the supplied expression, then it is
+   *      contained.
+   *    </li>
+   *    <li>
+   *      Otherwise, it is not contained.
+   *    </li>
+   * </ol>
+   *
+   * @param expression the expression to test.
+   * @return {@code true} if contained, {@code false} otherwise.
+   */
+  public boolean containsExpression(final Expression expression) {
+    if (includesAll) {
+      return true;
+    }
+
+    if (expression instanceof QualifiedColumnReferenceExp) {
+      final QualifiedColumnReferenceExp colRef = (QualifiedColumnReferenceExp) expression;
+
+      if (includeAllSources.contains(colRef.getQualifier())) {
+        return true;
+      }
+    }
+
+    return singles.contains(expression);
+  }
+
+  private static boolean isAllColumn(final SelectItem si) {
+    if (si instanceof SingleColumn) {
+      return false;
+    }
+
+    if (si instanceof AllColumns) {
+      return true;
+    }
+
+    throw new UnsupportedOperationException("Unsupported column type: si.");
+  }
+
+  private static boolean isSingleColumn(final SelectItem si) {
+    return !isAllColumn(si);
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
@@ -16,9 +16,11 @@
 package io.confluent.ksql.planner.plan;
 
 import static io.confluent.ksql.metastore.model.DataSource.DataSourceType;
+import static io.confluent.ksql.util.GrammaticalJoiner.and;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.analyzer.AggregateAnalysisResult;
 import io.confluent.ksql.analyzer.AggregateExpressionRewriter;
 import io.confluent.ksql.analyzer.ImmutableAnalysis;
@@ -37,6 +39,7 @@ import io.confluent.ksql.execution.plan.SelectExpression;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.tree.GroupBy;
 import io.confluent.ksql.parser.tree.WindowExpression;
 import io.confluent.ksql.schema.ksql.ColumnNames;
@@ -55,10 +58,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 
-public class AggregateNode extends PlanNode {
+public class AggregateNode extends PlanNode implements VerifiableNode {
 
   private static final String INTERNAL_COLUMN_NAME_PREFIX = "KSQL_INTERNAL_COL_";
 
@@ -76,6 +80,7 @@ public class AggregateNode extends PlanNode {
   private final ImmutableList<FunctionCall> functionList;
   private final ImmutableList<ColumnReferenceExp> requiredColumns;
   private final Optional<Expression> havingExpressions;
+  private final ImmutableList<SelectExpression> projection;
   private final ImmutableList<SelectExpression> finalSelectExpressions;
   private final ValueFormat valueFormat;
 
@@ -88,7 +93,8 @@ public class AggregateNode extends PlanNode {
       final FunctionRegistry functionRegistry,
       final ImmutableAnalysis analysis,
       final AggregateAnalysisResult rewrittenAggregateAnalysis,
-      final List<SelectExpression> projectionExpressions
+      final List<SelectExpression> projectionExpressions,
+      final boolean anyKeyName
   ) {
     super(id, DataSourceType.KTABLE, schema, Optional.empty());
 
@@ -105,13 +111,20 @@ public class AggregateNode extends PlanNode {
         .copyOf(rewrittenAggregateAnalysis.getAggregateFunctions());
     this.requiredColumns = ImmutableList
         .copyOf(rewrittenAggregateAnalysis.getRequiredColumns());
-    this.finalSelectExpressions = ImmutableList.copyOf(projectionExpressions.stream()
+
+    this.projection = ImmutableList.copyOf(projectionExpressions.stream()
         .map(se -> SelectExpression.of(
             se.getAlias(),
             ExpressionTreeRewriter
                 .rewriteWith(aggregateExpressionRewriter::process, se.getExpression())
         ))
         .collect(Collectors.toList()));
+
+    final Set<Expression> groupings = ImmutableSet.copyOf(groupBy.getGroupingExpressions());
+    this.finalSelectExpressions = ImmutableList.copyOf(projection.stream()
+        .filter(e -> !anyKeyName || !groupings.contains(e.getExpression()))
+        .collect(Collectors.toList()));
+
     this.havingExpressions = rewrittenAggregateAnalysis.getHavingExpression()
         .map(exp -> ExpressionTreeRewriter.rewriteWith(aggregateExpressionRewriter::process, exp));
     this.keyField = KeyField.of(requireNonNull(keyFieldName, "keyFieldName"))
@@ -175,6 +188,19 @@ public class AggregateNode extends PlanNode {
     aggregated = applyHavingFilter(aggregated, contextStacker);
 
     return selectRequiredOutputColumns(aggregated, contextStacker, builder);
+  }
+
+  @Override
+  public void validateKeyPresent(final SourceName sinkName) {
+    final List<Expression> missing = new ArrayList<>(groupBy.getGroupingExpressions());
+
+    projection.stream()
+        .map(SelectExpression::getExpression)
+        .forEach(missing::remove);
+
+    if (!missing.isEmpty()) {
+      throwKeysNotIncludedError(sinkName, "grouping expression", missing, and());
+    }
   }
 
   protected int getPartitions(final KafkaTopicClient kafkaTopicClient) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/FinalProjectNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/FinalProjectNode.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.planner.plan;
+
+import io.confluent.ksql.execution.plan.SelectExpression;
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.parser.tree.SelectItem;
+import io.confluent.ksql.planner.Projection;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The user supplied projection.
+ *
+ * <p>Used by all plans except those with GROUP BY, which has its own custom projection handling
+ * in {@link AggregateNode}.
+ */
+public class FinalProjectNode extends ProjectNode implements VerifiableNode {
+
+  private final Projection projection;
+
+  public FinalProjectNode(
+      final PlanNodeId id,
+      final PlanNode source,
+      final List<SelectExpression> projectExpressions,
+      final LogicalSchema schema,
+      final Optional<ColumnName> keyFieldName,
+      final List<SelectItem> selectItems,
+      final boolean anyKeyName
+  ) {
+    super(id, source, projectExpressions, schema, keyFieldName, false, anyKeyName);
+    this.projection = Projection.of(selectItems);
+  }
+
+  @Override
+  public void validateKeyPresent(final SourceName sinkName) {
+    getSource().validateKeyPresent(sinkName, projection);
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/ProjectNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/ProjectNode.java
@@ -17,12 +17,15 @@ package io.confluent.ksql.planner.plan;
 
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
+import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
 import io.confluent.ksql.execution.plan.SelectExpression;
+import io.confluent.ksql.function.udf.AsValue;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
@@ -30,16 +33,19 @@ import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.structured.SchemaKStream;
+import io.confluent.ksql.util.GrammaticalJoiner;
 import io.confluent.ksql.util.KsqlException;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Immutable
 public class ProjectNode extends PlanNode {
 
   private final PlanNode source;
-  private final ImmutableList<SelectExpression> projectExpressions;
+  private final ImmutableList<SelectExpression> valueProjection;
   private final KeyField keyField;
   private final ImmutableMap<ColumnName, ColumnName> aliases;
 
@@ -49,16 +55,29 @@ public class ProjectNode extends PlanNode {
       final List<SelectExpression> projectExpressions,
       final LogicalSchema schema,
       final Optional<ColumnName> keyFieldName,
-      final boolean aliased
+      final boolean aliased,
+      final boolean anyKeyName
   ) {
     super(id, source.getNodeOutputType(), schema, source.getSourceName());
 
     this.source = requireNonNull(source, "source");
-    this.projectExpressions = ImmutableList.copyOf(
-        requireNonNull(projectExpressions, "projectExpressions")
-    );
-    this.keyField = KeyField.of(requireNonNull(keyFieldName, "keyFieldName"))
-        .validateKeyExistsIn(schema);
+
+    final Set<SelectExpression> keyColumns = source.getSchema().key().stream()
+        .map(Column::name)
+        .map(name -> resolveProjectionAlias(name, projectExpressions))
+        .collect(Collectors.toSet());
+
+    this.valueProjection = anyKeyName && !aliased
+        ? ImmutableList.copyOf(projectExpressions.stream()
+        .filter(se -> !keyColumns.contains(se))
+        .collect(Collectors.toList()))
+        : ImmutableList.copyOf(requireNonNull(projectExpressions, "projectExpressions"));
+
+    this.keyField = anyKeyName
+        ? KeyField.none()
+        : KeyField.of(requireNonNull(keyFieldName, "keyFieldName"))
+            .validateKeyExistsIn(schema);
+
     this.aliases = aliased
         ? buildAliasMapping(projectExpressions)
         : ImmutableMap.of();
@@ -86,7 +105,7 @@ public class ProjectNode extends PlanNode {
   }
 
   public List<SelectExpression> getSelectExpressions() {
-    return projectExpressions;
+    return valueProjection;
   }
 
   @Override
@@ -98,7 +117,7 @@ public class ProjectNode extends PlanNode {
   public SchemaKStream<?> buildStream(final KsqlQueryBuilder builder) {
     return getSource().buildStream(builder)
         .select(
-            projectExpressions,
+            valueProjection,
             builder.buildNodeContext(getId().toString()),
             builder
         );
@@ -114,14 +133,30 @@ public class ProjectNode extends PlanNode {
   }
 
   private void validate() {
-    if (getSchema().value().size() != projectExpressions.size()) {
-      throw new KsqlException("Error in projection. Schema fields and expression list are not "
-          + "compatible.");
+    final LogicalSchema schema = getSchema();
+
+    if (schema.key().size() > 1) {
+      final String keys = GrammaticalJoiner.and().join(schema.key().stream().map(Column::name));
+      throw new KsqlException("The projection contains the key column more than once: " + keys + "."
+          + System.lineSeparator()
+          + "Each key column must only be in the projection once. "
+          + "If you intended to copy the key into the value, then consider using the "
+          + AsValue.NAME + " function to indicate which key reference should be copied."
+      );
     }
 
-    for (int i = 0; i < projectExpressions.size(); i++) {
-      final Column column = getSchema().value().get(i);
-      final SelectExpression selectExpression = projectExpressions.get(i);
+    if (schema.value().isEmpty()) {
+      throw new KsqlException("The projection contains no value columns.");
+    }
+
+    if (schema.value().size() != valueProjection.size()) {
+      throw new IllegalArgumentException("Error in projection. "
+          + "Schema fields and expression list are not compatible.");
+    }
+
+    for (int i = 0; i < valueProjection.size(); i++) {
+      final Column column = schema.value().get(i);
+      final SelectExpression selectExpression = valueProjection.get(i);
 
       if (!column.name().equals(selectExpression.getAlias())) {
         throw new IllegalArgumentException("Mismatch between schema and selects");
@@ -129,10 +164,10 @@ public class ProjectNode extends PlanNode {
     }
   }
 
-  private static ImmutableMap<ColumnName, ColumnName> buildAliasMapping(
+  private static ImmutableBiMap<ColumnName, ColumnName> buildAliasMapping(
       final List<SelectExpression> projectExpressions
   ) {
-    final ImmutableMap.Builder<ColumnName, ColumnName> builder = ImmutableMap.builder();
+    final ImmutableBiMap.Builder<ColumnName, ColumnName> builder = ImmutableBiMap.builder();
 
     projectExpressions.stream()
         .filter(se -> se.getExpression() instanceof ColumnReferenceExp)
@@ -142,5 +177,19 @@ public class ProjectNode extends PlanNode {
         ));
 
     return builder.build();
+  }
+
+  private static SelectExpression resolveProjectionAlias(
+      final ColumnName name,
+      final List<SelectExpression> projection
+  ) {
+    final ColumnName alias = projection.stream()
+        .filter(se -> se.getExpression() instanceof ColumnReferenceExp)
+        .filter(se -> ((ColumnReferenceExp) se.getExpression()).getColumnName().equals(name))
+        .map(SelectExpression::getAlias)
+        .findFirst()
+        .orElse(name);
+
+    return SelectExpression.of(alias, new UnqualifiedColumnReferenceExp(name));
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/RepartitionNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/RepartitionNode.java
@@ -15,17 +15,20 @@
 
 package io.confluent.ksql.planner.plan;
 
+import static io.confluent.ksql.util.GrammaticalJoiner.and;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.expression.tree.Expression;
+import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
-import io.confluent.ksql.parser.tree.PartitionBy;
+import io.confluent.ksql.planner.Projection;
 import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.services.KafkaTopicClient;
@@ -38,20 +41,29 @@ import java.util.stream.Stream;
 public class RepartitionNode extends PlanNode {
 
   private final PlanNode source;
-  private final PartitionBy partitionBy;
+  private final Expression originalPartitionBy;
+  private final Expression partitionBy;
   private final KeyField keyField;
+  private final boolean anyKeyEnabled;
+  private final boolean internal;
 
   public RepartitionNode(
       final PlanNodeId id,
       final PlanNode source,
       final LogicalSchema schema,
-      final PartitionBy partitionBy,
-      final KeyField keyField
+      final Expression originalPartitionBy,
+      final Expression partitionBy,
+      final KeyField keyField,
+      final boolean anyKeyEnabled,
+      final boolean internal
   ) {
     super(id, source.getNodeOutputType(), schema, source.getSourceName());
     this.source = requireNonNull(source, "source");
+    this.originalPartitionBy = requireNonNull(originalPartitionBy, "originalPartitionBy");
     this.partitionBy = requireNonNull(partitionBy, "partitionBy");
     this.keyField = requireNonNull(keyField, "keyField");
+    this.anyKeyEnabled = anyKeyEnabled;
+    this.internal = internal;
   }
 
   @Override
@@ -73,15 +85,15 @@ public class RepartitionNode extends PlanNode {
   public SchemaKStream<?> buildStream(final KsqlQueryBuilder builder) {
     return source.buildStream(builder)
         .selectKey(
-            partitionBy.getExpression(),
-            partitionBy.getAlias(),
+            partitionBy,
+            Optional.empty(),
             builder.buildNodeContext(getId().toString())
         );
   }
 
   @VisibleForTesting
   public Expression getPartitionBy() {
-    return partitionBy.getExpression();
+    return partitionBy;
   }
 
   @Override
@@ -89,18 +101,54 @@ public class RepartitionNode extends PlanNode {
     return visitor.visitRepartition(this, context);
   }
 
+  public Expression resolveSelect(final int idx, final Expression expression) {
+    if (!anyKeyEnabled) {
+      return expression;
+    }
+
+    return partitionBy.equals(expression)
+        ? new UnqualifiedColumnReferenceExp(Iterables.getOnlyElement(getSchema().key()).name())
+        : expression;
+  }
+
   @Override
   public Stream<ColumnName> resolveSelectStar(
       final Optional<SourceName> sourceName,
       final boolean valueOnly
   ) {
-    final boolean sourceNameMatches = !sourceName.isPresent() || sourceName.equals(getSourceName());
-    if (sourceNameMatches && valueOnly) {
-      // Override set of value columns to take into account the repartition:
-      return getSchema().withoutPseudoAndKeyColsInValue().value().stream().map(Column::name);
+    if (!anyKeyEnabled) {
+      final boolean sourceNameMatches =
+          !sourceName.isPresent() || sourceName.equals(getSourceName());
+
+      if (sourceNameMatches && valueOnly) {
+        // Override set of value columns to take into account the repartition:
+        return getSchema().withoutPseudoAndKeyColsInValue().value().stream().map(Column::name);
+      }
+
+      // Set of all columns not changed by a repartition:
+      return super.resolveSelectStar(sourceName, valueOnly);
     }
 
-    // Set of all columns not changed by a repartition:
-    return super.resolveSelectStar(sourceName, valueOnly);
+    if (sourceName.isPresent() && !sourceName.equals(getSourceName())) {
+      throw new IllegalArgumentException("Expected sourceName of " + getSourceName()
+          + ", but was " + sourceName.get());
+    }
+
+    if (internal) {
+      // An internal repartition is an impl detail, so should not change the set of columns:
+      return super.resolveSelectStar(sourceName, valueOnly);
+    }
+
+    return valueOnly
+        ? getSchema().withoutPseudoAndKeyColsInValue().value().stream().map(Column::name)
+        : orderColumns(getSchema().value(), getSchema());
+  }
+
+  @Override
+  void validateKeyPresent(final SourceName sinkName, final Projection projection) {
+    if (!projection.containsExpression(partitionBy)) {
+      final ImmutableList<Expression> keys = ImmutableList.of(originalPartitionBy);
+      throwKeysNotIncludedError(sinkName, "partitioning expression", keys, and());
+    }
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/VerifiableNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/VerifiableNode.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.planner.plan;
+
+import io.confluent.ksql.name.SourceName;
+
+public interface VerifiableNode {
+
+  /**
+   * Throws if the key is not present in the projection.
+   *
+   * @param sinkName the name of the source being built.
+   */
+  void validateKeyPresent(SourceName sinkName);
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -199,17 +199,20 @@ public class SchemaKStream<K> {
 
   public SchemaKStream<K> leftJoin(
       final SchemaKTable<K> schemaKTable,
+      final ColumnName keyColName,
       final KeyField keyField,
       final ValueFormat valueFormat,
-      final QueryContext.Stacker contextStacker
+      final Stacker contextStacker
   ) {
     final StreamTableJoin<K> step = ExecutionStepFactory.streamTableJoin(
         contextStacker,
         JoinType.LEFT,
+        keyColName,
         Formats.of(keyFormat, valueFormat, SerdeOption.none()),
         sourceStep,
         schemaKTable.getSourceTableStep()
     );
+
     return new SchemaKStream<>(
         step,
         resolveSchema(step, schemaKTable),
@@ -222,21 +225,24 @@ public class SchemaKStream<K> {
 
   public SchemaKStream<K> leftJoin(
       final SchemaKStream<K> otherSchemaKStream,
+      final ColumnName keyColName,
       final KeyField keyField,
       final JoinWindows joinWindows,
       final ValueFormat leftFormat,
       final ValueFormat rightFormat,
-      final QueryContext.Stacker contextStacker) {
-
+      final Stacker contextStacker
+  ) {
     final StreamStreamJoin<K> step = ExecutionStepFactory.streamStreamJoin(
         contextStacker,
         JoinType.LEFT,
+        keyColName,
         Formats.of(keyFormat, leftFormat, SerdeOption.none()),
         Formats.of(keyFormat, rightFormat, SerdeOption.none()),
         sourceStep,
         otherSchemaKStream.sourceStep,
         joinWindows
     );
+
     return new SchemaKStream<>(
         step,
         resolveSchema(step, otherSchemaKStream),
@@ -249,17 +255,20 @@ public class SchemaKStream<K> {
 
   public SchemaKStream<K> join(
       final SchemaKTable<K> schemaKTable,
+      final ColumnName keyColName,
       final KeyField keyField,
       final ValueFormat valueFormat,
-      final QueryContext.Stacker contextStacker
+      final Stacker contextStacker
   ) {
     final StreamTableJoin<K> step = ExecutionStepFactory.streamTableJoin(
         contextStacker,
         JoinType.INNER,
+        keyColName,
         Formats.of(keyFormat, valueFormat, SerdeOption.none()),
         sourceStep,
         schemaKTable.getSourceTableStep()
     );
+
     return new SchemaKStream<>(
         step,
         resolveSchema(step, schemaKTable),
@@ -272,20 +281,24 @@ public class SchemaKStream<K> {
 
   public SchemaKStream<K> join(
       final SchemaKStream<K> otherSchemaKStream,
+      final ColumnName keyColName,
       final KeyField keyField,
       final JoinWindows joinWindows,
       final ValueFormat leftFormat,
       final ValueFormat rightFormat,
-      final QueryContext.Stacker contextStacker) {
+      final Stacker contextStacker
+  ) {
     final StreamStreamJoin<K> step = ExecutionStepFactory.streamStreamJoin(
         contextStacker,
         JoinType.INNER,
+        keyColName,
         Formats.of(keyFormat, leftFormat, SerdeOption.none()),
         Formats.of(keyFormat, rightFormat, SerdeOption.none()),
         sourceStep,
         otherSchemaKStream.sourceStep,
         joinWindows
     );
+
     return new SchemaKStream<>(
         step,
         resolveSchema(step, otherSchemaKStream),
@@ -298,20 +311,24 @@ public class SchemaKStream<K> {
 
   public SchemaKStream<K> outerJoin(
       final SchemaKStream<K> otherSchemaKStream,
+      final ColumnName keyColName,
       final KeyField keyField,
       final JoinWindows joinWindows,
       final ValueFormat leftFormat,
       final ValueFormat rightFormat,
-      final QueryContext.Stacker contextStacker) {
+      final Stacker contextStacker
+  ) {
     final StreamStreamJoin<K> step = ExecutionStepFactory.streamStreamJoin(
         contextStacker,
         JoinType.OUTER,
+        keyColName,
         Formats.of(keyFormat, leftFormat, SerdeOption.none()),
         Formats.of(keyFormat, rightFormat, SerdeOption.none()),
         sourceStep,
         otherSchemaKStream.sourceStep,
         joinWindows
     );
+
     return new SchemaKStream<>(
         step,
         resolveSchema(step, otherSchemaKStream),

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
@@ -199,12 +199,14 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
 
   public SchemaKTable<K> join(
       final SchemaKTable<K> schemaKTable,
+      final ColumnName keyColName,
       final KeyField keyField,
-      final QueryContext.Stacker contextStacker
+      final Stacker contextStacker
   ) {
     final TableTableJoin<K> step = ExecutionStepFactory.tableTableJoin(
         contextStacker,
         JoinType.INNER,
+        keyColName,
         sourceTableStep,
         schemaKTable.getSourceTableStep()
     );
@@ -220,12 +222,14 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
 
   public SchemaKTable<K> leftJoin(
       final SchemaKTable<K> schemaKTable,
+      final ColumnName keyColName,
       final KeyField keyField,
-      final QueryContext.Stacker contextStacker
+      final Stacker contextStacker
   ) {
     final TableTableJoin<K> step = ExecutionStepFactory.tableTableJoin(
         contextStacker,
         JoinType.LEFT,
+        keyColName,
         sourceTableStep,
         schemaKTable.getSourceTableStep()
     );
@@ -241,12 +245,14 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
 
   public SchemaKTable<K> outerJoin(
       final SchemaKTable<K> schemaKTable,
+      final ColumnName keyColName,
       final KeyField keyField,
       final QueryContext.Stacker contextStacker
   ) {
     final TableTableJoin<K> step = ExecutionStepFactory.tableTableJoin(
         contextStacker,
         JoinType.OUTER,
+        keyColName,
         sourceTableStep,
         schemaKTable.getSourceTableStep()
     );

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/JoinKeyUdfTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/JoinKeyUdfTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class JoinKeyUdfTest {
+
+  private JoinKeyUdf udf;
+
+  @Before
+  public void setUp()  {
+    udf = new JoinKeyUdf();
+  }
+
+  @Test
+  public void shouldHandlePrimitiveTypes() {
+    assertThat(udf.joinKey(Boolean.TRUE, null), is(Boolean.TRUE));
+    assertThat(udf.joinKey(Integer.MIN_VALUE, null), is(Integer.MIN_VALUE));
+    assertThat(udf.joinKey(Long.MAX_VALUE, null), is(Long.MAX_VALUE));
+    assertThat(udf.joinKey(Double.MAX_VALUE, null), is(Double.MAX_VALUE));
+    assertThat(udf.joinKey("string", null), is("string"));
+  }
+
+  @Test
+  public void shouldReturnFirstNonNull() {
+    assertThat(udf.joinKey(null, 1), is(1));
+    assertThat(udf.joinKey(2, 3), is(2));
+    assertThat(udf.joinKey(4, null), is(4));
+    assertThat(udf.joinKey(null, null), is(nullValue()));
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/JoinTreeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/JoinTreeTest.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.analyzer.Analysis.AliasedDataSource;
 import io.confluent.ksql.analyzer.Analysis.JoinInfo;
 import io.confluent.ksql.execution.expression.tree.Expression;
+import io.confluent.ksql.execution.expression.tree.QualifiedColumnReferenceExp;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.planner.JoinTree.Join;
 import io.confluent.ksql.planner.JoinTree.Leaf;
@@ -57,6 +58,11 @@ public class JoinTreeTest {
   @Mock private Expression e2;
   @Mock private Expression e3;
   @Mock private Expression e4;
+
+  @Mock private QualifiedColumnReferenceExp col1;
+  @Mock private QualifiedColumnReferenceExp col2;
+  @Mock private QualifiedColumnReferenceExp col3;
+  @Mock private QualifiedColumnReferenceExp col4;
 
   @Before
   public void setUp() {
@@ -212,7 +218,7 @@ public class JoinTreeTest {
     final Node root = JoinTree.build(joins);
 
     // Then:
-    assertThat(root.joinEquivalenceSet(), contains(e3, e4));
+    assertThat(root.joinEquivalenceSet(), containsInAnyOrder(e3, e4));
   }
 
   @Test
@@ -283,4 +289,115 @@ public class JoinTreeTest {
     assertThat(e.getMessage(), containsString("neither source in the join is the FROM source"));
   }
 
+  @Test
+  public void shouldComputeEmptyViableKeysForOuterJoins() {
+    // Given:
+    when(j1.getLeftSource()).thenReturn(a);
+    when(j1.getRightSource()).thenReturn(b);
+
+    when(j1.getType()).thenReturn(JoinType.OUTER);
+
+    final List<JoinInfo> joins = ImmutableList.of(j1);
+
+    final Node root = JoinTree.build(joins);
+
+    // When:
+    final List<?> keys = root.viableKeyColumns();
+
+    // Then:
+    assertThat(keys, is(empty()));
+  }
+
+  @Test
+  public void shouldIgnoreNonQualifiedColumnReferencesWhenComputingViableKeys() {
+    // Given:
+    when(j1.getLeftSource()).thenReturn(a);
+    when(j1.getRightSource()).thenReturn(b);
+    when(j2.getLeftSource()).thenReturn(a);
+    when(j2.getRightSource()).thenReturn(c);
+
+    when(j1.getLeftJoinExpression()).thenReturn(e1);
+    when(j1.getRightJoinExpression()).thenReturn(e2);
+    when(j2.getLeftJoinExpression()).thenReturn(e1);
+    when(j2.getRightJoinExpression()).thenReturn(e3);
+
+    final List<JoinInfo> joins = ImmutableList.of(j1, j2);
+
+    final Node root = JoinTree.build(joins);
+
+    // When:
+    final List<?> keys = root.viableKeyColumns();
+
+    // Then:
+    assertThat(keys, is(empty()));
+  }
+
+  @Test
+  public void shouldIgnoreOuterJoinsWhenComputingViableKeys() {
+    // Given:
+    when(j1.getLeftSource()).thenReturn(a);
+    when(j1.getRightSource()).thenReturn(b);
+    when(j2.getLeftSource()).thenReturn(a);
+    when(j2.getRightSource()).thenReturn(c);
+
+    when(j1.getType()).thenReturn(JoinType.OUTER);
+    when(j2.getLeftJoinExpression()).thenReturn(col1);
+    when(j2.getRightJoinExpression()).thenReturn(col2);
+
+    final Node root = JoinTree.build(ImmutableList.of(j1, j2));
+
+    // When:
+    final List<?> keys = root.viableKeyColumns();
+
+    // Then:
+    assertThat(keys, contains(col1, col2));
+  }
+
+  @Test
+  public void shouldComputeViableKeysWithOverlap() {
+    // Given:
+    when(j1.getLeftSource()).thenReturn(a);
+    when(j1.getRightSource()).thenReturn(b);
+    when(j2.getLeftSource()).thenReturn(a);
+    when(j2.getRightSource()).thenReturn(c);
+
+    when(j1.getLeftJoinExpression()).thenReturn(col1);
+    when(j1.getRightJoinExpression()).thenReturn(col2);
+    when(j2.getLeftJoinExpression()).thenReturn(col1);
+    when(j2.getRightJoinExpression()).thenReturn(col3);
+
+    final List<JoinInfo> joins = ImmutableList.of(j1, j2);
+
+    final Node root = JoinTree.build(joins);
+
+    // When:
+    final List<?> keys = root.viableKeyColumns();
+
+    // Then:
+    assertThat(keys, contains(col1, col2, col3));
+  }
+
+  @Test
+  public void shouldComputeViableKeysWithoutOverlap() {
+    // Given:
+    when(j1.getLeftSource()).thenReturn(a);
+    when(j1.getRightSource()).thenReturn(b);
+    when(j2.getLeftSource()).thenReturn(a);
+    when(j2.getRightSource()).thenReturn(c);
+
+    when(j1.getLeftJoinExpression()).thenReturn(col1);
+    when(j1.getRightJoinExpression()).thenReturn(col2);
+    when(j2.getLeftJoinExpression()).thenReturn(col3);
+    when(j2.getRightJoinExpression()).thenReturn(col4);
+
+    final List<JoinInfo> joins = ImmutableList.of(j1, j2);
+
+    final Node root = JoinTree.build(joins);
+
+    // When:
+    final List<?> keys = root.viableKeyColumns();
+
+    // Then:
+    assertThat(keys, contains(col3, col4));
+  }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/JoinTreeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/JoinTreeTest.java
@@ -400,4 +400,77 @@ public class JoinTreeTest {
     // Then:
     assertThat(keys, contains(col3, col4));
   }
+
+  @Test
+  public void shouldIncludeOnlyColFromFirstInViableKeyIfOverlap() {
+    // Given:
+    when(j1.getLeftSource()).thenReturn(a);
+    when(j1.getRightSource()).thenReturn(b);
+    when(j2.getLeftSource()).thenReturn(a);
+    when(j2.getRightSource()).thenReturn(c);
+
+    when(j1.getLeftJoinExpression()).thenReturn(e1);
+    when(j1.getRightJoinExpression()).thenReturn(col2);
+    when(j2.getLeftJoinExpression()).thenReturn(e1);
+    when(j2.getRightJoinExpression()).thenReturn(e2);
+
+    final List<JoinInfo> joins = ImmutableList.of(j1, j2);
+
+    final Node root = JoinTree.build(joins);
+
+    // When:
+    final List<?> keys = root.viableKeyColumns();
+
+    // Then:
+    assertThat(keys, contains(col2));
+  }
+
+  @Test
+  public void shouldNotIncludeOnlyColFromFirstInViableKeysIfNoOverlap() {
+    // Given:
+    when(j1.getLeftSource()).thenReturn(a);
+    when(j1.getRightSource()).thenReturn(b);
+    when(j2.getLeftSource()).thenReturn(a);
+    when(j2.getRightSource()).thenReturn(c);
+
+    when(j1.getLeftJoinExpression()).thenReturn(e1);
+    when(j1.getRightJoinExpression()).thenReturn(col2);
+    when(j2.getLeftJoinExpression()).thenReturn(e2);
+    when(j2.getRightJoinExpression()).thenReturn(e3);
+
+    final List<JoinInfo> joins = ImmutableList.of(j1, j2);
+
+    final Node root = JoinTree.build(joins);
+
+    // When:
+    final List<?> keys = root.viableKeyColumns();
+
+    // Then:
+    assertThat(keys, is(empty()));
+  }
+
+  @Test
+  public void shouldIncludeOnlyColFromLastInViableKeyEvenWithoutOverlap() {
+    // Given:
+    when(j1.getLeftSource()).thenReturn(a);
+    when(j1.getRightSource()).thenReturn(b);
+    when(j2.getLeftSource()).thenReturn(a);
+    when(j2.getRightSource()).thenReturn(c);
+
+    when(j1.getLeftJoinExpression()).thenReturn(e1);
+    when(j1.getRightJoinExpression()).thenReturn(e2);
+    when(j2.getLeftJoinExpression()).thenReturn(col1);
+    when(j2.getRightJoinExpression()).thenReturn(e3);
+
+    final List<JoinInfo> joins = ImmutableList.of(j1, j2);
+
+    final Node root = JoinTree.build(joins);
+
+    // When:
+    final List<?> keys = root.viableKeyColumns();
+
+    // Then:
+    assertThat(keys, contains(col1));
+  }
+
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/ProjectionTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/ProjectionTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.planner;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.execution.expression.tree.Expression;
+import io.confluent.ksql.execution.expression.tree.QualifiedColumnReferenceExp;
+import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.parser.tree.AllColumns;
+import io.confluent.ksql.parser.tree.SelectItem;
+import io.confluent.ksql.parser.tree.SingleColumn;
+import java.util.Optional;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProjectionTest {
+
+  private static final SourceName A = SourceName.of("A");
+  private static final SourceName B = SourceName.of("B");
+
+  private static final ColumnName COL0 = ColumnName.of("COL0");
+  private static final ColumnName COL1 = ColumnName.of("COL1");
+
+  private static final AllColumns ALL_COLUMNS = new AllColumns(Optional.empty());
+  private static final AllColumns ALL_A_COLUMNS = new AllColumns(Optional.of(A));
+
+  @Mock
+  private Expression expression;
+  @Mock
+  private Expression expression2;
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void shouldThrowOnUnsupportedColumnType() {
+    Projection.of(ImmutableList.of(mock(SelectItem.class)));
+  }
+
+  @Test
+  public void shouldMatchEverythingOnUnqualifiedAllColumns() {
+    // Given:
+    final Projection projection = Projection.of(ImmutableList.of(ALL_COLUMNS));
+
+    // Then:
+    assertThat(projection.containsExpression(expression), is(true));
+  }
+
+  @Test
+  public void shouldMatchQualifiedColumnToMatchingQualifiedAllColumns() {
+    // Given:
+    final Projection projection = Projection.of(ImmutableList.of(ALL_A_COLUMNS));
+
+    // Then:
+    assertThat(projection.containsExpression(new QualifiedColumnReferenceExp(A, COL0)), is(true));
+  }
+
+  @Test
+  public void shouldNotMatchQualifiedColumnToQualifiedAllColumnsIfDifferentSource() {
+    // Given:
+    final Projection projection = Projection.of(ImmutableList.of(ALL_A_COLUMNS));
+
+    // Then:
+    assertThat(projection.containsExpression(new QualifiedColumnReferenceExp(B, COL0)), is(false));
+  }
+
+  @Test
+  public void shouldNotMatchUnqualifiedColumnToQualifiedAllColumns() {
+    // Given:
+    final Projection projection = Projection.of(ImmutableList.of(ALL_A_COLUMNS));
+
+    // Then:
+    assertThat(projection.containsExpression(new UnqualifiedColumnReferenceExp(COL0)), is(false));
+  }
+
+  @Test
+  public void shouldMatchQualifiedColumnToMatchingSingleColumn() {
+    // Given:
+    final Projection projection = Projection.of(ImmutableList.of(
+        new SingleColumn(new QualifiedColumnReferenceExp(A, COL0), Optional.empty())
+    ));
+
+    // Then:
+    assertThat(projection.containsExpression(new QualifiedColumnReferenceExp(A, COL0)), is(true));
+  }
+
+  @Test
+  public void shouldNotMatchQualifiedColumnToUnqualifiedSingleColumn() {
+    // Given:
+    final Projection projection = Projection.of(ImmutableList.of(
+        new SingleColumn(new QualifiedColumnReferenceExp(A, COL0), Optional.empty())
+    ));
+
+    // Then:
+    assertThat(projection.containsExpression(new UnqualifiedColumnReferenceExp(COL0)), is(false));
+  }
+
+  @Test
+  public void shouldNotMatchQualifiedColumnToDifferentQualifiedSingleColumn() {
+    // Given:
+    final Projection projection = Projection.of(ImmutableList.of(
+        new SingleColumn(new QualifiedColumnReferenceExp(A, COL0), Optional.empty())
+    ));
+
+    // Then:
+    assertThat(projection.containsExpression(new QualifiedColumnReferenceExp(B, COL0)), is(false));
+  }
+
+  @Test
+  public void shouldMatchUnqualifiedColumnToMatchingSingleColumn() {
+    // Given:
+    final Projection projection = Projection.of(ImmutableList.of(
+        new SingleColumn(new UnqualifiedColumnReferenceExp(COL0), Optional.empty())
+    ));
+
+    // Then:
+    assertThat(projection.containsExpression(new UnqualifiedColumnReferenceExp(COL0)), is(true));
+  }
+
+  @Test
+  public void shouldNotMatchUnqualifiedColumnToQualifiedSingleColumn() {
+    // Given:
+    final Projection projection = Projection.of(ImmutableList.of(
+        new SingleColumn(new UnqualifiedColumnReferenceExp(COL0), Optional.empty())
+    ));
+
+    // Then:
+    assertThat(projection.containsExpression(new QualifiedColumnReferenceExp(A, COL0)), is(false));
+  }
+
+  @Test
+  public void shouldNotMatchUnqualifiedColumnToDifferentUnqualifiedSingleColumn() {
+    // Given:
+    final Projection projection = Projection.of(ImmutableList.of(
+        new SingleColumn(new UnqualifiedColumnReferenceExp(COL0), Optional.empty())
+    ));
+
+    // Then:
+    assertThat(projection.containsExpression(new UnqualifiedColumnReferenceExp(COL1)), is(false));
+  }
+
+  @Test
+  public void shouldMatchExpressionToMatchingSingleColumn() {
+    // Given:
+    final Projection projection = Projection.of(ImmutableList.of(
+        new SingleColumn(expression, Optional.empty())
+    ));
+
+    // Then:
+    assertThat(projection.containsExpression(expression), is(true));
+  }
+
+  @Test
+  public void shouldNotMatchExpressionToQualifiedSingleColumn() {
+    // Given:
+    final Projection projection = Projection.of(ImmutableList.of(
+        new AllColumns(Optional.of(A))
+    ));
+
+    // Then:
+    assertThat(projection.containsExpression(expression), is(false));
+  }
+
+  @Test
+  public void shouldNotMatchExpressionNonMatchingExpression() {
+    // Given:
+    final Projection projection = Projection.of(ImmutableList.of(
+        new SingleColumn(expression2, Optional.empty())
+    ));
+
+    // Then:
+    assertThat(projection.containsExpression(expression), is(false));
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
@@ -53,7 +53,6 @@ import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.tree.WithinExpression;
 import io.confluent.ksql.planner.Projection;
 import io.confluent.ksql.planner.plan.JoinNode.JoinKey;
-import io.confluent.ksql.planner.plan.JoinNode.JoinKey.Type;
 import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.ColumnNames;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
@@ -745,7 +744,7 @@ public class JoinNodeTest {
   @Test
   public void shouldIncludeSyntheticJoinKeyInResolvedSelectStart() {
     // Given:
-    when(joinKey.getType()).thenReturn(Type.SYNTHETIC);
+    when(joinKey.isSynthetic()).thenReturn(true);
 
     final JoinNode joinNode = new JoinNode(nodeId, OUTER, joinKey, true, left, right, empty());
 
@@ -791,8 +790,8 @@ public class JoinNodeTest {
 
     final JoinNode joinNode = new JoinNode(nodeId, LEFT, joinKey, true, left, right, empty());
 
-    when(joinKey.getOriginalAvailableKeys()).thenReturn((List)ImmutableList.of(expression1));
-    when(joinKey.getAvailableKeys()).thenReturn((List)ImmutableList.of(expression2));
+    when(joinKey.getOriginalViableKeys()).thenReturn((List) ImmutableList.of(expression1));
+    when(joinKey.getViableKeys()).thenReturn((List) ImmutableList.of(expression2));
 
     // When:
     joinNode.validateKeyPresent(SINK, projection);
@@ -808,7 +807,7 @@ public class JoinNodeTest {
     final JoinNode joinNode = new JoinNode(nodeId, LEFT, joinKey, true, left, right, empty());
 
     when(projection.containsExpression(any())).thenReturn(false);
-    when(joinKey.getOriginalAvailableKeys())
+    when(joinKey.getOriginalViableKeys())
         .thenReturn((List)ImmutableList.of(expression1, expression1, expression2));
 
     // When:

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
@@ -71,7 +71,7 @@ public class KsqlBareOutputNodeTest {
   private StreamsBuilder builder;
   private final MetaStore metaStore = MetaStoreFixture
       .getNewMetaStore(new InternalFunctionRegistry());
-  private final QueryId queryId = new QueryId("output-test");
+
   private final KsqlConfig ksqlConfig = new KsqlConfig(Collections.emptyMap());
 
   @Mock
@@ -87,7 +87,6 @@ public class KsqlBareOutputNodeTest {
   public void before() {
     builder = new StreamsBuilder();
 
-    when(ksqlStreamBuilder.getQueryId()).thenReturn(queryId);
     when(ksqlStreamBuilder.getKsqlConfig()).thenReturn(new KsqlConfig(Collections.emptyMap()));
     when(ksqlStreamBuilder.getStreamsBuilder()).thenReturn(builder);
     when(ksqlStreamBuilder.getProcessingLogger(any())).thenReturn(processingLogger);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/PlanNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/PlanNodeTest.java
@@ -101,7 +101,8 @@ public class PlanNodeTest {
   @Test
   public void shouldResolveAliasedSelectStarByCallingOnlyCorrectParent() {
     // When:
-    final Stream<ColumnName> result = planNode.resolveSelectStar(Optional.of(SOURCE_2_NAME), false);
+    final Stream<ColumnName> result = planNode.resolveSelectStar(Optional.of(SOURCE_2_NAME), false
+    );
 
     // Then:
     final List<ColumnName> columns = result.collect(Collectors.toList());

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/ProjectNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/ProjectNodeTest.java
@@ -17,7 +17,9 @@ package io.confluent.ksql.planner.plan;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
@@ -37,7 +39,6 @@ import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
-import io.confluent.ksql.schema.ksql.SystemColumns;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.structured.SchemaKStream;
 import io.confluent.ksql.util.KsqlException;
@@ -56,6 +57,7 @@ public class ProjectNodeTest {
 
   private static final PlanNodeId NODE_ID = new PlanNodeId("1");
 
+  private static final ColumnName K = ColumnName.of("K");
   private static final ColumnName COL_0 = ColumnName.of("col0");
   private static final ColumnName COL_1 = ColumnName.of("col1");
   private static final ColumnName COL_2 = ColumnName.of("col2");
@@ -70,8 +72,13 @@ public class ProjectNodeTest {
 
   private static final String KEY_FIELD_NAME = "col0";
 
+  private static final LogicalSchema SOURCE_SCHEMA = LogicalSchema.builder()
+      .keyColumn(K, SqlTypes.STRING)
+      .valueColumn(COL_2, SqlTypes.STRING)
+      .build();
+
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .keyColumn(SystemColumns.ROWKEY_NAME, SqlTypes.STRING)
+      .keyColumn(ColumnName.of("K"), SqlTypes.STRING)
       .valueColumn(COL_0, SqlTypes.STRING)
       .valueColumn(COL_1, SqlTypes.STRING)
       .valueColumn(ALIASED_COL_2, SqlTypes.STRING)
@@ -97,6 +104,7 @@ public class ProjectNodeTest {
   @SuppressWarnings("unchecked")
   @Before
   public void init() {
+    when(source.getSchema()).thenReturn(SOURCE_SCHEMA);
     when(source.buildStream(any())).thenReturn((SchemaKStream) stream);
     when(source.getNodeOutputType()).thenReturn(DataSourceType.KSTREAM);
     when(ksqlStreamBuilder.buildNodeContext(NODE_ID.toString())).thenReturn(stacker);
@@ -108,11 +116,35 @@ public class ProjectNodeTest {
         SELECTS,
         SCHEMA,
         Optional.of(ColumnName.of(KEY_FIELD_NAME)),
-        false
-    );
+        false,
+        false);
   }
 
-  @Test(expected = KsqlException.class)
+  @Test
+  public void shouldThrowIfSchemaHasNoValueColumns() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        .keyColumn(ColumnName.of("bob"), SqlTypes.STRING)
+        .build();
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> new ProjectNode(
+            NODE_ID,
+            source,
+            ImmutableList.of(),
+            schema,
+            Optional.empty(),
+            false,
+            false)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), is("The projection contains no value columns."));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
   public void shouldThrowIfSchemaSizeDoesntMatchProjection() {
     new ProjectNode(
         NODE_ID,
@@ -120,8 +152,8 @@ public class ProjectNodeTest {
         ImmutableList.of(SELECT_0), // <-- not enough expressions
         SCHEMA,
         Optional.of(ColumnName.of(KEY_FIELD_NAME)),
-        false
-    );
+        false,
+        false);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -136,8 +168,8 @@ public class ProjectNodeTest {
         ),
         SCHEMA,
         Optional.of(ColumnName.of(KEY_FIELD_NAME)),
-        false
-    );
+        false,
+        false);
   }
 
   @Test
@@ -170,8 +202,8 @@ public class ProjectNodeTest {
         SELECTS,
         SCHEMA,
         Optional.of(ColumnName.of("Unknown Key Field")),
-        false
-    );
+        false,
+        false);
   }
 
   @Test
@@ -224,8 +256,8 @@ public class ProjectNodeTest {
         SELECTS,
         SCHEMA,
         Optional.of(ColumnName.of(KEY_FIELD_NAME)),
-        true
-    );
+        true,
+        false);
 
     when(source.resolveSelectStar(any(), anyBoolean()))
         .thenReturn(ImmutableList.of(COL_1, COL_0, COL_2).stream());
@@ -236,5 +268,36 @@ public class ProjectNodeTest {
     // Then:
     final List<ColumnName> columns = result.collect(Collectors.toList());
     assertThat(columns, contains(COL_1, COL_0, ALIASED_COL_2));
+  }
+
+  @Test
+  public void shouldThrowOnMultipleKeyColumns() {
+    // Given:
+    final LogicalSchema badSchema = LogicalSchema.builder()
+        .keyColumn(ColumnName.of("K"), SqlTypes.STRING)
+        .keyColumn(ColumnName.of("SecondKey"), SqlTypes.STRING)
+        .valueColumn(COL_0, SqlTypes.STRING)
+        .valueColumn(COL_1, SqlTypes.STRING)
+        .valueColumn(ALIASED_COL_2, SqlTypes.STRING)
+        .build();
+
+    // When:
+    final KsqlException e = assertThrows(
+        KsqlException.class,
+        () -> {
+          new ProjectNode(
+              NODE_ID,
+              source,
+              SELECTS,
+              badSchema,
+              Optional.empty(),
+              true,
+              false);
+        }
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString("The projection contains the key column "
+        + "more than once: `K` and `SecondKey`."));
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/RepartitionNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/RepartitionNodeTest.java
@@ -17,7 +17,9 @@ package io.confluent.ksql.planner.plan;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.verify;
@@ -25,14 +27,16 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.execution.expression.tree.Expression;
+import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
 import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
-import io.confluent.ksql.parser.tree.PartitionBy;
+import io.confluent.ksql.planner.Projection;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SystemColumns;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.util.KsqlException;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -47,13 +51,11 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class RepartitionNodeTest {
 
   private static final PlanNodeId PLAN_ID = new PlanNodeId("Blah") ;
-  private static final SourceName MATCHING_SOURCE_NAME = SourceName.of("S1");
+  private static final SourceName SOURCE_NAME = SourceName.of("S1");
   private static final ColumnName K0 = ColumnName.of("K");
   private static final ColumnName V0 = ColumnName.of("V0");
   private static final ColumnName V1 = ColumnName.of("V1");
   private static final ColumnName V2 = ColumnName.of("V2");
-  private static final Optional<ColumnName> PARTITION_BY_ALIAS =
-      Optional.of(ColumnName.of("SomeAlias"));
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
       .keyColumn(K0, SqlTypes.DOUBLE)
@@ -71,29 +73,30 @@ public class RepartitionNodeTest {
 
   @Mock
   private PlanNode parent;
+  @Mock(name = "T.ID")
+  private Expression originalPartitionBy;
+  @Mock(name = "T_ID")
+  private Expression rewrittenPartitionBy;
   @Mock
-  private PartitionBy partitionBy;
-  @Mock
-  private Expression partitionByExpression;
+  private Projection projection;
+
   private RepartitionNode repartitionNode;
 
   @Before
   public void setUp() {
     when(parent.getNodeOutputType()).thenReturn(DataSourceType.KSTREAM);
-    when(parent.getSourceName()).thenReturn(Optional.of(MATCHING_SOURCE_NAME));
+    when(parent.getSourceName()).thenReturn(Optional.of(SOURCE_NAME));
     when(parent.resolveSelectStar(any(), anyBoolean())).thenReturn(PARENT_COL_NAMES.stream());
 
-    when(partitionBy.getAlias()).thenReturn(PARTITION_BY_ALIAS);
-    when(partitionBy.getExpression()).thenReturn(partitionByExpression);
-
-    repartitionNode = new RepartitionNode(PLAN_ID, parent, SCHEMA, partitionBy, KeyField.none());
+    repartitionNode = new RepartitionNode(PLAN_ID, parent, SCHEMA, originalPartitionBy,
+        rewrittenPartitionBy, KeyField.none(), false, false);
   }
 
   @Test
   public void shouldResolveSelectStarIfSourceMatchesAndValuesOnly() {
     // When:
     final Stream<ColumnName> result = repartitionNode.resolveSelectStar(
-        Optional.of(MATCHING_SOURCE_NAME),
+        Optional.of(SOURCE_NAME),
         true
     );
 
@@ -128,5 +131,73 @@ public class RepartitionNodeTest {
     assertThat(names, is(PARENT_COL_NAMES));
 
     verify(parent).resolveSelectStar(Optional.empty(), false);
+  }
+
+  @Test
+  public void shouldPassResolveSelectStarToParentIfInternal() {
+    // Given:
+    givenInternalRepartition();
+
+    // When:
+    final Stream<ColumnName> result = repartitionNode.resolveSelectStar(
+        Optional.empty(),
+        false
+    );
+
+    // Then:
+    final List<ColumnName> names = result.collect(Collectors.toList());
+    assertThat(names, is(PARENT_COL_NAMES));
+
+    verify(parent).resolveSelectStar(Optional.empty(), false);
+  }
+
+  @Test
+  public void shouldResolveSelectToPartitionByColumn() {
+    // Given:
+    givenAnyKeyEnabled();
+
+    // When:
+    final Expression result = repartitionNode.resolveSelect(0, rewrittenPartitionBy);
+
+    // Then:
+    assertThat(result, is(new UnqualifiedColumnReferenceExp(K0)));
+  }
+
+  @Test
+  public void shouldThrowIfProjectionMissingPartitionBy() {
+    // Given:
+    givenAnyKeyEnabled();
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> repartitionNode.validateKeyPresent(SOURCE_NAME, projection)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString("The query used to build `S1` "
+        + "must include the partitioning expression T.ID in its projection."));
+  }
+
+  @Test
+  public void shouldNotThrowIfProjectionHasPartitionBy() {
+    // Given:
+    givenAnyKeyEnabled();
+    when(projection.containsExpression(rewrittenPartitionBy)).thenReturn(true);
+
+    // When:
+    repartitionNode.validateKeyPresent(SOURCE_NAME, projection);
+
+    // Then: did not throw.
+  }
+
+  private void givenAnyKeyEnabled() {
+    repartitionNode = new RepartitionNode(PLAN_ID, parent, SCHEMA, originalPartitionBy,
+        rewrittenPartitionBy, KeyField.none(), true, false);
+  }
+
+  private void givenInternalRepartition() {
+    repartitionNode = new RepartitionNode(PLAN_ID, parent, SCHEMA, originalPartitionBy,
+        rewrittenPartitionBy, KeyField.none(), true, true);
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
@@ -83,6 +83,7 @@ import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.schema.ksql.SystemColumns;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.schema.utils.Pair;
 import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.GenericRowSerDe;
@@ -92,7 +93,6 @@ import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.testutils.AnalysisTestUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.MetaStoreFixture;
-import io.confluent.ksql.schema.utils.Pair;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -122,6 +122,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 @SuppressWarnings("unchecked")
 @RunWith(MockitoJUnitRunner.class)
 public class SchemaKTableTest {
+
+  private static final ColumnName KEY = ColumnName.of("Bob");
 
   private static final KeyBuilder STRING_KEY_BUILDER = StructKeyUtil
       .keyBuilder(SystemColumns.ROWKEY_NAME, SqlTypes.STRING);
@@ -221,7 +223,7 @@ public class SchemaKTableTest {
       final LogicalSchema schema,
       final KeyField keyField,
       final KTable kTable) {
-    return new SchemaKTable(
+    return new SchemaKTable<>(
         buildSourceStep(schema, kTable),
         schema,
         keyFormat,
@@ -315,7 +317,7 @@ public class SchemaKTableTest {
     initialSchemaKTable = buildSchemaKTableFromPlan(logicalPlan);
 
     // When:
-    final SchemaKTable projectedSchemaKStream = initialSchemaKTable.select(
+    final SchemaKTable<?> projectedSchemaKStream = initialSchemaKTable.select(
         projectNode.getSelectExpressions(),
         childContextStacker,
         queryBuilder
@@ -343,7 +345,7 @@ public class SchemaKTableTest {
     initialSchemaKTable = buildSchemaKTableFromPlan(logicalPlan);
 
     // When:
-    final SchemaKTable projectedSchemaKStream = initialSchemaKTable.select(
+    final SchemaKTable<?> projectedSchemaKStream = initialSchemaKTable.select(
         projectNode.getSelectExpressions(),
         childContextStacker,
         queryBuilder
@@ -366,7 +368,7 @@ public class SchemaKTableTest {
     initialSchemaKTable = buildSchemaKTableFromPlan(logicalPlan);
 
     // When:
-    final SchemaKTable projectedSchemaKStream = initialSchemaKTable.select(
+    final SchemaKTable<?> projectedSchemaKStream = initialSchemaKTable.select(
         projectNode.getSelectExpressions(),
         childContextStacker,
         queryBuilder
@@ -389,7 +391,7 @@ public class SchemaKTableTest {
     initialSchemaKTable = buildSchemaKTableFromPlan(logicalPlan);
 
     // When:
-    final SchemaKTable filteredSchemaKStream = initialSchemaKTable.filter(
+    final SchemaKTable<?> filteredSchemaKStream = initialSchemaKTable.filter(
         filterNode.getPredicate(),
         childContextStacker
     );
@@ -418,13 +420,13 @@ public class SchemaKTableTest {
     initialSchemaKTable = buildSchemaKTableFromPlan(logicalPlan);
 
     // When:
-    final SchemaKTable filteredSchemaKTable = initialSchemaKTable.filter(
+    final SchemaKTable<?> filteredSchemaKTable = initialSchemaKTable.filter(
         filterNode.getPredicate(),
         childContextStacker
     );
 
     // Then:
-    final TableFilter step = (TableFilter) filteredSchemaKTable.getSourceTableStep();
+    final TableFilter<?> step = (TableFilter) filteredSchemaKTable.getSourceTableStep();
     assertThat(
         step.getFilterExpression(),
         Matchers.equalTo(
@@ -446,7 +448,7 @@ public class SchemaKTableTest {
     initialSchemaKTable = buildSchemaKTableFromPlan(logicalPlan);
 
     // When:
-    final SchemaKTable filteredSchemaKStream = initialSchemaKTable.filter(
+    final SchemaKTable<?> filteredSchemaKStream = initialSchemaKTable.filter(
         filterNode.getPredicate(),
         childContextStacker
     );
@@ -558,7 +560,7 @@ public class SchemaKTableTest {
     replay(groupedFactory, mockKTable);
 
     final List<Expression> groupByExpressions = Collections.singletonList(TEST_2_COL_1);
-    final SchemaKTable schemaKTable = buildSchemaKTable(ksqlTable, mockKTable);
+    final SchemaKTable<?> schemaKTable = buildSchemaKTable(ksqlTable, mockKTable);
 
     // When:
     final SchemaKGroupedTable result =
@@ -615,16 +617,13 @@ public class SchemaKTableTest {
   @Test
   public void shouldPerformTableToTableLeftJoin() {
     expect(mockKTable.leftJoin(eq(secondKTable),
-                               anyObject(KsqlValueJoiner.class)))
+        anyObject(KsqlValueJoiner.class)))
         .andReturn(EasyMock.niceMock(KTable.class));
 
     replay(mockKTable);
 
-    final SchemaKStream joinedKStream = firstSchemaKTable
-        .leftJoin(
-            secondSchemaKTable,
-            validKeyField,
-            childContextStacker);
+    final SchemaKStream<?> joinedKStream = firstSchemaKTable
+        .leftJoin(secondSchemaKTable, KEY, validKeyField, childContextStacker);
 
     ((SchemaKTable) joinedKStream).getSourceTableStep().build(planBuilder);
     verify(mockKTable);
@@ -636,15 +635,13 @@ public class SchemaKTableTest {
   @Test
   public void shouldPerformTableToTableInnerJoin() {
     expect(mockKTable.join(eq(secondKTable),
-                           anyObject(KsqlValueJoiner.class)))
+        anyObject(KsqlValueJoiner.class)))
         .andReturn(EasyMock.niceMock(KTable.class));
 
     replay(mockKTable);
 
-    final SchemaKStream joinedKStream = firstSchemaKTable
-        .join(secondSchemaKTable,
-            validKeyField,
-            childContextStacker);
+    final SchemaKStream<?> joinedKStream = firstSchemaKTable
+        .join(secondSchemaKTable, KEY, validKeyField, childContextStacker);
 
     ((SchemaKTable) joinedKStream).getSourceTableStep().build(planBuilder);
     verify(mockKTable);
@@ -656,15 +653,13 @@ public class SchemaKTableTest {
   @Test
   public void shouldPerformTableToTableOuterJoin() {
     expect(mockKTable.outerJoin(eq(secondKTable),
-                                anyObject(KsqlValueJoiner.class)))
+        anyObject(KsqlValueJoiner.class)))
         .andReturn(EasyMock.niceMock(KTable.class));
 
     replay(mockKTable);
 
-    final SchemaKStream joinedKStream = firstSchemaKTable
-        .outerJoin(secondSchemaKTable,
-            validKeyField,
-            childContextStacker);
+    final SchemaKStream<?> joinedKStream = firstSchemaKTable
+        .outerJoin(secondSchemaKTable, ColumnName.of("KEY"), validKeyField, childContextStacker);
 
     ((SchemaKTable) joinedKStream).getSourceTableStep().build(planBuilder);
     verify(mockKTable);
@@ -672,9 +667,12 @@ public class SchemaKTableTest {
     assertThat(joinedKStream.getKeyField(), is(validKeyField));
   }
 
-  interface Join {
+  @FunctionalInterface
+  private interface Join {
+
     SchemaKTable join(
         SchemaKTable schemaKTable,
+        ColumnName keyColName,
         KeyField keyField,
         QueryContext.Stacker contextStacker
     );
@@ -684,18 +682,16 @@ public class SchemaKTableTest {
   public void shouldBuildStepForTableTableJoin() {
     // Given:
     givenJoin();
-    givenOuterJoin();
     givenLeftJoin();
     final List<Pair<JoinType, Join>> cases = ImmutableList.of(
         Pair.of(JoinType.LEFT, firstSchemaKTable::leftJoin),
-        Pair.of(JoinType.INNER, firstSchemaKTable::join),
-        Pair.of(JoinType.OUTER, firstSchemaKTable::outerJoin)
+        Pair.of(JoinType.INNER, firstSchemaKTable::join)
     );
 
     for (final Pair<JoinType, Join> testCase : cases) {
       // When:
-      final SchemaKTable result =
-          testCase.right.join(secondSchemaKTable, validKeyField, childContextStacker);
+      final SchemaKTable<?> result = testCase.right
+          .join(secondSchemaKTable, KEY, validKeyField, childContextStacker);
 
       // Then:
       assertThat(
@@ -704,6 +700,7 @@ public class SchemaKTableTest {
               ExecutionStepFactory.tableTableJoin(
                   childContextStacker,
                   testCase.left,
+                  KEY,
                   firstSchemaKTable.getSourceTableStep(),
                   secondSchemaKTable.getSourceTableStep()
               )
@@ -716,18 +713,16 @@ public class SchemaKTableTest {
   public void shouldBuildSchemaForTableTableJoin() {
     // Given:
     givenJoin();
-    givenOuterJoin();
     givenLeftJoin();
     final List<Pair<JoinType, Join>> cases = ImmutableList.of(
         Pair.of(JoinType.LEFT, firstSchemaKTable::leftJoin),
-        Pair.of(JoinType.INNER, firstSchemaKTable::join),
-        Pair.of(JoinType.OUTER, firstSchemaKTable::outerJoin)
+        Pair.of(JoinType.INNER, firstSchemaKTable::join)
     );
 
     for (final Pair<JoinType, Join> testCase : cases) {
       // When:
-      final SchemaKTable result =
-          testCase.right.join(secondSchemaKTable, validKeyField, childContextStacker);
+      final SchemaKTable<?> result = testCase.right
+          .join(secondSchemaKTable, KEY, validKeyField, childContextStacker);
 
       // Then:
       assertThat(result.getSchema(), is(schemaResolver.resolve(
@@ -743,7 +738,7 @@ public class SchemaKTableTest {
         "SELECT col0 as NEWKEY, col2, col3 FROM test1 EMIT CHANGES;");
 
     // When:
-    final SchemaKTable result = initialSchemaKTable
+    final SchemaKTable<?> result = initialSchemaKTable
         .select(selectExpressions, childContextStacker, queryBuilder);
 
     assertThat(result.getKeyField(),
@@ -757,7 +752,7 @@ public class SchemaKTableTest {
         "SELECT test1.col0 as NEWKEY, col2, col3 FROM test1 EMIT CHANGES;");
 
     // When:
-    final SchemaKTable result = initialSchemaKTable
+    final SchemaKTable<?> result = initialSchemaKTable
         .select(selectExpressions, childContextStacker, queryBuilder);
 
     // Then:
@@ -772,7 +767,7 @@ public class SchemaKTableTest {
         "SELECT t.col0 as NEWKEY, col2, col3 FROM test1 t EMIT CHANGES;");
 
     // When:
-    final SchemaKTable result = initialSchemaKTable
+    final SchemaKTable<?> result = initialSchemaKTable
         .select(selectExpressions, childContextStacker, queryBuilder);
 
     // Then:
@@ -787,7 +782,7 @@ public class SchemaKTableTest {
         "SELECT * FROM test1 EMIT CHANGES;");
 
     // When:
-    final SchemaKTable result = initialSchemaKTable
+    final SchemaKTable<?> result = initialSchemaKTable
         .select(selectExpressions, childContextStacker, queryBuilder);
 
     // Then:
@@ -801,7 +796,7 @@ public class SchemaKTableTest {
         "SELECT col2, col0, col3 FROM test1 EMIT CHANGES;");
 
     // When:
-    final SchemaKTable result = initialSchemaKTable
+    final SchemaKTable<?> result = initialSchemaKTable
         .select(selectExpressions, childContextStacker, queryBuilder);
 
     // Then:
@@ -816,7 +811,7 @@ public class SchemaKTableTest {
         "SELECT col2, col3 FROM test1 EMIT CHANGES;");
 
     // When:
-    final SchemaKTable result = initialSchemaKTable
+    final SchemaKTable<?> result = initialSchemaKTable
         .select(selectExpressions, childContextStacker, queryBuilder);
 
     // Then:
@@ -830,7 +825,7 @@ public class SchemaKTableTest {
         "SELECT * FROM test4 EMIT CHANGES;");
 
     // When:
-    final SchemaKTable result = initialSchemaKTable
+    final SchemaKTable<?> result = initialSchemaKTable
         .select(selectExpressions, childContextStacker, queryBuilder);
 
     // Then:
@@ -843,7 +838,7 @@ public class SchemaKTableTest {
     final List<SelectExpression> selectExpressions = givenInitialKTableOf(
         "SELECT * FROM test2 EMIT CHANGES;");
 
-    final SchemaKTable selected = initialSchemaKTable
+    final SchemaKTable<?> selected = initialSchemaKTable
         .select(selectExpressions, childContextStacker, queryBuilder);
 
     final List<Expression> groupByExprs =  ImmutableList.of(
@@ -866,7 +861,7 @@ public class SchemaKTableTest {
         metaStore
     );
 
-    initialSchemaKTable = new SchemaKTable(
+    initialSchemaKTable = new SchemaKTable<>(
         buildSourceStep(logicalPlan.getTheSourceNode().getSchema(), kTable),
         logicalPlan.getTheSourceNode().getSchema(),
         keyFormat,

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateSourceCommand.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateSourceCommand.java
@@ -95,7 +95,8 @@ public abstract class CreateSourceCommand implements DdlCommand {
     }
 
     if (schema.key().size() != 1) {
-      throw new UnsupportedOperationException("Only single key columns supported");
+      throw new UnsupportedOperationException("Only single key columns supported. "
+          + "Got: " + schema.key() + " (" + schema.key().size() + ")");
     }
 
     if (keyField.isPresent()) {

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/StreamTableJoin.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/StreamTableJoin.java
@@ -14,35 +14,67 @@
 
 package io.confluent.ksql.execution.plan;
 
+import static io.confluent.ksql.execution.plan.StreamStreamJoin.LEGACY_KEY_COL;
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.name.ColumnName;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 @Immutable
 public class StreamTableJoin<K> implements ExecutionStep<KStreamHolder<K>> {
 
   private final ExecutionStepPropertiesV1 properties;
   private final JoinType joinType;
+  private final ColumnName keyColName;
   private final Formats internalFormats;
   private final ExecutionStep<KStreamHolder<K>> leftSource;
   private final ExecutionStep<KTableHolder<K>> rightSource;
 
-  public StreamTableJoin(
+  @SuppressWarnings("unused") // Invoked by reflection
+  @JsonCreator
+  @Deprecated() // Can be removed at next incompatible version
+  private StreamTableJoin(
       @JsonProperty(value = "properties", required = true) final ExecutionStepPropertiesV1 props,
       @JsonProperty(value = "joinType", required = true) final JoinType joinType,
+      @JsonProperty(value = "keyName", defaultValue = LEGACY_KEY_COL)
+      final Optional<ColumnName> keyColName,
       @JsonProperty(value = "internalFormats", required = true) final Formats internalFormats,
-      @JsonProperty(value = "leftSource", required = true) final
-      ExecutionStep<KStreamHolder<K>> leftSource,
-      @JsonProperty(value = "rightSource", required = true) final
-      ExecutionStep<KTableHolder<K>> rightSource) {
-    this.properties = Objects.requireNonNull(props, "props");
-    this.internalFormats = Objects.requireNonNull(internalFormats, "internalFormats");
-    this.joinType = Objects.requireNonNull(joinType, "joinType");
-    this.leftSource = Objects.requireNonNull(leftSource, "leftSource");
-    this.rightSource = Objects.requireNonNull(rightSource, "rightSource");
+      @JsonProperty(value = "leftSource", required = true)
+      final ExecutionStep<KStreamHolder<K>> leftSource,
+      @JsonProperty(value = "rightSource", required = true)
+      final ExecutionStep<KTableHolder<K>> rightSource
+  ) {
+    this(
+        props,
+        joinType,
+        keyColName.orElse(ColumnName.of(LEGACY_KEY_COL)),
+        internalFormats,
+        leftSource,
+        rightSource
+    );
+  }
+
+  public StreamTableJoin(
+      final ExecutionStepPropertiesV1 props,
+      final JoinType joinType,
+      final ColumnName keyColName,
+      final Formats internalFormats,
+      final ExecutionStep<KStreamHolder<K>> leftSource,
+      final ExecutionStep<KTableHolder<K>> rightSource
+  ) {
+    this.properties = requireNonNull(props, "props");
+    this.internalFormats = requireNonNull(internalFormats, "internalFormats");
+    this.joinType = requireNonNull(joinType, "joinType");
+    this.keyColName = requireNonNull(keyColName, "keyColName");
+    this.leftSource = requireNonNull(leftSource, "leftSource");
+    this.rightSource = requireNonNull(rightSource, "rightSource");
   }
 
   @Override
@@ -72,6 +104,10 @@ public class StreamTableJoin<K> implements ExecutionStep<KStreamHolder<K>> {
     return joinType;
   }
 
+  public ColumnName getKeyColName() {
+    return keyColName;
+  }
+
   @Override
   public KStreamHolder<K> build(final PlanBuilder builder) {
     return builder.visitStreamTableJoin(this);
@@ -88,6 +124,7 @@ public class StreamTableJoin<K> implements ExecutionStep<KStreamHolder<K>> {
     final StreamTableJoin<?> that = (StreamTableJoin<?>) o;
     return Objects.equals(properties, that.properties)
         && joinType == that.joinType
+        && Objects.equals(keyColName, that.keyColName)
         && Objects.equals(internalFormats, that.internalFormats)
         && Objects.equals(leftSource, that.leftSource)
         && Objects.equals(rightSource, that.rightSource);
@@ -95,7 +132,6 @@ public class StreamTableJoin<K> implements ExecutionStep<KStreamHolder<K>> {
 
   @Override
   public int hashCode() {
-
-    return Objects.hash(properties, joinType, internalFormats, leftSource, rightSource);
+    return Objects.hash(properties, joinType, keyColName, internalFormats, leftSource, rightSource);
   }
 }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/schema/ksql/ColumnNames.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/schema/ksql/ColumnNames.java
@@ -23,6 +23,7 @@ import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.util.KsqlException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -97,6 +98,23 @@ public final class ColumnNames {
             : nextKsqlColAlias();
       }
     };
+  }
+
+  /**
+   * Short hand helper for when only a single generated alias is required.
+   *
+   * <p>Short hand for:
+   * <pre>
+   * {@code
+   *   ColumnNames.columnAliasGenerator(Arrays.stream(schemas)).nextKsqlColAlias();
+   * }
+   * </pre>
+   *
+   * @param schemas the source schemas.
+   * @return a unique column name.
+   */
+  public static ColumnName nextKsqlColAlias(final LogicalSchema... schemas) {
+    return columnAliasGenerator(Arrays.stream(schemas)).nextKsqlColAlias();
   }
 
   /**

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/plan/StreamStreamJoinTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/plan/StreamStreamJoinTest.java
@@ -14,7 +14,11 @@
 
 package io.confluent.ksql.execution.plan;
 
+import static io.confluent.ksql.execution.plan.JoinType.INNER;
+import static io.confluent.ksql.execution.plan.JoinType.LEFT;
+
 import com.google.common.testing.EqualsTester;
+import io.confluent.ksql.name.ColumnName;
 import java.time.Duration;
 import org.apache.kafka.connect.data.Struct;
 import org.junit.Test;
@@ -24,128 +28,64 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StreamStreamJoinTest {
+
+  private static final ColumnName KEY = ColumnName.of("Bob");
+  private static final ColumnName KEY2 = ColumnName.of("Vic");
+
+  private static final Duration SIX_SEC = Duration.ofSeconds(6);
+  private static final Duration TEN_SEC = Duration.ofSeconds(10);
+
   @Mock
-  private ExecutionStepPropertiesV1 properties1;
+  private ExecutionStepPropertiesV1 props;
   @Mock
-  private ExecutionStepPropertiesV1 properties2;
+  private ExecutionStepPropertiesV1 props2;
   @Mock
-  private ExecutionStep<KStreamHolder<Struct>> left1;
+  private ExecutionStep<KStreamHolder<Struct>> left;
   @Mock
-  private ExecutionStep<KStreamHolder<Struct>> right1;
+  private ExecutionStep<KStreamHolder<Struct>> right;
   @Mock
   private ExecutionStep<KStreamHolder<Struct>> left2;
   @Mock
   private ExecutionStep<KStreamHolder<Struct>> right2;
   @Mock
-  private Formats leftFormats1;
+  private Formats lFmts;
   @Mock
-  private Formats leftFormats2;
-  @Mock
-  private Formats rightFormats1;
-  @Mock
-  private Formats rightFormats2;
+  private Formats rFmts;
 
+  @SuppressWarnings("UnstableApiUsage")
   @Test
   public void shouldImplementEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            new StreamStreamJoin<>(
-                properties1,
-                JoinType.INNER,
-                leftFormats1,
-                rightFormats1,
-                left1,
-                right1,
-                Duration.ofSeconds(10),
-                Duration.ofSeconds(20)),
-            new StreamStreamJoin<>(
-                properties1,
-                JoinType.INNER,
-                leftFormats1,
-                rightFormats1,
-                left1,
-                right1,
-                Duration.ofSeconds(10),
-                Duration.ofSeconds(20)))
+            new StreamStreamJoin<>(props, INNER, KEY, lFmts, rFmts, left, right, TEN_SEC, SIX_SEC),
+            new StreamStreamJoin<>(props, INNER, KEY, lFmts, rFmts, left, right, TEN_SEC, SIX_SEC)
+        )
         .addEqualityGroup(
-            new StreamStreamJoin<>(
-                properties2,
-                JoinType.INNER,
-                leftFormats1,
-                rightFormats1,
-                left1,
-                right1,
-                Duration.ofSeconds(10),
-                Duration.ofSeconds(20)))
+            new StreamStreamJoin<>(props2, INNER, KEY, lFmts, rFmts, left, right, TEN_SEC, SIX_SEC)
+        )
         .addEqualityGroup(
-            new StreamStreamJoin<>(
-                properties1,
-                JoinType.LEFT,
-                leftFormats1,
-                rightFormats1,
-                left1,
-                right1,
-                Duration.ofSeconds(10),
-                Duration.ofSeconds(20)))
+            new StreamStreamJoin<>(props, LEFT, KEY, lFmts, rFmts, left, right, TEN_SEC, SIX_SEC)
+        )
         .addEqualityGroup(
-            new StreamStreamJoin<>(
-                properties1,
-                JoinType.INNER,
-                leftFormats2,
-                rightFormats1,
-                left1,
-                right1,
-                Duration.ofSeconds(10),
-                Duration.ofSeconds(20)))
+            new StreamStreamJoin<>(props, LEFT, KEY2, lFmts, rFmts, left, right, TEN_SEC, SIX_SEC)
+        )
         .addEqualityGroup(
-            new StreamStreamJoin<>(
-                properties1,
-                JoinType.INNER,
-                leftFormats1,
-                rightFormats2,
-                left1,
-                right1,
-                Duration.ofSeconds(10),
-                Duration.ofSeconds(20)))
+            new StreamStreamJoin<>(props, INNER, KEY, rFmts, rFmts, left, right, TEN_SEC, SIX_SEC)
+        )
         .addEqualityGroup(
-            new StreamStreamJoin<>(
-                properties1,
-                JoinType.INNER,
-                leftFormats1,
-                rightFormats1,
-                left2,
-                right1,
-                Duration.ofSeconds(10),
-                Duration.ofSeconds(20)))
+            new StreamStreamJoin<>(props, INNER, KEY, lFmts, lFmts, left, right, TEN_SEC, SIX_SEC)
+        )
         .addEqualityGroup(
-            new StreamStreamJoin<>(
-                properties1,
-                JoinType.INNER,
-                leftFormats1,
-                rightFormats1,
-                left1,
-                right2,
-                Duration.ofSeconds(10),
-                Duration.ofSeconds(20)))
+            new StreamStreamJoin<>(props, INNER, KEY, lFmts, rFmts, left2, right, TEN_SEC, SIX_SEC)
+        )
         .addEqualityGroup(
-            new StreamStreamJoin<>(
-                properties1,
-                JoinType.INNER,
-                leftFormats1,
-                rightFormats1,
-                left1,
-                right1,
-                Duration.ofSeconds(11),
-                Duration.ofSeconds(20)))
+            new StreamStreamJoin<>(props, INNER, KEY, lFmts, rFmts, left, right2, TEN_SEC, SIX_SEC)
+        )
         .addEqualityGroup(
-            new StreamStreamJoin<>(
-                properties1,
-                JoinType.INNER,
-                leftFormats1,
-                rightFormats1,
-                left1,
-                right1,
-                Duration.ofSeconds(10),
-                Duration.ofSeconds(21)));
+            new StreamStreamJoin<>(props, INNER, KEY, lFmts, rFmts, left, right, SIX_SEC, SIX_SEC)
+        )
+        .addEqualityGroup(
+            new StreamStreamJoin<>(props, INNER, KEY, lFmts, rFmts, left, right, TEN_SEC, TEN_SEC)
+        );
   }
 }

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/plan/StreamTableJoinTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/plan/StreamTableJoinTest.java
@@ -14,7 +14,11 @@
 
 package io.confluent.ksql.execution.plan;
 
+import static io.confluent.ksql.execution.plan.JoinType.INNER;
+import static io.confluent.ksql.execution.plan.JoinType.LEFT;
+
 import com.google.common.testing.EqualsTester;
+import io.confluent.ksql.name.ColumnName;
 import org.apache.kafka.connect.data.Struct;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,10 +27,14 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StreamTableJoinTest {
+
+  private static final ColumnName KEY = ColumnName.of("Bob");
+  private static final ColumnName KEY2 = ColumnName.of("Vic");
+
   @Mock
-  private ExecutionStepPropertiesV1 properties1;
+  private ExecutionStepPropertiesV1 props1;
   @Mock
-  private ExecutionStepPropertiesV1 properties2;
+  private ExecutionStepPropertiesV1 props2;
   @Mock
   private ExecutionStep<KStreamHolder<Struct>> left1;
   @Mock
@@ -40,56 +48,31 @@ public class StreamTableJoinTest {
   @Mock
   private Formats leftFormats2;
 
+  @SuppressWarnings("UnstableApiUsage")
   @Test
   public void shouldImplementEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            new StreamTableJoin<>(
-                properties1,
-                JoinType.INNER,
-                leftFormats1,
-                left1,
-                right1),
-            new StreamTableJoin<>(
-                properties1,
-                JoinType.INNER,
-                leftFormats1,
-                left1,
-                right1))
+            new StreamTableJoin<>(props1, INNER, KEY, leftFormats1, left1, right1),
+            new StreamTableJoin<>(props1, INNER, KEY, leftFormats1, left1, right1)
+        )
         .addEqualityGroup(
-            new StreamTableJoin<>(
-                properties2,
-                JoinType.INNER,
-                leftFormats1,
-                left1,
-                right1))
+            new StreamTableJoin<>(props2, INNER, KEY, leftFormats1, left1, right1)
+        )
         .addEqualityGroup(
-            new StreamTableJoin<>(
-                properties1,
-                JoinType.LEFT,
-                leftFormats1,
-                left1,
-                right1))
+            new StreamTableJoin<>(props1, LEFT, KEY, leftFormats1, left1, right1)
+        )
         .addEqualityGroup(
-            new StreamTableJoin<>(
-                properties1,
-                JoinType.INNER,
-                leftFormats2,
-                left1,
-                right1))
+            new StreamTableJoin<>(props1, INNER, KEY2, leftFormats1, left1, right1)
+        )
         .addEqualityGroup(
-            new StreamTableJoin<>(
-                properties1,
-                JoinType.INNER,
-                leftFormats1,
-                left2,
-                right1))
+            new StreamTableJoin<>(props1, INNER, KEY, leftFormats2, left1, right1)
+        )
         .addEqualityGroup(
-            new StreamTableJoin<>(
-                properties1,
-                JoinType.INNER,
-                leftFormats1,
-                left1,
-                right2));
+            new StreamTableJoin<>(props1, INNER, KEY, leftFormats1, left2, right1)
+        )
+        .addEqualityGroup(
+            new StreamTableJoin<>(props1, INNER, KEY, leftFormats1, left1, right2)
+        );
   }
 }

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/plan/TableTableJoinTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/plan/TableTableJoinTest.java
@@ -14,7 +14,11 @@
 
 package io.confluent.ksql.execution.plan;
 
+import static io.confluent.ksql.execution.plan.JoinType.INNER;
+import static io.confluent.ksql.execution.plan.JoinType.LEFT;
+
 import com.google.common.testing.EqualsTester;
+import io.confluent.ksql.name.ColumnName;
 import org.apache.kafka.connect.data.Struct;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,10 +27,14 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TableTableJoinTest {
+
+  private static final ColumnName KEY = ColumnName.of("Bob");
+  private static final ColumnName KEY2 = ColumnName.of("Vic");
+
   @Mock
-  private ExecutionStepPropertiesV1 properties1;
+  private ExecutionStepPropertiesV1 props1;
   @Mock
-  private ExecutionStepPropertiesV1 properties2;
+  private ExecutionStepPropertiesV1 props2;
   @Mock
   private ExecutionStep<KTableHolder<Struct>> left1;
   @Mock
@@ -36,43 +44,28 @@ public class TableTableJoinTest {
   @Mock
   private ExecutionStep<KTableHolder<Struct>> right2;
 
+  @SuppressWarnings("UnstableApiUsage")
   @Test
   public void shouldImplementEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            new TableTableJoin<>(
-                properties1,
-                JoinType.INNER,
-                left1,
-                right1),
-            new TableTableJoin<>(
-                properties1,
-                JoinType.INNER,
-                left1,
-                right1))
+            new TableTableJoin<>(props1, INNER, KEY, left1, right1),
+            new TableTableJoin<>(props1, INNER, KEY, left1, right1)
+        )
         .addEqualityGroup(
-            new TableTableJoin<>(
-                properties2,
-                JoinType.INNER,
-                left1,
-                right1))
+            new TableTableJoin<>(props2, INNER, KEY, left1, right1)
+        )
         .addEqualityGroup(
-            new TableTableJoin<>(
-                properties1,
-                JoinType.LEFT,
-                left1,
-                right1))
+            new TableTableJoin<>(props1, LEFT, KEY, left1, right1)
+        )
         .addEqualityGroup(
-            new TableTableJoin<>(
-                properties1,
-                JoinType.INNER,
-                left2,
-                right1))
+            new TableTableJoin<>(props1, INNER, KEY2, left1, right1)
+        )
         .addEqualityGroup(
-            new TableTableJoin<>(
-                properties1,
-                JoinType.INNER,
-                left1,
-                right2));
+            new TableTableJoin<>(props1, INNER, KEY, left2, right1)
+        )
+        .addEqualityGroup(
+            new TableTableJoin<>(props1, INNER, KEY, left1, right2)
+        );
   }
 }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/as_value.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/as_value.json
@@ -7,10 +7,9 @@
   "tests": [
     {
       "name": "key column",
-      "comment": "awaiting other changes for KLIP-24 to enable expected behaviour",
       "statements": [
         "CREATE STREAM INPUT (ID INT KEY, V0 INT, V1 INT) WITH (kafka_topic='input', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT AS_VALUE(ID) AS ID_COPY, V1 FROM INPUT;"
+        "CREATE STREAM OUTPUT AS SELECT ID, AS_VALUE(ID) AS ID_COPY, V1 FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -31,7 +30,7 @@
       "name": "value column",
       "statements": [
         "CREATE STREAM INPUT (ID INT KEY, V0 INT, V1 INT) WITH (kafka_topic='input', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT AS_VALUE(V0) FROM INPUT;"
+        "CREATE STREAM OUTPUT AS SELECT ID, AS_VALUE(V0) FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -52,7 +51,7 @@
       "name": "expression",
       "statements": [
         "CREATE STREAM INPUT (ID INT KEY, V0 INT, V1 INT) WITH (kafka_topic='input', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT AS_VALUE(V0 + V1) FROM INPUT;"
+        "CREATE STREAM OUTPUT AS SELECT ID, AS_VALUE(V0 + V1) FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -103,11 +102,11 @@
         {"topic": "input", "key": 1, "value": {"V0": 2, "V1": 3}}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 1, "value": {"K": 1, "KSQL_COL_0": 1}}
+        {"topic": "OUTPUT", "key": 1, "value": {"KSQL_COL_0": 1}}
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "schema": "KSQL_COL_1 INT KEY, K INT, KSQL_COL_0 BIGINT"}
+          {"name": "OUTPUT", "type": "table", "schema": "K INT KEY, KSQL_COL_0 BIGINT"}
         ]
       }
     },
@@ -126,11 +125,11 @@
         {"topic": "i1", "key": 1, "value": {"V0": 2, "V1": 3}}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 1, "value": {"I1_ID": 1, "I1_V0": 2, "I1_V1": 3, "I2_ID": 1, "I2_V0": 2, "I2_V1": 3}}
+        {"topic": "OUTPUT", "key": 1, "value": {"I1_ID": 1, "I1_V0": 2, "I1_V1": 3, "I2_V0": 2, "I2_V1": 3}}
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "KSQL_COL_0 INT KEY, I1_ID INT, I1_V0 INT, I1_V1 INT, I2_ID INT, I2_V0 INT, I2_V1 INT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "I2_ID INT KEY, I1_ID INT, I1_V0 INT, I1_V1 INT, I2_V0 INT, I2_V1 INT"}
         ]
       }
     }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/binary-arithmetic.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/binary-arithmetic.json
@@ -7,7 +7,7 @@
       "name": "in projection",
       "statements": [
         "CREATE STREAM INPUT (col0 INT KEY, col1 BIGINT, col2 DOUBLE) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT col0+col1, col2+10, col1*25, 12*4+2 FROM INPUT;"
+        "CREATE STREAM OUTPUT AS SELECT col0, col0+col1, col2+10, col1*25, 12*4+2 FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/binary-comparison.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/binary-comparison.json
@@ -7,7 +7,7 @@
       "name": "equals",
       "statements": [
         "CREATE STREAM INPUT (A INT KEY, B BOOLEAN, C BIGINT, D DOUBLE, E DECIMAL(4,3), F STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT A = 1, B = true, C = 11, D = 1.1, E = 1.20, F = 'foo' FROM INPUT;"
+        "CREATE STREAM OUTPUT AS SELECT A, A = 1, B = true, C = 11, D = 1.1, E = 1.20, F = 'foo' FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -25,7 +25,7 @@
       "name": "not equals",
       "statements": [
         "CREATE STREAM INPUT (A INT KEY, B BOOLEAN, C BIGINT, D DOUBLE, E DECIMAL(4,3), F STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT A <> 1, B <> true, C <> 11, D <> 1.1, E <> 1.20, F <> 'foo' FROM INPUT;"
+        "CREATE STREAM OUTPUT AS SELECT A, A <> 1, B <> true, C <> 11, D <> 1.1, E <> 1.20, F <> 'foo' FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -43,7 +43,7 @@
       "name": "less than",
       "statements": [
         "CREATE STREAM INPUT (A INT KEY, B BIGINT, C DOUBLE, D DECIMAL(4,3), E STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT A < 1, B < 11, C < 1.1, D < 1.20, E < 'foo' FROM INPUT;"
+        "CREATE STREAM OUTPUT AS SELECT A, A < 1, B < 11, C < 1.1, D < 1.20, E < 'foo' FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -61,7 +61,7 @@
       "name": "less than or equal",
       "statements": [
         "CREATE STREAM INPUT (A INT KEY, B BIGINT, C DOUBLE, D DECIMAL(4,3), E STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT A <= 1, B <= 11, C <= 1.1, D <= 1.20, E <= 'foo' FROM INPUT;"
+        "CREATE STREAM OUTPUT AS SELECT A, A <= 1, B <= 11, C <= 1.1, D <= 1.20, E <= 'foo' FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -81,7 +81,7 @@
       "name": "greater than",
       "statements": [
         "CREATE STREAM INPUT (A INT KEY, B BIGINT, C DOUBLE, D DECIMAL(4,3), E STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT A > 1, B > 11, C > 1.1, D > 1.20, E > 'foo' FROM INPUT;"
+        "CREATE STREAM OUTPUT AS SELECT A, A > 1, B > 11, C > 1.1, D > 1.20, E > 'foo' FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -99,7 +99,7 @@
       "name": "greater than or equal",
       "statements": [
         "CREATE STREAM INPUT (A INT KEY, B BIGINT, C DOUBLE, D DECIMAL(4,3), E STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT A >= 1, B >= 11, C >= 1.1, D >= 1.20, E >= 'foo' FROM INPUT;"
+        "CREATE STREAM OUTPUT AS SELECT A, A >= 1, B >= 11, C >= 1.1, D >= 1.20, E >= 'foo' FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -119,7 +119,7 @@
       "name": "between",
       "statements": [
         "CREATE STREAM INPUT (A INT KEY, B BIGINT, C DOUBLE, D DECIMAL(4,3), E STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT A BETWEEN 0 AND 2, B BETWEEN 10 AND 12, C BETWEEN 1.0 AND 1.11, D BETWEEN 1.19 AND 1.21, E BETWEEN 'eoo' AND 'goo' FROM INPUT;"
+        "CREATE STREAM OUTPUT AS SELECT A, A BETWEEN 0 AND 2, B BETWEEN 10 AND 12, C BETWEEN 1.0 AND 1.11, D BETWEEN 1.19 AND 1.21, E BETWEEN 'eoo' AND 'goo' FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -143,7 +143,7 @@
       "name": "not between",
       "statements": [
         "CREATE STREAM INPUT (A INT KEY, B BIGINT, C DOUBLE, D DECIMAL(4,3), E STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT A NOT BETWEEN 0 AND 2, B NOT BETWEEN 10 AND 12, C NOT BETWEEN 1.0 AND 1.11, D NOT BETWEEN 1.19 AND 1.21, E NOT BETWEEN 'eoo' AND 'goo' FROM INPUT;"
+        "CREATE STREAM OUTPUT AS SELECT A, A NOT BETWEEN 0 AND 2, B NOT BETWEEN 10 AND 12, C NOT BETWEEN 1.0 AND 1.11, D NOT BETWEEN 1.19 AND 1.21, E NOT BETWEEN 'eoo' AND 'goo' FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -167,7 +167,7 @@
       "name": "is distinct from",
       "statements": [
         "CREATE STREAM INPUT (ID INT KEY, ID2 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT ID IS DISTINCT FROM ID2 FROM INPUT;"
+        "CREATE STREAM OUTPUT AS SELECT ID, ID IS DISTINCT FROM ID2 FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -191,7 +191,7 @@
       "name": "is not distinct from",
       "statements": [
         "CREATE STREAM INPUT (ID INT KEY, ID2 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT ID IS NOT DISTINCT FROM ID2 FROM INPUT;"
+        "CREATE STREAM OUTPUT AS SELECT ID, ID IS NOT DISTINCT FROM ID2 FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -215,7 +215,7 @@
       "name": "comparison array fails",
       "statements": [
         "CREATE STREAM INPUT (A INT KEY, B ARRAY<INT>, C ARRAY<INT>) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT B = C FROM INPUT;"
+        "CREATE STREAM OUTPUT AS SELECT A, B = C FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -229,7 +229,7 @@
       "name": "comparison map fails",
       "statements": [
         "CREATE STREAM INPUT (A INT KEY, B MAP<STRING, INT>, C MAP<STRING, INT>) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT B = C FROM INPUT;"
+        "CREATE STREAM OUTPUT AS SELECT A, B = C FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -243,7 +243,7 @@
       "name": "comparison struct fails",
       "statements": [
         "CREATE STREAM INPUT (A INT KEY, B STRUCT<ID INT>, C STRUCT<ID INT>) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT B = C FROM INPUT;"
+        "CREATE STREAM OUTPUT AS SELECT A, B = C FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/elements.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/elements.json
@@ -578,26 +578,6 @@
       }
     },
     {
-      "name": "non-join should reject KEY column name in projection",
-      "comments": [
-        "changes to the ksql query semantics are required to allow this.",
-        "At the moment, the key schema passes through the select un-changed.",
-        "which means the key column in the projection is added to the value schema",
-        "but the name of the column clashes with the key column, resulting in an error"
-      ],
-      "statements": [
-        "CREATE STREAM INPUT (K INT KEY, F0 INT) WITH (kafka_topic='input', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT K FROM INPUT;"
-      ],
-      "properties": {
-        "ksql.any.key.name.enabled": true
-      },
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Value column name(s) `K` clashes with key column name(s)."
-      }
-    },
-    {
       "name": "non-join should reject WINDOWSTART in projection",
       "statements": [
         "CREATE STREAM INPUT (F0 INT) WITH (kafka_topic='input', value_format='JSON', window_type='session');",
@@ -650,27 +630,6 @@
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
         "message": "Value column name(s) `ROWKEY` clashes with key column name(s)."
-      }
-    },
-    {
-      "name": "join should reject KEY column name in projection",
-      "comments": [
-        "changes to the ksql query semantics are required to allow this.",
-        "At the moment, the key schema passes through the select un-changed.",
-        "which means the key column in the projection is added to the value schema",
-        "but the name of the column clashes with the key column, resulting in an error"
-      ],
-      "statements": [
-        "CREATE STREAM LEFT_STREAM (K DOUBLE KEY, F0 INT) WITH (kafka_topic='left', value_format='JSON');",
-        "CREATE STREAM RIGHT_STREAM (K DOUBLE KEY, F1 INT) WITH (kafka_topic='right', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT l.K AS K, f0, f1 FROM left_stream l join right_stream r WITHIN 1 seconds ON l.k = r.k;"
-      ],
-      "properties": {
-        "ksql.any.key.name.enabled": true
-      },
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Value column name(s) `K` clashes with key column name(s)."
       }
     },
     {
@@ -881,7 +840,7 @@
       "name": "should handle sources with generated column names",
       "statements": [
         "CREATE STREAM INPUT (KSQL_COL_3 INT KEY, KSQL_COL_2 INT, KSQL_COL_4 INT) WITH (kafka_topic='input', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT KSQL_COL_2, ABS(KSQL_COL_2), ABS(KSQL_COL_2), ABS(KSQL_COL_2) FROM INPUT;"
+        "CREATE STREAM OUTPUT as SELECT KSQL_COL_3, KSQL_COL_2, ABS(KSQL_COL_2), ABS(KSQL_COL_2), ABS(KSQL_COL_2) FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -946,6 +905,27 @@
       "expectedException": {
         "type": "io.confluent.ksql.parser.exception.ParseFailedException",
         "message": "Line: 1, Col: 22: Column `ID` is a 'PRIMARY KEY' column: please use 'KEY' for streams."
+      }
+    },
+    {
+      "name": "copy simple key column into value",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT KEY, F0 INT) WITH (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT ID, AS_VALUE(ID) AS ID_COPY FROM INPUT;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "input", "key": 10, "value": {"F0": 4}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 10, "value": {"ID_COPY": 10}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, ID_COPY INT"}
+        ]
       }
     }
   ]

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
@@ -466,7 +466,7 @@
       },
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Duplicate values found in schema: `COUNT` BIGINT"
+        "message": "Duplicate value columns found in schema: `COUNT` BIGINT"
       }
     },
     {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
@@ -7,7 +7,7 @@
       "name": "only key column (stream->table)",
       "statements": [
         "CREATE STREAM INPUT (ID INT KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE TABLE OUTPUT AS SELECT COUNT(1) AS COUNT FROM INPUT GROUP BY ID;"
+        "CREATE TABLE OUTPUT AS SELECT ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ID;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -43,7 +43,7 @@
       "name": "value column (stream->table)",
       "statements": [
         "CREATE STREAM TEST (ID INT KEY, data STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE TABLE OUTPUT AS SELECT COUNT(*) AS COUNT FROM TEST GROUP BY DATA;"
+        "CREATE TABLE OUTPUT AS SELECT DATA, COUNT(*) AS COUNT FROM TEST GROUP BY DATA;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -82,7 +82,7 @@
       "name": "struct field (stream->table)",
       "statements": [
         "CREATE STREAM TEST (ID INT KEY, ADDRESS STRUCT<STREET STRING, TOWN STRING>) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE TABLE OUTPUT AS SELECT COUNT(*) AS COUNT FROM TEST GROUP BY ADDRESS->TOWN;"
+        "CREATE TABLE OUTPUT AS SELECT ADDRESS->TOWN, COUNT(*) AS COUNT FROM TEST GROUP BY ADDRESS->TOWN;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -118,10 +118,49 @@
       }
     },
     {
-      "name": "single expression with alias (stream->table)",
+      "name": "single expression (stream->table)",
+      "statements": [
+        "CREATE STREAM TEST (ID INT KEY, DATA STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT LEN(DATA), COUNT(*) AS COUNT FROM TEST GROUP BY LEN(DATA);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"data": "22"}},
+        {"topic": "test_topic", "key": 1, "value": {"data": "333"}},
+        {"topic": "test_topic", "key": 2, "value": {"data": "-2"}},
+        {"topic": "test_topic", "key": 3, "value": {"data": "003"}},
+        {"topic": "test_topic", "key": 4, "value": {"data": "2-"}}
+      ],
+      "outputs": [
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 2, "value": {"ROWTIME": 0, "DATA": "22"}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 3, "value": {"ROWTIME": 0, "DATA": "333"}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 2, "value": {"ROWTIME": 0, "DATA": "-2"}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 3, "value": {"ROWTIME": 0, "DATA": "003"}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 2, "value": {"ROWTIME": 0, "DATA": "2-"}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 2, "value": {"ROWTIME": 0, "DATA": "22", "KSQL_AGG_VARIABLE_0": 1}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 3, "value": {"ROWTIME": 0, "DATA": "333", "KSQL_AGG_VARIABLE_0": 1}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 2, "value": {"ROWTIME": 0, "DATA": "-2", "KSQL_AGG_VARIABLE_0": 2}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 3, "value": {"ROWTIME": 0, "DATA": "003", "KSQL_AGG_VARIABLE_0": 2}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 2, "value": {"ROWTIME": 0, "DATA": "2-", "KSQL_AGG_VARIABLE_0": 3}},
+        {"topic": "OUTPUT", "key": 2, "value": {"COUNT": 1}},
+        {"topic": "OUTPUT", "key": 3, "value": {"COUNT": 1}},
+        {"topic": "OUTPUT", "key": 2, "value": {"COUNT": 2}},
+        {"topic": "OUTPUT", "key": 3, "value": {"COUNT": 2}},
+        {"topic": "OUTPUT", "key": 2, "value": {"COUNT": 3}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "schema": "KSQL_COL_0 INT KEY, COUNT BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "single column with alias (stream->table)",
       "statements": [
         "CREATE STREAM TEST (ID INT KEY, data STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE TABLE OUTPUT AS SELECT COUNT(*) AS COUNT FROM TEST GROUP BY DATA AS NEW_KEY;"
+        "CREATE TABLE OUTPUT AS SELECT DATA AS NEW_KEY, COUNT(*) AS COUNT FROM TEST GROUP BY DATA;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -153,6 +192,84 @@
       "post": {
         "sources": [
           {"name": "OUTPUT", "type": "table", "schema": "NEW_KEY STRING KEY, COUNT BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "single column with alias (table->table)",
+      "statements": [
+        "CREATE TABLE TEST (ID INT PRIMARY KEY, data STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT DATA AS NEW_KEY, COUNT(*) AS COUNT FROM TEST GROUP BY DATA;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"data": "d1"}},
+        {"topic": "test_topic", "key": 1, "value": {"data": "d2"}},
+        {"topic": "test_topic", "key": 2, "value": {"data": "d1"}},
+        {"topic": "test_topic", "key": 3, "value": {"data": "d2"}},
+        {"topic": "test_topic", "key": 4, "value": {"data": "d1"}}
+      ],
+      "outputs": [
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d1", "value": {"ROWTIME": 0, "DATA": "d1"}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d2", "value": {"ROWTIME": 0, "DATA": "d2"}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d1", "value": {"ROWTIME": 0, "DATA": "d1"}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d2", "value": {"ROWTIME": 0, "DATA": "d2"}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d1", "value": {"ROWTIME": 0, "DATA": "d1"}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": {"ROWTIME": 0, "DATA": "d1", "KSQL_AGG_VARIABLE_0": 1}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d2", "value": {"ROWTIME": 0, "DATA": "d2", "KSQL_AGG_VARIABLE_0": 1}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": {"ROWTIME": 0, "DATA": "d1", "KSQL_AGG_VARIABLE_0": 2}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d2", "value": {"ROWTIME": 0, "DATA": "d2", "KSQL_AGG_VARIABLE_0": 2}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": {"ROWTIME": 0, "DATA": "d1", "KSQL_AGG_VARIABLE_0": 3}},
+        {"topic": "OUTPUT", "key": "d1", "value": {"COUNT": 1}},
+        {"topic": "OUTPUT", "key": "d2", "value": {"COUNT": 1}},
+        {"topic": "OUTPUT", "key": "d1", "value": {"COUNT": 2}},
+        {"topic": "OUTPUT", "key": "d2", "value": {"COUNT": 2}},
+        {"topic": "OUTPUT", "key": "d1", "value": {"COUNT": 3}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "schema": "NEW_KEY STRING KEY, COUNT BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "single expression with alias (stream->table)",
+      "statements": [
+        "CREATE STREAM TEST (ID INT KEY, data STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT LEN(DATA) AS NEW_KEY, COUNT(*) AS COUNT FROM TEST GROUP BY LEN(DATA);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"data": "22"}},
+        {"topic": "test_topic", "key": 1, "value": {"data": "333"}},
+        {"topic": "test_topic", "key": 2, "value": {"data": "-2"}},
+        {"topic": "test_topic", "key": 3, "value": {"data": "003"}},
+        {"topic": "test_topic", "key": 4, "value": {"data": "2-"}}
+      ],
+      "outputs": [
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 2, "value": {"ROWTIME": 0, "DATA": "22"}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 3, "value": {"ROWTIME": 0, "DATA": "333"}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 2, "value": {"ROWTIME": 0, "DATA": "-2"}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 3, "value": {"ROWTIME": 0, "DATA": "003"}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 2, "value": {"ROWTIME": 0, "DATA": "2-"}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 2, "value": {"ROWTIME": 0, "DATA": "22", "KSQL_AGG_VARIABLE_0": 1}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 3, "value": {"ROWTIME": 0, "DATA": "333", "KSQL_AGG_VARIABLE_0": 1}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 2, "value": {"ROWTIME": 0, "DATA": "-2", "KSQL_AGG_VARIABLE_0": 2}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 3, "value": {"ROWTIME": 0, "DATA": "003", "KSQL_AGG_VARIABLE_0": 2}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 2, "value": {"ROWTIME": 0, "DATA": "2-", "KSQL_AGG_VARIABLE_0": 3}},
+        {"topic": "OUTPUT", "key": 2, "value": {"COUNT": 1}},
+        {"topic": "OUTPUT", "key": 3, "value": {"COUNT": 1}},
+        {"topic": "OUTPUT", "key": 2, "value": {"COUNT": 2}},
+        {"topic": "OUTPUT", "key": 3, "value": {"COUNT": 2}},
+        {"topic": "OUTPUT", "key": 2, "value": {"COUNT": 3}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "schema": "NEW_KEY INT KEY, COUNT BIGINT"}
         ]
       }
     },
@@ -160,106 +277,63 @@
       "name": "single expression with alias (table->table)",
       "statements": [
         "CREATE TABLE TEST (ID INT PRIMARY KEY, data STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE TABLE OUTPUT AS SELECT COUNT(*) AS COUNT FROM TEST GROUP BY DATA AS NEW_KEY;"
+        "CREATE TABLE OUTPUT AS SELECT LEN(DATA) AS NEW_KEY, COUNT(*) AS COUNT FROM TEST GROUP BY LEN(DATA);"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
       },
       "inputs": [
-        {"topic": "test_topic", "key": 0, "value": {"data": "d1"}},
-        {"topic": "test_topic", "key": 1, "value": {"data": "d2"}},
-        {"topic": "test_topic", "key": 2, "value": {"data": "d1"}},
-        {"topic": "test_topic", "key": 3, "value": {"data": "d2"}},
-        {"topic": "test_topic", "key": 4, "value": {"data": "d1"}}
+        {"topic": "test_topic", "key": 0, "value": {"data": "22"}},
+        {"topic": "test_topic", "key": 1, "value": {"data": "333"}},
+        {"topic": "test_topic", "key": 2, "value": {"data": "-2"}},
+        {"topic": "test_topic", "key": 3, "value": {"data": "003"}},
+        {"topic": "test_topic", "key": 4, "value": {"data": "2-"}}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d1", "value": {"ROWTIME": 0, "DATA": "d1"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d2", "value": {"ROWTIME": 0, "DATA": "d2"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d1", "value": {"ROWTIME": 0, "DATA": "d1"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d2", "value": {"ROWTIME": 0, "DATA": "d2"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d1", "value": {"ROWTIME": 0, "DATA": "d1"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": {"ROWTIME": 0, "DATA": "d1", "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d2", "value": {"ROWTIME": 0, "DATA": "d2", "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": {"ROWTIME": 0, "DATA": "d1", "KSQL_AGG_VARIABLE_0": 2}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d2", "value": {"ROWTIME": 0, "DATA": "d2", "KSQL_AGG_VARIABLE_0": 2}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": {"ROWTIME": 0, "DATA": "d1", "KSQL_AGG_VARIABLE_0": 3}},
-        {"topic": "OUTPUT", "key": "d1", "value": {"COUNT": 1}},
-        {"topic": "OUTPUT", "key": "d2", "value": {"COUNT": 1}},
-        {"topic": "OUTPUT", "key": "d1", "value": {"COUNT": 2}},
-        {"topic": "OUTPUT", "key": "d2", "value": {"COUNT": 2}},
-        {"topic": "OUTPUT", "key": "d1", "value": {"COUNT": 3}}
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 2, "value": {"ROWTIME": 0, "DATA": "22"}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 3, "value": {"ROWTIME": 0, "DATA": "333"}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 2, "value": {"ROWTIME": 0, "DATA": "-2"}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 3, "value": {"ROWTIME": 0, "DATA": "003"}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 2, "value": {"ROWTIME": 0, "DATA": "2-"}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 2, "value": {"ROWTIME": 0, "DATA": "22", "KSQL_AGG_VARIABLE_0": 1}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 3, "value": {"ROWTIME": 0, "DATA": "333", "KSQL_AGG_VARIABLE_0": 1}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 2, "value": {"ROWTIME": 0, "DATA": "-2", "KSQL_AGG_VARIABLE_0": 2}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 3, "value": {"ROWTIME": 0, "DATA": "003", "KSQL_AGG_VARIABLE_0": 2}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 2, "value": {"ROWTIME": 0, "DATA": "2-", "KSQL_AGG_VARIABLE_0": 3}},
+        {"topic": "OUTPUT", "key": 2, "value": {"COUNT": 1}},
+        {"topic": "OUTPUT", "key": 3, "value": {"COUNT": 1}},
+        {"topic": "OUTPUT", "key": 2, "value": {"COUNT": 2}},
+        {"topic": "OUTPUT", "key": 3, "value": {"COUNT": 2}},
+        {"topic": "OUTPUT", "key": 2, "value": {"COUNT": 3}}
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "schema": "NEW_KEY STRING KEY, COUNT BIGINT"}
+          {"name": "OUTPUT", "type": "table", "schema": "NEW_KEY INT KEY, COUNT BIGINT"}
         ]
       }
     },
     {
-      "name": "multiple expression and alias",
+      "name": "multiple expressions",
       "statements": [
-        "CREATE STREAM TEST (f1 INT KEY, f2 INT) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
-        "CREATE TABLE OUTPUT AS SELECT f2 + f1, COUNT(*) FROM TEST GROUP BY (f1, f2) AS NEW_KEY;"
+        "CREATE STREAM TEST (f1 INT KEY, f2 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT f2, f1, f2+f1, COUNT(*) FROM TEST GROUP BY f1, f2;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
       },
       "inputs": [
-        {"topic": "test_topic", "key": 1, "value": "2"},
-        {"topic": "test_topic", "key": 2, "value": "4"},
-        {"topic": "test_topic", "key": 1, "value": "2"},
-        {"topic": "test_topic", "key": 2, "value": "4"},
-        {"topic": "test_topic", "key": 2, "value": "1"}
+        {"topic": "test_topic", "key": 1, "value": {"f2": "2"}},
+        {"topic": "test_topic", "key": 2, "value": {"f2": "4"}},
+        {"topic": "test_topic", "key": 1, "value": {"f2": "2"}},
+        {"topic": "test_topic", "key": 2, "value": {"f2": "4"}},
+        {"topic": "test_topic", "key": 2, "value": {"f2": "1"}}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": "1|+|2", "value": "3,1"},
-        {"topic": "OUTPUT", "key": "2|+|4", "value": "6,1"},
-        {"topic": "OUTPUT", "key": "1|+|2", "value": "3,2"},
-        {"topic": "OUTPUT", "key": "2|+|4", "value": "6,2"},
-        {"topic": "OUTPUT", "key": "2|+|1", "value": "3,1"}
-      ],
-      "post": {
-        "sources": [
-          {"name": "OUTPUT", "type": "table", "schema": "NEW_KEY STRING KEY, KSQL_COL_0 INT, KSQL_COL_1 BIGINT"}
-        ]
-      }
-    },
-    {
-      "name": "with alias that clashes with projection",
-      "statements": [
-        "CREATE STREAM TEST (ID INT KEY, data STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE TABLE OUTPUT AS SELECT COUNT(*) AS COUNT FROM TEST GROUP BY DATA AS COUNT;"
-      ],
-      "properties": {
-        "ksql.any.key.name.enabled": true
-      },
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Value column name(s) `COUNT` clashes with key column name(s)"
-      }
-    },
-    {
-      "name": "multiple used in expression in projection",
-      "statements": [
-        "CREATE STREAM TEST (f1 INT KEY, f2 INT) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
-        "CREATE TABLE OUTPUT AS SELECT f2 + f1, COUNT(*) FROM TEST GROUP BY f1, f2;"
-      ],
-      "properties": {
-        "ksql.any.key.name.enabled": true
-      },
-      "inputs": [
-        {"topic": "test_topic", "key": 1, "value": "2"},
-        {"topic": "test_topic", "key": 2, "value": "4"},
-        {"topic": "test_topic", "key": 1, "value": "2"},
-        {"topic": "test_topic", "key": 2, "value": "4"},
-        {"topic": "test_topic", "key": 2, "value": "1"}
-      ],
-      "outputs": [
-        {"topic": "OUTPUT", "key": "1|+|2", "value": "3,1"},
-        {"topic": "OUTPUT", "key": "2|+|4", "value": "6,1"},
-        {"topic": "OUTPUT", "key": "1|+|2", "value": "3,2"},
-        {"topic": "OUTPUT", "key": "2|+|4", "value": "6,2"},
-        {"topic": "OUTPUT", "key": "2|+|1", "value": "3,1"}
+        {"topic": "OUTPUT", "key": "1|+|2", "value": {"KSQL_COL_0": 3, "KSQL_COL_1": 1}},
+        {"topic": "OUTPUT", "key": "2|+|4", "value": {"KSQL_COL_0": 6, "KSQL_COL_1": 1}},
+        {"topic": "OUTPUT", "key": "1|+|2", "value": {"KSQL_COL_0": 3, "KSQL_COL_1": 2}},
+        {"topic": "OUTPUT", "key": "2|+|4", "value": {"KSQL_COL_0": 6, "KSQL_COL_1": 2}},
+        {"topic": "OUTPUT", "key": "2|+|1", "value": {"KSQL_COL_0": 3, "KSQL_COL_1": 1}}
       ],
       "post": {
         "sources": [
@@ -268,10 +342,138 @@
       }
     },
     {
+      "name": "single expression - key in projection more than once",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT KEY, NAME STRING) WITH (kafka_topic='input',value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT NAME, NAME AS NAME2, COUNT(1) FROM INPUT GROUP BY NAME;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The projection contains a key column more than once: `NAME` and `NAME2`."
+      }
+    },
+    {
+      "name": "single expression - key missing from projection - with other column of same name",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT KEY, NAME STRING) WITH (kafka_topic='input',value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT COUNT(1) AS NAME FROM INPUT GROUP BY NAME;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The query used to build `OUTPUT` must include the grouping expression NAME in its projection."
+      }
+    },
+    {
+      "name": "single expression - key missing from projection",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT KEY, NAME STRING) WITH (kafka_topic='input',value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT COUNT(1) FROM INPUT GROUP BY NAME;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The query used to build `OUTPUT` must include the grouping expression NAME in its projection."
+      }
+    },
+    {
+      "name": "multiple expressions - single key missing from projection",
+      "statements": [
+        "CREATE STREAM TEST (f1 INT KEY, f2 INT) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "CREATE TABLE OUTPUT AS SELECT f2, COUNT(*) FROM TEST GROUP BY f1, f2;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The query used to build `OUTPUT` must include the grouping expression F1 in its projection."
+      }
+    },
+    {
+      "name": "multiple expression - key in projection more than once",
+      "statements": [
+        "CREATE STREAM TEST (f1 INT KEY, f2 INT) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "CREATE TABLE OUTPUT AS SELECT f1, f2, f1 AS F3, COUNT(*) FROM TEST GROUP BY f1, f2;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The projection contains a key column more than once: `F1` and `F3`."
+      }
+    },
+    {
+      "name": "multiple expressions - all keys missing from projection",
+      "statements": [
+        "CREATE STREAM TEST (f1 INT KEY, f2 INT, f3 INT) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "CREATE TABLE OUTPUT AS SELECT COUNT(*) FROM TEST GROUP BY f1, f2, f3;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The query used to build `OUTPUT` must include the grouping expressions F1, F2 and F3 in its projection."
+      }
+    },
+    {
+      "name": "select * where all columns in group by",
+      "statements": [
+        "CREATE STREAM TEST (id INT KEY, id2 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT *, COUNT() FROM TEST GROUP BY id, id2;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": {"ID2": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "1|+|2", "value": {"KSQL_COL_0": 1}}
+      ]
+    },
+    {
+      "name": "select * where not all columns in group by",
+      "statements": [
+        "CREATE STREAM TEST (id INT KEY, id2 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT *, COUNT() FROM TEST GROUP BY id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Non-aggregate SELECT expression(s) not part of GROUP BY: ID2"
+      }
+    },
+    {
+      "name": "with key alias that clashes with value alias",
+      "statements": [
+        "CREATE STREAM TEST (ID INT KEY, data STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT DATA AS COUNT, COUNT(*) AS COUNT FROM TEST GROUP BY DATA;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Duplicate values found in schema: `COUNT` BIGINT"
+      }
+    },
+    {
       "name": "complex UDAF params",
       "statements": [
         "CREATE STREAM TEST (V0 INT KEY, V1 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE TABLE OUTPUT AS SELECT SUM(V0 + V1) AS SUM FROM TEST GROUP BY V0, V1;"
+        "CREATE TABLE OUTPUT AS SELECT V0, V1, SUM(V0 + V1) AS SUM FROM TEST GROUP BY V0, V1;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -302,7 +504,7 @@
       "name": "complex UDAF params matching GROUP BY",
       "statements": [
         "CREATE STREAM TEST (V0 INT KEY, V1 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE TABLE OUTPUT AS SELECT SUM(V0 + V1) AS SUM FROM TEST GROUP BY V0 + V1;"
+        "CREATE TABLE OUTPUT AS SELECT (V0 + V1) AS NEW_KEY, SUM(V0 + V1) AS SUM FROM TEST GROUP BY V0 + V1;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -325,7 +527,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "schema": "KSQL_COL_0 INT KEY, SUM INT"}
+          {"name": "OUTPUT", "type": "table", "schema": "NEW_KEY INT KEY, SUM INT"}
         ]
       }
     },
@@ -333,7 +535,7 @@
       "name": "complex UDAF params matching HAVING",
       "statements": [
         "CREATE STREAM TEST (V0 INT KEY, V1 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE TABLE OUTPUT AS SELECT SUM(V0 + V1) AS SUM FROM TEST GROUP BY V0, V1 HAVING V0 + V1 <= 20;"
+        "CREATE TABLE OUTPUT AS SELECT SUM(V0 + V1) AS SUM, V0, V1 FROM TEST GROUP BY V0, V1 HAVING V0 + V1 <= 20;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -365,7 +567,7 @@
       "comment": "bad_udf return every other invocation - tables need a PRIMARY key so null keys are dropped",
       "statements": [
         "CREATE STREAM TEST (ID INT KEY, data STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE TABLE OUTPUT AS SELECT COUNT(*) FROM TEST GROUP BY bad_udf(DATA);"
+        "CREATE TABLE OUTPUT AS SELECT bad_udf(DATA), COUNT(*) FROM TEST GROUP BY bad_udf(DATA);"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -378,12 +580,12 @@
         {"topic": "test_topic", "key": 4, "value": {"data": "d1"}}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": "d2", "value": {"KSQL_COL_0": 1}},
-        {"topic": "OUTPUT", "key": "d2", "value": {"KSQL_COL_0": 2}}
+        {"topic": "OUTPUT", "key": "d2", "value": {"KSQL_COL_1": 1}},
+        {"topic": "OUTPUT", "key": "d2", "value": {"KSQL_COL_1": 2}}
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "schema": "KSQL_COL_1 STRING KEY, KSQL_COL_0 BIGINT"}
+          {"name": "OUTPUT", "type": "table", "schema": "KSQL_COL_0 STRING KEY, KSQL_COL_1 BIGINT"}
         ]
       }
     },
@@ -403,10 +605,10 @@
     },
     {
       "name": "multiple expressions with nulls",
-      "comment": "bad_udf return every other invocation - tables need a PRIMARY key so null keys are dropped",
+      "comment": "bad_udf returns null every other invocation - tables need a PRIMARY key so null keys are dropped",
       "statements": [
         "CREATE STREAM TEST (ID INT KEY, data STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE TABLE OUTPUT AS SELECT COUNT(*) FROM TEST GROUP BY bad_udf(DATA);"
+        "CREATE TABLE OUTPUT AS SELECT bad_udf(DATA), COUNT(*) FROM TEST GROUP BY bad_udf(DATA);"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -419,12 +621,12 @@
         {"topic": "test_topic", "key": 4, "value": {"data": "d1"}}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": "d2", "value": {"KSQL_COL_0": 1}},
-        {"topic": "OUTPUT", "key": "d2", "value": {"KSQL_COL_0": 2}}
+        {"topic": "OUTPUT", "key": "d2", "value": {"KSQL_COL_1": 1}},
+        {"topic": "OUTPUT", "key": "d2", "value": {"KSQL_COL_1": 2}}
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "schema": "KSQL_COL_1 STRING KEY, KSQL_COL_0 BIGINT"}
+          {"name": "OUTPUT", "type": "table", "schema": "KSQL_COL_0 STRING KEY, KSQL_COL_1 BIGINT"}
         ]
       }
     },
@@ -1890,7 +2092,7 @@
       "name": "should handled quoted key and value",
       "statements": [
         "CREATE STREAM INPUT (`Key` STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE TABLE OUTPUT AS SELECT COUNT(1) AS `Value` FROM INPUT GROUP BY `Key`;"
+        "CREATE TABLE OUTPUT AS SELECT `Key`, COUNT(1) AS `Value` FROM INPUT GROUP BY `Key`;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/joinkey.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/joinkey.json
@@ -80,26 +80,28 @@
     {
       "name": "multi-join",
       "statements": [
-        "CREATE TABLE L (ID INT PRIMARY KEY, V0 INT, V1 INT) WITH (kafka_topic='left_topic', value_format='JSON');",
-        "CREATE TABLE R (ID INT PRIMARY KEY, V0 INT, V1 INT) WITH (kafka_topic='right_topic', value_format='JSON');",
-        "CREATE TABLE OUTPUT as SELECT JOINKEY(L.ID, R.ID) AS ID, L.ID, R.ID, L.V0, R.V1 FROM L FULL OUTER JOIN R ON L.id = R.id;"
+        "CREATE TABLE T1 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
+        "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
+        "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
+        "CREATE TABLE OUTPUT as SELECT JOINKEY(T1.ID, T3.ID) AS ID, T1.V0, T2.V0, T3.V0 FROM T1 JOIN T2 ON T1.ID = T2.ID FULL JOIN T3 ON T1.ID = T3.ID;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
       },
       "inputs": [
-        {"topic": "left_topic", "key": 1, "value": {"V0": 2, "V1": 3}, "timestamp": 0},
-        {"topic": "right_topic", "key": 1, "value": {"V0": 4, "V1": 5}, "timestamp": 100},
-        {"topic": "right_topic", "key": 2, "value": {"V0": 6, "V1": 7}, "timestamp": 200}
+        {"topic": "left", "key": 0, "value": {"V0": 1}, "timestamp": 0},
+        {"topic": "right2", "key": 0, "value": {"V0": 3}, "timestamp": 2},
+        {"topic": "right", "key": 0, "value": {"V0": 2}, "timestamp": 3},
+        {"topic": "left", "key": 0, "value": {"V0": 4}, "timestamp": 1000}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 1, "value": {"L_ID": 1, "R_ID": null, "L_V0": 2, "R_V1": null}, "timestamp": 0},
-        {"topic": "OUTPUT", "key": 1, "value": {"L_ID": 1, "R_ID": 1, "L_V0": 2, "R_V1": 5}, "timestamp": 100},
-        {"topic": "OUTPUT", "key": 2, "value": {"L_ID": null, "R_ID": 2, "L_V0": null, "R_V1": 7}, "timestamp": 200}
+        {"topic": "OUTPUT", "key": 0, "value": {"T1_V0": null, "T2_V0": null, "T3_V0": 3}, "timestamp": 2},
+        {"topic": "OUTPUT", "key": 0, "value": {"T1_V0": 1, "T2_V0": 2, "T3_V0": 3}, "timestamp": 3},
+        {"topic": "OUTPUT", "key": 0, "value": {"T1_V0": 4, "T2_V0": 2, "T3_V0": 3}, "timestamp": 1000}
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "schema": "ID INT KEY, L_ID INT, R_ID INT, L_V0 INT, R_V1 INT"}
+          {"name": "OUTPUT", "type": "table", "schema": "ID INT PRIMARY KEY, T1_V0 BIGINT, T2_V0 BIGINT, T3_V0 BIGINT"}
         ]
       }
     },

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/joinkey.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/joinkey.json
@@ -1,0 +1,262 @@
+{
+  "comments": [
+    "JOINKEY is a special UDF that is used to include, and alias, the synthetic column created by some joins.",
+    "If used elsewhere it works in the same way as COALESCE"
+  ],
+  "tests": [
+    {
+      "name": "inner join with synthetic key",
+      "statements": [
+        "CREATE STREAM L (ID INT KEY, V0 INT, V1 INT) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE STREAM R (ID INT KEY, V0 INT, V1 INT) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT JOINKEY(ABS(L.ID), ABS(R.ID)) AS ID, L.ID, R.ID, L.V0, R.V1 FROM L INNER JOIN R WITHIN 1 SECOND ON ABS(L.id) = ABS(R.id);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 1, "value": {"V0": 2, "V1": 3}, "timestamp": 0},
+        {"topic": "right_topic", "key": 1, "value": {"V0": 4, "V1": 5}, "timestamp": 100}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"L_ID": 1, "R_ID": 1, "L_V0": 2, "R_V1": 5}, "timestamp": 100}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, L_ID INT, R_ID INT, L_V0 INT, R_V1 INT"}
+        ]
+      }
+    },
+    {
+      "name": "left join with synthetic key",
+      "statements": [
+        "CREATE STREAM L (ID INT KEY, V0 INT, V1 INT) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE STREAM R (ID INT KEY, V0 INT, V1 INT) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT JOINKEY(ABS(L.ID), ABS(R.ID)) AS ID, L.ID, R.ID, L.V0, R.V1 FROM L LEFT JOIN R WITHIN 1 SECOND ON ABS(L.id) = ABS(R.id);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 1, "value": {"V0": 2, "V1": 3}, "timestamp": 0},
+        {"topic": "right_topic", "key": 1, "value": {"V0": 4, "V1": 5}, "timestamp": 100}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"L_ID": 1, "R_ID": null, "L_V0": 2, "R_V1": null}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 1, "value": {"L_ID": 1, "R_ID": 1, "L_V0": 2, "R_V1": 5}, "timestamp": 100}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, L_ID INT, R_ID INT, L_V0 INT, R_V1 INT"}
+        ]
+      }
+    },
+    {
+      "name": "outer join with synthetic key",
+      "statements": [
+        "CREATE TABLE L (ID INT PRIMARY KEY, V0 INT, V1 INT) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE TABLE R (ID INT PRIMARY KEY, V0 INT, V1 INT) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT as SELECT JOINKEY(L.ID, R.ID) AS ID, L.ID, R.ID, L.V0, R.V1 FROM L FULL OUTER JOIN R ON L.id = R.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 1, "value": {"V0": 2, "V1": 3}, "timestamp": 0},
+        {"topic": "right_topic", "key": 1, "value": {"V0": 4, "V1": 5}, "timestamp": 100},
+        {"topic": "right_topic", "key": 2, "value": {"V0": 6, "V1": 7}, "timestamp": 200}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"L_ID": 1, "R_ID": null, "L_V0": 2, "R_V1": null}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 1, "value": {"L_ID": 1, "R_ID": 1, "L_V0": 2, "R_V1": 5}, "timestamp": 100},
+        {"topic": "OUTPUT", "key": 2, "value": {"L_ID": null, "R_ID": 2, "L_V0": null, "R_V1": 7}, "timestamp": 200}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "schema": "ID INT KEY, L_ID INT, R_ID INT, L_V0 INT, R_V1 INT"}
+        ]
+      }
+    },
+    {
+      "name": "multi-join",
+      "statements": [
+        "CREATE TABLE L (ID INT PRIMARY KEY, V0 INT, V1 INT) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE TABLE R (ID INT PRIMARY KEY, V0 INT, V1 INT) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT as SELECT JOINKEY(L.ID, R.ID) AS ID, L.ID, R.ID, L.V0, R.V1 FROM L FULL OUTER JOIN R ON L.id = R.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 1, "value": {"V0": 2, "V1": 3}, "timestamp": 0},
+        {"topic": "right_topic", "key": 1, "value": {"V0": 4, "V1": 5}, "timestamp": 100},
+        {"topic": "right_topic", "key": 2, "value": {"V0": 6, "V1": 7}, "timestamp": 200}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"L_ID": 1, "R_ID": null, "L_V0": 2, "R_V1": null}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 1, "value": {"L_ID": 1, "R_ID": 1, "L_V0": 2, "R_V1": 5}, "timestamp": 100},
+        {"topic": "OUTPUT", "key": 2, "value": {"L_ID": null, "R_ID": 2, "L_V0": null, "R_V1": 7}, "timestamp": 200}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "schema": "ID INT KEY, L_ID INT, R_ID INT, L_V0 INT, R_V1 INT"}
+        ]
+      }
+    },
+    {
+      "name": "join without synthetic key",
+      "statements": [
+        "CREATE STREAM L (ID INT KEY, V0 INT, V1 INT) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE STREAM R (ID INT KEY, V0 INT, V1 INT) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT JOINKEY(L.ID, R.ID) AS ID, L.ID, R.ID, L.V0, R.V1 FROM L INNER JOIN R WITHIN 1 SECOND ON L.id = R.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 1, "value": {"V0": 2, "V1": 3}, "timestamp": 0},
+        {"topic": "right_topic", "key": 1, "value": {"V0": 4, "V1": 5}, "timestamp": 100}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"ID": 1, "R_ID": 1, "L_V0": 2, "R_V1": 5}, "timestamp": 100}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "L_ID INT KEY, ID INT, R_ID INT, L_V0 INT, R_V1 INT"}
+        ]
+      }
+    },
+    {
+      "name": "non-join",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT KEY, V0 INT, V1 INT) WITH (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT ID, JOINKEY(ID, V0), V1 FROM INPUT;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "input", "key": 1, "value": {"V0": 2, "V1": 3}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"KSQL_COL_0": 1, "V1": 3}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, KSQL_COL_0 INT, V1 INT"}
+        ]
+      }
+    },
+    {
+      "name": "without alias",
+      "statements": [
+        "CREATE TABLE L (ID INT PRIMARY KEY, V0 INT, V1 INT) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE TABLE R (ID INT PRIMARY KEY, V0 INT, V1 INT) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT as SELECT JOINKEY(L.ID, R.ID), L.ID, R.ID, L.V0, R.V1 FROM L FULL OUTER JOIN R on L.id = R.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 1, "value": {"V0": 2, "V1": 3}, "timestamp": 0},
+        {"topic": "right_topic", "key": 1, "value": {"V0": 4, "V1": 5}, "timestamp": 100}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"L_ID": 1, "R_ID": null, "L_V0": 2, "R_V1": null}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 1, "value": {"L_ID": 1, "R_ID": 1, "L_V0": 2, "R_V1": 5}, "timestamp": 100}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "schema": "KSQL_COL_0 INT KEY, L_ID INT, R_ID INT, L_V0 INT, R_V1 INT"}
+        ]
+      }
+    },
+    {
+      "name": "with generated column name clashes",
+      "statements": [
+        "CREATE TABLE L (KSQL_COL_0 INT PRIMARY KEY, KSQL_COL_1 INT, KSQL_COL_2 INT) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE TABLE R (KSQL_COL_3 INT PRIMARY KEY, KSQL_COL_4 INT, KSQL_COL_5 INT) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT as SELECT JOINKEY(L.KSQL_COL_0, R.KSQL_COL_3), L.KSQL_COL_0, R.KSQL_COL_3, L.KSQL_COL_1, R.KSQL_COL_5 FROM L FULL OUTER JOIN R on L.KSQL_COL_0 = R.KSQL_COL_3;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 1, "value": {"KSQL_COL_1": 2, "KSQL_COL_2": 3}, "timestamp": 0},
+        {"topic": "right_topic", "key": 1, "value": {"KSQL_COL_4": 4, "KSQL_COL_5": 5}, "timestamp": 100}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"KSQL_COL_0": 1, "KSQL_COL_3": null, "KSQL_COL_1": 2, "KSQL_COL_5": null}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 1, "value": {"KSQL_COL_0": 1, "KSQL_COL_3": 1, "KSQL_COL_1": 2, "KSQL_COL_5": 5}, "timestamp": 100}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "schema": "KSQL_COL_6 INT KEY, KSQL_COL_0 INT, KSQL_COL_3 INT, KSQL_COL_1 INT, KSQL_COL_5 INT"}
+        ]
+      }
+    },
+    {
+      "name": "with complex join criteria",
+      "statements": [
+        "CREATE STREAM L (ID INT KEY, V0 INT, V1 INT) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE STREAM R (ID INT KEY, V0 INT, V1 INT) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT JOINKEY(ABS(L.ID), ABS(R.ID)) AS ID, L.ID, R.ID, L.V0, R.V1 FROM L FULL OUTER JOIN R WITHIN 1 SECOND on ABS(R.id) = ABS(L.id);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 1, "value": {"V0": 2, "V1": 3}, "timestamp": 0},
+        {"topic": "right_topic", "key": 1, "value": {"V0": 4, "V1": 5}, "timestamp": 100}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"L_ID": 1, "R_ID": null, "L_V0": 2, "R_V1": null}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 1, "value": {"L_ID": 1, "R_ID": 1, "L_V0": 2, "R_V1": 5}, "timestamp": 100}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, L_ID INT, R_ID INT, L_V0 INT, R_V1 INT"}
+        ]
+      }
+    },
+    {
+      "name": "with flipped join criteria",
+      "statements": [
+        "CREATE TABLE L (ID INT PRIMARY KEY, V0 INT, V1 INT) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE TABLE R (ID INT PRIMARY KEY, V0 INT, V1 INT) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT as SELECT JOINKEY(L.ID, R.ID) AS ID, L.ID, R.ID, L.V0, R.V1 FROM L FULL OUTER JOIN R on R.id = L.id;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "left_topic", "key": 1, "value": {"V0": 2, "V1": 3}, "timestamp": 0},
+        {"topic": "right_topic", "key": 1, "value": {"V0": 4, "V1": 5}, "timestamp": 100}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"L_ID": 1, "R_ID": null, "L_V0": 2, "R_V1": null}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 1, "value": {"L_ID": 1, "R_ID": 1, "L_V0": 2, "R_V1": 5}, "timestamp": 100}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "schema": "ID INT KEY, L_ID INT, R_ID INT, L_V0 INT, R_V1 INT"}
+        ]
+      }
+    },
+    {
+      "name": "with wrong join key parameters",
+      "statements": [
+        "CREATE TABLE L (ID INT PRIMARY KEY, V0 INT, V1 INT) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE TABLE R (ID INT PRIMARY KEY, V0 INT, V1 INT) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT as SELECT JOINKEY(ABS(R.ID), ABS(L.ID)) AS ID, L.ID, R.ID, L.V0, R.V1 FROM L INNER JOIN R on ABS(L.id) = ABS(R.id);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The query used to build `OUTPUT` must include the join expression JOINKEY(ABS(L.ID), ABS(R.ID)) in its projection.\nJOINKEY(ABS(L.ID), ABS(R.ID)) was added as a synthetic key column because the join criteria did not match any source column."
+      }
+    }
+  ]
+}

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/joins.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/joins.json
@@ -15,11 +15,11 @@
         {"topic": "RIGHT", "key": 0, "value": {"B": -1, "C": -2}, "timestamp": 11}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"L_A": 0, "R_A": 0, "L_B": 1, "R_B": -1, "L_C": 2, "R_C": -2}, "timestamp":  11}
+        {"topic": "OUTPUT", "key": 0, "value": {"R_A": 0, "L_B": 1, "R_B": -1, "L_C": 2, "R_C": -2}, "timestamp":  11}
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "A INT KEY, L_A INT, L_B INT, L_C INT, R_A INT, R_B INT, R_C INT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "L_A INT KEY, L_B INT, L_C INT, R_A INT, R_B INT, R_C INT"}
         ],
         "topics": {
           "blacklist": ".*-repartition"
@@ -41,15 +41,369 @@
         {"topic": "RIGHT", "key": 0, "value": {"B": -1, "C": -2}, "timestamp": 11}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"L_A": 0, "R_A": 0, "L_B": 1, "R_B": -1, "L_C": 2, "R_C": -2}, "timestamp":  11}
+        {"topic": "OUTPUT", "key": 0, "value": {"R_A": 0, "L_B": 1, "R_B": -1, "L_C": 2, "R_C": -2}, "timestamp":  11}
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "A INT KEY, L_A INT, L_B INT, L_C INT, R_A INT, R_B INT, R_C INT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "L_A INT KEY, L_B INT, L_C INT, R_A INT, R_B INT, R_C INT"}
         ],
         "topics": {
           "blacklist": ".*-repartition"
         }
+      }
+    },
+    {
+      "name": "aliased join key",
+      "statements": [
+        "CREATE STREAM L (A INT KEY, B INT, C INT) WITH (kafka_topic='LEFT', value_format='JSON');",
+        "CREATE STREAM R (A INT KEY, B INT, C INT) WITH (kafka_topic='RIGHT', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT l.A AS A, l.B, l.C, r.* FROM L INNER JOIN R WITHIN 10 SECONDS ON L.A = R.A;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "LEFT", "key": 0, "value": {"B": 1, "C": 2}, "timestamp": 10},
+        {"topic": "RIGHT", "key": 0, "value": {"B": -1, "C": -2}, "timestamp": 11}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"L_B": 1, "L_C": 2, "R_A": 0, "R_B": -1, "R_C": -2}, "timestamp":  11}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "A INT KEY, L_B INT, L_C INT, R_A INT, R_B INT, R_C INT"}
+        ],
+        "topics": {
+          "blacklist": ".*-repartition"
+        }
+      }
+    },
+    {
+      "name": "aliased synthetic join key",
+      "statements": [
+        "CREATE STREAM L (A INT KEY, B INT, C INT) WITH (kafka_topic='LEFT', value_format='JSON');",
+        "CREATE STREAM R (A INT KEY, B INT, C INT) WITH (kafka_topic='RIGHT', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT JOINKEY(ABS(L.A), ABS(R.A)) AS A, l.B, l.C, r.* FROM L INNER JOIN R WITHIN 10 SECONDS ON ABS(L.A) = ABS(R.A);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "LEFT", "key": 0, "value": {"B": 1, "C": 2}, "timestamp": 10},
+        {"topic": "RIGHT", "key": 0, "value": {"B": -1, "C": -2}, "timestamp": 11}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"L_B": 1, "L_C": 2, "R_A": 0, "R_B": -1, "R_C": -2}, "timestamp":  11}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "A INT KEY, L_B INT, L_C INT, R_A INT, R_B INT, R_C INT"}
+        ]
+      }
+    },
+    {
+      "name": "inner join - with both join column in projection",
+      "statements": [
+        "CREATE STREAM L (A INT KEY, B INT, C INT) WITH (kafka_topic='LEFT', value_format='JSON');",
+        "CREATE STREAM R (A INT KEY, B INT, C INT) WITH (kafka_topic='RIGHT', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM L INNER JOIN R WITHIN 10 SECONDS ON L.A = R.A;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "LEFT", "key": 0, "value": {"B": 1, "C": 2}, "timestamp": 10},
+        {"topic": "RIGHT", "key": 0, "value": {"B": -1, "C": -2}, "timestamp": 11}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"L_B": 1, "L_C": 2, "R_A": 0, "R_B": -1, "R_C": -2}, "timestamp":  11}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "L_A INT KEY, L_B INT, L_C INT, R_A INT, R_B INT, R_C INT"}
+        ]
+      }
+    },
+    {
+      "name": "inner join - with left join column in projection",
+      "statements": [
+        "CREATE STREAM L (A INT KEY, B INT, C INT) WITH (kafka_topic='LEFT', value_format='JSON');",
+        "CREATE STREAM R (A INT KEY, B INT, C INT) WITH (kafka_topic='RIGHT', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT L.*, R.* FROM L INNER JOIN R WITHIN 10 SECONDS ON L.A = ABS(R.A);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "LEFT", "key": 0, "value": {"B": 1, "C": 2}, "timestamp": 10},
+        {"topic": "RIGHT", "key": 0, "value": {"B": -1, "C": -2}, "timestamp": 11}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"L_B": 1, "L_C": 2, "R_A": 0, "R_B": -1, "R_C": -2}, "timestamp":  11}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "L_A INT KEY, L_B INT, L_C INT, R_A INT, R_B INT, R_C INT"}
+        ]
+      }
+    },
+    {
+      "name": "inner join - with right join column in projection",
+      "statements": [
+        "CREATE STREAM L (A INT KEY, B INT, C INT) WITH (kafka_topic='LEFT', value_format='JSON');",
+        "CREATE STREAM R (A INT KEY, B INT, C INT) WITH (kafka_topic='RIGHT', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT L.*, R.* FROM L INNER JOIN R WITHIN 10 SECONDS ON ABS(L.A) = R.A;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "LEFT", "key": 0, "value": {"B": 1, "C": 2}, "timestamp": 10},
+        {"topic": "RIGHT", "key": 0, "value": {"B": -1, "C": -2}, "timestamp": 11}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"L_A": 0, "L_B": 1, "L_C": 2, "R_B": -1, "R_C": -2}, "timestamp":  11}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "R_A INT KEY, L_A INT, L_B INT, L_C INT, R_B INT, R_C INT"}
+        ]
+      }
+    },
+    {
+      "name": "inner join - with only right join column in projection",
+      "statements": [
+        "CREATE STREAM L (A INT KEY, B INT, C INT) WITH (kafka_topic='LEFT', value_format='JSON');",
+        "CREATE STREAM R (A INT KEY, B INT, C INT) WITH (kafka_topic='RIGHT', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT L.B, L.C, R.* FROM L INNER JOIN R WITHIN 10 SECONDS ON L.A = R.A;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "LEFT", "key": 0, "value": {"B": 1, "C": 2}, "timestamp": 10},
+        {"topic": "RIGHT", "key": 0, "value": {"B": -1, "C": -2}, "timestamp": 11}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"L_B": 1, "L_C": 2, "R_B": -1, "R_C": -2}, "timestamp":  11}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "R_A INT KEY, L_B INT, L_C INT, R_B INT, R_C INT"}
+        ]
+      }
+    },
+    {
+      "name": "inner join - missing join columns in projection",
+      "statements": [
+        "CREATE STREAM L (A INT KEY, B INT, C INT) WITH (kafka_topic='LEFT', value_format='JSON');",
+        "CREATE STREAM R (A INT KEY, B INT, C INT) WITH (kafka_topic='RIGHT', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT l.B, l.C, R.B, R.C FROM L INNER JOIN R WITHIN 10 SECONDS ON L.A = R.A;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The query used to build `OUTPUT` must include the join expressions L.A or R.A in its projection."
+      }
+    },
+    {
+      "name": "inner join - missing synthetic join column in projection",
+      "statements": [
+        "CREATE STREAM L (A INT KEY, B INT, C INT) WITH (kafka_topic='LEFT', value_format='JSON');",
+        "CREATE STREAM R (A INT KEY, B INT, C INT) WITH (kafka_topic='RIGHT', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT l.*, r.* FROM L INNER JOIN R WITHIN 10 SECONDS ON ABS(L.A) = ABS(R.A);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The query used to build `OUTPUT` must include the join expression JOINKEY(ABS(L.A), ABS(R.A)) in its projection.\nJOINKEY(ABS(L.A), ABS(R.A)) was added as a synthetic key column because the join criteria did not match any source column."
+      }
+    },
+    {
+      "name": "left join - with both join column in projection",
+      "statements": [
+        "CREATE STREAM L (A INT KEY, B INT, C INT) WITH (kafka_topic='LEFT', value_format='JSON');",
+        "CREATE STREAM R (A INT KEY, B INT, C INT) WITH (kafka_topic='RIGHT', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM L LEFT JOIN R WITHIN 10 SECONDS ON L.A = R.A;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "RIGHT", "key": 0, "value": {"B": -1, "C": -2}, "timestamp": 10},
+        {"topic": "LEFT", "key": 0, "value": {"B": 1, "C": 2}, "timestamp": 10}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"L_B": 1, "L_C": 2, "R_A": 0, "R_B": -1, "R_C": -2}, "timestamp":  10}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "L_A INT KEY, L_B INT, L_C INT, R_A INT, R_B INT, R_C INT"}
+        ]
+      }
+    },
+    {
+      "name": "left join - with left join column in projection",
+      "statements": [
+        "CREATE STREAM L (A INT KEY, B INT, C INT) WITH (kafka_topic='LEFT', value_format='JSON');",
+        "CREATE STREAM R (A INT KEY, B INT, C INT) WITH (kafka_topic='RIGHT', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT L.*, R.* FROM L LEFT JOIN R WITHIN 10 SECONDS ON L.A = ABS(R.A);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "RIGHT", "key": 0, "value": {"B": -1, "C": -2}, "timestamp": 10},
+        {"topic": "LEFT", "key": 0, "value": {"B": 1, "C": 2}, "timestamp": 10}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"L_B": 1, "L_C": 2, "R_A": 0, "R_B": -1, "R_C": -2}, "timestamp":  10}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "L_A INT KEY, L_B INT, L_C INT, R_A INT, R_B INT, R_C INT"}
+        ]
+      }
+    },
+    {
+      "name": "left join - with right join column in projection",
+      "statements": [
+        "CREATE STREAM L (A INT KEY, B INT, C INT) WITH (kafka_topic='LEFT', value_format='JSON');",
+        "CREATE STREAM R (A INT KEY, B INT, C INT) WITH (kafka_topic='RIGHT', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT L.*, R.* FROM L LEFT JOIN R WITHIN 10 SECONDS ON ABS(L.A) = R.A;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "RIGHT", "key": 0, "value": {"B": -1, "C": -2}, "timestamp": 10},
+        {"topic": "LEFT", "key": 0, "value": {"B": 1, "C": 2}, "timestamp": 10}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"L_A": 0, "L_B": 1, "L_C": 2, "R_B": -1, "R_C": -2}, "timestamp":  10}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "R_A INT KEY, L_A INT, L_B INT, L_C INT, R_B INT, R_C INT"}
+        ]
+      }
+    },
+    {
+      "name": "left join - missing join columns in projection",
+      "statements": [
+        "CREATE STREAM L (A INT KEY, B INT, C INT) WITH (kafka_topic='LEFT', value_format='JSON');",
+        "CREATE STREAM R (A INT KEY, B INT, C INT) WITH (kafka_topic='RIGHT', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT l.B, l.C, r.B, r.C FROM L LEFT JOIN R WITHIN 10 SECONDS ON L.A = R.A;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The query used to build `OUTPUT` must include the join expressions L.A or R.A in its projection."
+      }
+    },
+    {
+      "name": "left join - missing join columns in projection - with star",
+      "statements": [
+        "CREATE STREAM L (A INT KEY, B INT, C INT) WITH (kafka_topic='LEFT', value_format='JSON');",
+        "CREATE STREAM R (A INT KEY, B INT, C INT) WITH (kafka_topic='RIGHT', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT l.*, r.B, r.C FROM L LEFT JOIN R WITHIN 10 SECONDS ON ABS(L.A) = R.A;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The query used to build `OUTPUT` must include the join expression R.A in its projection."
+      }
+    },
+    {
+      "name": "left join - missing synthetic join column in projection",
+      "statements": [
+        "CREATE STREAM L (A INT KEY, B INT, C INT) WITH (kafka_topic='LEFT', value_format='JSON');",
+        "CREATE STREAM R (A INT KEY, B INT, C INT) WITH (kafka_topic='RIGHT', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT l.*, r.* FROM L LEFT JOIN R WITHIN 10 SECONDS ON ABS(L.A) = ABS(R.A);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The query used to build `OUTPUT` must include the join expression JOINKEY(ABS(L.A), ABS(R.A)) in its projection.\nJOINKEY(ABS(L.A), ABS(R.A)) was added as a synthetic key column because the join criteria did not match any source column."
+      }
+    },
+    {
+      "name": "full join - with both join column in projection",
+      "statements": [
+        "CREATE STREAM L (A INT KEY, B INT, C INT) WITH (kafka_topic='LEFT', value_format='JSON');",
+        "CREATE STREAM R (A INT KEY, B INT, C INT) WITH (kafka_topic='RIGHT', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM L FULL OUTER JOIN R WITHIN 10 SECONDS ON L.A = R.A;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "RIGHT", "key": 0, "value": {"B": -1, "C": -2}, "timestamp": 9},
+        {"topic": "LEFT", "key": 0, "value": {"B": 1, "C": 2}, "timestamp": 10}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"L_A": null, "L_B": null, "L_C": null, "R_A": 0, "R_B": -1, "R_C": -2}, "timestamp": 9},
+        {"topic": "OUTPUT", "key": 0, "value": {"L_A": 0, "L_B": 1, "L_C": 2, "R_A": 0, "R_B": -1, "R_C": -2}, "timestamp": 10}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "KSQL_COL_0 INT KEY, L_A INT, L_B INT, L_C INT, R_A INT, R_B INT, R_C INT"}
+        ]
+      }
+    },
+    {
+      "name": "full join - missing synthetic join column in projection",
+      "statements": [
+        "CREATE STREAM L (A INT KEY, B INT, C INT) WITH (kafka_topic='LEFT', value_format='JSON');",
+        "CREATE STREAM R (A INT KEY, B INT, C INT) WITH (kafka_topic='RIGHT', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT l.B, l.C, r.* FROM L FULL OUTER JOIN R WITHIN 10 SECONDS ON L.A = R.A;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The query used to build `OUTPUT` must include the join expression JOINKEY(L.A, R.A) in its projection.\nJOINKEY(L.A, R.A) was added as a synthetic key column because the join criteria did not match any source column."
+      }
+    },
+    {
+      "name": "missing join columns in projection - with value column of same name",
+      "statements": [
+        "CREATE STREAM L (A INT KEY, B INT, C INT) WITH (kafka_topic='LEFT', value_format='JSON');",
+        "CREATE STREAM R (A INT KEY, B INT, C INT) WITH (kafka_topic='RIGHT', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT l.B AS L_A, l.C, R.B AS R_A, R.C FROM L JOIN R WITHIN 10 SECONDS ON L.A = R.A;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The query used to build `OUTPUT` must include the join expressions L.A or R.A in its projection."
+      }
+    },
+    {
+      "name": "key in projection more than once",
+      "statements": [
+        "CREATE STREAM L (A INT KEY, B INT, C INT) WITH (kafka_topic='LEFT', value_format='JSON');",
+        "CREATE STREAM R (A INT KEY, B INT, C INT) WITH (kafka_topic='RIGHT', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT l.A, l.A AS KEY2, l.C, R.C FROM L JOIN R WITHIN 10 SECONDS ON L.A = R.A;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The projection contains the key column more than once: `L_A` and `KEY2`."
       }
     },
     {
@@ -58,7 +412,7 @@
       "statements": [
         "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
         "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
-        "CREATE STREAM LEFT_OUTER_JOIN as SELECT name, value, f1, f2 FROM test t left join TEST_STREAM tt WITHIN 11 seconds ON t.id = tt.id;"
+        "CREATE STREAM OUTPUT as SELECT t.id, name, value, f1, f2 FROM test t left join TEST_STREAM tt WITHIN 11 seconds ON t.id = tt.id;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -74,25 +428,25 @@
         {"topic": "left_topic", "key": 0, "value": {"NAME": "bar", "VALUE": 99}, "timestamp": 30000}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 0, "end": 11000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 0, "T_ID": 0, "T_NAME": "zero", "T_VALUE": 0}, "timestamp": 0},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000009-store-changelog", "window": {"start": 10000, "end": 21000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 10000, "TT_ID": 0, "TT_F1": "blah", "TT_F2": 50}, "timestamp": 10000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 11000, "end": 22000, "type": "time"}, "key": 10, "value": {"T_ROWTIME": 11000, "T_ID": 10, "T_NAME": "100", "T_VALUE": 5}, "timestamp": 11000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 13000, "end": 24000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 13000, "T_ID": 0, "T_NAME": "foo", "T_VALUE": 100}, "timestamp": 13000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000009-store-changelog", "window": {"start": 15000, "end": 26000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 15000, "TT_ID": 0, "TT_F1": "a", "TT_F2": 10}, "timestamp": 15000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000009-store-changelog", "window": {"start": 16000, "end": 27000, "type": "time"}, "key": 100, "value": {"TT_ROWTIME": 16000, "TT_ID": 100, "TT_F1": "newblah", "TT_F2": 150}, "timestamp": 16000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 17000, "end": 28000, "type": "time"}, "key": 90, "value": {"T_ROWTIME": 17000, "T_ID": 90, "T_NAME": "ninety", "T_VALUE": 90}, "timestamp": 17000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 30000, "end": 41000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 30000, "T_ID": 0, "T_NAME": "bar", "T_VALUE": 99}, "timestamp": 30000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": null, "F2": null}, "timestamp": 0},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 10, "value": {"NAME": "100", "VALUE": 5, "F1": null, "F2": null}, "timestamp": 11000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 90, "value": {"NAME": "ninety", "VALUE": 90, "F1": null, "F2": null}, "timestamp": 17000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"NAME": "bar", "VALUE": 99, "F1": null, "F2": null}, "timestamp": 30000}
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 0, "end": 11000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 0, "T_ID": 0, "T_NAME": "zero", "T_VALUE": 0}, "timestamp": 0},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-OUTEROTHER-0000000009-store-changelog", "window": {"start": 10000, "end": 21000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 10000, "TT_ID": 0, "TT_F1": "blah", "TT_F2": 50}, "timestamp": 10000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 11000, "end": 22000, "type": "time"}, "key": 10, "value": {"T_ROWTIME": 11000, "T_ID": 10, "T_NAME": "100", "T_VALUE": 5}, "timestamp": 11000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 13000, "end": 24000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 13000, "T_ID": 0, "T_NAME": "foo", "T_VALUE": 100}, "timestamp": 13000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-OUTEROTHER-0000000009-store-changelog", "window": {"start": 15000, "end": 26000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 15000, "TT_ID": 0, "TT_F1": "a", "TT_F2": 10}, "timestamp": 15000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-OUTEROTHER-0000000009-store-changelog", "window": {"start": 16000, "end": 27000, "type": "time"}, "key": 100, "value": {"TT_ROWTIME": 16000, "TT_ID": 100, "TT_F1": "newblah", "TT_F2": 150}, "timestamp": 16000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 17000, "end": 28000, "type": "time"}, "key": 90, "value": {"T_ROWTIME": 17000, "T_ID": 90, "T_NAME": "ninety", "T_VALUE": 90}, "timestamp": 17000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 30000, "end": 41000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 30000, "T_ID": 0, "T_NAME": "bar", "T_VALUE": 99}, "timestamp": 30000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": null, "F2": null}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "OUTPUT", "key": 10, "value": {"NAME": "100", "VALUE": 5, "F1": null, "F2": null}, "timestamp": 11000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "OUTPUT", "key": 90, "value": {"NAME": "ninety", "VALUE": 90, "F1": null, "F2": null}, "timestamp": 17000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "bar", "VALUE": 99, "F1": null, "F2": null}, "timestamp": 30000}
       ],
       "post": {
         "sources": [
-          {"name": "LEFT_OUTER_JOIN", "type": "stream", "schema": "ID BIGINT KEY, NAME STRING, VALUE BIGINT, F1 STRING, F2 BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "T_ID BIGINT KEY, NAME STRING, VALUE BIGINT, F1 STRING, F2 BIGINT"}
         ]
       }
     },
@@ -102,7 +456,7 @@
       "statements": [
         "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
         "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
-        "CREATE STREAM LEFT_OUTER_JOIN as SELECT name, value, f1, f2 FROM test t left join TEST_STREAM tt WITHIN 11 seconds ON t.id = tt.id;"
+        "CREATE STREAM OUTPUT as SELECT t.id, name, value, f1, f2 FROM test t left join TEST_STREAM tt WITHIN 11 seconds ON t.id = tt.id;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -118,25 +472,25 @@
         {"topic": "left_topic", "key": 0, "value": {"NAME": "bar", "VALUE": 99}, "timestamp": 30000}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 0, "end": 11000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 0, "T_ID": 0, "T_NAME": "zero", "T_VALUE": 0}, "timestamp": 0},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000009-store-changelog", "window": {"start": 10000, "end": 21000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 10000, "TT_ID": 0, "TT_F1": "blah", "TT_F2": 50}, "timestamp": 10000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 11000, "end": 22000, "type": "time"}, "key": 10, "value": {"T_ROWTIME": 11000, "T_ID": 10, "T_NAME": "100", "T_VALUE": 5}, "timestamp": 11000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 13000, "end": 24000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 13000, "T_ID": 0, "T_NAME": "foo", "T_VALUE": 100}, "timestamp": 13000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000009-store-changelog", "window": {"start": 15000, "end": 26000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 15000, "TT_ID": 0, "TT_F1": "a", "TT_F2": 10}, "timestamp": 15000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000009-store-changelog", "window": {"start": 16000, "end": 27000, "type": "time"}, "key": 100, "value": {"TT_ROWTIME": 16000, "TT_ID": 100, "TT_F1": "newblah", "TT_F2": 150}, "timestamp": 16000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 17000, "end": 28000, "type": "time"}, "key": 90, "value": {"T_ROWTIME": 17000, "T_ID": 90, "T_NAME": "ninety", "T_VALUE": 90}, "timestamp": 17000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 30000, "end": 41000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 30000, "T_ID": 0, "T_NAME": "bar", "T_VALUE": 99}, "timestamp": 30000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": "", "F2": 0}, "timestamp": 0},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 10, "value": {"NAME": "100", "VALUE": 5, "F1": "", "F2": 0}, "timestamp": 11000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 90, "value": {"NAME": "ninety", "VALUE": 90, "F1": "", "F2": 0}, "timestamp": 17000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"NAME": "bar", "VALUE": 99, "F1": "", "F2": 0}, "timestamp": 30000}
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 0, "end": 11000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 0, "T_ID": 0, "T_NAME": "zero", "T_VALUE": 0}, "timestamp": 0},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-OUTEROTHER-0000000009-store-changelog", "window": {"start": 10000, "end": 21000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 10000, "TT_ID": 0, "TT_F1": "blah", "TT_F2": 50}, "timestamp": 10000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 11000, "end": 22000, "type": "time"}, "key": 10, "value": {"T_ROWTIME": 11000, "T_ID": 10, "T_NAME": "100", "T_VALUE": 5}, "timestamp": 11000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 13000, "end": 24000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 13000, "T_ID": 0, "T_NAME": "foo", "T_VALUE": 100}, "timestamp": 13000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-OUTEROTHER-0000000009-store-changelog", "window": {"start": 15000, "end": 26000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 15000, "TT_ID": 0, "TT_F1": "a", "TT_F2": 10}, "timestamp": 15000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-OUTEROTHER-0000000009-store-changelog", "window": {"start": 16000, "end": 27000, "type": "time"}, "key": 100, "value": {"TT_ROWTIME": 16000, "TT_ID": 100, "TT_F1": "newblah", "TT_F2": 150}, "timestamp": 16000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 17000, "end": 28000, "type": "time"}, "key": 90, "value": {"T_ROWTIME": 17000, "T_ID": 90, "T_NAME": "ninety", "T_VALUE": 90}, "timestamp": 17000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 30000, "end": 41000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 30000, "T_ID": 0, "T_NAME": "bar", "T_VALUE": 99}, "timestamp": 30000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": "", "F2": 0}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "OUTPUT", "key": 10, "value": {"NAME": "100", "VALUE": 5, "F1": "", "F2": 0}, "timestamp": 11000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "OUTPUT", "key": 90, "value": {"NAME": "ninety", "VALUE": 90, "F1": "", "F2": 0}, "timestamp": 17000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "bar", "VALUE": 99, "F1": "", "F2": 0}, "timestamp": 30000}
       ],
       "post": {
         "sources": [
-          {"name": "LEFT_OUTER_JOIN", "type": "stream", "schema": "ID BIGINT KEY, NAME STRING, VALUE BIGINT, F1 STRING, F2 BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "T_ID BIGINT KEY, NAME STRING, VALUE BIGINT, F1 STRING, F2 BIGINT"}
         ]
       }
     },
@@ -161,7 +515,7 @@
       "statements": [
         "CREATE STREAM TEST (K STRING KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
         "CREATE STREAM TEST_STREAM (K STRING KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
-        "CREATE STREAM LEFT_OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t left join TEST_STREAM tt WITHIN 11 seconds ON t.id = tt.id;"
+        "CREATE STREAM OUTPUT as SELECT t.id, name, value, f1, f2 FROM test t left join TEST_STREAM tt WITHIN 11 seconds ON t.id = tt.id;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -177,17 +531,17 @@
         {"topic": "left_topic", "key": "foo", "value": {"ID": 0, "NAME": "bar", "VALUE": 99}, "timestamp": 30000}
       ],
       "outputs": [
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": null, "F2": null}, "timestamp": 0},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 10, "value": {"T_ID": 10, "NAME": "100", "VALUE": 5, "F1": null, "F2": null}, "timestamp": 11000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 90, "value": {"T_ID": 90, "NAME": "ninety", "VALUE": 90, "F1": null, "F2": null}, "timestamp": 17000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": null, "F2": null}, "timestamp": 30000}
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": null, "F2": null}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "OUTPUT", "key": 10, "value": {"NAME": "100", "VALUE": 5, "F1": null, "F2": null}, "timestamp": 11000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "OUTPUT", "key": 90, "value": {"NAME": "ninety", "VALUE": 90, "F1": null, "F2": null}, "timestamp": 17000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "bar", "VALUE": 99, "F1": null, "F2": null}, "timestamp": 30000}
       ],
       "post": {
         "sources": [
-          {"name": "LEFT_OUTER_JOIN", "type": "stream", "schema": "ID BIGINT KEY, T_ID BIGINT, NAME STRING, VALUE BIGINT, F1 STRING, F2 BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "T_ID BIGINT KEY, NAME STRING, VALUE BIGINT, F1 STRING, F2 BIGINT"}
         ]
       }
     },
@@ -197,7 +551,7 @@
       "statements": [
         "CREATE STREAM TEST (K STRING KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
         "CREATE STREAM TEST_STREAM (K STRING KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
-        "CREATE STREAM LEFT_OUTER_JOIN as SELECT t.id, t.k, name, value, f1, f2 FROM test t left join TEST_STREAM tt WITHIN 11 seconds ON t.id = tt.id;"
+        "CREATE STREAM OUTPUT as SELECT t.id, t.k, name, value, f1, f2 FROM test t left join TEST_STREAM tt WITHIN 11 seconds ON t.id = tt.id;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -213,17 +567,17 @@
         {"topic": "left_topic", "key": "foo", "value": {"ID": 0, "NAME": "bar", "VALUE": 99}, "timestamp": 30000}
       ],
       "outputs": [
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "T_K": "foo","NAME": "zero", "VALUE": 0, "F1": "", "F2": 0}, "timestamp": 0},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "T_K": "foo", "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 10, "value": {"T_ID": 10, "T_K": "foo", "NAME": "100", "VALUE": 5, "F1": "", "F2": 0}, "timestamp": 11000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "T_K": "foo", "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "T_K": "foo", "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 90, "value": {"T_ID": 90, "T_K": "foo", "NAME": "ninety", "VALUE": 90, "F1": "", "F2": 0}, "timestamp": 17000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "T_K": "foo", "NAME": "bar", "VALUE": 99, "F1": "", "F2": 0}, "timestamp": 30000}
+        {"topic": "OUTPUT", "key": 0, "value": {"T_K": "foo","NAME": "zero", "VALUE": 0, "F1": "", "F2": 0}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 0, "value": {"T_K": "foo", "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "OUTPUT", "key": 10, "value": {"T_K": "foo", "NAME": "100", "VALUE": 5, "F1": "", "F2": 0}, "timestamp": 11000},
+        {"topic": "OUTPUT", "key": 0, "value": {"T_K": "foo", "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "OUTPUT", "key": 0, "value": {"T_K": "foo", "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "OUTPUT", "key": 90, "value": {"T_K": "foo", "NAME": "ninety", "VALUE": 90, "F1": "", "F2": 0}, "timestamp": 17000},
+        {"topic": "OUTPUT", "key": 0, "value": {"T_K": "foo", "NAME": "bar", "VALUE": 99, "F1": "", "F2": 0}, "timestamp": 30000}
       ],
       "post": {
         "sources": [
-          {"name": "LEFT_OUTER_JOIN", "type": "stream", "schema": "ID BIGINT KEY, T_ID BIGINT, T_K STRING, NAME STRING, VALUE BIGINT, F1 STRING, F2 BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "T_ID BIGINT KEY, T_K STRING, NAME STRING, VALUE BIGINT, F1 STRING, F2 BIGINT"}
         ]
       }
     },
@@ -233,7 +587,7 @@
       "statements": [
         "CREATE STREAM TEST (K STRING KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
         "CREATE STREAM TEST_STREAM (K STRING KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
-        "CREATE STREAM LEFT_OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t left join TEST_STREAM tt WITHIN 11 seconds ON t.id = tt.id;"
+        "CREATE STREAM OUTPUT as SELECT t.id, name, value, f1, f2 FROM test t left join TEST_STREAM tt WITHIN 11 seconds ON t.id = tt.id;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -249,33 +603,33 @@
         {"topic": "left_topic", "value": {"ID": 0, "NAME": "bar", "VALUE": 99}, "timestamp": 30000}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition", "key": 0, "value": {"T_ROWTIME": 0, "T_K": "", "T_ID": 0, "T_NAME": "zero", "T_VALUE": 0}, "timestamp": 0},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-right-repartition", "key": 0, "value": {"TT_ROWTIME": 10000, "TT_K": "", "TT_ID": 0, "TT_F1": "blah", "TT_F2": 50}, "timestamp": 10000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition", "key": 10, "value": {"T_ROWTIME": 11000, "T_K": "", "T_ID": 10, "T_NAME": "100", "T_VALUE": 5}, "timestamp": 11000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition", "key": 0, "value": {"T_ROWTIME": 13000, "T_K": "", "T_ID": 0, "T_NAME": "foo", "T_VALUE": 100}, "timestamp": 13000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-right-repartition", "key": 0, "value": {"TT_ROWTIME": 15000, "TT_K": "", "TT_ID": 0, "TT_F1": "a", "TT_F2": 10}, "timestamp": 15000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-right-repartition", "key": 100, "value": {"TT_ROWTIME": 16000, "TT_K": "", "TT_ID": 100, "TT_F1": "newblah", "TT_F2": 150}, "timestamp": 16000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition", "key": 90, "value": {"T_ROWTIME": 17000, "T_K": "", "T_ID": 90, "T_NAME": "ninety", "T_VALUE": 90}, "timestamp": 17000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition", "key": 0, "value": {"T_ROWTIME": 30000, "T_K": "", "T_ID": 0, "T_NAME": "bar", "T_VALUE": 99}, "timestamp": 30000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 0, "end": 11000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 0, "T_K": "", "T_ID": 0, "T_NAME": "zero", "T_VALUE": 0}, "timestamp": 0},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000017-store-changelog", "window": {"start": 10000, "end": 21000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 10000, "TT_K": "", "TT_ID": 0, "TT_F1": "blah", "TT_F2": 50}, "timestamp": 10000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 11000, "end": 22000, "type": "time"}, "key": 10, "value": {"T_ROWTIME": 11000, "T_K": "", "T_ID": 10, "T_NAME": "100", "T_VALUE": 5}, "timestamp": 11000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 13000, "end": 24000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 13000, "T_K": "", "T_ID": 0, "T_NAME": "foo", "T_VALUE": 100}, "timestamp": 13000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000017-store-changelog", "window": {"start": 15000, "end": 26000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 15000, "TT_K": "", "TT_ID": 0, "TT_F1": "a", "TT_F2": 10}, "timestamp": 15000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000017-store-changelog", "window": {"start": 16000, "end": 27000, "type": "time"}, "key": 100, "value": {"TT_ROWTIME": 16000, "TT_K": "", "TT_ID": 100, "TT_F1": "newblah", "TT_F2": 150}, "timestamp": 16000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 17000, "end": 28000, "type": "time"}, "key": 90, "value": {"T_ROWTIME": 17000, "T_K": "", "T_ID": 90, "T_NAME": "ninety", "T_VALUE": 90}, "timestamp": 17000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 30000, "end": 41000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 30000, "T_K": "", "T_ID": 0, "T_NAME": "bar", "T_VALUE": 99}, "timestamp": 30000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": null, "F2": null}, "timestamp": 0},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 10, "value": {"T_ID": 10, "NAME": "100", "VALUE": 5, "F1": null, "F2": null}, "timestamp": 11000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 90, "value": {"T_ID": 90, "NAME": "ninety", "VALUE": 90, "F1": null, "F2": null}, "timestamp": 17000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": null, "F2": null}, "timestamp": 30000}
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-left-repartition", "key": 0, "value": {"T_ROWTIME": 0, "T_K": "", "T_ID": 0, "T_NAME": "zero", "T_VALUE": 0}, "timestamp": 0},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-right-repartition", "key": 0, "value": {"TT_ROWTIME": 10000, "TT_K": "", "TT_ID": 0, "TT_F1": "blah", "TT_F2": 50}, "timestamp": 10000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-left-repartition", "key": 10, "value": {"T_ROWTIME": 11000, "T_K": "", "T_ID": 10, "T_NAME": "100", "T_VALUE": 5}, "timestamp": 11000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-left-repartition", "key": 0, "value": {"T_ROWTIME": 13000, "T_K": "", "T_ID": 0, "T_NAME": "foo", "T_VALUE": 100}, "timestamp": 13000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-right-repartition", "key": 0, "value": {"TT_ROWTIME": 15000, "TT_K": "", "TT_ID": 0, "TT_F1": "a", "TT_F2": 10}, "timestamp": 15000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-right-repartition", "key": 100, "value": {"TT_ROWTIME": 16000, "TT_K": "", "TT_ID": 100, "TT_F1": "newblah", "TT_F2": 150}, "timestamp": 16000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-left-repartition", "key": 90, "value": {"T_ROWTIME": 17000, "T_K": "", "T_ID": 90, "T_NAME": "ninety", "T_VALUE": 90}, "timestamp": 17000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-left-repartition", "key": 0, "value": {"T_ROWTIME": 30000, "T_K": "", "T_ID": 0, "T_NAME": "bar", "T_VALUE": 99}, "timestamp": 30000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 0, "end": 11000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 0, "T_K": "", "T_ID": 0, "T_NAME": "zero", "T_VALUE": 0}, "timestamp": 0},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-OUTEROTHER-0000000017-store-changelog", "window": {"start": 10000, "end": 21000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 10000, "TT_K": "", "TT_ID": 0, "TT_F1": "blah", "TT_F2": 50}, "timestamp": 10000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 11000, "end": 22000, "type": "time"}, "key": 10, "value": {"T_ROWTIME": 11000, "T_K": "", "T_ID": 10, "T_NAME": "100", "T_VALUE": 5}, "timestamp": 11000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 13000, "end": 24000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 13000, "T_K": "", "T_ID": 0, "T_NAME": "foo", "T_VALUE": 100}, "timestamp": 13000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-OUTEROTHER-0000000017-store-changelog", "window": {"start": 15000, "end": 26000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 15000, "TT_K": "", "TT_ID": 0, "TT_F1": "a", "TT_F2": 10}, "timestamp": 15000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-OUTEROTHER-0000000017-store-changelog", "window": {"start": 16000, "end": 27000, "type": "time"}, "key": 100, "value": {"TT_ROWTIME": 16000, "TT_K": "", "TT_ID": 100, "TT_F1": "newblah", "TT_F2": 150}, "timestamp": 16000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 17000, "end": 28000, "type": "time"}, "key": 90, "value": {"T_ROWTIME": 17000, "T_K": "", "T_ID": 90, "T_NAME": "ninety", "T_VALUE": 90}, "timestamp": 17000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 30000, "end": 41000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 30000, "T_K": "", "T_ID": 0, "T_NAME": "bar", "T_VALUE": 99}, "timestamp": 30000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": null, "F2": null}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "OUTPUT", "key": 10, "value": {"NAME": "100", "VALUE": 5, "F1": null, "F2": null}, "timestamp": 11000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "OUTPUT", "key": 90, "value": {"NAME": "ninety", "VALUE": 90, "F1": null, "F2": null}, "timestamp": 17000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "bar", "VALUE": 99, "F1": null, "F2": null}, "timestamp": 30000}
       ],
       "post": {
         "sources": [
-          {"name": "LEFT_OUTER_JOIN", "type": "stream", "schema": "ID BIGINT KEY, T_ID BIGINT, NAME STRING, VALUE BIGINT, F1 STRING, F2 BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "T_ID BIGINT KEY, NAME STRING, VALUE BIGINT, F1 STRING, F2 BIGINT"}
         ]
       }
     },
@@ -285,7 +639,7 @@
       "statements": [
         "CREATE STREAM TEST (K STRING KEY, ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
         "CREATE STREAM TEST_STREAM (K STRING KEY, ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
-        "CREATE STREAM LEFT_OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t left join TEST_STREAM tt WITHIN 11 seconds ON t.id = tt.id;"
+        "CREATE STREAM OUTPUT as SELECT t.id, name, value, f1, f2 FROM test t left join TEST_STREAM tt WITHIN 11 seconds ON t.id = tt.id;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -301,33 +655,33 @@
         {"topic": "left_topic", "value": {"ID": 0, "NAME": "bar", "VALUE": 99}, "timestamp": 30000}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition", "key": 0, "value": {"T_ROWTIME": 0, "T_K": "", "T_ID": 0, "T_NAME": "zero", "T_VALUE": 0}, "timestamp": 0},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-right-repartition", "key": 0, "value": {"TT_ROWTIME": 10000, "TT_K": "", "TT_ID": 0, "TT_F1": "blah", "TT_F2": 50}, "timestamp": 10000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition", "key": 10, "value": {"T_ROWTIME": 11000, "T_K": "", "T_ID": 10, "T_NAME": "100", "T_VALUE": 5}, "timestamp": 11000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition", "key": 0, "value": {"T_ROWTIME": 13000, "T_K": "", "T_ID": 0, "T_NAME": "foo", "T_VALUE": 100}, "timestamp": 13000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-right-repartition", "key": 0, "value": {"TT_ROWTIME": 15000, "TT_K": "", "TT_ID": 0, "TT_F1": "a", "TT_F2": 10}, "timestamp": 15000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-right-repartition", "key": 100, "value": {"TT_ROWTIME": 16000, "TT_K": "", "TT_ID": 100, "TT_F1": "newblah", "TT_F2": 150}, "timestamp": 16000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition", "key": 90, "value": {"T_ROWTIME": 17000, "T_K": "", "T_ID": 90, "T_NAME": "ninety", "T_VALUE": 90}, "timestamp": 17000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition", "key": 0, "value": {"T_ROWTIME": 30000, "T_K": "", "T_ID": 0, "T_NAME": "bar", "T_VALUE": 99}, "timestamp": 30000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 0, "end": 11000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 0, "T_K": "", "T_ID": 0, "T_NAME": "zero", "T_VALUE": 0}, "timestamp": 0},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000017-store-changelog", "window": {"start": 10000, "end": 21000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 10000, "TT_K": "", "TT_ID": 0, "TT_F1": "blah", "TT_F2": 50}, "timestamp": 10000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 11000, "end": 22000, "type": "time"}, "key": 10, "value": {"T_ROWTIME": 11000, "T_K": "", "T_ID": 10, "T_NAME": "100", "T_VALUE": 5}, "timestamp": 11000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 13000, "end": 24000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 13000, "T_K": "", "T_ID": 0, "T_NAME": "foo", "T_VALUE": 100}, "timestamp": 13000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000017-store-changelog", "window": {"start": 15000, "end": 26000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 15000, "TT_K": "", "TT_ID": 0, "TT_F1": "a", "TT_F2": 10}, "timestamp": 15000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000017-store-changelog", "window": {"start": 16000, "end": 27000, "type": "time"}, "key": 100, "value": {"TT_ROWTIME": 16000, "TT_K": "", "TT_ID": 100, "TT_F1": "newblah", "TT_F2": 150}, "timestamp": 16000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 17000, "end": 28000, "type": "time"}, "key": 90, "value": {"T_ROWTIME": 17000, "T_K": "", "T_ID": 90, "T_NAME": "ninety", "T_VALUE": 90}, "timestamp": 17000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 30000, "end": 41000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 30000, "T_K": "", "T_ID": 0, "T_NAME": "bar", "T_VALUE": 99}, "timestamp": 30000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "", "F2": 0}, "timestamp": 0},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 10, "value": {"T_ID": 10, "NAME": "100", "VALUE": 5, "F1": "", "F2": 0}, "timestamp": 11000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 90, "value": {"T_ID": 90, "NAME": "ninety", "VALUE": 90, "F1": "", "F2": 0}, "timestamp": 17000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": "", "F2": 0}, "timestamp": 30000}
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-left-repartition", "key": 0, "value": {"T_ROWTIME": 0, "T_K": "", "T_ID": 0, "T_NAME": "zero", "T_VALUE": 0}, "timestamp": 0},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-right-repartition", "key": 0, "value": {"TT_ROWTIME": 10000, "TT_K": "", "TT_ID": 0, "TT_F1": "blah", "TT_F2": 50}, "timestamp": 10000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-left-repartition", "key": 10, "value": {"T_ROWTIME": 11000, "T_K": "", "T_ID": 10, "T_NAME": "100", "T_VALUE": 5}, "timestamp": 11000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-left-repartition", "key": 0, "value": {"T_ROWTIME": 13000, "T_K": "", "T_ID": 0, "T_NAME": "foo", "T_VALUE": 100}, "timestamp": 13000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-right-repartition", "key": 0, "value": {"TT_ROWTIME": 15000, "TT_K": "", "TT_ID": 0, "TT_F1": "a", "TT_F2": 10}, "timestamp": 15000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-right-repartition", "key": 100, "value": {"TT_ROWTIME": 16000, "TT_K": "", "TT_ID": 100, "TT_F1": "newblah", "TT_F2": 150}, "timestamp": 16000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-left-repartition", "key": 90, "value": {"T_ROWTIME": 17000, "T_K": "", "T_ID": 90, "T_NAME": "ninety", "T_VALUE": 90}, "timestamp": 17000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-left-repartition", "key": 0, "value": {"T_ROWTIME": 30000, "T_K": "", "T_ID": 0, "T_NAME": "bar", "T_VALUE": 99}, "timestamp": 30000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 0, "end": 11000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 0, "T_K": "", "T_ID": 0, "T_NAME": "zero", "T_VALUE": 0}, "timestamp": 0},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-OUTEROTHER-0000000017-store-changelog", "window": {"start": 10000, "end": 21000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 10000, "TT_K": "", "TT_ID": 0, "TT_F1": "blah", "TT_F2": 50}, "timestamp": 10000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 11000, "end": 22000, "type": "time"}, "key": 10, "value": {"T_ROWTIME": 11000, "T_K": "", "T_ID": 10, "T_NAME": "100", "T_VALUE": 5}, "timestamp": 11000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 13000, "end": 24000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 13000, "T_K": "", "T_ID": 0, "T_NAME": "foo", "T_VALUE": 100}, "timestamp": 13000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-OUTEROTHER-0000000017-store-changelog", "window": {"start": 15000, "end": 26000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 15000, "TT_K": "", "TT_ID": 0, "TT_F1": "a", "TT_F2": 10}, "timestamp": 15000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-OUTEROTHER-0000000017-store-changelog", "window": {"start": 16000, "end": 27000, "type": "time"}, "key": 100, "value": {"TT_ROWTIME": 16000, "TT_K": "", "TT_ID": 100, "TT_F1": "newblah", "TT_F2": 150}, "timestamp": 16000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 17000, "end": 28000, "type": "time"}, "key": 90, "value": {"T_ROWTIME": 17000, "T_K": "", "T_ID": 90, "T_NAME": "ninety", "T_VALUE": 90}, "timestamp": 17000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 30000, "end": 41000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 30000, "T_K": "", "T_ID": 0, "T_NAME": "bar", "T_VALUE": 99}, "timestamp": 30000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": "", "F2": 0}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "OUTPUT", "key": 10, "value": {"NAME": "100", "VALUE": 5, "F1": "", "F2": 0}, "timestamp": 11000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "OUTPUT", "key": 90, "value": {"NAME": "ninety", "VALUE": 90, "F1": "", "F2": 0}, "timestamp": 17000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "bar", "VALUE": 99, "F1": "", "F2": 0}, "timestamp": 30000}
       ],
       "post": {
         "sources": [
-          {"name": "LEFT_OUTER_JOIN", "type": "stream", "schema": "ID BIGINT KEY, T_ID BIGINT, NAME STRING, VALUE BIGINT, F1 STRING, F2 BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "T_ID BIGINT KEY, NAME STRING, VALUE BIGINT, F1 STRING, F2 BIGINT"}
         ]
       }
     },
@@ -337,7 +691,7 @@
       "statements": [
         "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
         "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
-        "CREATE STREAM INNER_JOIN as SELECT name, value, f1, f2 FROM test t join TEST_STREAM tt WITHIN 11 SECONDS ON t.id = tt.id;"
+        "CREATE STREAM INNER_JOIN as SELECT t.id as ID, name, value, f1, f2 FROM test t join TEST_STREAM tt WITHIN 11 SECONDS ON t.id = tt.id;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -385,13 +739,13 @@
         {"topic": "left_topic", "key": 0, "value": {"NAME": "bar", "VALUE": 99}, "timestamp": 30000}
       ],
       "outputs": [
-        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_NAME": "zero", "T_VALUE": 0, "F1": "blah"}, "timestamp": 10000},
-        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_NAME": "foo", "T_VALUE": 100, "F1": "blah"}, "timestamp": 13000},
-        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_NAME": "foo", "T_VALUE": 100, "F1": "a"}, "timestamp": 15000}
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_NAME": "zero", "T_VALUE": 0, "F1": "blah"}, "timestamp": 10000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_NAME": "foo", "T_VALUE": 100, "F1": "blah"}, "timestamp": 13000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_NAME": "foo", "T_VALUE": 100, "F1": "a"}, "timestamp": 15000}
       ],
       "post": {
         "sources": [
-          {"name": "INNER_JOIN", "type": "stream", "schema": "ID BIGINT KEY, T_ID BIGINT, T_NAME STRING, T_VALUE BIGINT, F1 STRING"}
+          {"name": "INNER_JOIN", "type": "stream", "schema": "T_ID BIGINT KEY, T_NAME STRING, T_VALUE BIGINT, F1 STRING"}
         ]
       }
     },
@@ -404,7 +758,7 @@
       "statements": [
         "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
         "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
-        "CREATE STREAM INNER_JOIN as SELECT t.*, tt.name FROM test tt inner join TEST_STREAM t WITHIN 11 SECONDS ON t.id = tt.id;"
+        "CREATE STREAM INNER_JOIN as SELECT t.*, tt.name, tt.id FROM test tt inner join TEST_STREAM t WITHIN 11 SECONDS ON t.id = tt.id;"
       ],
       "inputs": [
         {"topic": "left_topic", "key": 0, "value": {"NAME": "zero", "VALUE": 0}, "timestamp": 0},
@@ -423,7 +777,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "INNER_JOIN", "type": "stream", "schema": "ID BIGINT KEY, T_ID BIGINT, T_F1 STRING, T_F2 BIGINT, NAME STRING"}
+          {"name": "INNER_JOIN", "type": "stream", "schema": "TT_ID BIGINT KEY, T_ID BIGINT, T_F1 STRING, T_F2 BIGINT, NAME STRING"}
         ]
       }
     },
@@ -448,13 +802,13 @@
         {"topic": "left_topic", "key": 0, "value": {"NAME": "bar", "VALUE": 99}, "timestamp": 30000}
       ],
       "outputs": [
-        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_F1": "blah", "T_F2": 50, "TT_ID": 0, "TT_NAME": "zero", "TT_VALUE": 0, "F1_2": "blah", "NAME_2": "zero"}, "timestamp": 10000},
-        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_F1": "blah", "T_F2": 50, "TT_ID": 0, "TT_NAME": "foo", "TT_VALUE": 100, "F1_2": "blah", "NAME_2": "foo"}, "timestamp": 13000},
-        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_F1": "a", "T_F2": 10, "TT_ID": 0, "TT_NAME": "foo", "TT_VALUE": 100, "F1_2": "a", "NAME_2": "foo"}, "timestamp": 15000}
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_F1": "blah", "T_F2": 50, "TT_NAME": "zero", "TT_VALUE": 0, "F1_2": "blah", "NAME_2": "zero"}, "timestamp": 10000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_F1": "blah", "T_F2": 50, "TT_NAME": "foo", "TT_VALUE": 100, "F1_2": "blah", "NAME_2": "foo"}, "timestamp": 13000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_F1": "a", "T_F2": 10, "TT_NAME": "foo", "TT_VALUE": 100, "F1_2": "a", "NAME_2": "foo"}, "timestamp": 15000}
       ],
       "post": {
         "sources": [
-          {"name": "INNER_JOIN", "type": "stream", "schema": "ID BIGINT KEY, T_ID BIGINT, T_F1 STRING, T_F2 BIGINT, F1_2 STRING, TT_ID BIGINT, TT_NAME STRING, TT_VALUE BIGINT, NAME_2 STRING"}
+          {"name": "INNER_JOIN", "type": "stream", "schema": "TT_ID BIGINT KEY, T_ID BIGINT, T_F1 STRING, T_F2 BIGINT, F1_2 STRING, TT_NAME STRING, TT_VALUE BIGINT, NAME_2 STRING"}
         ]
       }
     },
@@ -488,13 +842,13 @@
         {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINOTHER-0000000009-store-changelog", "window": {"start": 16000, "end": 27000, "type": "time"}, "key": 100, "value": {"T_ROWTIME": 16000, "T_ID": 100, "T_F1": "newblah"}, "timestamp": 16000},
         {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 17000, "end": 28000, "type": "time"}, "key": 90, "value": {"TT_ROWTIME": 17000, "TT_ID": 90, "TT_NAME": "ninety"}, "timestamp": 17000},
         {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 30000, "end": 41000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 30000, "TT_ID": 0, "TT_NAME": "bar"}, "timestamp": 30000},
-        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_F1": "blah", "TT_ID": 0, "TT_NAME": "zero"}, "timestamp": 10000},
-        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_F1": "blah", "TT_ID": 0, "TT_NAME": "foo"}, "timestamp": 13000},
-        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_F1": "a", "TT_ID": 0, "TT_NAME": "foo"}, "timestamp": 15000}
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_F1": "blah", "TT_NAME": "zero"}, "timestamp": 10000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_F1": "blah", "TT_NAME": "foo"}, "timestamp": 13000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_F1": "a", "TT_NAME": "foo"}, "timestamp": 15000}
       ],
       "post": {
         "sources": [
-          {"name": "INNER_JOIN", "type": "stream", "schema": "ID BIGINT KEY, TT_ID BIGINT, TT_NAME STRING, T_ID BIGINT, T_F1 STRING"}
+          {"name": "INNER_JOIN", "type": "stream", "schema": "TT_ID BIGINT KEY, TT_NAME STRING, T_ID BIGINT, T_F1 STRING"}
         ]
       }
     },
@@ -520,12 +874,12 @@
         {"topic": "left_topic", "key": 0, "value": {"NAME": "bar", "VALUE": 99}, "timestamp": 30000}
       ],
       "outputs": [
-        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
-        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000}
+        {"topic": "INNER_JOIN", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000}
       ],
       "post": {
         "sources": [
-          {"name": "INNER_JOIN", "type": "stream", "schema": "ID BIGINT KEY, T_ID BIGINT, NAME STRING, VALUE BIGINT, F1 STRING, F2 BIGINT"}
+          {"name": "INNER_JOIN", "type": "stream", "schema": "T_ID BIGINT KEY, NAME STRING, VALUE BIGINT, F1 STRING, F2 BIGINT"}
         ]
       }
     },
@@ -552,15 +906,15 @@
         {"topic": "left_topic", "key": 0, "value": {"NAME": "late-message", "VALUE": 10000}, "timestamp": 6000}
       ],
       "outputs": [
-        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 9999},
-        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
-        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
-        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "late-message", "VALUE": 10000, "F1": "blah", "F2": 50}, "timestamp": 9999},
-        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "late-message", "VALUE": 10000, "F1": "a", "F2": 10}, "timestamp": 15000}
+        {"topic": "INNER_JOIN", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 9999},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"NAME": "late-message", "VALUE": 10000, "F1": "blah", "F2": 50}, "timestamp": 9999},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"NAME": "late-message", "VALUE": 10000, "F1": "a", "F2": 10}, "timestamp": 15000}
       ],
       "post": {
         "sources": [
-          {"name": "INNER_JOIN", "type": "stream", "schema": "ID BIGINT KEY, T_ID BIGINT, NAME STRING, VALUE BIGINT, F1 STRING, F2 BIGINT"}
+          {"name": "INNER_JOIN", "type": "stream", "schema": "T_ID BIGINT KEY, NAME STRING, VALUE BIGINT, F1 STRING, F2 BIGINT"}
         ]
       }
     },
@@ -570,7 +924,7 @@
       "statements": [
         "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
         "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
-        "CREATE STREAM LEFT_OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t FULL OUTER join TEST_STREAM tt WITHIN 11 seconds on t.id = tt.id;"
+        "CREATE STREAM OUTPUT as SELECT * FROM test t FULL OUTER join TEST_STREAM tt WITHIN 11 seconds on t.id = tt.id;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -587,18 +941,18 @@
 
       ],
       "outputs": [
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": null, "F2": null}, "timestamp": 0},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 10, "value": {"T_ID": 10, "NAME": "100", "VALUE": 5, "F1": null, "F2": null}, "timestamp": 11000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": null, "F2": null}, "timestamp": 30000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 90, "value": {"T_ID": 90, "NAME": "ninety", "VALUE": 90, "F1": null, "F2": null}, "timestamp": 17000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 100, "value": {"T_ID": null, "NAME": null, "VALUE": null, "F1": "newblah", "F2": 150}, "timestamp": 20000}
+        {"topic": "OUTPUT", "key": 0, "value": {"T_ID": 0, "T_NAME": "zero", "T_VALUE": 0, "TT_ID": null, "TT_F1": null, "TT_F2": null}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 0, "value": {"T_ID": 0, "T_NAME": "zero", "T_VALUE": 0, "TT_ID": 0, "TT_F1": "blah", "TT_F2": 50}, "timestamp": 10000},
+        {"topic": "OUTPUT", "key": 10, "value": {"T_ID": 10, "T_NAME": "100", "T_VALUE": 5, "TT_ID": null, "TT_F1": null, "TT_F2": null}, "timestamp": 11000},
+        {"topic": "OUTPUT", "key": 0, "value": {"T_ID": 0, "T_NAME": "foo", "T_VALUE": 100, "TT_ID": 0, "TT_F1": "blah", "TT_F2": 50}, "timestamp": 13000},
+        {"topic": "OUTPUT", "key": 0, "value": {"T_ID": 0, "T_NAME": "foo", "T_VALUE": 100, "TT_ID": 0, "TT_F1": "a", "TT_F2": 10}, "timestamp": 15000},
+        {"topic": "OUTPUT", "key": 0, "value": {"T_ID": 0, "T_NAME": "bar", "T_VALUE": 99, "TT_ID": null, "TT_F1": null, "TT_F2": null}, "timestamp": 30000},
+        {"topic": "OUTPUT", "key": 90, "value": {"T_ID": 90, "T_NAME": "ninety", "T_VALUE": 90, "TT_ID": null, "TT_F1": null, "TT_F2": null}, "timestamp": 17000},
+        {"topic": "OUTPUT", "key": 100, "value": {"T_ID": null, "T_NAME": null, "T_VALUE": null, "TT_ID": 100, "TT_F1": "newblah", "TT_F2": 150}, "timestamp": 20000}
       ],
       "post": {
         "sources": [
-          {"name": "LEFT_OUTER_JOIN", "type": "stream", "schema": "ID BIGINT KEY, T_ID BIGINT, NAME STRING, VALUE BIGINT, F1 STRING, F2 BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "KSQL_COL_0 BIGINT KEY, T_ID BIGINT, T_NAME STRING, T_VALUE BIGINT, TT_ID BIGINT, TT_F1 STRING, TT_F2 BIGINT"}
         ]
       }
     },
@@ -607,7 +961,7 @@
       "statements": [
         "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='PROTOBUF');",
         "CREATE STREAM TEST_STREAM (ID BIGINT KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='PROTOBUF');",
-        "CREATE STREAM LEFT_OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t FULL OUTER join TEST_STREAM tt WITHIN 11 seconds on t.id = tt.id;"
+        "CREATE STREAM OUTPUT as SELECT JOINKEY(t.id, tt.id) as ID, name, value, f1, f2 FROM test t FULL OUTER join TEST_STREAM tt WITHIN 11 seconds on t.id = tt.id;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -624,18 +978,18 @@
 
       ],
       "outputs": [
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "", "F2": 0}, "timestamp": 0},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 10, "value": {"T_ID": 10, "NAME": "100", "VALUE": 5, "F1": "", "F2": 0}, "timestamp": 11000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": "", "F2": 0}, "timestamp": 30000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 90, "value": {"T_ID": 90, "NAME": "ninety", "VALUE": 90, "F1": "", "F2": 0}, "timestamp": 17000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 100, "value": {"T_ID": 0, "NAME": "", "VALUE": 0, "F1": "newblah", "F2": 150}, "timestamp": 20000}
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": "", "F2": 0}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "OUTPUT", "key": 10, "value": {"NAME": "100", "VALUE": 5, "F1": "", "F2": 0}, "timestamp": 11000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "bar", "VALUE": 99, "F1": "", "F2": 0}, "timestamp": 30000},
+        {"topic": "OUTPUT", "key": 90, "value": {"NAME": "ninety", "VALUE": 90, "F1": "", "F2": 0}, "timestamp": 17000},
+        {"topic": "OUTPUT", "key": 100, "value": {"NAME": "", "VALUE": 0, "F1": "newblah", "F2": 150}, "timestamp": 20000}
       ],
       "post": {
         "sources": [
-          {"name": "LEFT_OUTER_JOIN", "type": "stream", "schema": "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "ID BIGINT KEY, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT"}
         ]
       }
     },
@@ -645,7 +999,7 @@
       "statements": [
         "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
         "CREATE TABLE TEST_TABLE (ID BIGINT PRIMARY KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
-        "CREATE TABLE LEFT_OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t left join TEST_TABLE tt on t.id = tt.id;"
+        "CREATE TABLE OUTPUT as SELECT t.id, name, value, f1, f2 FROM test t left join TEST_TABLE tt on t.id = tt.id;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -660,17 +1014,17 @@
         {"topic": "left_topic", "key": 90, "value": {"NAME": "ninety", "VALUE": 90}, "timestamp": 17000}
       ],
       "outputs": [
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": null, "F2": null}, "timestamp": 0},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 10, "value": {"T_ID": 10, "NAME": "100", "VALUE": 5, "F1": null, "F2": null}, "timestamp": 11000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": "a", "F2": 10}, "timestamp": 16000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 90, "value": {"T_ID": 90, "NAME": "ninety", "VALUE": 90, "F1": null, "F2": null}, "timestamp": 17000}
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": null, "F2": null}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "OUTPUT", "key": 10, "value": {"NAME": "100", "VALUE": 5, "F1": null, "F2": null}, "timestamp": 11000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "bar", "VALUE": 99, "F1": "a", "F2": 10}, "timestamp": 16000},
+        {"topic": "OUTPUT", "key": 90, "value": {"NAME": "ninety", "VALUE": 90, "F1": null, "F2": null}, "timestamp": 17000}
       ],
       "post": {
         "sources": [
-          {"name": "LEFT_OUTER_JOIN", "type": "table", "schema": "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT"}
+          {"name": "OUTPUT", "type": "table", "schema": "`T_ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT"}
         ]
       }
     },
@@ -679,7 +1033,7 @@
       "statements": [
         "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='PROTOBUF');",
         "CREATE TABLE TEST_TABLE (ID BIGINT PRIMARY KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='PROTOBUF');",
-        "CREATE TABLE LEFT_OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t left join TEST_TABLE tt on t.id = tt.id;"
+        "CREATE TABLE OUTPUT as SELECT t.id, name, value, f1, f2 FROM test t left join TEST_TABLE tt on t.id = tt.id;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -694,17 +1048,17 @@
         {"topic": "left_topic", "key": 90, "value": {"NAME": "ninety", "VALUE": 90}, "timestamp": 17000}
       ],
       "outputs": [
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "", "F2": 0}, "timestamp": 0},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 10, "value": {"T_ID": 10, "NAME": "100", "VALUE": 5, "F1": "", "F2": 0}, "timestamp": 11000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": "a", "F2": 10}, "timestamp": 16000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 90, "value": {"T_ID": 90, "NAME": "ninety", "VALUE": 90, "F1": "", "F2": 0}, "timestamp": 17000}
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": "", "F2": 0}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "OUTPUT", "key": 10, "value": {"NAME": "100", "VALUE": 5, "F1": "", "F2": 0}, "timestamp": 11000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "bar", "VALUE": 99, "F1": "a", "F2": 10}, "timestamp": 16000},
+        {"topic": "OUTPUT", "key": 90, "value": {"NAME": "ninety", "VALUE": 90, "F1": "", "F2": 0}, "timestamp": 17000}
       ],
       "post": {
         "sources": [
-          {"name": "LEFT_OUTER_JOIN", "type": "table", "schema": "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT"}
+          {"name": "OUTPUT", "type": "table", "schema": "`T_ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT"}
         ]
       }
     },
@@ -730,14 +1084,14 @@
         {"topic": "left_topic", "key": 90, "value": {"NAME": "ninety", "VALUE": 90}, "timestamp": 17000}
       ],
       "outputs": [
-        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
-        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
-        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
-        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": "a", "F2": 10}, "timestamp": 16000}
+        {"topic": "INNER_JOIN", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"NAME": "bar", "VALUE": 99, "F1": "a", "F2": 10}, "timestamp": 16000}
       ],
       "post": {
         "sources": [
-          {"name": "INNER_JOIN", "type": "table", "schema": "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT"}
+          {"name": "INNER_JOIN", "type": "table", "schema": "`T_ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT"}
         ]
       }
     },
@@ -747,7 +1101,7 @@
       "statements": [
         "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
         "CREATE TABLE TEST_TABLE (ID BIGINT PRIMARY KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
-        "CREATE TABLE OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t FULL OUTER join TEST_TABLE tt on t.id = tt.id;"
+        "CREATE TABLE OUTER_JOIN as SELECT JOINKEY(T.ID, TT.ID) AS ID, name, value, f1, f2 FROM test t FULL OUTER join TEST_TABLE tt on t.id = tt.id;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -762,17 +1116,17 @@
         {"topic": "left_topic", "key": 0, "value": {"NAME": "bar", "VALUE": 99}, "timestamp": 16000}
       ],
       "outputs": [
-        {"topic": "OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": null, "F2": null}, "timestamp": 0},
-        {"topic": "OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
-        {"topic": "OUTER_JOIN", "key": 10, "value": {"T_ID": 10, "NAME": "100", "VALUE": 5, "F1": null, "F2": null}, "timestamp": 11000},
-        {"topic": "OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
-        {"topic": "OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
-        {"topic": "OUTER_JOIN", "key": 15, "value": {"T_ID": null, "NAME": null, "VALUE": null, "F1": "c", "F2": 20}, "timestamp": 15500},
-        {"topic": "OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": "a", "F2": 10}, "timestamp": 16000}
+        {"topic": "OUTER_JOIN", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": null, "F2": null}, "timestamp": 0},
+        {"topic": "OUTER_JOIN", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "OUTER_JOIN", "key": 10, "value": {"NAME": "100", "VALUE": 5, "F1": null, "F2": null}, "timestamp": 11000},
+        {"topic": "OUTER_JOIN", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "OUTER_JOIN", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "OUTER_JOIN", "key": 15, "value": {"NAME": null, "VALUE": null, "F1": "c", "F2": 20}, "timestamp": 15500},
+        {"topic": "OUTER_JOIN", "key": 0, "value": {"NAME": "bar", "VALUE": 99, "F1": "a", "F2": 10}, "timestamp": 16000}
       ],
       "post": {
         "sources": [
-          {"name": "OUTER_JOIN", "type": "table", "schema": "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT"}
+          {"name": "OUTER_JOIN", "type": "table", "schema": "ID BIGINT KEY, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT"}
         ]
       }
     },
@@ -781,32 +1135,32 @@
       "statements": [
         "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='PROTOBUF');",
         "CREATE TABLE TEST_TABLE (ID BIGINT PRIMARY KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='PROTOBUF');",
-        "CREATE TABLE OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t FULL OUTER join TEST_TABLE tt on t.id = tt.id;"
+        "CREATE TABLE OUTER_JOIN as SELECT JOINKEY(t.id, tt.id) AS ID, t.id, tt.id, name, value, f1, f2 FROM test t FULL OUTER join TEST_TABLE tt on t.id = tt.id;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
       },
       "inputs": [
-        {"topic": "left_topic", "key": 0, "value": {"NAME": "zero", "VALUE": 0}, "timestamp": 0},
-        {"topic": "right_topic", "key": 0, "value": {"F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "left_topic", "key": 1, "value": {"NAME": "zero", "VALUE": 0}, "timestamp": 0},
+        {"topic": "right_topic", "key": 1, "value": {"F1": "blah", "F2": 50}, "timestamp": 10000},
         {"topic": "left_topic", "key": 10, "value": {"NAME": "100", "VALUE": 5}, "timestamp": 11000},
-        {"topic": "left_topic", "key": 0, "value": {"NAME": "foo", "VALUE": 100}, "timestamp": 13000},
-        {"topic": "right_topic", "key": 0, "value": {"F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "left_topic", "key": 1, "value": {"NAME": "foo", "VALUE": 100}, "timestamp": 13000},
+        {"topic": "right_topic", "key": 1, "value": {"F1": "a", "F2": 10}, "timestamp": 15000},
         {"topic": "right_topic", "key": 15, "value": {"F1": "c", "F2": 20}, "timestamp": 15500},
-        {"topic": "left_topic", "key": 0, "value": {"NAME": "bar", "VALUE": 99}, "timestamp": 16000}
+        {"topic": "left_topic", "key": 1, "value": {"NAME": "bar", "VALUE": 99}, "timestamp": 16000}
       ],
       "outputs": [
-        {"topic": "OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "", "F2": 0}, "timestamp": 0},
-        {"topic": "OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
-        {"topic": "OUTER_JOIN", "key": 10, "value": {"T_ID": 10, "NAME": "100", "VALUE": 5, "F1": "", "F2": 0}, "timestamp": 11000},
-        {"topic": "OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
-        {"topic": "OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
-        {"topic": "OUTER_JOIN", "key": 15, "value": {"T_ID": 0, "NAME": "", "VALUE": 0, "F1": "c", "F2": 20}, "timestamp": 15500},
-        {"topic": "OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": "a", "F2": 10}, "timestamp": 16000}
+        {"topic": "OUTER_JOIN", "key": 1, "value": {"T_ID": 1, "TT_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "", "F2": 0}, "timestamp": 0},
+        {"topic": "OUTER_JOIN", "key": 1, "value": {"T_ID": 1, "TT_ID": 1, "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "OUTER_JOIN", "key": 10, "value": {"T_ID": 10, "TT_ID": 0, "NAME": "100", "VALUE": 5, "F1": "", "F2": 0}, "timestamp": 11000},
+        {"topic": "OUTER_JOIN", "key": 1, "value": {"T_ID": 1, "TT_ID": 1, "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "OUTER_JOIN", "key": 1, "value": {"T_ID": 1, "TT_ID": 1, "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "OUTER_JOIN", "key": 15, "value": {"T_ID": 0, "TT_ID": 15, "NAME": "", "VALUE": 0, "F1": "c", "F2": 20}, "timestamp": 15500},
+        {"topic": "OUTER_JOIN", "key": 1, "value": {"T_ID": 1, "TT_ID": 1, "NAME": "bar", "VALUE": 99, "F1": "a", "F2": 10}, "timestamp": 16000}
       ],
       "post": {
         "sources": [
-          {"name": "OUTER_JOIN", "type": "table", "schema": "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT"}
+          {"name": "OUTER_JOIN", "type": "table", "schema": "ID BIGINT KEY, T_ID BIGINT, TT_ID BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT"}
         ]
       }
     },
@@ -831,14 +1185,14 @@
         {"topic": "test_topic", "key": 90, "value": {"NAME": "ninety", "VALUE": 90}, "timestamp": 15000}
       ],
       "outputs": [
-        {"topic": "LEFT_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "blah", "VALUE": 50, "F1": "zero", "F2": 0}, "timestamp": 10000},
-        {"topic": "LEFT_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "zero", "F2": 0}, "timestamp": 10000},
-        {"topic": "LEFT_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": "a", "F2": 10}, "timestamp": 15000},
-        {"topic": "LEFT_JOIN", "key": 90, "value": {"T_ID": 90, "NAME": "ninety", "VALUE": 90, "F1": null, "F2": null}, "timestamp": 15000}
+        {"topic": "LEFT_JOIN", "key": 0, "value": {"NAME": "blah", "VALUE": 50, "F1": "zero", "F2": 0}, "timestamp": 10000},
+        {"topic": "LEFT_JOIN", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "zero", "F2": 0}, "timestamp": 10000},
+        {"topic": "LEFT_JOIN", "key": 0, "value": {"NAME": "bar", "VALUE": 99, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "LEFT_JOIN", "key": 90, "value": {"NAME": "ninety", "VALUE": 90, "F1": null, "F2": null}, "timestamp": 15000}
       ],
       "post": {
         "sources": [
-          {"name": "LEFT_JOIN", "type": "stream", "schema": "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT"}
+          {"name": "LEFT_JOIN", "type": "stream", "schema": "T_ID BIGINT KEY, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT"}
         ]
       }
     },
@@ -862,14 +1216,14 @@
         {"topic": "test_topic", "key": 90, "value": {"NAME": "ninety", "VALUE": 90}, "timestamp": 15000}
       ],
       "outputs": [
-        {"topic": "LEFT_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "blah", "VALUE": 50, "F1": "zero", "F2": 0}, "timestamp": 10000},
-        {"topic": "LEFT_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "zero", "F2": 0}, "timestamp": 10000},
-        {"topic": "LEFT_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": "a", "F2": 10}, "timestamp": 15000},
-        {"topic": "LEFT_JOIN", "key": 90, "value": {"T_ID": 90, "NAME": "ninety", "VALUE": 90, "F1": "", "F2": 0}, "timestamp": 15000}
+        {"topic": "LEFT_JOIN", "key": 0, "value": {"NAME": "blah", "VALUE": 50, "F1": "zero", "F2": 0}, "timestamp": 10000},
+        {"topic": "LEFT_JOIN", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "zero", "F2": 0}, "timestamp": 10000},
+        {"topic": "LEFT_JOIN", "key": 0, "value": {"NAME": "bar", "VALUE": 99, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "LEFT_JOIN", "key": 90, "value": {"NAME": "ninety", "VALUE": 90, "F1": "", "F2": 0}, "timestamp": 15000}
       ],
       "post": {
         "sources": [
-          {"name": "LEFT_JOIN", "type": "stream", "schema": "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT"}
+          {"name": "LEFT_JOIN", "type": "stream", "schema": "T_ID BIGINT KEY, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT"}
         ]
       }
     },
@@ -894,13 +1248,13 @@
         {"topic": "test_topic", "key": 90, "value": {"NAME": "ninety", "VALUE": 90}, "timestamp": 15000}
       ],
       "outputs": [
-        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "blah", "VALUE": 50, "F1": "zero", "F2": 0}, "timestamp": 10000},
-        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "zero", "F2": 0}, "timestamp": 10000},
-        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": "a", "F2": 10}, "timestamp": 15000}
+        {"topic": "INNER_JOIN", "key": 0, "value": {"NAME": "blah", "VALUE": 50, "F1": "zero", "F2": 0}, "timestamp": 10000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"NAME": "foo", "VALUE": 100, "F1": "zero", "F2": 0}, "timestamp": 10000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"NAME": "bar", "VALUE": 99, "F1": "a", "F2": 10}, "timestamp": 15000}
       ],
       "post": {
         "sources": [
-          {"name": "INNER_JOIN", "type": "stream", "schema": "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT"}
+          {"name": "INNER_JOIN", "type": "stream", "schema": "T_ID BIGINT KEY, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT"}
         ]
       }
     },
@@ -911,8 +1265,8 @@
         "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
         "CREATE TABLE TEST_TABLE (ID BIGINT PRIMARY KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
         "CREATE TABLE TEST_TABLE_2 (ID BIGINT PRIMARY KEY, F3 varchar) WITH (kafka_topic='right_topic_2', value_format='{FORMAT}');",
-        "CREATE TABLE INNER_JOIN WITH (PARTITIONS=4) as SELECT name, value, f1, f2 FROM test t join TEST_TABLE tt on t.id = tt.id;",
-        "CREATE TABLE INNER_JOIN_2 AS SELECT name, f1, f3 FROM inner_join tt join TEST_TABLE_2 t ON t.id = tt.id;"
+        "CREATE TABLE INNER_JOIN WITH (PARTITIONS=4) as SELECT t.id AS ID, name, value, f1, f2 FROM test t join TEST_TABLE tt on t.id = tt.id;",
+        "CREATE TABLE INNER_JOIN_2 AS SELECT tt.id, name, f1, f3 FROM inner_join tt join TEST_TABLE_2 t ON t.id = tt.id;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -958,14 +1312,14 @@
       "outputs": [
         {"topic": "OUTPUT", "key": 0, "value": null, "timestamp": 10000},
         {"topic": "OUTPUT", "key": 0, "value": null, "timestamp": 13000},
-        {"topic": "OUTPUT", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "F1": "a", "F2": 10}, "timestamp": 15000},
-        {"topic": "OUTPUT", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "F1": "a", "F2": 10}, "timestamp": 16000},
-        {"topic": "OUTPUT", "key": 90, "value": {"T_ID": 90, "NAME": "ninety", "F1": "b", "F2": 10}, "timestamp": 18000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "foo", "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "bar", "F1": "a", "F2": 10}, "timestamp": 16000},
+        {"topic": "OUTPUT", "key": 90, "value": {"NAME": "ninety", "F1": "b", "F2": 10}, "timestamp": 18000},
         {"topic": "OUTPUT", "key": 90, "value": null, "timestamp": 19000}
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "schema": "`ID` BIGINT KEY, `T_ID` BIGINT, `NAME` STRING, `F1` STRING, `F2` BIGINT"}
+          {"name": "OUTPUT", "type": "table", "schema": "T_ID BIGINT KEY, `NAME` STRING, `F1` STRING, `F2` BIGINT"}
         ]
       }
     },
@@ -989,7 +1343,7 @@
       "statements": [
         "CREATE STREAM S1 (ID BIGINT KEY, NAME STRING) WITH (kafka_topic='S1', value_format='JSON');",
         "CREATE STREAM S2 (ID BIGINT KEY, NAME STRING) WITH (kafka_topic='S2', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT s1.name name1, s2.name name2 FROM S1 JOIN S2 WITHIN 1 second ON s1.id = s2.id;"
+        "CREATE STREAM OUTPUT as SELECT s1.id, s1.name name1, s2.name name2 FROM S1 JOIN S2 WITHIN 1 second ON s1.id = s2.id;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -1020,7 +1374,7 @@
       "statements": [
         "CREATE STREAM S1 (ID BIGINT KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='S1', value_format='JSON');",
         "CREATE STREAM S2 (ID BIGINT KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='S2', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT s1.name name1, s2.name name2 FROM S1 JOIN S2 WITHIN 1 second ON s1.id = s2.id;"
+        "CREATE STREAM OUTPUT as SELECT s1.id, s1.name name1, s2.name name2 FROM S1 JOIN S2 WITHIN 1 second ON s1.id = s2.id;"
       ],
       "inputs": [
         {"topic": "S1", "key": 0, "value": "a", "timestamp": 0},
@@ -1042,7 +1396,7 @@
       "statements": [
         "CREATE STREAM S1 (ID BIGINT KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='S1', value_format='JSON');",
         "CREATE STREAM S2 (ID BIGINT KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='S2', value_format='JSON');",
-        "CREATE STREAM OUTPUT WITH (WRAP_SINGLE_VALUE=false) AS SELECT s1.name name FROM S1 JOIN S2 WITHIN 1 second ON s1.id = s2.id;"
+        "CREATE STREAM OUTPUT WITH (WRAP_SINGLE_VALUE=false) AS SELECT s1.id, s1.name name FROM S1 JOIN S2 WITHIN 1 second ON s1.id = s2.id;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -1062,7 +1416,7 @@
       "statements": [
         "CREATE STREAM S (ID BIGINT KEY, NAME STRING) WITH (kafka_topic='S', value_format='JSON');",
         "CREATE TABLE T (ID BIGINT PRIMARY KEY, NAME STRING) WITH (kafka_topic='T', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT s.name name1, t.name name2 FROM S JOIN T ON S.id = T.id;"
+        "CREATE STREAM OUTPUT as SELECT s.id, s.name name1, t.name name2 FROM S JOIN T ON S.id = T.id;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -1092,7 +1446,7 @@
       "statements": [
         "CREATE STREAM S (ID BIGINT KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='S', value_format='JSON');",
         "CREATE TABLE T (ID BIGINT PRIMARY KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='T', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT s.name name1, t.name name2 FROM S JOIN T ON S.id = T.id;"
+        "CREATE STREAM OUTPUT as SELECT s.id, s.name name1, t.name name2 FROM S JOIN T ON S.id = T.id;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -1118,7 +1472,7 @@
       "statements": [
         "CREATE STREAM S (ID BIGINT KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='S', value_format='JSON');",
         "CREATE TABLE T (ID BIGINT PRIMARY KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='T', value_format='JSON');",
-        "CREATE STREAM OUTPUT WITH (WRAP_SINGLE_VALUE=false) AS SELECT s.name name FROM S JOIN T ON S.id = T.id;"
+        "CREATE STREAM OUTPUT WITH (WRAP_SINGLE_VALUE=false) AS SELECT s.id, s.name name FROM S JOIN T ON S.id = T.id;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -1139,7 +1493,7 @@
       "statements": [
         "CREATE TABLE T1 (ID BIGINT PRIMARY KEY, NAME STRING) WITH (kafka_topic='T1', value_format='JSON');",
         "CREATE TABLE T2 (ID BIGINT PRIMARY KEY, NAME STRING) WITH (kafka_topic='T2', value_format='JSON');",
-        "CREATE TABLE OUTPUT as SELECT t1.name name1, t2.name name2 FROM T1 JOIN T2 ON T1.id = T2.id;"
+        "CREATE TABLE OUTPUT as SELECT t1.id, t1.name name1, t2.name name2 FROM T1 JOIN T2 ON T1.id = T2.id;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -1166,7 +1520,7 @@
       "statements": [
         "CREATE TABLE T1 (ID BIGINT PRIMARY KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='T1', value_format='JSON');",
         "CREATE TABLE T2 (ID BIGINT PRIMARY KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='T2', value_format='JSON');",
-        "CREATE TABLE OUTPUT as SELECT t1.name name1, t2.name name2 FROM T1 JOIN T2 ON T1.id = T2.id;"
+        "CREATE TABLE OUTPUT as SELECT t1.id, t1.name name1, t2.name name2 FROM T1 JOIN T2 ON T1.id = T2.id;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -1188,7 +1542,7 @@
       "statements": [
         "CREATE TABLE T1 (ID BIGINT PRIMARY KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='T1', value_format='JSON');",
         "CREATE TABLE T2 (ID BIGINT PRIMARY KEY, NAME STRING) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='T2', value_format='JSON');",
-        "CREATE TABLE OUTPUT WITH (WRAP_SINGLE_VALUE=false) AS SELECT t1.name name FROM T1 JOIN T2 ON T1.id = T2.id;"
+        "CREATE TABLE OUTPUT WITH (WRAP_SINGLE_VALUE=false) AS SELECT t1.id, t1.name name FROM T1 JOIN T2 ON T1.id = T2.id;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -1210,7 +1564,7 @@
       "statements": [
         "CREATE STREAM TEST1 (ID BIGINT KEY, NAME STRING) WITH (kafka_topic='left_topic', value_format='JSON');",
         "CREATE STREAM TEST2 (ID BIGINT KEY, NAME STRING) WITH (kafka_topic='right_topic', value_format='JSON');",
-        "CREATE STREAM LEFT_OUTER_JOIN as SELECT * FROM test1 t left join test2 tt ON t.id = 0;"
+        "CREATE STREAM OUTPUT as SELECT * FROM test1 t left join test2 tt ON t.id = 0;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -1225,7 +1579,7 @@
       "statements": [
         "CREATE STREAM TEST1 (ID BIGINT KEY, NAME STRING) WITH (kafka_topic='left_topic', value_format='JSON');",
         "CREATE STREAM TEST2 (ID BIGINT KEY, NAME STRING) WITH (kafka_topic='right_topic', value_format='JSON');",
-        "CREATE STREAM LEFT_OUTER_JOIN as SELECT * FROM test1 t left join test2 tt ON 0 = t.id;"
+        "CREATE STREAM OUTPUT as SELECT * FROM test1 t left join test2 tt ON 0 = t.id;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -1240,7 +1594,7 @@
       "statements": [
         "CREATE STREAM TEST1 (ID varchar) WITH (kafka_topic='left_topic', value_format='JSON');",
         "CREATE STREAM TEST2 (ID varchar) WITH (kafka_topic='right_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT T.ID FROM test1 t join test2 tt WITHIN 30 SECONDS ON t.id = SUBSTRING(tt.id, 2);"
+        "CREATE STREAM OUTPUT as SELECT T.ID, tt.ID FROM test1 t join test2 tt WITHIN 30 SECONDS ON t.id = SUBSTRING(tt.id, 2);"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -1250,7 +1604,7 @@
         {"topic": "right_topic", "key": "!foo", "value": {"id": "!foo"}, "timestamp": 10}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": "foo", "value": {"T_ID":  "foo"}, "timestamp": 10}
+        {"topic": "OUTPUT", "key": "foo", "value": {"TT_ID":  "!foo"}, "timestamp": 10}
       ]
     },
     {
@@ -1258,7 +1612,7 @@
       "statements": [
         "CREATE STREAM TEST1 (ID bigint KEY, x bigint) WITH (kafka_topic='left_topic', value_format='JSON');",
         "CREATE STREAM TEST2 (ID int KEY, x int) WITH (kafka_topic='right_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT t.x FROM test1 t JOIN test2 tt WITHIN 30 seconds ON t.id = CAST(tt.id AS BIGINT);"
+        "CREATE STREAM OUTPUT as SELECT t.id, t.x FROM test1 t JOIN test2 tt WITHIN 30 seconds ON t.id = CAST(tt.id AS BIGINT);"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -1277,7 +1631,7 @@
       "statements": [
         "CREATE STREAM L (ID INT KEY, x bigint) WITH (kafka_topic='left_topic', value_format='JSON');",
         "CREATE STREAM R (ID DOUBLE KEY, x bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT L.x FROM L JOIN R WITHIN 30 seconds ON L.id = CAST(R.id AS INT);"
+        "CREATE STREAM OUTPUT as SELECT l.id, L.x FROM L JOIN R WITHIN 30 seconds ON L.id = CAST(R.id AS INT);"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -1295,7 +1649,7 @@
       "statements": [
         "CREATE STREAM TEST1 (KSQL_COL_0 bigint KEY, KSQL_COL_2 bigint) WITH (kafka_topic='left_topic', value_format='JSON');",
         "CREATE STREAM TEST2 (KSQL_COL_1 int KEY, KSQL_COL_3 int) WITH (kafka_topic='right_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT t.KSQL_COL_2 FROM test1 t JOIN test2 tt WITHIN 30 seconds ON t.KSQL_COL_0 = CAST(tt.KSQL_COL_1 AS BIGINT);"
+        "CREATE STREAM OUTPUT as SELECT t.KSQL_COL_0, t.KSQL_COL_2 FROM test1 t JOIN test2 tt WITHIN 30 seconds ON t.KSQL_COL_0 = CAST(tt.KSQL_COL_1 AS BIGINT);"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -1314,7 +1668,7 @@
       "statements": [
         "CREATE STREAM TEST1 (ID INT KEY, NAME STRING) WITH (kafka_topic='left_topic', value_format='JSON');",
         "CREATE STREAM TEST2 (K STRING KEY, ID ARRAY<INT>) WITH (kafka_topic='right_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT T.ID FROM test1 t JOIN test2 tt WITHIN 30 SECONDS ON t.id = tt.id[1];"
+        "CREATE STREAM OUTPUT as SELECT T.ID, TT.K FROM test1 t JOIN test2 tt WITHIN 30 SECONDS ON t.id = tt.id[1];"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -1325,7 +1679,7 @@
         {"topic": "right_topic", "key": "k", "value": {"id": [1,2,3]}, "timestamp": 10}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 1, "value": {"T_ID": 1}, "timestamp": 10}
+        {"topic": "OUTPUT", "key": 1, "value": {"K": "k"}, "timestamp": 10}
       ]
     },
     {
@@ -1343,7 +1697,7 @@
         {"topic": "right_topic", "key": 0, "value": {"name": "-"}, "timestamp": 10}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 1, "value": {"T_ID": 1, "TT_ID": 0}, "timestamp": 10}
+        {"topic": "OUTPUT", "key": 1, "value": {"TT_ID": 0}, "timestamp": 10}
       ]
     },
     {
@@ -1351,7 +1705,7 @@
       "statements": [
         "CREATE STREAM TEST1 (ID INT KEY, NAME STRING) WITH (kafka_topic='left_topic', value_format='JSON');",
         "CREATE STREAM TEST2 (ID INT KEY, NAME STRING) WITH (kafka_topic='right_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT T.NAME, TT.NAME FROM test1 t join test2 tt WITHIN 30 seconds ON t.id = -tt.id;"
+        "CREATE STREAM OUTPUT as SELECT T.ID, T.NAME, TT.NAME FROM test1 t join test2 tt WITHIN 30 seconds ON t.id = -tt.id;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -1369,7 +1723,7 @@
       "statements": [
         "CREATE STREAM TEST1 (ID INT KEY, IGNORED STRING) WITH (kafka_topic='left_topic', value_format='JSON');",
         "CREATE STREAM TEST2 (ID INT KEY, IGNORED STRING) WITH (kafka_topic='right_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT T.ID FROM test1 t join test2 tt WITHIN 30 SECONDS ON t.id = (CASE WHEN tt.id = 2 THEN 1 ELSE 3 END);"
+        "CREATE STREAM OUTPUT as SELECT T.ID, TT.ID FROM test1 t join test2 tt WITHIN 30 SECONDS ON t.id = (CASE WHEN tt.id = 2 THEN 1 ELSE 3 END);"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -1380,7 +1734,7 @@
         {"topic": "right_topic", "key": 2, "value": {}, "timestamp": 10}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 1, "value": {"T_ID": 1}, "timestamp": 10}
+        {"topic": "OUTPUT", "key": 1, "value": {"TT_ID": 2}, "timestamp": 10}
       ]
     },
     {
@@ -1388,7 +1742,7 @@
       "statements": [
         "CREATE STREAM TEST1 (ID INT KEY, IGNORED STRING) WITH (kafka_topic='left_topic', value_format='JSON');",
         "CREATE STREAM TEST2 (ID INT KEY, IGNORED STRING) WITH (kafka_topic='right_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT T.ID FROM test1 t join test2 tt WITHIN 30 seconds ON -tt.id = t.id;"
+        "CREATE STREAM OUTPUT as SELECT T.ID, TT.ID FROM test1 t join test2 tt WITHIN 30 seconds ON -tt.id = t.id;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -1398,7 +1752,7 @@
         {"topic": "right_topic", "key": -1, "value": {}, "timestamp": 10}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 1, "value": {"T_ID": 1}, "timestamp": 10}
+        {"topic": "OUTPUT", "key": 1, "value": {"TT_ID": -1}, "timestamp": 10}
       ]
     },
     {
@@ -1406,7 +1760,7 @@
       "statements": [
         "CREATE STREAM TEST1 (ID INT KEY, IGNORED STRING) WITH (kafka_topic='left_topic', value_format='JSON');",
         "CREATE STREAM TEST2 (ID INT KEY, IGNORED STRING) WITH (kafka_topic='right_topic', value_format='JSON');",
-        "CREATE STREAM LEFT_OUTER_JOIN as SELECT * FROM test1 t left join test2 tt ON t.iid= tt.id;"
+        "CREATE STREAM OUTPUT as SELECT * FROM test1 t left join test2 tt ON t.iid= tt.id;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -1421,7 +1775,7 @@
       "statements": [
         "CREATE STREAM TEST1 (ID INT KEY, IGNORED STRING) WITH (kafka_topic='left_topic', value_format='JSON');",
         "CREATE STREAM TEST2 (ID INT KEY, IGNORED STRING) WITH (kafka_topic='right_topic', value_format='JSON');",
-        "CREATE STREAM LEFT_OUTER_JOIN as SELECT * FROM test1 t left join test2 tt ON t.id= tt.iid;"
+        "CREATE STREAM OUTPUT as SELECT * FROM test1 t left join test2 tt ON t.id= tt.iid;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -1436,7 +1790,7 @@
       "statements": [
         "CREATE STREAM TEST (LEFT_ID BIGINT KEY, NAME varchar) WITH (kafka_topic='left_topic', value_format='JSON');",
         "CREATE STREAM TEST_STREAM (RIGHT_ID BIGINT KEY, F1 varchar) WITH (kafka_topic='right_topic', value_format='JSON');",
-        "CREATE STREAM LEFT_OUTER_JOIN as SELECT name, f1 FROM test t left join TEST_STREAM tt WITHIN 11 seconds ON left_id = right_id;"
+        "CREATE STREAM OUTPUT as SELECT left_id, name, f1 FROM test t left join TEST_STREAM tt WITHIN 11 seconds ON left_id = right_id;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -1452,17 +1806,17 @@
         {"topic": "left_topic", "key": 0, "value": {"NAME": "bar"}, "timestamp": 30000}
       ],
       "outputs": [
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"NAME": "zero", "F1": null}, "timestamp": 0},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"NAME": "zero", "F1": "blah"}, "timestamp": 10000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 10, "value": {"NAME": "100", "F1": null}, "timestamp": 11000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"NAME": "foo", "F1": "blah"}, "timestamp": 13000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"NAME": "foo", "F1": "a"}, "timestamp": 15000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 90, "value": {"NAME": "ninety", "F1": null}, "timestamp": 17000},
-        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"NAME": "bar", "F1": null}, "timestamp": 30000}
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "zero", "F1": null}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "zero", "F1": "blah"}, "timestamp": 10000},
+        {"topic": "OUTPUT", "key": 10, "value": {"NAME": "100", "F1": null}, "timestamp": 11000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "foo", "F1": "blah"}, "timestamp": 13000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "foo", "F1": "a"}, "timestamp": 15000},
+        {"topic": "OUTPUT", "key": 90, "value": {"NAME": "ninety", "F1": null}, "timestamp": 17000},
+        {"topic": "OUTPUT", "key": 0, "value": {"NAME": "bar", "F1": null}, "timestamp": 30000}
       ],
       "post": {
         "sources": [
-          {"name": "LEFT_OUTER_JOIN", "type": "stream", "schema": "LEFT_ID BIGINT KEY, NAME STRING, F1 STRING"}
+          {"name": "OUTPUT", "type": "stream", "schema": "LEFT_ID BIGINT KEY, NAME STRING, F1 STRING"}
         ]
       }
     },
@@ -1483,7 +1837,7 @@
         {"topic": "stream_topic", "key": "b", "value": {"SF": 12589}, "timestamp": 300}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 12589, "value": {"S_K": "b", "S_ROWTIME": 300, "S_SF": 12589, "T_ROWTIME": 300, "T_ID": 12589, "T_TF": 12}, "timestamp": 300}
+        {"topic": "OUTPUT", "key": 12589, "value": {"S_K": "b", "S_ROWTIME": 300, "T_ROWTIME": 300, "T_ID": 12589, "T_TF": 12}, "timestamp": 300}
       ],
       "post": {
         "sources": [
@@ -1491,7 +1845,7 @@
             "name": "OUTPUT",
             "type": "stream",
             "keyFormat": {"format": "KAFKA"},
-            "schema": "SF BIGINT KEY, S_K STRING, S_SF BIGINT, T_ID BIGINT, T_TF INT, S_ROWTIME BIGINT, T_ROWTIME BIGINT"
+            "schema": "S_SF BIGINT KEY, S_K STRING, T_ID BIGINT, T_TF INT, S_ROWTIME BIGINT, T_ROWTIME BIGINT"
           }
         ]
       }
@@ -1517,7 +1871,7 @@
       "statements": [
         "CREATE STREAM L (ID STRING KEY, l0 INT, l1 INT) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
         "CREATE STREAM R (ID STRING KEY, r0 INT, r1 INT) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
-        "CREATE STREAM OUTPUT as SELECT L.ID, L1, R1 FROM L join R WITHIN 11 SECONDS ON L.l0 = R.r0;"
+        "CREATE STREAM OUTPUT as SELECT L.l0, L.ID, L1, R1 FROM L join R WITHIN 11 SECONDS ON L.l0 = R.r0;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -1541,7 +1895,7 @@
       "statements": [
         "CREATE STREAM L (ID STRING KEY, l0 BIGINT, l1 INT) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
         "CREATE STREAM R (ID STRING KEY, r0 BIGINT, r1 INT) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
-        "CREATE STREAM OUTPUT as SELECT L.ID, L1, R1 FROM L join R WITHIN 11 SECONDS ON L.l0 = R.r0;"
+        "CREATE STREAM OUTPUT as SELECT L.l0, L.ID, L1, R1 FROM L join R WITHIN 11 SECONDS ON L.l0 = R.r0;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -1565,7 +1919,7 @@
       "statements": [
         "CREATE STREAM L (ID STRING KEY, l0 DOUBLE, l1 INT) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
         "CREATE STREAM R (ID STRING KEY, r0 DOUBLE, r1 INT) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
-        "CREATE STREAM OUTPUT as SELECT L.ID, L1, R1 FROM L join R WITHIN 11 SECONDS ON L.l0 = R.r0;"
+        "CREATE STREAM OUTPUT as SELECT L.l0, L.ID, L1, R1 FROM L join R WITHIN 11 SECONDS ON L.l0 = R.r0;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -1589,7 +1943,7 @@
       "statements": [
         "CREATE STREAM L (ID STRING KEY, l0 STRING, l1 INT) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
         "CREATE STREAM R (ID STRING KEY, r0 STRING, r1 INT) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
-        "CREATE STREAM OUTPUT as SELECT L.ID, L1, R1 FROM L join R WITHIN 11 SECONDS ON L.l0 = R.r0;"
+        "CREATE STREAM OUTPUT as SELECT L.l0, L.ID, L1, R1 FROM L join R WITHIN 11 SECONDS ON L.l0 = R.r0;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -1630,7 +1984,7 @@
       "statements": [
         "CREATE STREAM S1 (ID INT KEY, V bigint) WITH (kafka_topic='left_topic', value_format='JSON', WINDOW_TYPE='SESSION');",
         "CREATE STREAM S2 (ID INT KEY, V bigint) WITH (kafka_topic='right_topic', value_format='JSON', WINDOW_TYPE='SESSION');",
-        "CREATE STREAM OUTPUT as SELECT S1.V, S2.V FROM S1 JOIN S2 WITHIN 1 MINUTE ON S1.ID = S2.ID;"
+        "CREATE STREAM OUTPUT as SELECT S1.ID, S1.V, S2.V FROM S1 JOIN S2 WITHIN 1 MINUTE ON S1.ID = S2.ID;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -1649,7 +2003,7 @@
             "name": "OUTPUT",
             "type": "stream",
             "keyFormat": {"format": "KAFKA", "windowType": "SESSION"},
-            "schema": "ID INT KEY, S1_V BIGINT, S2_V BIGINT"
+            "schema": "S1_ID INT KEY, S1_V BIGINT, S2_V BIGINT"
           }
         ]
       }
@@ -1677,8 +2031,8 @@
         {"topic": "right_topic", "key": 1, "value": {"V": 5}, "timestamp": 2000, "window": {"start": 2000, "end": 4000, "type": "time"}}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 1, "value": {"S1_ROWTIME": 0, "S1_WINDOWSTART": 0, "S1_WINDOWEND": 5000, "S1_ID": 1, "S1_V": 1, "S2_ROWTIME": 0, "S2_WINDOWSTART": 0, "S2_WINDOWEND": 2000, "S2_ID": 1, "S2_V": 4}, "timestamp": 0, "window": {"start": 0, "end":5000, "type": "time"}},
-        {"topic": "OUTPUT", "key": 1, "value": {"S1_ROWTIME": 2000, "S1_WINDOWSTART": 2000, "S1_WINDOWEND": 7000, "S1_ID": 1, "S1_V": 3, "S2_ROWTIME": 2000, "S2_WINDOWSTART": 2000, "S2_WINDOWEND": 4000, "S2_ID": 1, "S2_V": 5}, "timestamp": 2000, "window": {"start": 2000, "end":7000, "type": "time"}}
+        {"topic": "OUTPUT", "key": 1, "value": {"S1_ROWTIME": 0, "S1_WINDOWSTART": 0, "S1_WINDOWEND": 5000, "S1_V": 1, "S2_ROWTIME": 0, "S2_WINDOWSTART": 0, "S2_WINDOWEND": 2000, "S2_ID": 1, "S2_V": 4}, "timestamp": 0, "window": {"start": 0, "end":5000, "type": "time"}},
+        {"topic": "OUTPUT", "key": 1, "value": {"S1_ROWTIME": 2000, "S1_WINDOWSTART": 2000, "S1_WINDOWEND": 7000, "S1_V": 3, "S2_ROWTIME": 2000, "S2_WINDOWSTART": 2000, "S2_WINDOWEND": 4000, "S2_ID": 1, "S2_V": 5}, "timestamp": 2000, "window": {"start": 2000, "end":7000, "type": "time"}}
       ],
       "post": {
         "sources": [
@@ -1686,7 +2040,7 @@
             "name": "OUTPUT",
             "type": "stream",
             "keyFormat": {"format": "KAFKA", "windowType": "HOPPING", "windowSize": 5000},
-            "schema": "`ID` INTEGER KEY, `S1_ID` INTEGER, `S1_WINDOWSTART` BIGINT, `S1_WINDOWEND` BIGINT, `S1_V` BIGINT, `S2_ID` INTEGER, `S2_WINDOWSTART` BIGINT, `S2_WINDOWEND` BIGINT, `S2_V` BIGINT, S1_ROWTIME BIGINT, S2_ROWTIME BIGINT"
+            "schema": "S1_ID INT KEY, `S1_WINDOWSTART` BIGINT, `S1_WINDOWEND` BIGINT, `S1_V` BIGINT, S2_ID INTEGER, `S2_WINDOWSTART` BIGINT, `S2_WINDOWEND` BIGINT, `S2_V` BIGINT, S1_ROWTIME BIGINT, S2_ROWTIME BIGINT"
           }
         ]
       }
@@ -1770,10 +2124,10 @@
         {"topic": "right_topic", "key": 2, "value": {"X": 4, "Y": {"Z": 10}}, "timestamp": 100}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-left-repartition", "key": 10, "value": {"S1_ROWTIME": 20, "S1_ID": 1, "S1_A": 1, "S1_B": {"C": 10}}, "timestamp": 20},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-right-repartition", "key": 10, "value": {"S2_ROWTIME": 100, "S2_ID": 2, "S2_X": 4, "S2_Y": {"Z": 10}}, "timestamp": 100},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "key": 10, "value": {"S1_ROWTIME": 20, "S1_ID": 1, "S1_A": 1, "S1_B": {"C": 10}}, "timestamp": 20, "window": {"start": 20, "end": 60020, "type": "time"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINOTHER-0000000017-store-changelog", "key": 10, "value": {"S2_ROWTIME": 100, "S2_ID": 2, "S2_X": 4, "S2_Y": {"Z": 10}}, "timestamp": 100, "window": {"start": 100, "end": 60100, "type": "time"}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-left-repartition", "key": 10, "value": {"S1_ROWTIME": 20, "S1_ID": 1, "S1_A": 1, "S1_B": {"C": 10}, "S1_C": 10}, "timestamp": 20},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-right-repartition", "key": 10, "value": {"S2_ROWTIME": 100, "S2_ID": 2, "S2_X": 4, "S2_Y": {"Z": 10}, "S2_Z": 10}, "timestamp": 100},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "key": 10, "value": {"S1_ROWTIME": 20, "S1_ID": 1, "S1_A": 1, "S1_B": {"C": 10}, "S1_C": 10}, "timestamp": 20, "window": {"start": 20, "end": 60020, "type": "time"}},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINOTHER-0000000017-store-changelog", "key": 10, "value": {"S2_ROWTIME": 100, "S2_ID": 2, "S2_X": 4, "S2_Y": {"Z": 10}, "S2_Z": 10}, "timestamp": 100, "window": {"start": 100, "end": 60100, "type": "time"}},
         {"topic": "OUTPUT", "key": 10, "value": {"S1_ROWTIME": 20, "S1_ID": 1, "S1_A": 1, "S1_B": {"C": 10}, "S2_ROWTIME": 100, "S2_ID": 2, "S2_X": 4, "S2_Y": {"Z": 10}}, "timestamp": 100}
       ],
       "post": {
@@ -1782,9 +2136,39 @@
             "name": "OUTPUT",
             "type": "stream",
             "keyFormat": {"format": "KAFKA"},
-            "schema": "C INTEGER KEY, S1_ID INTEGER, S1_A BIGINT, S1_B STRUCT<C INTEGER>, S2_ID INTEGER, S2_X BIGINT, S2_Y STRUCT<Z INTEGER>, S1_ROWTIME BIGINT, S2_ROWTIME BIGINT"
+            "schema": "KSQL_COL_0 INT KEY, S1_ID INT, S1_A BIGINT, S1_B STRUCT<C INT>, S2_ID INT, S2_X BIGINT, S2_Y STRUCT<Z INT>, S1_ROWTIME BIGINT, S2_ROWTIME BIGINT"
           }
         ]
+      }
+    },
+    {
+      "name": "join and group by without key column",
+      "statements": [
+        "CREATE TABLE INPUT1 (ID INT PRIMARY KEY, NAME STRING) WITH (kafka_topic='input-1',value_format='JSON');",
+        "CREATE TABLE INPUT2 (ID INT PRIMARY KEY, NAME STRING) WITH (kafka_topic='input-2',value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT SUM(LEN(I1.NAME) + LEN(I2.NAME)) FROM INPUT1 I1 JOIN INPUT2 I2 ON (I1.ID = I2.ID) GROUP BY I1.ID;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The query used to build `OUTPUT` must include the grouping expression I1_ID in its projection."
+      }
+    },
+    {
+      "name": "join and partition by without key column",
+      "statements": [
+        "CREATE STREAM INPUT1 (ID INT KEY, NAME STRING) WITH (kafka_topic='input-1',value_format='JSON');",
+        "CREATE STREAM INPUT2 (ID INT KEY, NAME STRING) WITH (kafka_topic='input-2',value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT I1.ID, I2.ID, I2.NAME FROM INPUT1 I1 JOIN INPUT2 I2 WITHIN 10 SECONDS ON (I1.ID = I2.ID) PARTITION BY I1.NAME;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The query used to build `OUTPUT` must include the partitioning expression I1.NAME in its projection."
       }
     },
 
@@ -4050,6 +4434,21 @@
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
         "message": "Implicit repartitioning of windowed sources is not supported. See https://github.com/confluentinc/ksql/issues/4385."
+      }
+    },
+    {
+      "name": "join on literal",
+      "statements": [
+        "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE STREAM S2 (ID INT KEY, V0 bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT * FROM S1 JOIN S2 WITHIN 1 MINUTE ON S1.ID = 0;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid comparison expression '0' in join '(S1.ID = 0)'. Each side of the join comparision must contain references from exactly one source."
       }
     }
   ]

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/key-schemas.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/key-schemas.json
@@ -320,7 +320,7 @@
       "name": "explicit key field named other than ROWKEY",
       "statements": [
         "CREATE STREAM INPUT (OTHER DOUBLE KEY, ID bigint) WITH (kafka_topic='input',value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT ID, OTHER as KEY FROM INPUT;"
+        "CREATE STREAM OUTPUT as SELECT OTHER, ID, AS_VALUE(OTHER) as KEY FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -347,7 +347,7 @@
       "comment": "tests that `KEY` is allowed as a KEY column name",
       "statements": [
         "CREATE STREAM INPUT (KEY STRING KEY, ID bigint) WITH (kafka_topic='input',value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT ID, KEY as KEY2 FROM INPUT;"
+        "CREATE STREAM OUTPUT as SELECT KEY, ID, AS_VALUE(KEY) as KEY2 FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/map.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/map.json
@@ -7,7 +7,7 @@
       "name": "string map",
       "statements": [
         "CREATE STREAM INPUT (ID STRING KEY, A_MAP MAP<STRING, INT>) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT A_MAP['expected'], A_MAP['missing'] FROM INPUT;"
+        "CREATE STREAM OUTPUT AS SELECT ID, A_MAP['expected'], A_MAP['missing'] FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -23,7 +23,7 @@
       "name": "map value as UDF param",
       "statements": [
         "CREATE STREAM INPUT (ID STRING KEY, col11 MAP<STRING, STRING>) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT EXTRACTJSONFIELD(col11['address'], '$.city') FROM INPUT;"
+        "CREATE STREAM OUTPUT AS SELECT ID, EXTRACTJSONFIELD(col11['address'], '$.city') FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/multi-joins.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/multi-joins.json
@@ -5,12 +5,263 @@
   ],
   "tests": [
     {
+      "name": "first join column in projection",
+      "statements": [
+        "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
+        "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
+        "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT S1.ID, s1.V0, t2.V0, t3.V0 FROM S1 JOIN T2 ON S1.ID = T2.ID JOIN T3 ON S1.ID = T3.ID;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "right2", "key": 0, "value": {"V0": 3}, "timestamp": 10},
+        {"topic": "right", "key": 0, "value": {"V0": 2}, "timestamp": 11},
+        {"topic": "left", "key": 0, "value": {"V0": 1}, "timestamp": 12}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_V0": 2, "T3_V0": 3}, "timestamp": 12}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "S1_ID INT KEY, S1_V0 BIGINT, T2_V0 BIGINT, T3_V0 BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "second join column in projection",
+      "statements": [
+        "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
+        "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
+        "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT T2.ID, s1.V0, t2.V0, t3.V0 FROM S1 JOIN T2 ON S1.ID = T2.ID JOIN T3 ON S1.ID = T3.ID;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "right2", "key": 0, "value": {"V0": 3}, "timestamp": 10},
+        {"topic": "right", "key": 0, "value": {"V0": 2}, "timestamp": 11},
+        {"topic": "left", "key": 0, "value": {"V0": 1}, "timestamp": 12}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_V0": 2, "T3_V0": 3}, "timestamp": 12}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "T2_ID INT KEY, S1_V0 BIGINT, T2_V0 BIGINT, T3_V0 BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "third join column in projection",
+      "statements": [
+        "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
+        "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
+        "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT T3.ID, s1.V0, t2.V0, t3.V0 FROM S1 JOIN T2 ON S1.ID = T2.ID JOIN T3 ON S1.ID = T3.ID;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "right2", "key": 0, "value": {"V0": 3}, "timestamp": 10},
+        {"topic": "right", "key": 0, "value": {"V0": 2}, "timestamp": 11},
+        {"topic": "left", "key": 0, "value": {"V0": 1}, "timestamp": 12}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_V0": 2, "T3_V0": 3}, "timestamp": 12}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "T3_ID INT KEY, S1_V0 BIGINT, T2_V0 BIGINT, T3_V0 BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "inner-inner - missing join columns in projection",
+      "statements": [
+        "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
+        "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
+        "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT s1.V0, t2.V0, t3.V0 FROM S1 INNER JOIN T2 ON S1.ID = T2.ID INNER JOIN T3 ON S1.ID = T3.ID;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The query used to build `OUTPUT` must include the join expressions S1.ID, T3.ID or T2.ID in its projection."
+      }
+    },
+    {
+      "name": "inner-inner with single expression in first - missing join columns in projection",
+      "statements": [
+        "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
+        "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
+        "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT s1.V0, t2.V0, t3.V0 FROM S1 INNER JOIN T2 ON S1.ID = T2.ID + 1 INNER JOIN T3 ON S1.ID = T3.ID;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The query used to build `OUTPUT` must include the join expressions S1.ID or T3.ID in its projection."
+      }
+    },
+    {
+      "name": "inner-inner with double expression in first - missing join columns in projection",
+      "statements": [
+        "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
+        "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
+        "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT s1.V0, t2.V0, t3.V0 FROM S1 INNER JOIN T2 ON S1.ID + 1 = T2.ID + 1 INNER JOIN T3 ON S1.ID = T3.ID;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The query used to build `OUTPUT` must include the join expressions S1.ID or T3.ID in its projection."
+      }
+    },
+    {
+      "name": "inner-inner with single expression in second - missing join columns in projection",
+      "statements": [
+        "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
+        "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
+        "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT s1.V0, t2.V0, t3.V0 FROM S1 INNER JOIN T2 ON S1.ID = T2.ID INNER JOIN T3 ON S1.ID + 1 = T3.ID;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The query used to build `OUTPUT` must include the join expression T3.ID in its projection."
+      }
+    },
+    {
+      "name": "inner-inner with double expression in second - missing join columns in projection",
+      "statements": [
+        "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
+        "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
+        "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT s1.V0, t2.V0, t3.V0 FROM S1 INNER JOIN T2 ON S1.ID = T2.ID INNER JOIN T3 ON S1.ID + 1 = T3.ID + 1;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The query used to build `OUTPUT` must include the join expression JOINKEY((S1.ID + 1), (T3.ID + 1)) in its projection."
+      }
+    },
+    {
+      "name": "left-left - missing join columns in projection",
+      "statements": [
+        "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
+        "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
+        "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT s1.V0, t2.V0, t3.V0 FROM S1 LEFT JOIN T2 ON S1.ID = T2.ID LEFT JOIN T3 ON S1.ID = T3.ID;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The query used to build `OUTPUT` must include the join expressions S1.ID, T3.ID or T2.ID in its projection."
+      }
+    },
+    {
+      "name": "left-left with single expression in first - missing join columns in projection",
+      "statements": [
+        "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
+        "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
+        "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT s1.V0, t2.V0, t3.V0 FROM S1 LEFT JOIN T2 ON S1.ID + 1 = T2.ID LEFT JOIN T3 ON S1.ID = T3.ID;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The query used to build `OUTPUT` must include the join expressions S1.ID or T3.ID in its projection."
+      }
+    },
+    {
+      "name": "left-left with double expression in first - missing join columns in projection",
+      "statements": [
+        "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
+        "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
+        "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT s1.V0, t2.V0, t3.V0 FROM S1 LEFT JOIN T2 ON S1.ID + 1 = T2.ID + 1 LEFT JOIN T3 ON S1.ID = T3.ID;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The query used to build `OUTPUT` must include the join expressions S1.ID or T3.ID in its projection."
+      }
+    },
+    {
+      "name": "left-left with single expression in second - missing join columns in projection",
+      "statements": [
+        "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
+        "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
+        "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT s1.V0, t2.V0, t3.V0 FROM S1 LEFT JOIN T2 ON S1.ID = T2.ID LEFT JOIN T3 ON S1.ID = T3.ID + 1;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The query used to build `OUTPUT` must include the join expressions S1.ID or T2.ID in its projection."
+      }
+    },
+    {
+      "name": "left-left with double expression in second - missing join columns in projection",
+      "statements": [
+        "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
+        "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
+        "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT s1.V0, t2.V0, t3.V0 FROM S1 LEFT JOIN T2 ON S1.ID = T2.ID LEFT JOIN T3 ON S1.ID + 1 = T3.ID + 1;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The query used to build `OUTPUT` must include the join expression JOINKEY((S1.ID + 1), (T3.ID + 1)) in its projection."
+      }
+    },
+    {
+      "name": "full-full missing join expression in projection",
+      "statements": [
+        "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
+        "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
+        "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT s1.V0, t2.V0, t3.V0 FROM S1 FULL OUTER JOIN T2 ON S1.ID = T2.ID FULL OUTER JOIN T3 ON S1.ID = T3.ID;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The query used to build `OUTPUT` must include the join expression JOINKEY(S1.ID, T3.ID) in its projection."
+      }
+    },
+    {
       "name": "stream-table-table - inner-inner",
       "statements": [
         "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
         "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
         "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT s1.V0, t2.V0, t3.V0 FROM S1 JOIN T2 ON S1.ID = T2.ID JOIN T3 ON S1.ID = T3.ID;"
+        "CREATE STREAM OUTPUT as SELECT S1.ID, s1.V0, t2.V0, t3.V0 FROM S1 JOIN T2 ON S1.ID = T2.ID JOIN T3 ON S1.ID = T3.ID;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -22,12 +273,12 @@
         {"topic": "left", "key": 1, "value": {"V0": 1}, "timestamp": 14}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_V0": 2, "T3_V0": 3}, "timestamp":  12}
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_V0": 2, "T3_V0": 3}, "timestamp": 12}
       ],
       "post": {
         "topics": {"blacklist": ".*-repartition"},
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, S1_V0 BIGINT, T2_V0 BIGINT, T3_V0 BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "S1_ID INT KEY, S1_V0 BIGINT, T2_V0 BIGINT, T3_V0 BIGINT"}
         ]
       }
     },
@@ -37,7 +288,7 @@
         "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
         "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
         "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT s1.V0, t2.V0, t3.V0 FROM S1 LEFT JOIN T2 ON S1.ID = T2.ID LEFT JOIN T3 ON S1.ID = T3.ID;"
+        "CREATE STREAM OUTPUT as SELECT S1.ID, s1.V0, t2.V0, t3.V0 FROM S1 LEFT JOIN T2 ON S1.ID = T2.ID LEFT JOIN T3 ON S1.ID = T3.ID;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -50,14 +301,14 @@
         {"topic": "left", "key": 0, "value": {"V0": 1}, "timestamp": 13}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_V0": null, "T3_V0": null}, "timestamp":  9},
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_V0": 2, "T3_V0": null}, "timestamp":  11},
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_V0": 2, "T3_V0": 3}, "timestamp":  13}
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_V0": null, "T3_V0": null}, "timestamp": 9},
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_V0": 2, "T3_V0": null}, "timestamp": 11},
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_V0": 2, "T3_V0": 3}, "timestamp": 13}
       ],
       "post": {
         "topics": {"blacklist": ".*-repartition"},
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, S1_V0 BIGINT, T2_V0 BIGINT, T3_V0 BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "S1_ID INT KEY, S1_V0 BIGINT, T2_V0 BIGINT, T3_V0 BIGINT"}
         ]
       }
     },
@@ -67,7 +318,7 @@
         "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
         "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
         "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT s1.V0, t2.V0, t3.V0 FROM S1 LEFT JOIN T2 ON S1.ID = T2.ID JOIN T3 ON S1.ID = T3.ID;"
+        "CREATE STREAM OUTPUT as SELECT S1.ID, s1.V0, t2.V0, t3.V0 FROM S1 LEFT JOIN T2 ON S1.ID = T2.ID JOIN T3 ON S1.ID = T3.ID;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -80,12 +331,12 @@
         {"topic": "left", "key": 0, "value": {"V0": 1}, "timestamp": 13}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_V0": 2, "T3_V0": 3}, "timestamp":  13}
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_V0": 2, "T3_V0": 3}, "timestamp": 13}
       ],
       "post": {
         "topics": {"blacklist": ".*-repartition"},
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, S1_V0 BIGINT, T2_V0 BIGINT, T3_V0 BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "S1_ID INT KEY, S1_V0 BIGINT, T2_V0 BIGINT, T3_V0 BIGINT"}
         ]
       }
     },
@@ -95,7 +346,7 @@
         "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
         "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
         "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT s1.V0, t2.V0, t3.V0 FROM S1 JOIN T2 ON S1.ID = T2.ID LEFT JOIN T3 ON S1.ID = T3.ID;"
+        "CREATE STREAM OUTPUT as SELECT S1.ID, s1.V0, t2.V0, t3.V0 FROM S1 JOIN T2 ON S1.ID = T2.ID LEFT JOIN T3 ON S1.ID = T3.ID;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -108,13 +359,13 @@
         {"topic": "left", "key": 0, "value": {"V0": 1}, "timestamp": 13}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_V0": 2, "T3_V0": null}, "timestamp":  11},
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_V0": 2, "T3_V0": 3}, "timestamp":  13}
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_V0": 2, "T3_V0": null}, "timestamp": 11},
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_V0": 2, "T3_V0": 3}, "timestamp": 13}
       ],
       "post": {
         "topics": {"blacklist": ".*-repartition"},
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, S1_V0 BIGINT, T2_V0 BIGINT, T3_V0 BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "S1_ID INT KEY, S1_V0 BIGINT, T2_V0 BIGINT, T3_V0 BIGINT"}
         ]
       }
     },
@@ -124,7 +375,7 @@
         "CREATE STREAM S1 (ID INT KEY, K INT, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
         "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
         "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT s1.V0, t2.V0, t3.V0 FROM S1 JOIN T2 ON S1.K = T2.ID JOIN T3 ON S1.K = T3.ID;"
+        "CREATE STREAM OUTPUT as SELECT S1.K, s1.V0, t2.V0, t3.V0 FROM S1 JOIN T2 ON S1.K = T2.ID JOIN T3 ON S1.K = T3.ID;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -136,7 +387,7 @@
       ],
       "outputs": [
         {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-L_Join-repartition", "key": 1, "value": {"S1_K": 1, "S1_V0": 1, "S1_ROWTIME": 12, "S1_ID": 0}, "timestamp": 12},
-        {"topic": "OUTPUT", "key": 1, "value": {"S1_V0": 1, "T2_V0": 2, "T3_V0": 3}, "timestamp":  12}
+        {"topic": "OUTPUT", "key": 1, "value": {"S1_V0": 1, "T2_V0": 2, "T3_V0": 3}, "timestamp": 12}
       ],
       "post": {
         "sources": [
@@ -150,7 +401,7 @@
         "CREATE STREAM S1 (ID INT KEY, K INT, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
         "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
         "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT s1.V0, t2.V0, t3.V0 FROM S1 JOIN T2 ON S1.K - 1 = T2.ID JOIN T3 ON S1.K + 1 = T3.ID;"
+        "CREATE STREAM OUTPUT as SELECT T3.ID, s1.V0, t2.V0, t3.V0 FROM S1 JOIN T2 ON S1.K - 1 = T2.ID JOIN T3 ON S1.K + 1 = T3.ID;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -161,11 +412,11 @@
         {"topic": "left", "key": 0, "value": {"k": 2, "V0": 1}, "timestamp": 12}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 3, "value": {"S1_V0": 1, "T2_V0": 2, "T3_V0": 3}, "timestamp":  12}
+        {"topic": "OUTPUT", "key": 3, "value": {"S1_V0": 1, "T2_V0": 2, "T3_V0": 3}, "timestamp": 12}
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "KSQL_COL_1 INT KEY, S1_V0 BIGINT, T2_V0 BIGINT, T3_V0 BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "T3_ID INT KEY, S1_V0 BIGINT, T2_V0 BIGINT, T3_V0 BIGINT"}
         ]
       }
     },
@@ -176,7 +427,7 @@
         "CREATE STREAM S1 (ID INT KEY, K INT, V0 int) WITH (kafka_topic='left', value_format='JSON');",
         "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 int) WITH (kafka_topic='right', value_format='JSON');",
         "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 int) WITH (kafka_topic='right2', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT s1.V0, t2.V0, t3.V0 FROM S1 JOIN T2 ON S1.V0 = T2.ID JOIN T3 ON S1.K = T3.ID;"
+        "CREATE STREAM OUTPUT as SELECT S1.K, s1.V0, t2.V0, t3.V0 FROM S1 JOIN T2 ON S1.V0 = T2.ID JOIN T3 ON S1.K = T3.ID;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -187,11 +438,11 @@
         {"topic": "left", "key": 0, "value": {"k": 2, "V0": 1}, "timestamp": 12}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 2, "value": {"S1_V0": 1, "T2_V0": 2, "T3_V0": 3}, "timestamp":  12}
+        {"topic": "OUTPUT", "key": 2, "value": {"S1_V0": 1, "T2_V0": 2, "T3_V0": 3}, "timestamp": 12}
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "S1_K INT KEY, S1_V0 INT, T2_V0 INT, T3_V0 INT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "K INT KEY, S1_V0 INT, T2_V0 INT, T3_V0 INT"}
         ]
       }
     },
@@ -212,12 +463,12 @@
         {"topic": "left", "key": 0, "value": {"V0": 1}, "timestamp": 12}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_ROWTIME": 12, "S1_ID": 0, "S1_V0": 1, "T2_ROWTIME": 12, "T2_ID": 0, "T2_V0": 2, "T3_ROWTIME": 12, "T3_ID": 0, "T3_V0": 3}, "timestamp":  12}
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_ID": 0, "T2_V0": 2, "T3_ID": 0, "T3_V0": 3, "S1_ROWTIME": 12, "T2_ROWTIME": 12, "T3_ROWTIME": 12}, "timestamp": 12}
       ],
       "post": {
         "topics": {"blacklist": ".*-repartition"},
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, S1_ID INT, S1_V0 BIGINT, T2_ID INT, T2_V0 BIGINT, T3_ID INT, T3_V0 BIGINT, S1_ROWTIME BIGINT, T2_ROWTIME BIGINT, T3_ROWTIME BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "S1_ID INT KEY, S1_V0 BIGINT, T2_ID INT, T2_V0 BIGINT, T3_ID INT, T3_V0 BIGINT, S1_ROWTIME BIGINT, T2_ROWTIME BIGINT, T3_ROWTIME BIGINT"}
         ]
       }
     },
@@ -238,12 +489,12 @@
         {"topic": "left", "key": 0, "value": {"V0": 1}, "timestamp": 12}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_ID": 0, "S1_V0": 1, "T2_ID": 0, "T2_V0": 2, "T3_ID": 0, "T3_V0": 3}, "timestamp":  12}
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_ID": 0, "T2_V0": 2, "T3_ID": 0, "T3_V0": 3}, "timestamp": 12}
       ],
       "post": {
         "topics": {"blacklist": ".*-repartition"},
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, S1_ID INT, S1_V0 BIGINT, T2_ID INT, T2_V0 BIGINT, T3_ID INT, T3_V0 BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "S1_ID INT KEY, S1_V0 BIGINT, T2_ID INT, T2_V0 BIGINT, T3_ID INT, T3_V0 BIGINT"}
         ]
       }
     },
@@ -264,12 +515,12 @@
         {"topic": "left", "key": 0, "value": {"V0": 1}, "timestamp": 12}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_ID": 0, "S1_V0": 1}, "timestamp":  12}
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1}, "timestamp": 12}
       ],
       "post": {
         "topics": {"blacklist": ".*-repartition"},
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, S1_ID INT, S1_V0 BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "S1_ID INT KEY, S1_V0 BIGINT"}
         ]
       }
     },
@@ -290,12 +541,12 @@
         {"topic": "left", "key": 0, "value": {"V0": 1}, "timestamp": 12}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_ID": 0, "S1_V0": 1, "T2_V0": 2, "T3_V0": 3}, "timestamp":  12}
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_V0": 2, "T3_V0": 3}, "timestamp": 12}
       ],
       "post": {
         "topics": {"blacklist": ".*-repartition"},
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, S1_ID INT, S1_V0 BIGINT, T2_V0 BIGINT, T3_V0 BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "S1_ID INT KEY, S1_V0 BIGINT, T2_V0 BIGINT, T3_V0 BIGINT"}
         ]
       }
     },
@@ -316,12 +567,12 @@
         {"topic": "left", "key": 0, "value": {"V0": 1}, "timestamp": 12}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_ID": 0, "S1_V0": 1, "T2_ID": 0, "T2_V0": 2, "T3_ID": 0, "T3_V0": 3}, "timestamp":  12}
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_ID": 0, "T2_V0": 2, "T3_ID": 0, "T3_V0": 3}, "timestamp": 12}
       ],
       "post": {
         "topics": {"blacklist": ".*-repartition"},
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, S1_ID INT, S1_V0 BIGINT, T2_ID INT, T2_V0 BIGINT, T3_ID INT, T3_V0 BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "S1_ID INT KEY, S1_V0 BIGINT, T2_ID INT, T2_V0 BIGINT, T3_ID INT, T3_V0 BIGINT"}
         ]
       }
     },
@@ -331,7 +582,7 @@
         "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
         "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
         "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT s1.V0, t2.V0, t3.V0 FROM S1 JOIN T2 ON T2.ID = S1.ID JOIN T3 ON T3.ID = S1.ID;"
+        "CREATE STREAM OUTPUT as SELECT T2.ID, s1.V0, t2.V0, t3.V0 FROM S1 JOIN T2 ON T2.ID = S1.ID JOIN T3 ON T3.ID = S1.ID;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -343,12 +594,12 @@
         {"topic": "left", "key": 1, "value": {"V0": 1}, "timestamp": 14}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_V0": 2, "T3_V0": 3}, "timestamp":  12}
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_V0": 2, "T3_V0": 3}, "timestamp": 12}
       ],
       "post": {
         "topics": {"blacklist": ".*-repartition"},
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, S1_V0 BIGINT, T2_V0 BIGINT, T3_V0 BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "T2_ID INT KEY, S1_V0 BIGINT, T2_V0 BIGINT, T3_V0 BIGINT"}
         ]
       }
     },
@@ -358,7 +609,7 @@
         "CREATE STREAM S1 (ID INT KEY, K INT, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
         "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
         "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT s1.V0, t2.V0, t3.V0 FROM S1 JOIN T2 ON T2.ID = S1.K JOIN T3 ON T3.ID = S1.K;"
+        "CREATE STREAM OUTPUT as SELECT T3.ID, s1.V0, t2.V0, t3.V0 FROM S1 JOIN T2 ON T2.ID = S1.K JOIN T3 ON T3.ID = S1.K;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -370,11 +621,11 @@
       ],
       "outputs": [
         {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-L_Join-repartition", "key": 1, "value": {"S1_K": 1, "S1_V0": 1, "S1_ROWTIME": 12, "S1_ID": 0}, "timestamp": 12},
-        {"topic": "OUTPUT", "key": 1, "value": {"S1_V0": 1, "T2_V0": 2, "T3_V0": 3}, "timestamp":  12}
+        {"topic": "OUTPUT", "key": 1, "value": {"S1_V0": 1, "T2_V0": 2, "T3_V0": 3}, "timestamp": 12}
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "K INT KEY, S1_V0 BIGINT, T2_V0 BIGINT, T3_V0 BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "T3_ID INT KEY, S1_V0 BIGINT, T2_V0 BIGINT, T3_V0 BIGINT"}
         ]
       }
     },
@@ -384,7 +635,7 @@
         "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
         "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
         "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT s.V0, t.V0, tt.V0 FROM S1 s JOIN T2 t ON S.ID = T.ID JOIN T3 tt ON S.ID = TT.ID;"
+        "CREATE STREAM OUTPUT as SELECT S.ID, s.V0, t.V0, tt.V0 FROM S1 s JOIN T2 t ON S.ID = T.ID JOIN T3 tt ON S.ID = TT.ID;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -396,12 +647,12 @@
         {"topic": "left", "key": 1, "value": {"V0": 1}, "timestamp": 14}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"S_V0": 1, "T_V0": 2, "TT_V0": 3}, "timestamp":  12}
+        {"topic": "OUTPUT", "key": 0, "value": {"S_V0": 1, "T_V0": 2, "TT_V0": 3}, "timestamp": 12}
       ],
       "post": {
         "topics": {"blacklist": ".*-repartition"},
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, S_V0 BIGINT, T_V0 BIGINT, TT_V0 BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "S_ID INT KEY, S_V0 BIGINT, T_V0 BIGINT, TT_V0 BIGINT"}
         ]
       }
     },
@@ -411,7 +662,7 @@
         "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
         "CREATE STREAM S2 (ID INT KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
         "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT s1.V0, s2.V0, t3.V0 FROM S1 JOIN S2 WITHIN 10 seconds ON S1.ID = S2.ID JOIN T3 ON S1.ID = T3.ID;"
+        "CREATE STREAM OUTPUT as SELECT S2.ID, s1.V0, s2.V0, t3.V0 FROM S1 JOIN S2 WITHIN 10 seconds ON S1.ID = S2.ID JOIN T3 ON S1.ID = T3.ID;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -425,14 +676,14 @@
         {"topic": "right", "key": 0, "value": {"V0": 6}, "timestamp": 100001}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 2, "T3_V0": 3}, "timestamp":  12},
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 4, "T3_V0": 3}, "timestamp":  13},
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 5, "S2_V0": 6, "T3_V0": 3}, "timestamp":  100001}
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 2, "T3_V0": 3}, "timestamp": 12},
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 4, "T3_V0": 3}, "timestamp": 13},
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 5, "S2_V0": 6, "T3_V0": 3}, "timestamp": 100001}
       ],
       "post": {
         "topics": {"blacklist": ".*-repartition"},
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, S1_V0 BIGINT, S2_V0 BIGINT, T3_V0 BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "S2_ID INT KEY, S1_V0 BIGINT, S2_V0 BIGINT, T3_V0 BIGINT"}
         ]
       }
     },
@@ -442,7 +693,7 @@
         "CREATE STREAM S1 (ID INT KEY, k int, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
         "CREATE STREAM S2 (ID INT KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
         "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT s1.V0, s2.V0, t3.V0 FROM S1 JOIN S2 WITHIN 10 seconds ON S1.K = S2.ID JOIN T3 ON S1.K = T3.ID;"
+        "CREATE STREAM OUTPUT as SELECT S1.K, s1.V0, s2.V0, t3.V0 FROM S1 JOIN S2 WITHIN 10 seconds ON S1.K = S2.ID JOIN T3 ON S1.K = T3.ID;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -456,9 +707,9 @@
         {"topic": "right", "key": 0, "value": {"V0": 6}, "timestamp": 100001}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 2, "T3_V0": 3}, "timestamp":  12},
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 4, "T3_V0": 3}, "timestamp":  13},
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 5, "S2_V0": 6, "T3_V0": 3}, "timestamp":  100001}
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 2, "T3_V0": 3}, "timestamp": 12},
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 4, "T3_V0": 3}, "timestamp": 13},
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 5, "S2_V0": 6, "T3_V0": 3}, "timestamp": 100001}
       ],
       "post": {
         "sources": [
@@ -472,7 +723,7 @@
         "CREATE STREAM S1 (ID INT KEY, k int, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
         "CREATE STREAM S2 (ID INT KEY, k int, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
         "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT s1.V0, s2.V0, t3.V0 FROM S1 JOIN S2 WITHIN 10 seconds ON S1.K = S2.K JOIN T3 ON S1.K = T3.ID;"
+        "CREATE STREAM OUTPUT as SELECT T3.ID, s1.V0, s2.V0, t3.V0 FROM S1 JOIN S2 WITHIN 10 seconds ON S1.K = S2.K JOIN T3 ON S1.K = T3.ID;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -491,13 +742,13 @@
         {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-L_Join-right-repartition", "key": 0, "value": {"S2_K": 0, "S2_V0": 6, "S2_ROWTIME": 100001, "S2_ID": 2}, "timestamp": 100001},
         {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-L_Join-left-repartition", "key": 0, "value": {"S1_K": 0, "S1_V0": 1, "S1_ROWTIME": 12, "S1_ID": 1}, "timestamp": 12},
         {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-L_Join-left-repartition", "key": 0, "value": {"S1_K": 0, "S1_V0": 5, "S1_ROWTIME": 100000, "S1_ID": 1}, "timestamp": 100000},
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 2, "T3_V0": 3}, "timestamp":  12},
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 4, "T3_V0": 3}, "timestamp":  13},
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 5, "S2_V0": 6, "T3_V0": 3}, "timestamp":  100001}
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 2, "T3_V0": 3}, "timestamp": 12},
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 4, "T3_V0": 3}, "timestamp": 13},
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 5, "S2_V0": 6, "T3_V0": 3}, "timestamp": 100001}
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "K INT KEY, S1_V0 BIGINT, S2_V0 BIGINT, T3_V0 BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "T3_ID INT KEY, S1_V0 BIGINT, S2_V0 BIGINT, T3_V0 BIGINT"}
         ]
       }
     },
@@ -507,7 +758,7 @@
         "CREATE STREAM S1 (ID INT KEY, k int, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
         "CREATE STREAM S2 (ID INT KEY, k int, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
         "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT s1.V0, s2.V0, t3.V0 FROM S1 JOIN S2 WITHIN 10 seconds ON S1.K = S2.K JOIN T3 ON S2.K = T3.ID;"
+        "CREATE STREAM OUTPUT as SELECT s1.k, s1.V0, s2.V0, t3.V0 FROM S1 JOIN S2 WITHIN 10 seconds ON S1.K = S2.K JOIN T3 ON S2.K = T3.ID;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -521,13 +772,13 @@
         {"topic": "right", "key": 2, "value": {"k": 0, "V0": 6}, "timestamp": 100001}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 2, "T3_V0": 3}, "timestamp":  12},
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 4, "T3_V0": 3}, "timestamp":  13},
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 5, "S2_V0": 6, "T3_V0": 3}, "timestamp":  100001}
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 2, "T3_V0": 3}, "timestamp": 12},
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 4, "T3_V0": 3}, "timestamp": 13},
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 5, "S2_V0": 6, "T3_V0": 3}, "timestamp": 100001}
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "K INT KEY, S1_V0 BIGINT, S2_V0 BIGINT, T3_V0 BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "S1_K INT KEY, S1_V0 BIGINT, S2_V0 BIGINT, T3_V0 BIGINT"}
         ]
       }
     },
@@ -537,7 +788,7 @@
         "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
         "CREATE STREAM S2 (ID INT KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
         "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT s1.V0, s2.V0, t3.V0 FROM S1 LEFT JOIN S2 WITHIN 10 seconds ON S1.ID = S2.ID JOIN T3 ON S1.ID = T3.ID;"
+        "CREATE STREAM OUTPUT as SELECT s1.V0, s2.V0, t3.V0, S2.ID FROM S1 LEFT JOIN S2 WITHIN 10 seconds ON S1.ID = S2.ID JOIN T3 ON S1.ID = T3.ID;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -551,15 +802,15 @@
         {"topic": "right", "key": 0, "value": {"V0": 6}, "timestamp": 100001}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 2, "T3_V0": 3}, "timestamp":  12},
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 4, "T3_V0": 3}, "timestamp":  13},
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 5, "S2_V0": null, "T3_V0": 3}, "timestamp":  100000},
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 5, "S2_V0": 6, "T3_V0": 3}, "timestamp":  100001}
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 2, "T3_V0": 3}, "timestamp": 12},
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 4, "T3_V0": 3}, "timestamp": 13},
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 5, "S2_V0": null, "T3_V0": 3}, "timestamp": 100000},
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 5, "S2_V0": 6, "T3_V0": 3}, "timestamp": 100001}
       ],
       "post": {
         "topics": {"blacklist": ".*-repartition"},
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, S1_V0 BIGINT, S2_V0 BIGINT, T3_V0 BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "S2_ID INT KEY, S1_V0 BIGINT, S2_V0 BIGINT, T3_V0 BIGINT"}
         ]
       }
     },
@@ -569,7 +820,7 @@
         "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
         "CREATE STREAM S2 (ID INT KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
         "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT s1.V0, s2.V0, t3.V0 FROM S1 FULL JOIN S2 WITHIN 10 seconds ON S1.ID = S2.ID JOIN T3 ON S1.ID = T3.ID;"
+        "CREATE STREAM OUTPUT as SELECT S1.ID, s1.V0, s2.V0, t3.V0 FROM S1 FULL JOIN S2 WITHIN 10 seconds ON S1.ID = S2.ID JOIN T3 ON S1.ID = T3.ID;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -583,19 +834,55 @@
         {"topic": "right", "key": 0, "value": {"V0": 6}, "timestamp": 100001}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition", "key": null, "value": {"S1_V0": null, "S1_ROWTIME": null, "S1_ID": null, "S2_V0": 2, "S2_ROWTIME": 11, "S2_ID": 0}, "timestamp":  11},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition", "key": 0, "value": {"S1_V0": 1, "S1_ROWTIME": 12, "S1_ID": 0, "S2_V0": 2, "S2_ROWTIME": 11, "S2_ID": 0}, "timestamp":  12},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition", "key": 0, "value": {"S1_V0": 1, "S1_ROWTIME": 12, "S1_ID": 0, "S2_V0": 4, "S2_ROWTIME": 13, "S2_ID": 0}, "timestamp":  13},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition", "key": 0, "value": {"S1_V0": 5, "S1_ROWTIME": 100000, "S1_ID": 0, "S2_V0": null, "S2_ROWTIME": null, "S2_ID": null}, "timestamp":  100000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition", "key": 0, "value": {"S1_V0": 5, "S1_ROWTIME": 100000, "S1_ID": 0, "S2_V0": 6, "S2_ROWTIME": 100001, "S2_ID": 0}, "timestamp":  100001},
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 2, "T3_V0": 3}, "timestamp":  12},
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 4, "T3_V0": 3}, "timestamp":  13},
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 5, "S2_V0": null, "T3_V0": 3}, "timestamp":  100000},
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 5, "S2_V0": 6, "T3_V0": 3}, "timestamp":  100001}
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition", "key": null, "value": {"S1_V0": null, "S1_ROWTIME": null, "S1_ID": null, "S2_V0": 2, "S2_ROWTIME": 11, "S2_ID": 0, "KSQL_COL_0": null}, "timestamp": 11},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition", "key": 0, "value": {"S1_V0": 1, "S1_ROWTIME": 12, "S1_ID": 0, "S2_V0": 2, "S2_ROWTIME": 11, "S2_ID": 0, "KSQL_COL_0": null}, "timestamp": 12},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition", "key": 0, "value": {"S1_V0": 1, "S1_ROWTIME": 12, "S1_ID": 0, "S2_V0": 4, "S2_ROWTIME": 13, "S2_ID": 0, "KSQL_COL_0": null}, "timestamp": 13},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition", "key": 0, "value": {"S1_V0": 5, "S1_ROWTIME": 100000, "S1_ID": 0, "S2_V0": null, "S2_ROWTIME": null, "S2_ID": null, "KSQL_COL_0": null}, "timestamp": 100000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition", "key": 0, "value": {"S1_V0": 5, "S1_ROWTIME": 100000, "S1_ID": 0, "S2_V0": 6, "S2_ROWTIME": 100001, "S2_ID": 0, "KSQL_COL_0": null}, "timestamp": 100001},
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 2, "T3_V0": 3}, "timestamp": 12},
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 4, "T3_V0": 3}, "timestamp": 13},
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 5, "S2_V0": null, "T3_V0": 3}, "timestamp": 100000},
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 5, "S2_V0": 6, "T3_V0": 3}, "timestamp": 100001}
       ],
       "post": {
         "sources": [
           {"name": "OUTPUT", "type": "stream", "schema": "S1_ID INT KEY, S1_V0 BIGINT, S2_V0 BIGINT, T3_V0 BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "stream-stream-table - full-inner - select *",
+      "statements": [
+        "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
+        "CREATE STREAM S2 (ID INT KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
+        "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT * FROM S1 FULL JOIN S2 WITHIN 10 seconds ON S1.ID = S2.ID JOIN T3 ON S1.ID = T3.ID;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "right2", "key": 0, "value": {"V0": 3}, "timestamp": 10},
+        {"topic": "right", "key": 0, "value": {"V0": 2}, "timestamp": 11},
+        {"topic": "left", "key": 0, "value": {"V0": 1}, "timestamp": 12},
+        {"topic": "right", "key": 0, "value": {"V0": 4}, "timestamp": 13},
+        {"topic": "left", "key": 0, "value": {"V0": 5}, "timestamp": 100000},
+        {"topic": "right", "key": 0, "value": {"V0": 6}, "timestamp": 100001}
+      ],
+      "outputs": [
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition", "key": null, "value": {"S1_V0": null, "S1_ROWTIME": null, "S1_ID": null, "S2_V0": 2, "S2_ROWTIME": 11, "S2_ID": 0, "KSQL_COL_0": null}, "timestamp": 11},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition", "key": 0, "value": {"S1_V0": 1, "S1_ROWTIME": 12, "S1_ID": 0, "S2_V0": 2, "S2_ROWTIME": 11, "S2_ID": 0, "KSQL_COL_0": null}, "timestamp": 12},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition", "key": 0, "value": {"S1_V0": 1, "S1_ROWTIME": 12, "S1_ID": 0, "S2_V0": 4, "S2_ROWTIME": 13, "S2_ID": 0, "KSQL_COL_0": null}, "timestamp": 13},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition", "key": 0, "value": {"S1_V0": 5, "S1_ROWTIME": 100000, "S1_ID": 0, "S2_V0": null, "S2_ROWTIME": null, "S2_ID": null, "KSQL_COL_0": null}, "timestamp": 100000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition", "key": 0, "value": {"S1_V0": 5, "S1_ROWTIME": 100000, "S1_ID": 0, "S2_V0": 6, "S2_ROWTIME": 100001, "S2_ID": 0, "KSQL_COL_0": null}, "timestamp": 100001},
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_ID": 0, "S2_V0": 2, "T3_ID": 0, "T3_V0": 3}, "timestamp": 12},
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_ID": 0, "S2_V0": 4, "T3_ID": 0, "T3_V0": 3}, "timestamp": 13},
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 5, "S2_ID": null, "S2_V0": null, "T3_ID": 0, "T3_V0": 3}, "timestamp": 100000},
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 5, "S2_ID": 0, "S2_V0": 6, "T3_ID": 0, "T3_V0": 3}, "timestamp": 100001}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "S1_ID INT KEY, S1_V0 BIGINT, S2_ID INT, S2_V0 BIGINT, T3_ID INT, T3_V0 BIGINT"}
         ]
       }
     },
@@ -605,7 +892,7 @@
         "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
         "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
         "CREATE STREAM S3 (ID INT KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT s1.V0, t2.V0, s3.V0 FROM S1 JOIN T2 ON S1.ID = T2.ID JOIN S3 WITHIN 10 seconds ON S1.ID = S3.ID;"
+        "CREATE STREAM OUTPUT as SELECT S3.ID, s1.V0, t2.V0, s3.V0 FROM S1 JOIN T2 ON S1.ID = T2.ID JOIN S3 WITHIN 10 seconds ON S1.ID = S3.ID;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -619,13 +906,13 @@
         {"topic": "right2", "key": 0, "value": {"V0": 6}, "timestamp": 100001}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_V0": 2, "S3_V0": 3}, "timestamp":  12},
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 5, "T2_V0": 4, "S3_V0": 6}, "timestamp":  100001}
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_V0": 2, "S3_V0": 3}, "timestamp": 12},
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 5, "T2_V0": 4, "S3_V0": 6}, "timestamp": 100001}
       ],
       "post": {
         "topics": {"blacklist": ".*-repartition"},
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, S1_V0 BIGINT, T2_V0 BIGINT, S3_V0 BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "S3_ID INT KEY, S1_V0 BIGINT, T2_V0 BIGINT, S3_V0 BIGINT"}
         ]
       }
     },
@@ -635,7 +922,7 @@
         "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
         "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
         "CREATE STREAM S3 (ID INT KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT s1.V0, t2.V0, s3.V0 FROM S1 LEFT JOIN T2 ON S1.ID = T2.ID JOIN S3 WITHIN 10 seconds ON S1.ID = S3.ID;"
+        "CREATE STREAM OUTPUT as SELECT S3.ID, s1.V0, t2.V0, s3.V0 FROM S1 LEFT JOIN T2 ON S1.ID = T2.ID JOIN S3 WITHIN 10 seconds ON S1.ID = S3.ID;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -649,13 +936,13 @@
         {"topic": "right2", "key": 0, "value": {"V0": 6}, "timestamp": 100001}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_V0": null, "S3_V0": 3}, "timestamp":  12},
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 5, "T2_V0": 4, "S3_V0": 6}, "timestamp":  100001}
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_V0": null, "S3_V0": 3}, "timestamp": 12},
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 5, "T2_V0": 4, "S3_V0": 6}, "timestamp": 100001}
       ],
       "post": {
         "topics": {"blacklist": ".*-repartition"},
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, S1_V0 BIGINT, T2_V0 BIGINT, S3_V0 BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "S3_ID INT KEY, S1_V0 BIGINT, T2_V0 BIGINT, S3_V0 BIGINT"}
         ]
       }
     },
@@ -665,7 +952,7 @@
         "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
         "CREATE STREAM S2 (ID INT KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
         "CREATE STREAM S3 (ID INT KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT s1.V0, s2.V0, s3.V0 FROM S1 JOIN S2 WITHIN 5 seconds ON S1.ID = S2.ID JOIN S3 WITHIN 10 seconds ON S1.ID = S3.ID;"
+        "CREATE STREAM OUTPUT as SELECT S2.ID, s1.V0, s2.V0, s3.V0 FROM S1 JOIN S2 WITHIN 5 seconds ON S1.ID = S2.ID JOIN S3 WITHIN 10 seconds ON S1.ID = S3.ID;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -694,7 +981,7 @@
       "post": {
         "topics": {"blacklist": ".*-repartition"},
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, S1_V0 BIGINT, S2_V0 BIGINT, S3_V0 BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "S2_ID INT KEY, S1_V0 BIGINT, S2_V0 BIGINT, S3_V0 BIGINT"}
         ]
       }
     },
@@ -704,7 +991,7 @@
         "CREATE TABLE T1 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
         "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
         "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
-        "CREATE TABLE OUTPUT as SELECT T1.V0, T2.V0, T3.V0 FROM T1 JOIN T2 ON T1.ID = T2.ID JOIN T3 ON T1.ID = T3.ID;"
+        "CREATE TABLE OUTPUT as SELECT T1.ID, T1.V0, T2.V0, T3.V0 FROM T1 JOIN T2 ON T1.ID = T2.ID JOIN T3 ON T1.ID = T3.ID;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -722,7 +1009,7 @@
       "post": {
         "topics": {"blacklist": ".*-repartition"},
         "sources": [
-          {"name": "OUTPUT", "type": "table", "schema": "ID INT PRIMARY KEY, T1_V0 BIGINT, T2_V0 BIGINT, T3_V0 BIGINT"}
+          {"name": "OUTPUT", "type": "table", "schema": "T1_ID INT PRIMARY KEY, T1_V0 BIGINT, T2_V0 BIGINT, T3_V0 BIGINT"}
         ]
       }
     },
@@ -732,7 +1019,7 @@
         "CREATE TABLE T1 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
         "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
         "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
-        "CREATE TABLE OUTPUT as SELECT T1.V0, T2.V0, T3.V0 FROM T1 JOIN T2 ON T1.ID = T2.ID FULL JOIN T3 ON T1.ID = T3.ID;"
+        "CREATE TABLE OUTPUT as SELECT JOINKEY(T1.ID, T3.ID) AS ID, T1.V0, T2.V0, T3.V0 FROM T1 JOIN T2 ON T1.ID = T2.ID FULL JOIN T3 ON T1.ID = T3.ID;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -809,7 +1096,7 @@
         "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
         "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
         "CREATE TABLE T3 (ID INT PRIMARY KEY, DIFF bigint) WITH (kafka_topic='right2', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT s1.V0, t2.V0, t3.DIFF FROM S1 JOIN T2 ON S1.ID = T2.ID JOIN T3 ON S1.ID = T3.ID;"
+        "CREATE STREAM OUTPUT as SELECT S1.ID, s1.V0, t2.V0, t3.DIFF FROM S1 JOIN T2 ON S1.ID = T2.ID JOIN T3 ON S1.ID = T3.ID;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -821,13 +1108,29 @@
         {"topic": "left", "key": 1, "value": {"V0": 1}, "timestamp": 14}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_V0": 2, "DIFF": 3}, "timestamp":  12}
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_V0": 2, "DIFF": 3}, "timestamp": 12}
       ],
       "post": {
         "topics": {"blacklist": ".*-repartition"},
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, S1_V0 BIGINT, T2_V0 BIGINT, DIFF BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "S1_ID INT KEY, S1_V0 BIGINT, T2_V0 BIGINT, DIFF BIGINT"}
         ]
+      }
+    },
+    {
+      "name": "join on literal",
+      "statements": [
+        "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
+        "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
+        "CREATE TABLE T3 (ID INT PRIMARY KEY, DIFF bigint) WITH (kafka_topic='right2', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT S1.ID, s1.V0, t2.V0, t3.DIFF FROM S1 JOIN T2 ON S1.ID = 0 JOIN T3 ON S1.ID = T3.ID;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid comparison expression '0' in join '(S1.ID = 0)'. Each side of the join comparision must contain references from exactly one source."
       }
     }
   ]

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/multi-joins.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/multi-joins.json
@@ -80,6 +80,48 @@
       }
     },
     {
+      "name": "only viable in projection",
+      "statements": [
+        "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
+        "CREATE STREAM S2 (ID INT KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
+        "CREATE STREAM S3 (ID INT KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT S1.ID, s1.V0, s2.V0, s3.V0 FROM S1 JOIN S2 WITHIN 10 seconds ON S1.ID = abs(S2.ID) JOIN S3 WITHIN 10 seconds ON abs(S2.ID) = abs(S3.ID);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "right2", "key": 0, "value": {"V0": 3}, "timestamp": 10},
+        {"topic": "right", "key": 0, "value": {"V0": 2}, "timestamp": 11},
+        {"topic": "left", "key": 0, "value": {"V0": 1}, "timestamp": 12}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 2, "S3_V0": 3}, "timestamp": 12}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "S1_ID INT KEY, S1_V0 BIGINT, S2_V0 BIGINT, S3_V0 BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "unsupported joinkey parameters",
+      "comment": "while the parameters are semantically correct, its not currently supported",
+      "statements": [
+        "CREATE TABLE T1 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
+        "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
+        "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT JOINKEY(T1.ID, T3.ID), t1.V0, t2.V0, t3.V0 FROM T1 JOIN T2 ON T1.ID = abs(T2.ID) FULL OUTER JOIN T3 ON abs(T2.ID) = T3.ID;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The query used to build `OUTPUT` must include the join expression JOINKEY(ABS(T2.ID), T3.ID) in its projection."
+      }
+    },
+    {
       "name": "inner-inner - missing join columns in projection",
       "statements": [
         "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
@@ -92,7 +134,7 @@
       },
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "The query used to build `OUTPUT` must include the join expressions S1.ID, T3.ID or T2.ID in its projection."
+        "message": "The query used to build `OUTPUT` must include the join expressions S1.ID, T2.ID or T3.ID in its projection."
       }
     },
     {
@@ -172,7 +214,7 @@
       },
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "The query used to build `OUTPUT` must include the join expressions S1.ID, T3.ID or T2.ID in its projection."
+        "message": "The query used to build `OUTPUT` must include the join expressions S1.ID, T2.ID or T3.ID in its projection."
       }
     },
     {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/null.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/null.json
@@ -7,7 +7,7 @@
       "name": "is null",
       "statements": [
         "CREATE STREAM INPUT (ID INT KEY, NAME STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT ID IS NULL AS ID_NULL, NAME IS NULL AS NAME_NULL FROM INPUT;"
+        "CREATE STREAM OUTPUT AS SELECT ID, ID IS NULL AS ID_NULL, NAME IS NULL AS NAME_NULL FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -27,7 +27,7 @@
       "name": "is not null",
       "statements": [
         "CREATE STREAM INPUT (ID INT KEY, NAME STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT ID IS NOT NULL AS ID_NULL, NAME IS NOT NULL AS NAME_NULL FROM INPUT;"
+        "CREATE STREAM OUTPUT AS SELECT ID, ID IS NOT NULL AS ID_NULL, NAME IS NOT NULL AS NAME_NULL FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -47,7 +47,7 @@
       "name": "null equals",
       "statements": [
         "CREATE STREAM INPUT (ID INT KEY, COL0 BIGINT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT ID = COL0, NULL IS NULL FROM INPUT;"
+        "CREATE STREAM OUTPUT AS SELECT ID, ID = COL0, NULL IS NULL FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -67,7 +67,7 @@
       "name": "comparison with null",
       "statements": [
         "CREATE STREAM INPUT (ID INT KEY, COL0 BIGINT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT NULL <> NULL FROM INPUT;"
+        "CREATE STREAM OUTPUT AS SELECT ID, NULL <> NULL FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -81,7 +81,7 @@
       "name": "coalesce",
       "statements": [
         "CREATE STREAM INPUT (COL0 INT KEY, COL1 INT, COL2 STRING, COL3 ARRAY<INT>) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT COALESCE(COL0, COL1, COL0, COL1) AS A, COALESCE(COL2, 'x') AS B, COALESCE(COL3, ARRAY[10, 20]) AS C FROM INPUT;"
+        "CREATE STREAM OUTPUT AS SELECT COL0, COALESCE(COL0, COL1, COL0, COL1) AS A, COALESCE(COL2, 'x') AS B, COALESCE(COL3, ARRAY[10, 20]) AS C FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -103,7 +103,7 @@
       "name": "coalesce - no params",
       "statements": [
         "CREATE STREAM INPUT (COL0 INT KEY, COL1 STRING, COL2 ARRAY<INT>) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT COALESCE() FROM INPUT;"
+        "CREATE STREAM OUTPUT AS SELECT COL0, COALESCE() FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -117,7 +117,7 @@
       "name": "if null",
       "statements": [
         "CREATE STREAM INPUT (COL0 INT KEY, COL1 STRING, COL2 ARRAY<INT>) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT IFNULL(COL0, 10) AS A, IFNULL(COL1, 'x') AS B, IFNULL(COL2, ARRAY[10, 20]) AS C FROM INPUT;"
+        "CREATE STREAM OUTPUT AS SELECT COL0, IFNULL(COL0, 10) AS A, IFNULL(COL1, 'x') AS B, IFNULL(COL2, ARRAY[10, 20]) AS C FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -140,6 +140,9 @@
       "statements": [
         "CREATE STREAM INPUT (ROWKEY INT KEY, COL0 NULL) WITH (kafka_topic='test_topic', value_format='JSON');"
       ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
       "expectedException": {
         "type": "io.confluent.ksql.parser.exception.ParseFailedException",
         "message": "mismatched input 'NULL'"
@@ -148,8 +151,11 @@
     {
       "name": "NULL element type",
       "statements": [
-        "CREATE STREAM INPUT (ROWKEY INT KEY, COL0 ARRAY<NULL>) WITH (kafka_topic='test_topic', value_format='JSON');"
+        "CREATE STREAM INPUT (ID INT KEY, COL0 ARRAY<NULL>) WITH (kafka_topic='test_topic', value_format='JSON');"
       ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
       "expectedException": {
         "type": "io.confluent.ksql.parser.exception.ParseFailedException",
         "message": "mismatched input 'NULL'"
@@ -158,8 +164,11 @@
     {
       "name": "NULL value type",
       "statements": [
-        "CREATE STREAM INPUT (ROWKEY INT KEY, COL0 MAP<STRING, NULL>) WITH (kafka_topic='test_topic', value_format='JSON');"
+        "CREATE STREAM INPUT (ID INT KEY, COL0 MAP<STRING, NULL>) WITH (kafka_topic='test_topic', value_format='JSON');"
       ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
       "expectedException": {
         "type": "io.confluent.ksql.parser.exception.ParseFailedException",
         "message": "mismatched input 'NULL'"
@@ -168,8 +177,11 @@
     {
       "name": "NULL field type",
       "statements": [
-        "CREATE STREAM INPUT (ROWKEY INT KEY, COL0 STRUCT<fo NULL>) WITH (kafka_topic='test_topic', value_format='JSON');"
+        "CREATE STREAM INPUT (ID INT KEY, COL0 STRUCT<fo NULL>) WITH (kafka_topic='test_topic', value_format='JSON');"
       ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
       "expectedException": {
         "type": "io.confluent.ksql.parser.exception.ParseFailedException",
         "message": "mismatched input 'NULL'"

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/partition-by.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/partition-by.json
@@ -21,6 +21,26 @@
       }
     },
     {
+      "name": "only key column - select explicit",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT KEY, NAME STRING) with (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS select ID, NAME from INPUT partition by ID;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [{"topic": "input", "key": 10, "value": {"NAME": "bob"}}],
+      "outputs": [{"topic": "OUTPUT", "key": 10, "value": {"NAME": "bob"}}],
+      "post": {
+        "topics": {
+          "blacklist": ".*-repartition"
+        },
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, NAME STRING"}
+        ]
+      }
+    },
+    {
       "name": "single value column - select star",
       "statements": [
         "CREATE STREAM INPUT (ID INT KEY, NAME STRING, AGE INT) with (kafka_topic='input', value_format='JSON');",
@@ -37,6 +57,26 @@
         },
         "sources": [
           {"name": "OUTPUT", "type": "stream", "schema": "NAME STRING KEY, AGE INT, ID INT"}
+        ]
+      }
+    },
+    {
+      "name": "single value column - select explicit",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT KEY, NAME STRING, AGE INT) with (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS select ID, NAME, AGE from INPUT partition by NAME;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [{"topic": "input", "key": 10, "value": {"NAME": "bob", "AGE": 22}}],
+      "outputs": [{"topic": "OUTPUT", "key": "bob", "value": {"ID": 10, "AGE": 22}}],
+      "post": {
+        "topics": {
+          "blacklist": ".*-repartition"
+        },
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "NAME STRING KEY, ID INT, AGE INT"}
         ]
       }
     },
@@ -58,17 +98,37 @@
       }
     },
     {
-      "name": "struct field - select duplicate",
+      "name": "struct field - select explicit",
       "statements": [
         "CREATE STREAM INPUT (ID INT KEY, ADDRESS STRUCT<STREET STRING, TOWN STRING>, AGE INT) with (kafka_topic='input', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS select ADDRESS->TOWN from INPUT partition by ADDRESS->TOWN;"
+        "CREATE STREAM OUTPUT AS select ID, AGE, ADDRESS->TOWN from INPUT partition by ADDRESS->TOWN;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
       },
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Value column name(s) `TOWN` clashes with key column name(s)"
+      "inputs": [{"topic": "input", "key": 10, "value": {"ADDRESS": {"STREET": "1st Steet", "Town": "Oxford"}, "AGE": 22}}],
+      "outputs": [{"topic": "OUTPUT", "key": "Oxford", "value": {"ID": 10, "AGE": 22}}],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "TOWN STRING KEY, ID INT, AGE INT"}
+        ]
+      }
+    },
+   {
+      "name": "struct field - with alias",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT KEY, ADDRESS STRUCT<STREET STRING, TOWN STRING>, AGE INT) with (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS select ADDRESS->TOWN AS K, ID, AGE from INPUT partition by ADDRESS->TOWN;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [{"topic": "input", "key": 10, "value": {"ADDRESS": {"STREET": "1st Steet", "Town": "Oxford"}, "AGE": 22}}],
+      "outputs": [{"topic": "OUTPUT", "key": "Oxford", "value": {"ID": 10, "AGE": 22}}],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "K STRING KEY, ID INT, AGE INT"}
+        ]
       }
     },
     {
@@ -92,36 +152,65 @@
       }
     },
     {
-      "name": "only key column - select columns",
+      "name": "expression - select explicit",
       "statements": [
-        "CREATE STREAM INPUT (ID INT KEY, NAME STRING, OTHER INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT NAME FROM INPUT PARTITION BY ID;"
+        "CREATE STREAM INPUT (ID INT KEY, NAME STRING) with (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS select NAME, ID, ABS(ID) from INPUT partition by ABS(ID);"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
       },
-      "inputs": [
-        {"topic": "test_topic", "key": 11, "value": {"name": "a"}},
-        {"topic": "test_topic", "key": 10, "value": {"name": "b"}},
-        {"topic": "test_topic", "key": 11, "value": {"name": "c"}}
-      ],
-      "outputs": [
-        {"topic": "OUTPUT", "key": 11, "value": {"NAME": "a"}},
-        {"topic": "OUTPUT", "key": 10, "value": {"NAME": "b"}},
-        {"topic": "OUTPUT", "key": 11, "value": {"NAME": "c"}}
-      ],
+      "inputs": [{"topic": "input", "key": 10, "value": {"NAME": "bob"}}],
+      "outputs": [{"topic": "OUTPUT", "key": 10, "value": {"NAME": "bob", "ID": 10}}],
       "post": {
         "topics": {
           "blacklist": ".*-repartition"
         },
         "sources": [
-          {
-            "name": "OUTPUT",
-            "type": "stream",
-            "keyFormat": {"format": "KAFKA"},
-            "schema": "ID INT KEY, NAME STRING"
-          }
+          {"name": "OUTPUT", "type": "stream", "schema": "KSQL_COL_0 INT KEY, NAME STRING, ID INT"}
         ]
+      }
+    },
+    {
+      "name": "key in projection more than once",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT KEY, NAME STRING) with (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS select NAME, NAME AS NAME2, ID from INPUT partition by NAME;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The projection contains the key column more than once: `NAME` and `NAME2`."
+      }
+    },
+    {
+      "name": "expression - missing key from projection",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT KEY, NAME STRING) with (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS select NAME, ID from INPUT partition by ABS(ID);"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The query used to build `OUTPUT` must include the partitioning expression ABS(INPUT.ID) in its projection."
+      }
+    },
+    {
+      "name": "expression - missing key from projection - with value column of same name",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT KEY, NAME STRING) with (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS select NAME AS ID, NAME from INPUT partition by ID;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The query used to build `OUTPUT` must include the partitioning expression INPUT.ID in its projection."
       }
     },
     {
@@ -174,7 +263,7 @@
       "name": "nulls",
       "statements": [
         "CREATE STREAM TEST (ROWKEY BIGINT KEY, ID bigint, NAME varchar) with (kafka_topic='test_topic', value_format = 'delimited');",
-        "CREATE STREAM REPARTITIONED AS select id from TEST partition by name;"
+        "CREATE STREAM REPARTITIONED AS select name, id from TEST partition by name;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -192,26 +281,21 @@
     },
     {
       "name": "single column - with alias",
-      "comment": [
-        "Note: as the partition by is aliased, it is treated as a new column and the 'select *' ",
-        "expansion still includes 'NAME'. Where as without the alias it would not.",
-        "This can be through of as similar to `SELECT *, NAME as NEW KEY FROM'."
-      ],
       "statements": [
         "CREATE STREAM INPUT (ID INT KEY, NAME STRING, AGE INT) with (kafka_topic='input', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS select * from INPUT partition by NAME AS NEW_KEY;"
+        "CREATE STREAM OUTPUT AS select NAME AS NEW_KEY, ID, AGE from INPUT partition by NAME;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
       },
       "inputs": [{"topic": "input", "key": 10, "value": {"NAME": "bob", "AGE": 22}}],
-      "outputs": [{"topic": "OUTPUT", "key": "bob", "value": {"NAME": "bob", "ID": 10, "AGE": 22}}],
+      "outputs": [{"topic": "OUTPUT", "key": "bob", "value": {"ID": 10, "AGE": 22}}],
       "post": {
         "topics": {
           "blacklist": ".*-repartition"
         },
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "NEW_KEY STRING KEY, NAME STRING, AGE INT, ID INT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "NEW_KEY STRING KEY, ID INT, AGE INT"}
         ]
       }
     },
@@ -219,7 +303,7 @@
       "name": "only key column - with alias that matches key column",
       "statements": [
         "CREATE STREAM INPUT (ID INT KEY, NAME STRING, OTHER INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT NAME FROM INPUT PARTITION BY ID AS ID;"
+        "CREATE STREAM OUTPUT AS SELECT ID AS ID, NAME FROM INPUT PARTITION BY ID;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -252,16 +336,16 @@
       "name": "single non-key column - with alias that matches old key column",
       "statements": [
         "CREATE STREAM INPUT (ID INT KEY, NAME STRING, AGE INT) with (kafka_topic='input', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS select * from INPUT partition by NAME AS ID;"
+        "CREATE STREAM OUTPUT AS select NAME AS ID, AGE, ID AS OLD from INPUT partition by NAME;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
       },
       "inputs": [{"topic": "input", "key": 10, "value": {"NAME": "bob", "AGE": 22}}],
-      "outputs": [{"topic": "OUTPUT", "key": "bob", "value": {"NAME": "bob", "AGE": 22}}],
+      "outputs": [{"topic": "OUTPUT", "key": "bob", "value": {"OLD": 10, "AGE": 22}}],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ID STRING KEY, NAME STRING, AGE INT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "ID STRING KEY, AGE INT, OLD INT"}
         ]
       }
     },
@@ -269,7 +353,7 @@
       "name": "single expression - with alias",
       "statements": [
         "CREATE STREAM INPUT (ID INT KEY, NAME STRING, AGE INT) with (kafka_topic='input', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS select * from INPUT partition by UCASE(NAME) AS NEW_KEY;"
+        "CREATE STREAM OUTPUT AS select UCASE(NAME) AS NEW_KEY, NAME, AGE, ID from INPUT partition by UCASE(NAME);"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -293,16 +377,16 @@
       ],
       "statements": [
         "CREATE STREAM INPUT (ID INT KEY, NAME STRING, AGE INT) with (kafka_topic='input', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS select NAME, ID from INPUT partition by NAME AS AGE;"
+        "CREATE STREAM OUTPUT AS select NAME AS AGE, ID from INPUT partition by NAME;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
       },
       "inputs": [{"topic": "input", "key": 10, "value": {"NAME": "bob", "AGE": 22}}],
-      "outputs": [{"topic": "OUTPUT", "key": "bob", "value": {"NAME": "bob", "ID": 10}}],
+      "outputs": [{"topic": "OUTPUT", "key": "bob", "value": {"ID": 10}}],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "AGE STRING KEY, NAME STRING, ID INT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "AGE STRING KEY, ID INT"}
         ]
       }
     },
@@ -679,7 +763,7 @@
       }
     },
     {
-      "name": "should handled quoted key and value",
+      "name": "should handle quoted key and value",
       "statements": [
         "CREATE STREAM INPUT (`Key` STRING KEY, `Name` STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE STREAM OUTPUT AS SELECT *, `Name` AS `Name2` FROM INPUT PARTITION BY `Key`;"
@@ -712,7 +796,7 @@
       "name": "nulls using coalesce",
       "statements": [
         "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar) with (kafka_topic='test_topic', value_format = 'json');",
-        "CREATE STREAM REPARTITIONED AS select id from TEST partition by COALESCE(name, 'default');"
+        "CREATE STREAM REPARTITIONED AS select COALESCE(name, 'default'), id from TEST partition by COALESCE(name, 'default');"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/project-filter.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/project-filter.json
@@ -389,7 +389,7 @@
       "name": "project nulls",
       "statements": [
         "CREATE STREAM INPUT (ID INT KEY, NAME STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT as SELECT name FROM INPUT;"
+        "CREATE STREAM OUTPUT as SELECT ID, name FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -428,6 +428,99 @@
       "outputs": [
         {"topic": "OUTPUT", "key": 1, "value": {"NAME": "Nick"}},
         {"topic": "OUTPUT", "key": 4, "value": {"NAME": "Fred"}}
+      ]
+    },
+    {
+      "name": "projection with aliased key column",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT KEY, NAME STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT ID AS NEW_KEY, NAME FROM INPUT;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": {"NAME": "Nick"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"NAME": "Nick"}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "NEW_KEY INT KEY, NAME STRING"}
+        ]
+      }
+    },
+    {
+      "name": "key in projection more than once",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT KEY, NAME STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT ID, ID AS ID2, NAME FROM INPUT;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The projection contains the key column more than once: `ID` and `ID2`."
+      }
+    },
+    {
+      "name": "projection with missing key column",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT KEY, NAME STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT NAME FROM INPUT;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The query used to build `OUTPUT` must include the key column ID in its projection."
+      }
+    },
+    {
+      "name": "projection with missing key column - with value column with same name",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT KEY, NAME STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT NAME AS ID, NAME FROM INPUT;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The query used to build `OUTPUT` must include the key column ID in its projection."
+      }
+    },
+    {
+      "name": "projection no value columns",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT KEY, NAME STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT ID FROM INPUT;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The projection contains no value columns."
+      }
+    },
+    {
+      "name": "project with value column aliased multiple times",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT KEY, NAME STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT ID, name, name as name2 FROM INPUT;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": {"NAME": "Nick"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"NAME": "Nick", "NAME2": "Nick"}}
       ]
     }
   ]

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/select.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/select.json
@@ -7,28 +7,7 @@
       "name": "key column",
       "statements": [
         "CREATE STREAM INPUT (id int KEY, name STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT id as ID_COPY FROM INPUT;"
-      ],
-      "properties": {
-        "ksql.any.key.name.enabled": true
-      },
-      "inputs": [
-        {"topic":  "test_topic", "key": 8, "value": {"name": "a"}}
-      ],
-      "outputs": [
-        {"topic":  "OUTPUT", "key": 8, "value": {"ID_COPY": 8}}
-      ],
-      "post": {
-        "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, ID_COPY INT"}
-        ]
-      }
-    },
-    {
-      "name": "value column",
-      "statements": [
-        "CREATE STREAM INPUT (id int KEY, name STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT NAME FROM INPUT;"
+        "CREATE STREAM OUTPUT AS SELECT id as ID_COPY, NAME FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -41,7 +20,28 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, NAME STRING"}
+          {"name": "OUTPUT", "type": "stream", "schema": "ID_COPY INT KEY, NAME STRING"}
+        ]
+      }
+    },
+    {
+      "name": "value column",
+      "statements": [
+        "CREATE STREAM INPUT (id int KEY, name STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT ID, NAME AS NEW_NAME FROM INPUT;"
+      ],
+      "properties": {
+        "ksql.any.key.name.enabled": true
+      },
+      "inputs": [
+        {"topic":  "test_topic", "key": 8, "value": {"name": "a"}}
+      ],
+      "outputs": [
+        {"topic":  "OUTPUT", "key": 8, "value": {"NEW_NAME": "a"}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, NEW_NAME STRING"}
         ]
       }
     },
@@ -70,7 +70,7 @@
       "name": "all columns - explicit",
       "statements": [
         "CREATE STREAM INPUT (id int KEY, name STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT ID AS ID_COPY, ROWTIME AS ROWTIME_COPY, NAME FROM INPUT;"
+        "CREATE STREAM OUTPUT AS SELECT ID AS ID_COPY, ROWTIME AS ROWTIME_COPY, NAME AS NAME_COPY FROM INPUT;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true
@@ -79,11 +79,11 @@
         {"topic":  "test_topic", "timestamp": 1234, "key": 8, "value": {"name": "a"}}
       ],
       "outputs": [
-        {"topic":  "OUTPUT", "timestamp": 1234, "key": 8, "value": {"ID_COPY": 8, "ROWTIME_COPY": 1234, "NAME": "a"}}
+        {"topic":  "OUTPUT", "timestamp": 1234, "key": 8, "value": {"ROWTIME_COPY": 1234, "NAME_COPY": "a"}}
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, ID_COPY INT, ROWTIME_COPY BIGINT, NAME STRING"}
+          {"name": "OUTPUT", "type": "stream", "schema": "ID_COPY INT KEY, ROWTIME_COPY BIGINT, NAME_COPY STRING"}
         ]
       }
     }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/table-functions.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/table-functions.json
@@ -156,7 +156,7 @@
       "name": "test_udtf - key column",
       "statements": [
         "CREATE STREAM TEST (ID INT KEY, NAME STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT TEST_UDTF(ID) FROM TEST;"
+        "CREATE STREAM OUTPUT AS SELECT ID, TEST_UDTF(ID) FROM TEST;"
       ],
       "properties": {
         "ksql.any.key.name.enabled": true

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
@@ -1064,7 +1064,7 @@
       "name": "should handled quoted key and value",
       "statements": [
         "CREATE STREAM INPUT (`Key` STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE TABLE AGGREGATE AS SELECT COUNT(1) AS `Value` FROM INPUT GROUP BY `Key`;",
+        "CREATE TABLE AGGREGATE AS SELECT `Key`, COUNT(1) AS `Value` FROM INPUT GROUP BY `Key`;",
         "SELECT * FROM AGGREGATE WHERE `Key`='10';"
       ],
       "properties": {

--- a/ksqldb-rest-app/src/test/resources/ksql-plan-schema/schema.json
+++ b/ksqldb-rest-app/src/test/resources/ksql-plan-schema/schema.json
@@ -560,6 +560,9 @@
           "type" : "string",
           "enum" : [ "INNER", "LEFT", "OUTER" ]
         },
+        "keyColName" : {
+          "type" : "string"
+        },
         "leftInternalFormats" : {
           "$ref" : "#/definitions/Formats"
         },
@@ -597,6 +600,9 @@
         "joinType" : {
           "type" : "string",
           "enum" : [ "INNER", "LEFT", "OUTER" ]
+        },
+        "keyColName" : {
+          "type" : "string"
         },
         "internalFormats" : {
           "$ref" : "#/definitions/Formats"
@@ -862,6 +868,9 @@
         "joinType" : {
           "type" : "string",
           "enum" : [ "INNER", "LEFT", "OUTER" ]
+        },
+        "keyColName" : {
+          "type" : "string"
         },
         "leftSource" : {
           "$ref" : "#/definitions/ExecutionStep"

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/GenericRowSerDe.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/GenericRowSerDe.java
@@ -271,7 +271,8 @@ public final class GenericRowSerDe implements ValueSerdeFactory {
 
       if (data.size() != schema.fields().size()) {
         throw new SerializationException("Field count mismatch."
-            + " expected: " + schema.fields().size()
+            + " topic: " + topic
+            + ", expected: " + schema.fields().size()
             + ", got: " + data.size()
         );
       }

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/GenericRowSerDeTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/GenericRowSerDeTest.java
@@ -344,7 +344,7 @@ public class GenericRowSerDeTest {
     );
 
     // Then:
-    assertThat(e.getMessage(), containsString("Field count mismatch. expected: 2, got: 1"));
+    assertThat(e.getMessage(), containsString("Field count mismatch. topic: fred, expected: 2, got: 1"));
   }
 
   @Test
@@ -362,7 +362,7 @@ public class GenericRowSerDeTest {
     );
 
     // Then:
-    assertThat(e.getMessage(), containsString("Field count mismatch. expected: 2, got: 3"));
+    assertThat(e.getMessage(), containsString("Field count mismatch. topic: fred, expected: 2, got: 3"));
   }
 
   @Test

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
@@ -198,6 +198,7 @@ public final class ExecutionStepFactory {
   public static <K> StreamTableJoin<K> streamTableJoin(
       final QueryContext.Stacker stacker,
       final JoinType joinType,
+      final ColumnName keyColName,
       final Formats formats,
       final ExecutionStep<KStreamHolder<K>> left,
       final ExecutionStep<KTableHolder<K>> right
@@ -206,6 +207,7 @@ public final class ExecutionStepFactory {
     return new StreamTableJoin<>(
         new ExecutionStepPropertiesV1(queryContext),
         joinType,
+        keyColName,
         formats,
         left,
         right
@@ -215,6 +217,7 @@ public final class ExecutionStepFactory {
   public static <K> StreamStreamJoin<K> streamStreamJoin(
       final QueryContext.Stacker stacker,
       final JoinType joinType,
+      final ColumnName keyColName,
       final Formats leftFormats,
       final Formats rightFormats,
       final ExecutionStep<KStreamHolder<K>> left,
@@ -225,6 +228,7 @@ public final class ExecutionStepFactory {
     return new StreamStreamJoin<>(
         new ExecutionStepPropertiesV1(queryContext),
         joinType,
+        keyColName,
         leftFormats,
         rightFormats,
         left,
@@ -305,6 +309,7 @@ public final class ExecutionStepFactory {
   public static <K> TableTableJoin<K> tableTableJoin(
       final QueryContext.Stacker stacker,
       final JoinType joinType,
+      final ColumnName keyColName,
       final ExecutionStep<KTableHolder<K>> left,
       final ExecutionStep<KTableHolder<K>> right
   ) {
@@ -312,6 +317,7 @@ public final class ExecutionStepFactory {
     return new TableTableJoin<>(
         new ExecutionStepPropertiesV1(queryContext),
         joinType,
+        keyColName,
         left,
         right
     );

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/GroupByParamsFactory.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/GroupByParamsFactory.java
@@ -266,7 +266,7 @@ final class GroupByParamsFactory {
   ) {
     final ColumnName keyName = alias
         .orElseGet(() -> ksqlConfig.getBoolean(KsqlConfig.KSQL_ANY_KEY_NAME_ENABLED)
-            ? ColumnNames.columnAliasGenerator(Stream.of(sourceSchema)).nextKsqlColAlias()
+            ? ColumnNames.nextKsqlColAlias(sourceSchema)
             : SystemColumns.ROWKEY_NAME);
 
     return buildSchemaWithKeyType(sourceSchema, keyName, SqlTypes.STRING);

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/PartitionByParamsFactory.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/PartitionByParamsFactory.java
@@ -19,7 +19,6 @@ import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.codegen.CodeGenRunner;
 import io.confluent.ksql.execution.codegen.ExpressionMetadata;
 import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
-import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.util.ExpressionTypeManager;
 import io.confluent.ksql.execution.util.StructKeyUtil;
@@ -28,7 +27,6 @@ import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.Column;
-import io.confluent.ksql.schema.ksql.ColumnAliasGenerator;
 import io.confluent.ksql.schema.ksql.ColumnNames;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.LogicalSchema.Builder;
@@ -121,7 +119,7 @@ public final class PartitionByParamsFactory {
     final ColumnName newKeyName = partitionByCol
         .orElseGet(() -> ColumnNames
             .columnAliasGenerator(Stream.of(sourceSchema))
-            .nextKsqlColAlias()
+            .uniqueAliasFor(partitionBy)
         );
 
     final Builder builder = LogicalSchema.builder()
@@ -156,14 +154,6 @@ public final class PartitionByParamsFactory {
               new IllegalStateException("Unknown partition by column: " + columnName));
 
       return Optional.of(column.name());
-    }
-
-    if (partitionBy instanceof DereferenceExpression) {
-      // PARTITION BY struct field:
-      final ColumnAliasGenerator aliasGenerator = ColumnNames
-          .columnAliasGenerator(Stream.of(sourceSchema));
-
-      return Optional.of(aliasGenerator.uniqueAliasFor(partitionBy));
     }
 
     return Optional.empty();

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StepSchemaResolver.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StepSchemaResolver.java
@@ -94,9 +94,9 @@ public final class StepSchemaResolver {
       = HandlerMaps.forClass(ExecutionStep.class)
       .withArgTypes(StepSchemaResolver.class, JoinSchemas.class)
       .withReturnType(LogicalSchema.class)
-      .put(StreamTableJoin.class, StepSchemaResolver::handleJoin)
-      .put(StreamStreamJoin.class, StepSchemaResolver::handleJoin)
-      .put(TableTableJoin.class, StepSchemaResolver::handleJoin)
+      .put(StreamTableJoin.class, StepSchemaResolver::handleStreamTableJoin)
+      .put(StreamStreamJoin.class, StepSchemaResolver::handleStreamStreamJoin)
+      .put(TableTableJoin.class, StepSchemaResolver::handleTableTableJoin)
       .build();
 
   private final KsqlConfig ksqlConfig;
@@ -247,8 +247,32 @@ public final class StepSchemaResolver {
     return buildSourceSchema(schema, true);
   }
 
-  private LogicalSchema handleJoin(final JoinSchemas schemas, final ExecutionStep<?> step) {
-    return JoinParamsFactory.createSchema(schemas.left, schemas.right);
+  private LogicalSchema handleStreamStreamJoin(
+      final JoinSchemas schemas,
+      final StreamStreamJoin<?> step
+  ) {
+    return handleJoin(schemas, step.getKeyColName());
+  }
+
+  private LogicalSchema handleStreamTableJoin(
+      final JoinSchemas schemas,
+      final StreamTableJoin<?> step
+  ) {
+    return handleJoin(schemas, step.getKeyColName());
+  }
+
+  private LogicalSchema handleTableTableJoin(
+      final JoinSchemas schemas,
+      final TableTableJoin<?> step
+  ) {
+    return handleJoin(schemas, step.getKeyColName());
+  }
+
+  private LogicalSchema handleJoin(
+      final JoinSchemas schemas,
+      final ColumnName keyColName
+  ) {
+    return JoinParamsFactory.createSchema(keyColName, schemas.left, schemas.right);
   }
 
   private LogicalSchema handleTableAggregate(

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilder.java
@@ -77,7 +77,10 @@ public final class StreamStreamJoinBuilder {
         StreamsUtil.buildOpName(queryContext),
         StreamsUtil.buildOpName(queryContext)
     );
-    final JoinParams joinParams = JoinParamsFactory.create(leftSchema, rightSchema);
+
+    final JoinParams joinParams = JoinParamsFactory
+        .create(join.getKeyColName(), leftSchema, rightSchema);
+
     final JoinWindows joinWindows =
         JoinWindows.of(join.getBeforeMillis()).after(join.getAfterMillis());
     final KStream<K, GenericRow> result;

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilder.java
@@ -29,6 +29,7 @@ import org.apache.kafka.streams.kstream.Joined;
 import org.apache.kafka.streams.kstream.KStream;
 
 public final class StreamTableJoinBuilder {
+
   private static final String SERDE_CTX = "Left";
 
   private StreamTableJoinBuilder() {
@@ -39,7 +40,8 @@ public final class StreamTableJoinBuilder {
       final KTableHolder<K> right,
       final StreamTableJoin<K> join,
       final KsqlQueryBuilder queryBuilder,
-      final JoinedFactory joinedFactory) {
+      final JoinedFactory joinedFactory
+  ) {
     final Formats leftFormats = join.getInternalFormats();
     final QueryContext queryContext = join.getProperties().getQueryContext();
     final QueryContext.Stacker stacker = QueryContext.Stacker.of(queryContext);
@@ -65,7 +67,10 @@ public final class StreamTableJoinBuilder {
         StreamsUtil.buildOpName(queryContext)
     );
     final LogicalSchema rightSchema = right.getSchema();
-    final JoinParams joinParams = JoinParamsFactory.create(leftSchema, rightSchema);
+
+    final JoinParams joinParams = JoinParamsFactory
+        .create(join.getKeyColName(), leftSchema, rightSchema);
+
     final KStream<K, GenericRow> result;
     switch (join.getJoinType()) {
       case LEFT:

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableTableJoinBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableTableJoinBuilder.java
@@ -22,16 +22,21 @@ import io.confluent.ksql.schema.ksql.LogicalSchema;
 import org.apache.kafka.streams.kstream.KTable;
 
 public final class TableTableJoinBuilder {
+
   private TableTableJoinBuilder() {
   }
 
   public static <K> KTableHolder<K> build(
       final KTableHolder<K> left,
       final KTableHolder<K> right,
-      final TableTableJoin join) {
+      final TableTableJoin<K> join
+  ) {
     final LogicalSchema leftSchema = left.getSchema();
     final LogicalSchema rightSchema = right.getSchema();
-    final JoinParams joinParams = JoinParamsFactory.create(leftSchema, rightSchema);
+
+    final JoinParams joinParams = JoinParamsFactory
+        .create(join.getKeyColName(), leftSchema, rightSchema);
+
     final KTable<K, GenericRow> result;
     switch (join.getJoinType()) {
       case LEFT:
@@ -46,6 +51,7 @@ public final class TableTableJoinBuilder {
       default:
         throw new IllegalStateException("invalid join type");
     }
+
     return left.withTable(result, joinParams.getSchema());
   }
 }

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/KsqlValueJoinerTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/KsqlValueJoinerTest.java
@@ -49,7 +49,9 @@ public class KsqlValueJoinerTest {
 
   @Test
   public void shouldJoinValueBothNonNull() {
-    final KsqlValueJoiner joiner = new KsqlValueJoiner(leftSchema, rightSchema);
+    final KsqlValueJoiner joiner = new KsqlValueJoiner(leftSchema.value().size(),
+        rightSchema.value().size(), 0
+    );
 
     final GenericRow joined = joiner.apply(leftRow, rightRow);
     final List<Object> expected = Arrays.asList(12L, "foobar", 20L, "baz");
@@ -58,7 +60,9 @@ public class KsqlValueJoinerTest {
 
   @Test
   public void shouldJoinValueRightEmpty() {
-    final KsqlValueJoiner joiner = new KsqlValueJoiner(leftSchema, rightSchema);
+    final KsqlValueJoiner joiner = new KsqlValueJoiner(leftSchema.value().size(),
+        rightSchema.value().size(), 0
+    );
 
     final GenericRow joined = joiner.apply(leftRow, null);
     final List<Object> expected = Arrays.asList(12L, "foobar", null, null);
@@ -67,7 +71,9 @@ public class KsqlValueJoinerTest {
 
   @Test
   public void shouldJoinValueLeftEmpty() {
-    final KsqlValueJoiner joiner = new KsqlValueJoiner(leftSchema, rightSchema);
+    final KsqlValueJoiner joiner = new KsqlValueJoiner(leftSchema.value().size(),
+        rightSchema.value().size(), 0
+    );
 
     final GenericRow joined = joiner.apply(null, rightRow);
     final List<Object> expected = Arrays.asList(null, null, 20L, "baz");

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/PartitionByParamsFactoryTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/PartitionByParamsFactoryTest.java
@@ -178,6 +178,7 @@ public class PartitionByParamsFactoryTest {
         .valueColumn(COL3, COL3_TYPE)
         .valueColumn(SystemColumns.ROWTIME_NAME, SqlTypes.BIGINT)
         .valueColumn(COL0, SqlTypes.STRING)
+        .valueColumn(ColumnName.of("someField"), SqlTypes.BIGINT)
         .build()));
   }
 

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilderTest.java
@@ -1,5 +1,7 @@
 package io.confluent.ksql.execution.streams;
 
+import static io.confluent.ksql.execution.plan.StreamStreamJoin.LEGACY_KEY_COL;
+import static io.confluent.ksql.schema.ksql.SystemColumns.ROWKEY_NAME;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
@@ -17,6 +19,7 @@ import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.ExecutionStepPropertiesV1;
+import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.plan.JoinType;
 import io.confluent.ksql.execution.plan.KStreamHolder;
 import io.confluent.ksql.execution.plan.KeySerdeFactory;
@@ -25,7 +28,6 @@ import io.confluent.ksql.execution.plan.StreamStreamJoin;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
-import io.confluent.ksql.schema.ksql.SystemColumns;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
@@ -45,16 +47,22 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class StreamStreamJoinBuilderTest {
 
+  private static final ColumnName L_KEY = ColumnName.of("L_KEY");
+  private static final ColumnName R_KEY = ColumnName.of("R_KEY");
+  private static final ColumnName SYNTH_KEY = ColumnName.of("KSQL_COL_0");
+
   private static final LogicalSchema LEFT_SCHEMA = LogicalSchema.builder()
-      .keyColumn(SystemColumns.ROWKEY_NAME, SqlTypes.STRING)
-      .valueColumn(ColumnName.of("BLUE"), SqlTypes.STRING)
-      .valueColumn(ColumnName.of("GREEN"), SqlTypes.INTEGER)
+      .keyColumn(L_KEY, SqlTypes.STRING)
+      .valueColumn(ColumnName.of("L_BLUE"), SqlTypes.STRING)
+      .valueColumn(ColumnName.of("L_GREEN"), SqlTypes.INTEGER)
+      .valueColumn(L_KEY, SqlTypes.STRING)
       .build();
 
   private static final LogicalSchema RIGHT_SCHEMA = LogicalSchema.builder()
-      .keyColumn(SystemColumns.ROWKEY_NAME, SqlTypes.STRING)
-      .valueColumn(ColumnName.of("RED"), SqlTypes.BIGINT)
-      .valueColumn(ColumnName.of("ORANGE"), SqlTypes.DOUBLE)
+      .keyColumn(R_KEY, SqlTypes.STRING)
+      .valueColumn(ColumnName.of("R_RED"), SqlTypes.BIGINT)
+      .valueColumn(ColumnName.of("R_ORANGE"), SqlTypes.DOUBLE)
+      .valueColumn(R_KEY, SqlTypes.STRING)
       .build();
 
   private static final PhysicalSchema LEFT_PHYSICAL =
@@ -63,15 +71,13 @@ public class StreamStreamJoinBuilderTest {
   private static final PhysicalSchema RIGHT_PHYSICAL =
       PhysicalSchema.from(RIGHT_SCHEMA, SerdeOption.none());
 
-  private static final io.confluent.ksql.execution.plan.Formats LEFT_FMT = io.confluent.ksql.execution.plan.Formats
-      .of(
+  private static final io.confluent.ksql.execution.plan.Formats LEFT_FMT = Formats.of(
       FormatInfo.of(FormatFactory.KAFKA.name()),
       FormatInfo.of(FormatFactory.JSON.name()),
       SerdeOption.none()
   );
 
-  private static final io.confluent.ksql.execution.plan.Formats RIGHT_FMT = io.confluent.ksql.execution.plan.Formats
-      .of(
+  private static final io.confluent.ksql.execution.plan.Formats RIGHT_FMT = Formats.of(
       FormatInfo.of(FormatFactory.KAFKA.name()),
       FormatInfo.of(FormatFactory.AVRO.name()),
       SerdeOption.none()
@@ -80,6 +86,7 @@ public class StreamStreamJoinBuilderTest {
   private static final Duration BEFORE = Duration.ofMillis(1000);
   private static final Duration AFTER = Duration.ofMillis(2000);
   private static final JoinWindows WINDOWS = JoinWindows.of(BEFORE).after(AFTER);
+
   private final QueryContext CTX =
       new QueryContext.Stacker().push("jo").push("in").getQueryContext();
 
@@ -124,6 +131,11 @@ public class StreamStreamJoinBuilderTest {
         new KStreamHolder<>(leftKStream, LEFT_SCHEMA, keySerdeFactory));
     when(right.build(any())).thenReturn(
         new KStreamHolder<>(rightKStream, RIGHT_SCHEMA, keySerdeFactory));
+
+    when(leftKStream.leftJoin(any(KStream.class), any(), any(), any(StreamJoined.class))).thenReturn(resultKStream);
+    when(leftKStream.outerJoin(any(KStream.class), any(), any(), any(StreamJoined.class))).thenReturn(resultKStream);
+    when(leftKStream.join(any(KStream.class), any(), any(), any(StreamJoined.class))).thenReturn(resultKStream);
+
     planBuilder = new KSPlanBuilder(
         queryBuilder,
         mock(SqlPredicateFactory.class),
@@ -138,55 +150,10 @@ public class StreamStreamJoinBuilderTest {
     );
   }
 
-  @SuppressWarnings("unchecked")
-  private void givenLeftJoin() {
-    when(leftKStream.leftJoin(any(KStream.class), any(), any(), any(StreamJoined.class))).thenReturn(resultKStream);
-    join = new StreamStreamJoin<>(
-        new ExecutionStepPropertiesV1(CTX),
-        JoinType.LEFT,
-        LEFT_FMT,
-        RIGHT_FMT,
-        left,
-        right,
-        BEFORE,
-        AFTER
-    );
-  }
-
-  @SuppressWarnings("unchecked")
-  private void givenOuterJoin() {
-    when(leftKStream.outerJoin(any(KStream.class), any(), any(), any(StreamJoined.class))).thenReturn(resultKStream);
-    join = new StreamStreamJoin<>(
-        new ExecutionStepPropertiesV1(CTX),
-        JoinType.OUTER,
-        LEFT_FMT,
-        RIGHT_FMT,
-        left,
-        right,
-        BEFORE,
-        AFTER
-    );
-  }
-
-  @SuppressWarnings("unchecked")
-  private void givenInnerJoin() {
-    when(leftKStream.join(any(KStream.class), any(), any(), any(StreamJoined.class))).thenReturn(resultKStream);
-    join = new StreamStreamJoin<>(
-        new ExecutionStepPropertiesV1(CTX),
-        JoinType.INNER,
-        LEFT_FMT,
-        RIGHT_FMT,
-        left,
-        right,
-        BEFORE,
-        AFTER
-    );
-  }
-
   @Test
   public void shouldDoLeftJoin() {
     // Given:
-    givenLeftJoin();
+    givenLeftJoin(L_KEY);
 
     // When:
     final KStreamHolder<Struct> result = join.build(planBuilder);
@@ -194,7 +161,27 @@ public class StreamStreamJoinBuilderTest {
     // Then:
     verify(leftKStream).leftJoin(
         same(rightKStream),
-        eq(new KsqlValueJoiner(LEFT_SCHEMA, RIGHT_SCHEMA)),
+        eq(new KsqlValueJoiner(LEFT_SCHEMA.value().size(), RIGHT_SCHEMA.value().size(), 0)),
+        eq(WINDOWS),
+        same(joined)
+    );
+    verifyNoMoreInteractions(leftKStream, rightKStream, resultKStream);
+    assertThat(result.getStream(), is(resultKStream));
+    assertThat(result.getKeySerdeFactory(), is(keySerdeFactory));
+  }
+
+  @Test
+  public void shouldDoLeftJoinWithSyntheticKey() {
+    // Given:
+    givenLeftJoin(SYNTH_KEY);
+
+    // When:
+    final KStreamHolder<Struct> result = join.build(planBuilder);
+
+    // Then:
+    verify(leftKStream).leftJoin(
+        same(rightKStream),
+        eq(new KsqlValueJoiner(LEFT_SCHEMA.value().size(), RIGHT_SCHEMA.value().size(), 1)),
         eq(WINDOWS),
         same(joined)
     );
@@ -214,7 +201,7 @@ public class StreamStreamJoinBuilderTest {
     // Then:
     verify(leftKStream).outerJoin(
         same(rightKStream),
-        eq(new KsqlValueJoiner(LEFT_SCHEMA, RIGHT_SCHEMA)),
+        eq(new KsqlValueJoiner(LEFT_SCHEMA.value().size(), RIGHT_SCHEMA.value().size(), 1)),
         eq(WINDOWS),
         same(joined)
     );
@@ -226,7 +213,7 @@ public class StreamStreamJoinBuilderTest {
   @Test
   public void shouldDoInnerJoin() {
     // Given:
-    givenInnerJoin();
+    givenInnerJoin(L_KEY);
 
     // When:
     final KStreamHolder<Struct> result = join.build(planBuilder);
@@ -234,7 +221,27 @@ public class StreamStreamJoinBuilderTest {
     // Then:
     verify(leftKStream).join(
         same(rightKStream),
-        eq(new KsqlValueJoiner(LEFT_SCHEMA, RIGHT_SCHEMA)),
+        eq(new KsqlValueJoiner(LEFT_SCHEMA.value().size(), RIGHT_SCHEMA.value().size(), 0)),
+        eq(WINDOWS),
+        same(joined)
+    );
+    verifyNoMoreInteractions(leftKStream, rightKStream, resultKStream);
+    assertThat(result.getStream(), is(resultKStream));
+    assertThat(result.getKeySerdeFactory(), is(keySerdeFactory));
+  }
+
+  @Test
+  public void shouldDoInnerJoinWithSyntheticKey() {
+    // Given:
+    givenInnerJoin(SYNTH_KEY);
+
+    // When:
+    final KStreamHolder<Struct> result = join.build(planBuilder);
+
+    // Then:
+    verify(leftKStream).join(
+        same(rightKStream),
+        eq(new KsqlValueJoiner(LEFT_SCHEMA.value().size(), RIGHT_SCHEMA.value().size(), 1)),
         eq(WINDOWS),
         same(joined)
     );
@@ -246,7 +253,7 @@ public class StreamStreamJoinBuilderTest {
   @Test
   public void shouldReturnCorrectSchema() {
     // Given:
-    givenInnerJoin();
+    givenInnerJoin(R_KEY);
 
     // When:
     final KStreamHolder<Struct> result = join.build(planBuilder);
@@ -254,7 +261,34 @@ public class StreamStreamJoinBuilderTest {
     // Then:
     assertThat(
         result.getSchema(),
-        is(JoinParamsFactory.create(LEFT_SCHEMA, RIGHT_SCHEMA).getSchema())
+        is(JoinParamsFactory.create(R_KEY, LEFT_SCHEMA, RIGHT_SCHEMA).getSchema())
+    );
+  }
+
+  @Test
+  public void shouldReturnCorrectLegacySchema() {
+    // Given:
+    givenInnerJoin(L_KEY);
+
+    join = new StreamStreamJoin<>(
+        new ExecutionStepPropertiesV1(CTX),
+        JoinType.INNER,
+        ColumnName.of(LEGACY_KEY_COL),
+        LEFT_FMT,
+        RIGHT_FMT,
+        left,
+        right,
+        BEFORE,
+        AFTER
+    );
+
+    // When:
+    final KStreamHolder<Struct> result = join.build(planBuilder);
+
+    // Then:
+    assertThat(
+        result.getSchema(),
+        is(JoinParamsFactory.create(ROWKEY_NAME, LEFT_SCHEMA, RIGHT_SCHEMA).getSchema())
     );
   }
 
@@ -262,7 +296,7 @@ public class StreamStreamJoinBuilderTest {
   @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   public void shouldBuildJoinedCorrectly() {
     // Given:
-    givenInnerJoin();
+    givenInnerJoin(L_KEY);
 
     // When:
     join.build(planBuilder);
@@ -274,7 +308,7 @@ public class StreamStreamJoinBuilderTest {
   @Test
   public void shouldBuildKeySerdeCorrectly() {
     // Given:
-    givenInnerJoin();
+    givenInnerJoin(L_KEY);
 
     // When:
     join.build(planBuilder);
@@ -286,7 +320,7 @@ public class StreamStreamJoinBuilderTest {
   @Test
   public void shouldBuildLeftSerdeCorrectly() {
     // Given:
-    givenInnerJoin();
+    givenInnerJoin(L_KEY);
 
     // When:
     join.build(planBuilder);
@@ -299,7 +333,7 @@ public class StreamStreamJoinBuilderTest {
   @Test
   public void shouldBuildRightSerdeCorrectly() {
     // Given:
-    givenInnerJoin();
+    givenInnerJoin(L_KEY);
 
     // When:
     join.build(planBuilder);
@@ -307,5 +341,47 @@ public class StreamStreamJoinBuilderTest {
     // Then:
     final QueryContext leftCtx = QueryContext.Stacker.of(CTX).push("Right").getQueryContext();
     verify(queryBuilder).buildValueSerde(FormatInfo.of(FormatFactory.AVRO.name()), RIGHT_PHYSICAL, leftCtx);
+  }
+
+  private void givenLeftJoin(final ColumnName keyName) {
+    join = new StreamStreamJoin<>(
+        new ExecutionStepPropertiesV1(CTX),
+        JoinType.LEFT,
+        keyName,
+        LEFT_FMT,
+        RIGHT_FMT,
+        left,
+        right,
+        BEFORE,
+        AFTER
+    );
+  }
+
+  private void givenOuterJoin() {
+    join = new StreamStreamJoin<>(
+        new ExecutionStepPropertiesV1(CTX),
+        JoinType.OUTER,
+        SYNTH_KEY,
+        LEFT_FMT,
+        RIGHT_FMT,
+        left,
+        right,
+        BEFORE,
+        AFTER
+    );
+  }
+
+  private void givenInnerJoin(final ColumnName keyName) {
+    join = new StreamStreamJoin<>(
+        new ExecutionStepPropertiesV1(CTX),
+        JoinType.INNER,
+        keyName,
+        LEFT_FMT,
+        RIGHT_FMT,
+        left,
+        right,
+        BEFORE,
+        AFTER
+    );
   }
 }

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableTableJoinBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableTableJoinBuilderTest.java
@@ -1,5 +1,7 @@
 package io.confluent.ksql.execution.streams;
 
+import static io.confluent.ksql.execution.plan.StreamStreamJoin.LEGACY_KEY_COL;
+import static io.confluent.ksql.schema.ksql.SystemColumns.ROWKEY_NAME;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
@@ -22,7 +24,6 @@ import io.confluent.ksql.execution.plan.PlanBuilder;
 import io.confluent.ksql.execution.plan.TableTableJoin;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
-import io.confluent.ksql.schema.ksql.SystemColumns;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.kstream.KTable;
@@ -35,27 +36,32 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class TableTableJoinBuilderTest {
 
+  private static final ColumnName L_KEY = ColumnName.of("L_KEY");
+  private static final ColumnName R_KEY = ColumnName.of("R_KEY");
+  private static final ColumnName SYNTH_KEY = ColumnName.of("KSQL_COL_0");
+
   private static final LogicalSchema LEFT_SCHEMA = LogicalSchema.builder()
-      .keyColumn(SystemColumns.ROWKEY_NAME, SqlTypes.STRING)
-      .valueColumn(ColumnName.of("BLUE"), SqlTypes.STRING)
-      .valueColumn(ColumnName.of("GREEN"), SqlTypes.INTEGER)
+      .keyColumn(L_KEY, SqlTypes.STRING)
+      .valueColumn(ColumnName.of("L_BLUE"), SqlTypes.STRING)
+      .valueColumn(ColumnName.of("L_GREEN"), SqlTypes.INTEGER)
+      .valueColumn(L_KEY, SqlTypes.STRING)
       .build();
 
   private static final LogicalSchema RIGHT_SCHEMA = LogicalSchema.builder()
-      .keyColumn(SystemColumns.ROWKEY_NAME, SqlTypes.STRING)
-      .valueColumn(ColumnName.of("RED"), SqlTypes.BIGINT)
-      .valueColumn(ColumnName.of("ORANGE"), SqlTypes.DOUBLE)
+      .keyColumn(R_KEY, SqlTypes.STRING)
+      .valueColumn(ColumnName.of("R_RED"), SqlTypes.BIGINT)
+      .valueColumn(ColumnName.of("R_ORANGE"), SqlTypes.DOUBLE)
+      .valueColumn(R_KEY, SqlTypes.STRING)
       .build();
 
-  private final QueryContext CTX =
-      new QueryContext.Stacker().push("jo").push("in").getQueryContext();
-
+  @Mock
+  private QueryContext ctx;
   @Mock
   private KTable<Struct, GenericRow> leftKTable;
   @Mock
-  private KTable<Struct, GenericRow>  rightKTable;
+  private KTable<Struct, GenericRow> rightKTable;
   @Mock
-  private KTable<Struct, GenericRow>  resultKTable;
+  private KTable<Struct, GenericRow> resultKTable;
   @Mock
   private ExecutionStep<KTableHolder<Struct>> left;
   @Mock
@@ -66,12 +72,18 @@ public class TableTableJoinBuilderTest {
   private PlanBuilder planBuilder;
   private TableTableJoin<Struct> join;
 
+  @SuppressWarnings("unchecked")
   @Before
   public void init() {
     when(left.build(any())).thenReturn(
         KTableHolder.unmaterialized(leftKTable, LEFT_SCHEMA, keySerdeFactory));
     when(right.build(any())).thenReturn(
         KTableHolder.unmaterialized(rightKTable, RIGHT_SCHEMA, keySerdeFactory));
+
+    when(leftKTable.leftJoin(any(KTable.class), any())).thenReturn(resultKTable);
+    when(leftKTable.outerJoin(any(KTable.class), any())).thenReturn(resultKTable);
+    when(leftKTable.join(any(KTable.class), any())).thenReturn(resultKTable);
+
     planBuilder = new KSPlanBuilder(
         mock(KsqlQueryBuilder.class),
         mock(SqlPredicateFactory.class),
@@ -80,43 +92,10 @@ public class TableTableJoinBuilderTest {
     );
   }
 
-  @SuppressWarnings("unchecked")
-  private void givenLeftJoin() {
-    when(leftKTable.leftJoin(any(KTable.class), any())).thenReturn(resultKTable);
-    join = new TableTableJoin<>(
-        new ExecutionStepPropertiesV1(CTX),
-        JoinType.LEFT,
-        left,
-        right
-    );
-  }
-
-  @SuppressWarnings("unchecked")
-  private void givenOuterJoin() {
-    when(leftKTable.outerJoin(any(KTable.class), any())).thenReturn(resultKTable);
-    join = new TableTableJoin<>(
-        new ExecutionStepPropertiesV1(CTX),
-        JoinType.OUTER,
-        left,
-        right
-    );
-  }
-
-  @SuppressWarnings("unchecked")
-  private void givenInnerJoin() {
-    when(leftKTable.join(any(KTable.class), any())).thenReturn(resultKTable);
-    join = new TableTableJoin<>(
-        new ExecutionStepPropertiesV1(CTX),
-        JoinType.INNER,
-        left,
-        right
-    );
-  }
-
   @Test
   public void shouldDoLeftJoin() {
     // Given:
-    givenLeftJoin();
+    givenLeftJoin(L_KEY);
 
     // When:
     final KTableHolder<Struct> result = join.build(planBuilder);
@@ -124,11 +103,26 @@ public class TableTableJoinBuilderTest {
     // Then:
     verify(leftKTable).leftJoin(
         same(rightKTable),
-        eq(new KsqlValueJoiner(LEFT_SCHEMA, RIGHT_SCHEMA))
+        eq(new KsqlValueJoiner(LEFT_SCHEMA.value().size(), RIGHT_SCHEMA.value().size(), 0))
     );
     verifyNoMoreInteractions(leftKTable, rightKTable, resultKTable);
     assertThat(result.getTable(), is(resultKTable));
     assertThat(result.getKeySerdeFactory(), is(keySerdeFactory));
+  }
+
+  @Test
+  public void shouldDoLeftJoinWithSyntheticKey() {
+    // Given:
+    givenLeftJoin(SYNTH_KEY);
+
+    // When:
+    join.build(planBuilder);
+
+    // Then:
+    verify(leftKTable).leftJoin(
+        same(rightKTable),
+        eq(new KsqlValueJoiner(LEFT_SCHEMA.value().size(), RIGHT_SCHEMA.value().size(), 1))
+    );
   }
 
   @Test
@@ -142,7 +136,7 @@ public class TableTableJoinBuilderTest {
     // Then:
     verify(leftKTable).outerJoin(
         same(rightKTable),
-        eq(new KsqlValueJoiner(LEFT_SCHEMA, RIGHT_SCHEMA))
+        eq(new KsqlValueJoiner(LEFT_SCHEMA.value().size(), RIGHT_SCHEMA.value().size(), 1))
     );
     verifyNoMoreInteractions(leftKTable, rightKTable, resultKTable);
     assertThat(result.getTable(), is(resultKTable));
@@ -152,7 +146,7 @@ public class TableTableJoinBuilderTest {
   @Test
   public void shouldDoInnerJoin() {
     // Given:
-    givenInnerJoin();
+    givenInnerJoin(R_KEY);
 
     // When:
     final KTableHolder<Struct> result = join.build(planBuilder);
@@ -160,7 +154,7 @@ public class TableTableJoinBuilderTest {
     // Then:
     verify(leftKTable).join(
         same(rightKTable),
-        eq(new KsqlValueJoiner(LEFT_SCHEMA, RIGHT_SCHEMA))
+        eq(new KsqlValueJoiner(LEFT_SCHEMA.value().size(), RIGHT_SCHEMA.value().size(), 0))
     );
     verifyNoMoreInteractions(leftKTable, rightKTable, resultKTable);
     assertThat(result.getTable(), is(resultKTable));
@@ -168,9 +162,24 @@ public class TableTableJoinBuilderTest {
   }
 
   @Test
+  public void shouldDoInnerJoinWithSytheticKey() {
+    // Given:
+    givenInnerJoin(SYNTH_KEY);
+
+    // When:
+    join.build(planBuilder);
+
+    // Then:
+    verify(leftKTable).join(
+        same(rightKTable),
+        eq(new KsqlValueJoiner(LEFT_SCHEMA.value().size(), RIGHT_SCHEMA.value().size(), 1))
+    );
+  }
+
+  @Test
   public void shouldReturnCorrectSchema() {
     // Given:
-    givenInnerJoin();
+    givenInnerJoin(R_KEY);
 
     // When:
     final KTableHolder<Struct> result = join.build(planBuilder);
@@ -178,7 +187,73 @@ public class TableTableJoinBuilderTest {
     // Then:
     assertThat(
         result.getSchema(),
-        is(JoinParamsFactory.create(LEFT_SCHEMA, RIGHT_SCHEMA).getSchema())
+        is(JoinParamsFactory.create(R_KEY, LEFT_SCHEMA, RIGHT_SCHEMA).getSchema())
+    );
+  }
+
+  @Test
+  public void shouldReturnCorrectSchemaWithSyntheticKey() {
+    // Given:
+    givenInnerJoin(SYNTH_KEY);
+
+    // When:
+    final KTableHolder<Struct> result = join.build(planBuilder);
+
+    // Then:
+    assertThat(
+        result.getSchema(),
+        is(JoinParamsFactory.create(SYNTH_KEY, LEFT_SCHEMA, RIGHT_SCHEMA).getSchema())
+    );
+  }
+
+  @Test
+  public void shouldReturnCorrectLegacySchema() {
+    // Given:
+    join = new TableTableJoin<>(
+        new ExecutionStepPropertiesV1(ctx),
+        JoinType.INNER,
+        ColumnName.of(LEGACY_KEY_COL),
+        left,
+        right
+    );
+
+    // When:
+    final KTableHolder<Struct> result = join.build(planBuilder);
+
+    // Then:
+    assertThat(
+        result.getSchema(),
+        is(JoinParamsFactory.create(ROWKEY_NAME, LEFT_SCHEMA, RIGHT_SCHEMA).getSchema())
+    );
+  }
+
+  private void givenLeftJoin(final ColumnName keyName) {
+    join = new TableTableJoin<>(
+        new ExecutionStepPropertiesV1(ctx),
+        JoinType.LEFT,
+        keyName,
+        left,
+        right
+    );
+  }
+
+  private void givenOuterJoin() {
+    join = new TableTableJoin<>(
+        new ExecutionStepPropertiesV1(ctx),
+        JoinType.OUTER,
+        SYNTH_KEY,
+        left,
+        right
+    );
+  }
+
+  private void givenInnerJoin(final ColumnName keyName) {
+    join = new TableTableJoin<>(
+        new ExecutionStepPropertiesV1(ctx),
+        JoinType.INNER,
+        keyName,
+        left,
+        right
     );
   }
 }


### PR DESCRIPTION
### Description 

This change implements the change in key semantics in queries outlined in [KLIP-24](#5115).

With this change the projection of persistent queries must include any key columns. For everything other than a `GROUP BY` this will be a single column. `GROUP BY` supports multiple key columns, (even though they end up munged into a single string key at the moment).

To detect the missing key columns I've extended `LogicalPlanner` and the logical `PlanNode`s. When building a persistent query the planner calls `validateKeyPresent` on the final node in the logical plan before the output node: this will either be a `AggregateNode` or a `FinalProjectNode`, depending on where there is a `GROUP BY` clause.  

The `validateKeyPresent` method percolate up the logical plan from child to parent nodes until it reaches a node that knows how to handle it.

* for any query with `GROUP BY`, this will be the `AggregateNode`.
* from any query with `PARTITION BY`, this will be the `RepartitionNode`.
* for join queries, with no aggregation or repartition, this will be the `JoinNode`.
* for simple queries, (no join, repartition or aggregation), this will be the `DataSourceNode`.

Joins are the complicated one, as they can have a synthetic key column. This necessitated adding an optional `keyCol` to the schema of joins, which defaults to the legacy `ROWKEY` name.

To get an error message that makes sense to the user required that original, as well as rewritten, expressions got passed around.  This is a bit ugly, but refactoring to remove this is out of scope.

There are some remaining tasks to do to complete this work and tidy things up - but they will be done in follow up tasks.  Also a lot of the added complexity will be removed once the 'any key name` feature is turned on, and the legacy code removed.

### Reviewing:

This is a big change. Apologies for this. Not sure how I can could break this down really.

* I'd start with looking at the changes to the josn QTT tests to get a feel for what's changed in the syntax.
* Then look at the logical plan and its nodes
* then check out the changes to `StreamStreamJoin` and the table variants.

I'll add some notes to the PR to hopefully help.

### Testing done 

Usual.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

