### PR TITLE
docs: cherry-pick: fix broken links in syntax reference (DOCS-4236)

### DIFF
--- a/docs/developer-guide/syntax-reference.md
+++ b/docs/developer-guide/syntax-reference.md
@@ -85,7 +85,7 @@ Access the fields in a `STRUCT` by using the dereference operator
 SELECT address->city, address->zip FROM orders;
 ```
 
-For more info, see [Operators](#operators).
+For more info, see [Operators](ksqldb-reference/operators.md).
 
 You can create a `STRUCT` in a query by specifying the names of the columns
 and expressions that construct the values, separated by commas. The following
@@ -251,7 +251,7 @@ SQL type.
 The elements of an array are zero-indexed and can be accessed by using
 the `[]` operator passing in the index. For example, `SOME_ARRAY[0]`
 retrieves the first element from the array. For more information, see
-[Operators](#operators).
+[Operators](ksqldb-reference/operators.md).
 
 You can define arrays within a `CREATE TABLE` or `CREATE STREAM`
 statement by using the syntax `ARRAY<ElementType>`. For example,
@@ -293,7 +293,7 @@ value type can be any valid SQL type.
 Access the values of a map by using the `[]` operator and passing in the
 key. For example, `SOME_MAP['cost']` retrieves the value for the entry
 with key `cost`, or `null` For more information, see
-[Operators](#operators).
+[Operators](ksqldb-reference/operators.md).
 
 You can define maps within a `CREATE TABLE` or `CREATE STREAM` statement
 by using the syntax `MAP<KeyType, ValueType>`. For example,
@@ -319,7 +319,7 @@ that have a specific type. The field types can be any valid SQL type.
 
 Access the fields of a struct by using the `->` operator. For example,
 `SOME_STRUCT->ID` retrieves the value of the struct's `ID` field. For
-more information, see [Operators](#operators).
+more information, see [Operators](ksqldb-reference/operators.md).
 
 You can define a structs within a `CREATE TABLE` or `CREATE STREAM`
 statement by using the syntax `STRUCT<FieldName FieldType, ...>`. For


### PR DESCRIPTION
From https://github.com/confluentinc/ksql/pull/5259.