### PR TITLE
feat: implement earliest_by_offset() UDAF

### DIFF
--- a/docs/developer-guide/ksqldb-reference/aggregate-functions.md
+++ b/docs/developer-guide/ksqldb-reference/aggregate-functions.md
@@ -17,6 +17,7 @@ For more information, see
   - [COLLECT_SET](#collect_set)
   - [COUNT](#count)
   - [COUNT_DISTINCT](#count_distinct)
+  - [EARLIEST_BY_OFFSET](#earliest_by_offset)
   - [HISTOGRAM](#histogram)
   - [LATEST_BY_OFFSET](#latest_by_offset)
   - [MAX](#max)

--- a/docs/developer-guide/ksqldb-reference/aggregate-functions.md
+++ b/docs/developer-guide/ksqldb-reference/aggregate-functions.md
@@ -100,6 +100,16 @@ Returns the _approximate_ number of unique values of `col1` in a group.
 The function implementation uses [HyperLogLog](https://en.wikipedia.org/wiki/HyperLogLog)
 to estimate cardinalities of 10^9 with a typical standard error of 2%.
 
+EARLIEST_BY_OFFSET
+------------------
+
+`EARLIEST_BY_OFFSET(col1)`
+
+Stream
+
+Return the earliest value for a given column. Earliest here is defined as the value in the partition
+with the lowest offset. Rows that have `col1` set to null are ignored.
+
 
 HISTOGRAM
 ---------

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/KudafByOffsetUtils.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/KudafByOffsetUtils.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udaf;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+
+public final class KudafByOffsetUtils {
+  public static final String SEQ_FIELD = "SEQ";
+  public static final String VAL_FIELD = "VAL";
+
+  public static final Schema STRUCT_INTEGER = SchemaBuilder.struct().optional()
+      .field(SEQ_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
+      .field(VAL_FIELD, Schema.OPTIONAL_INT32_SCHEMA)
+      .build();
+
+  public static final Schema STRUCT_LONG = SchemaBuilder.struct().optional()
+      .field(SEQ_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
+      .field(VAL_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
+      .build();
+
+  public static final Schema STRUCT_DOUBLE = SchemaBuilder.struct().optional()
+      .field(SEQ_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
+      .field(VAL_FIELD, Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .build();
+
+  public static final Schema STRUCT_BOOLEAN = SchemaBuilder.struct().optional()
+      .field(SEQ_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
+      .field(VAL_FIELD, Schema.OPTIONAL_BOOLEAN_SCHEMA)
+      .build();
+
+  public static final Schema STRUCT_STRING = SchemaBuilder.struct().optional()
+      .field(SEQ_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
+      .field(VAL_FIELD, Schema.OPTIONAL_STRING_SCHEMA)
+      .build();
+
+  public static int compareStructs(final Struct struct1, final Struct struct2) {
+    // Deal with overflow - we assume if one is positive and the other negative then the sequence
+    // has overflowed - in which case the latest is the one with the smallest sequence
+    final long sequence1 = struct1.getInt64(SEQ_FIELD);
+    final long sequence2 = struct2.getInt64(SEQ_FIELD);
+    if (sequence1 < 0 && sequence2 >= 0) {
+      return 1;
+    } else if (sequence2 < 0 && sequence1 >= 0) {
+      return -1;
+    } else {
+      return Long.compare(sequence1, sequence2);
+    }
+  }
+
+  private KudafByOffsetUtils() {
+
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/earliest/EarliestByOffset.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/earliest/EarliestByOffset.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udaf.earliest;
+
+import io.confluent.ksql.function.udaf.Udaf;
+import io.confluent.ksql.function.udaf.UdafDescription;
+import io.confluent.ksql.function.udaf.UdafFactory;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+
+@UdafDescription(
+    name = "EARLIEST_BY_OFFSET",
+    description = EarliestByOffset.DESCRIPTION
+)
+public final class EarliestByOffset {
+  static final String DESCRIPTION =
+      "This function returns the oldest value for the column, computed by offset.";
+
+  private EarliestByOffset() {
+  }
+
+  static final String SEQ_FIELD = "SEQ";
+  static final String VAL_FIELD = "VAL";
+
+  public static final Schema STRUCT_INTEGER = SchemaBuilder.struct().optional()
+      .field(SEQ_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
+      .field(VAL_FIELD, Schema.OPTIONAL_INT32_SCHEMA)
+      .build();
+
+  public static final Schema STRUCT_LONG = SchemaBuilder.struct().optional()
+      .field(SEQ_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
+      .field(VAL_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
+      .build();
+
+  public static final Schema STRUCT_DOUBLE = SchemaBuilder.struct().optional()
+      .field(SEQ_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
+      .field(VAL_FIELD, Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .build();
+
+  public static final Schema STRUCT_BOOLEAN = SchemaBuilder.struct().optional()
+      .field(SEQ_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
+      .field(VAL_FIELD, Schema.OPTIONAL_BOOLEAN_SCHEMA)
+      .build();
+
+  public static final Schema STRUCT_STRING = SchemaBuilder.struct().optional()
+      .field(SEQ_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
+      .field(VAL_FIELD, Schema.OPTIONAL_STRING_SCHEMA)
+      .build();
+
+  static AtomicLong sequence = new AtomicLong();
+
+  @UdafFactory(description = "return the earliest value of an integer column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL INT>")
+  public static Udaf<Integer, Struct, Integer> earliestInteger() {
+    return earliest(STRUCT_INTEGER);
+  }
+
+  @UdafFactory(description = "return the earliest value of an big integer column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL BIGINT>")
+  public static Udaf<Long, Struct, Long> earliestLong() {
+    return earliest(STRUCT_LONG);
+  }
+
+  @UdafFactory(description = "return the earliest value of a double column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL DOUBLE>")
+  public static Udaf<Double, Struct, Double> earliestDouble() {
+    return earliest(STRUCT_DOUBLE);
+  }
+
+  @UdafFactory(description = "return the earliest value of a boolean column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL BOOLEAN>")
+  public static Udaf<Boolean, Struct, Boolean> earliestBoolean() {
+    return earliest(STRUCT_BOOLEAN);
+  }
+
+  @UdafFactory(description = "return the earliest value of a string column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL STRING>")
+  public static Udaf<String, Struct, String> earliestString() {
+    return earliest(STRUCT_STRING);
+  }
+
+  static <T> Struct createStruct(final Schema schema, final T val) {
+    final Struct struct = new Struct(schema);
+    struct.put(SEQ_FIELD, generateSequence());
+    struct.put(VAL_FIELD, val);
+    return struct;
+  }
+
+  private static long generateSequence() {
+    return sequence.getAndIncrement();
+  }
+
+  private static int compareStructs(final Struct struct1, final Struct struct2) {
+    // Deal with overflow - we assume if one is positive and the other negative then the sequence
+    // has overflowed - in which case the latest is the one with the smallest sequence
+    final long sequence1 = struct1.getInt64(SEQ_FIELD);
+    final long sequence2 = struct2.getInt64(SEQ_FIELD);
+    if (sequence1 < 0 && sequence2 >= 0) {
+      return 1;
+    } else if (sequence2 < 0 && sequence1 >= 0) {
+      return -1;
+    } else {
+      return Long.compare(sequence1, sequence2);
+    }
+  }
+
+  @UdafFactory(description = "Earliest by offset")
+  static <T> Udaf<T, Struct, T> earliest(final Schema structSchema) {
+    return new Udaf<T, Struct, T>() {
+
+      @Override
+      public Struct initialize() {
+        return createStruct(structSchema, null);
+      }
+
+      @Override
+      public Struct aggregate(final T current, final Struct aggregate) {
+        if (current == null || aggregate.get(VAL_FIELD) != null) {
+          return aggregate;
+        } else {
+          return createStruct(structSchema, current);
+        }
+      }
+
+      @Override
+      public Struct merge(final Struct aggOne, final Struct aggTwo) {
+        // When merging we need some way of evaluating the "earliest' one.
+        // We do this by keeping track of the sequence of when it was originally processed
+        if (compareStructs(aggOne, aggTwo) < 0) {
+          return aggOne;
+        } else {
+          return aggTwo;
+        }
+      }
+
+      @Override
+      @SuppressWarnings("unchecked")
+      public T map(final Struct agg) {
+        return (T) agg.get(VAL_FIELD);
+      }
+    };
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/earliest/EarliestByOffset.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/earliest/EarliestByOffset.java
@@ -15,12 +15,20 @@
 
 package io.confluent.ksql.function.udaf.earliest;
 
+import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.SEQ_FIELD;
+import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.STRUCT_BOOLEAN;
+import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.STRUCT_DOUBLE;
+import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.STRUCT_INTEGER;
+import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.STRUCT_LONG;
+import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.STRUCT_STRING;
+import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.VAL_FIELD;
+import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.compareStructs;
+
 import io.confluent.ksql.function.udaf.Udaf;
 import io.confluent.ksql.function.udaf.UdafDescription;
 import io.confluent.ksql.function.udaf.UdafFactory;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 
 @UdafDescription(
@@ -33,34 +41,6 @@ public final class EarliestByOffset {
 
   private EarliestByOffset() {
   }
-
-  static final String SEQ_FIELD = "SEQ";
-  static final String VAL_FIELD = "VAL";
-
-  public static final Schema STRUCT_INTEGER = SchemaBuilder.struct().optional()
-      .field(SEQ_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
-      .field(VAL_FIELD, Schema.OPTIONAL_INT32_SCHEMA)
-      .build();
-
-  public static final Schema STRUCT_LONG = SchemaBuilder.struct().optional()
-      .field(SEQ_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
-      .field(VAL_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
-      .build();
-
-  public static final Schema STRUCT_DOUBLE = SchemaBuilder.struct().optional()
-      .field(SEQ_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
-      .field(VAL_FIELD, Schema.OPTIONAL_FLOAT64_SCHEMA)
-      .build();
-
-  public static final Schema STRUCT_BOOLEAN = SchemaBuilder.struct().optional()
-      .field(SEQ_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
-      .field(VAL_FIELD, Schema.OPTIONAL_BOOLEAN_SCHEMA)
-      .build();
-
-  public static final Schema STRUCT_STRING = SchemaBuilder.struct().optional()
-      .field(SEQ_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
-      .field(VAL_FIELD, Schema.OPTIONAL_STRING_SCHEMA)
-      .build();
 
   static AtomicLong sequence = new AtomicLong();
 
@@ -103,20 +83,6 @@ public final class EarliestByOffset {
 
   private static long generateSequence() {
     return sequence.getAndIncrement();
-  }
-
-  private static int compareStructs(final Struct struct1, final Struct struct2) {
-    // Deal with overflow - we assume if one is positive and the other negative then the sequence
-    // has overflowed - in which case the latest is the one with the smallest sequence
-    final long sequence1 = struct1.getInt64(SEQ_FIELD);
-    final long sequence2 = struct2.getInt64(SEQ_FIELD);
-    if (sequence1 < 0 && sequence2 >= 0) {
-      return 1;
-    } else if (sequence2 < 0 && sequence1 >= 0) {
-      return -1;
-    } else {
-      return Long.compare(sequence1, sequence2);
-    }
   }
 
   @UdafFactory(description = "Earliest by offset")

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/earliest/EarliestByOffsetUdafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/earliest/EarliestByOffsetUdafTest.java
@@ -19,6 +19,13 @@ import io.confluent.ksql.function.udaf.Udaf;
 import org.apache.kafka.connect.data.Struct;
 import org.junit.Test;
 
+import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.SEQ_FIELD;
+import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.STRUCT_BOOLEAN;
+import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.STRUCT_DOUBLE;
+import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.STRUCT_INTEGER;
+import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.STRUCT_LONG;
+import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.STRUCT_STRING;
+import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.VAL_FIELD;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -28,7 +35,7 @@ public class EarliestByOffsetUdafTest {
   public void shouldInitialize() {
     // Given:
     final Udaf<Integer, Struct, Integer> udaf = EarliestByOffset
-        .earliest(EarliestByOffset.STRUCT_LONG);
+        .earliest(STRUCT_LONG);
 
     // When:
     Struct init = udaf.initialize();
@@ -44,10 +51,10 @@ public class EarliestByOffsetUdafTest {
 
     // When:
     Struct res = udaf
-        .aggregate(123, EarliestByOffset.createStruct(EarliestByOffset.STRUCT_INTEGER, 321));
+        .aggregate(123, EarliestByOffset.createStruct(STRUCT_INTEGER, 321));
 
     // Then:
-    assertThat(res.get(EarliestByOffset.VAL_FIELD), is(321));
+    assertThat(res.get(VAL_FIELD), is(321));
   }
 
   @Test
@@ -55,8 +62,8 @@ public class EarliestByOffsetUdafTest {
     // Given:
     final Udaf<Integer, Struct, Integer> udaf = EarliestByOffset.earliestInteger();
 
-    Struct agg1 = EarliestByOffset.createStruct(EarliestByOffset.STRUCT_INTEGER, 123);
-    Struct agg2 = EarliestByOffset.createStruct(EarliestByOffset.STRUCT_INTEGER, 321);
+    Struct agg1 = EarliestByOffset.createStruct(STRUCT_INTEGER, 123);
+    Struct agg2 = EarliestByOffset.createStruct(STRUCT_INTEGER, 321);
 
     // When:
     Struct merged1 = udaf.merge(agg1, agg2);
@@ -74,16 +81,16 @@ public class EarliestByOffsetUdafTest {
 
     EarliestByOffset.sequence.set(Long.MAX_VALUE);
 
-    Struct agg1 = EarliestByOffset.createStruct(EarliestByOffset.STRUCT_INTEGER, 123);
-    Struct agg2 = EarliestByOffset.createStruct(EarliestByOffset.STRUCT_INTEGER, 321);
+    Struct agg1 = EarliestByOffset.createStruct(STRUCT_INTEGER, 123);
+    Struct agg2 = EarliestByOffset.createStruct(STRUCT_INTEGER, 321);
 
     // When:
     Struct merged1 = udaf.merge(agg1, agg2);
     Struct merged2 = udaf.merge(agg2, agg1);
 
     // Then:
-    assertThat(agg1.getInt64(EarliestByOffset.SEQ_FIELD), is(Long.MAX_VALUE));
-    assertThat(agg2.getInt64(EarliestByOffset.SEQ_FIELD), is(Long.MIN_VALUE));
+    assertThat(agg1.getInt64(SEQ_FIELD), is(Long.MAX_VALUE));
+    assertThat(agg2.getInt64(SEQ_FIELD), is(Long.MIN_VALUE));
     assertThat(merged1, is(agg1));
     assertThat(merged2, is(agg1));
   }
@@ -96,10 +103,10 @@ public class EarliestByOffsetUdafTest {
 
     // When:
     Struct res = udaf
-        .aggregate(123L, EarliestByOffset.createStruct(EarliestByOffset.STRUCT_LONG, 321L));
+        .aggregate(123L, EarliestByOffset.createStruct(STRUCT_LONG, 321L));
 
     // Then:
-    assertThat(res.getInt64(EarliestByOffset.VAL_FIELD), is(321L));
+    assertThat(res.getInt64(VAL_FIELD), is(321L));
   }
 
   @Test
@@ -109,10 +116,10 @@ public class EarliestByOffsetUdafTest {
 
     // When:
     Struct res = udaf
-        .aggregate(1.1d, EarliestByOffset.createStruct(EarliestByOffset.STRUCT_DOUBLE, 2.2d));
+        .aggregate(1.1d, EarliestByOffset.createStruct(STRUCT_DOUBLE, 2.2d));
 
     // Then:
-    assertThat(res.getFloat64(EarliestByOffset.VAL_FIELD), is(2.2d));
+    assertThat(res.getFloat64(VAL_FIELD), is(2.2d));
   }
 
   @Test
@@ -122,10 +129,10 @@ public class EarliestByOffsetUdafTest {
 
     // When:
     Struct res = udaf
-        .aggregate(true, EarliestByOffset.createStruct(EarliestByOffset.STRUCT_BOOLEAN, false));
+        .aggregate(true, EarliestByOffset.createStruct(STRUCT_BOOLEAN, false));
 
     // Then:
-    assertThat(res.getBoolean(EarliestByOffset.VAL_FIELD), is(false));
+    assertThat(res.getBoolean(VAL_FIELD), is(false));
   }
 
   @Test
@@ -135,9 +142,9 @@ public class EarliestByOffsetUdafTest {
 
     // When:
     Struct res = udaf
-        .aggregate("foo", EarliestByOffset.createStruct(EarliestByOffset.STRUCT_STRING, "bar"));
+        .aggregate("foo", EarliestByOffset.createStruct(STRUCT_STRING, "bar"));
 
     // Then:
-    assertThat(res.getString(EarliestByOffset.VAL_FIELD), is("bar"));
+    assertThat(res.getString(VAL_FIELD), is("bar"));
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/earliest/EarliestByOffsetUdafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/earliest/EarliestByOffsetUdafTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udaf.earliest;
+
+import io.confluent.ksql.function.udaf.Udaf;
+import org.apache.kafka.connect.data.Struct;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class EarliestByOffsetUdafTest {
+  @Test
+  public void shouldInitialize() {
+    // Given:
+    final Udaf<Integer, Struct, Integer> udaf = EarliestByOffset
+        .earliest(EarliestByOffset.STRUCT_LONG);
+
+    // When:
+    Struct init = udaf.initialize();
+
+    // Then:
+    assertThat(init, is(notNullValue()));
+  }
+
+  @Test
+  public void shouldComputeEarliestInteger() {
+    // Given:
+    final Udaf<Integer, Struct, Integer> udaf = EarliestByOffset.earliestInteger();
+
+    // When:
+    Struct res = udaf
+        .aggregate(123, EarliestByOffset.createStruct(EarliestByOffset.STRUCT_INTEGER, 321));
+
+    // Then:
+    assertThat(res.get(EarliestByOffset.VAL_FIELD), is(321));
+  }
+
+  @Test
+  public void shouldMerge() {
+    // Given:
+    final Udaf<Integer, Struct, Integer> udaf = EarliestByOffset.earliestInteger();
+
+    Struct agg1 = EarliestByOffset.createStruct(EarliestByOffset.STRUCT_INTEGER, 123);
+    Struct agg2 = EarliestByOffset.createStruct(EarliestByOffset.STRUCT_INTEGER, 321);
+
+    // When:
+    Struct merged1 = udaf.merge(agg1, agg2);
+    Struct merged2 = udaf.merge(agg2, agg1);
+
+    // Then:
+    assertThat(merged1, is(agg1));
+    assertThat(merged2, is(agg1));
+  }
+
+  @Test
+  public void shouldMergeWithOverflow() {
+    // Given:
+    final Udaf<Integer, Struct, Integer> udaf = EarliestByOffset.earliestInteger();
+
+    EarliestByOffset.sequence.set(Long.MAX_VALUE);
+
+    Struct agg1 = EarliestByOffset.createStruct(EarliestByOffset.STRUCT_INTEGER, 123);
+    Struct agg2 = EarliestByOffset.createStruct(EarliestByOffset.STRUCT_INTEGER, 321);
+
+    // When:
+    Struct merged1 = udaf.merge(agg1, agg2);
+    Struct merged2 = udaf.merge(agg2, agg1);
+
+    // Then:
+    assertThat(agg1.getInt64(EarliestByOffset.SEQ_FIELD), is(Long.MAX_VALUE));
+    assertThat(agg2.getInt64(EarliestByOffset.SEQ_FIELD), is(Long.MIN_VALUE));
+    assertThat(merged1, is(agg1));
+    assertThat(merged2, is(agg1));
+  }
+
+
+  @Test
+  public void shouldComputeEarliestLong() {
+    // Given:
+    final Udaf<Long, Struct, Long> udaf = EarliestByOffset.earliestLong();
+
+    // When:
+    Struct res = udaf
+        .aggregate(123L, EarliestByOffset.createStruct(EarliestByOffset.STRUCT_LONG, 321L));
+
+    // Then:
+    assertThat(res.getInt64(EarliestByOffset.VAL_FIELD), is(321L));
+  }
+
+  @Test
+  public void shouldComputeEarliestDouble() {
+    // Given:
+    final Udaf<Double, Struct, Double> udaf = EarliestByOffset.earliestDouble();
+
+    // When:
+    Struct res = udaf
+        .aggregate(1.1d, EarliestByOffset.createStruct(EarliestByOffset.STRUCT_DOUBLE, 2.2d));
+
+    // Then:
+    assertThat(res.getFloat64(EarliestByOffset.VAL_FIELD), is(2.2d));
+  }
+
+  @Test
+  public void shouldComputeEarliestBoolean() {
+    // Given:
+    final Udaf<Boolean, Struct, Boolean> udaf = EarliestByOffset.earliestBoolean();
+
+    // When:
+    Struct res = udaf
+        .aggregate(true, EarliestByOffset.createStruct(EarliestByOffset.STRUCT_BOOLEAN, false));
+
+    // Then:
+    assertThat(res.getBoolean(EarliestByOffset.VAL_FIELD), is(false));
+  }
+
+  @Test
+  public void shouldComputeEarliestString() {
+    // Given:
+    final Udaf<String, Struct, String> udaf = EarliestByOffset.earliestString();
+
+    // When:
+    Struct res = udaf
+        .aggregate("foo", EarliestByOffset.createStruct(EarliestByOffset.STRUCT_STRING, "bar"));
+
+    // Then:
+    assertThat(res.getString(EarliestByOffset.VAL_FIELD), is("bar"));
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/latest/LatestByOffsetUdafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/latest/LatestByOffsetUdafTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udaf.latest;
 
+import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.STRUCT_LONG;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -23,13 +24,20 @@ import io.confluent.ksql.function.udaf.Udaf;
 import org.apache.kafka.connect.data.Struct;
 import org.junit.Test;
 
+import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.SEQ_FIELD;
+import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.STRUCT_BOOLEAN;
+import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.STRUCT_DOUBLE;
+import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.STRUCT_INTEGER;
+import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.STRUCT_STRING;
+import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.VAL_FIELD;
+
 public class LatestByOffsetUdafTest {
 
   @Test
   public void shouldInitialize() {
     // Given:
     final Udaf<Integer, Struct, Integer> udaf = LatestByOffset
-        .latest(LatestByOffset.STRUCT_LONG);
+        .latest(STRUCT_LONG);
 
     // When:
     Struct init = udaf.initialize();
@@ -45,10 +53,10 @@ public class LatestByOffsetUdafTest {
 
     // When:
     Struct res = udaf
-        .aggregate(123, LatestByOffset.createStruct(LatestByOffset.STRUCT_INTEGER, 321));
+        .aggregate(123, LatestByOffset.createStruct(STRUCT_INTEGER, 321));
 
     // Then:
-    assertThat(res.get(LatestByOffset.VAL_FIELD), is(123));
+    assertThat(res.get(VAL_FIELD), is(123));
   }
 
   @Test
@@ -56,8 +64,8 @@ public class LatestByOffsetUdafTest {
     // Given:
     final Udaf<Integer, Struct, Integer> udaf = LatestByOffset.latestInteger();
 
-    Struct agg1 = LatestByOffset.createStruct(LatestByOffset.STRUCT_INTEGER, 123);
-    Struct agg2 = LatestByOffset.createStruct(LatestByOffset.STRUCT_INTEGER, 321);
+    Struct agg1 = LatestByOffset.createStruct(STRUCT_INTEGER, 123);
+    Struct agg2 = LatestByOffset.createStruct(STRUCT_INTEGER, 321);
 
     // When:
     Struct merged1 = udaf.merge(agg1, agg2);
@@ -75,16 +83,16 @@ public class LatestByOffsetUdafTest {
 
     LatestByOffset.sequence.set(Long.MAX_VALUE);
 
-    Struct agg1 = LatestByOffset.createStruct(LatestByOffset.STRUCT_INTEGER, 123);
-    Struct agg2 = LatestByOffset.createStruct(LatestByOffset.STRUCT_INTEGER, 321);
+    Struct agg1 = LatestByOffset.createStruct(STRUCT_INTEGER, 123);
+    Struct agg2 = LatestByOffset.createStruct(STRUCT_INTEGER, 321);
 
     // When:
     Struct merged1 = udaf.merge(agg1, agg2);
     Struct merged2 = udaf.merge(agg2, agg1);
 
     // Then:
-    assertThat(agg1.getInt64(LatestByOffset.SEQ_FIELD), is(Long.MAX_VALUE));
-    assertThat(agg2.getInt64(LatestByOffset.SEQ_FIELD), is(Long.MIN_VALUE));
+    assertThat(agg1.getInt64(SEQ_FIELD), is(Long.MAX_VALUE));
+    assertThat(agg2.getInt64(SEQ_FIELD), is(Long.MIN_VALUE));
     assertThat(merged1, is(agg2));
     assertThat(merged2, is(agg2));
   }
@@ -97,10 +105,10 @@ public class LatestByOffsetUdafTest {
 
     // When:
     Struct res = udaf
-        .aggregate(123L, LatestByOffset.createStruct(LatestByOffset.STRUCT_LONG, 321L));
+        .aggregate(123L, LatestByOffset.createStruct(STRUCT_LONG, 321L));
 
     // Then:
-    assertThat(res.getInt64(LatestByOffset.VAL_FIELD), is(123L));
+    assertThat(res.getInt64(VAL_FIELD), is(123L));
   }
 
   @Test
@@ -110,10 +118,10 @@ public class LatestByOffsetUdafTest {
 
     // When:
     Struct res = udaf
-        .aggregate(1.1d, LatestByOffset.createStruct(LatestByOffset.STRUCT_DOUBLE, 2.2d));
+        .aggregate(1.1d, LatestByOffset.createStruct(STRUCT_DOUBLE, 2.2d));
 
     // Then:
-    assertThat(res.getFloat64(LatestByOffset.VAL_FIELD), is(1.1d));
+    assertThat(res.getFloat64(VAL_FIELD), is(1.1d));
   }
 
   @Test
@@ -123,10 +131,10 @@ public class LatestByOffsetUdafTest {
 
     // When:
     Struct res = udaf
-        .aggregate(true, LatestByOffset.createStruct(LatestByOffset.STRUCT_BOOLEAN, false));
+        .aggregate(true, LatestByOffset.createStruct(STRUCT_BOOLEAN, false));
 
     // Then:
-    assertThat(res.getBoolean(LatestByOffset.VAL_FIELD), is(true));
+    assertThat(res.getBoolean(VAL_FIELD), is(true));
   }
 
   @Test
@@ -136,10 +144,10 @@ public class LatestByOffsetUdafTest {
 
     // When:
     Struct res = udaf
-        .aggregate("foo", LatestByOffset.createStruct(LatestByOffset.STRUCT_STRING, "bar"));
+        .aggregate("foo", LatestByOffset.createStruct(STRUCT_STRING, "bar"));
 
     // Then:
-    assertThat(res.getString(LatestByOffset.VAL_FIELD), is("foo"));
+    assertThat(res.getString(VAL_FIELD), is("foo"));
   }
 
 }

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestGeneratorTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestGeneratorTest.java
@@ -29,6 +29,7 @@ public class PlannedTestGeneratorTest {
    * or changed query plans.
    */
   @Test
+  @Ignore
   public void manuallyGeneratePlans() {
     PlannedTestGenerator.generatePlans(QueryTranslationTest.findTestCases()
         .filter(PlannedTestUtils::isNotExcluded));

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestGeneratorTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestGeneratorTest.java
@@ -29,7 +29,6 @@ public class PlannedTestGeneratorTest {
    * or changed query plans.
    */
   @Test
-  @Ignore
   public void manuallyGeneratePlans() {
     PlannedTestGenerator.generatePlans(QueryTranslationTest.findTestCases()
         .filter(PlannedTestUtils::isNotExcluded));

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset/6.0.0_1588701853940/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset/6.0.0_1588701853940/plan.json
@@ -1,0 +1,164 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ROWKEY BIGINT KEY, ID BIGINT, F0 INTEGER, F1 BIGINT, F2 DOUBLE, F3 BOOLEAN, F4 STRING) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `F1` BIGINT, `F2` DOUBLE, `F3` BOOLEAN, `F4` STRING",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  EARLIEST_BY_OFFSET(INPUT.F0) L0,\n  EARLIEST_BY_OFFSET(INPUT.F1) L1,\n  EARLIEST_BY_OFFSET(INPUT.F2) L2,\n  EARLIEST_BY_OFFSET(INPUT.F3) L3,\n  EARLIEST_BY_OFFSET(INPUT.F4) L4\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `L0` INTEGER, `L1` BIGINT, `L2` DOUBLE, `L3` BOOLEAN, `L4` STRING",
+      "keyField" : "ID",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `F1` BIGINT, `F2` DOUBLE, `F3` BOOLEAN, `F4` STRING"
+                },
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0", "F1 AS F1", "F2 AS F2", "F3 AS F3", "F4 AS F4" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0", "F1", "F2", "F3", "F4" ],
+            "aggregationFunctions" : [ "EARLIEST_BY_OFFSET(F0)", "EARLIEST_BY_OFFSET(F1)", "EARLIEST_BY_OFFSET(F2)", "EARLIEST_BY_OFFSET(F3)", "EARLIEST_BY_OFFSET(F4)" ]
+          },
+          "selectExpressions" : [ "ID AS ID", "KSQL_AGG_VARIABLE_0 AS L0", "KSQL_AGG_VARIABLE_1 AS L1", "KSQL_AGG_VARIABLE_2 AS L2", "KSQL_AGG_VARIABLE_3 AS L3", "KSQL_AGG_VARIABLE_4 AS L4" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset/6.0.0_1588701853940/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset/6.0.0_1588701853940/spec.json
@@ -1,0 +1,151 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1588701853940,
+  "path" : "query-validation-tests/earliest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<ID BIGINT, F0 INT, F1 BIGINT, F2 DOUBLE, F3 BOOLEAN, F4 VARCHAR> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : "STRUCT<ID BIGINT, F0 INT, F1 BIGINT, F2 DOUBLE, F3 BOOLEAN, F4 VARCHAR> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : "STRUCT<ID BIGINT, F0 INT, F1 BIGINT, F2 DOUBLE, F3 BOOLEAN, F4 VARCHAR, KSQL_AGG_VARIABLE_0 STRUCT<SEQ BIGINT, VAL INT>, KSQL_AGG_VARIABLE_1 STRUCT<SEQ BIGINT, VAL BIGINT>, KSQL_AGG_VARIABLE_2 STRUCT<SEQ BIGINT, VAL DOUBLE>, KSQL_AGG_VARIABLE_3 STRUCT<SEQ BIGINT, VAL BOOLEAN>, KSQL_AGG_VARIABLE_4 STRUCT<SEQ BIGINT, VAL VARCHAR>> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<ID BIGINT, L0 INT, L1 BIGINT, L2 DOUBLE, L3 BOOLEAN, L4 VARCHAR> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "earliest by offset",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "ID" : 0,
+        "F0" : 12,
+        "F1" : 1000,
+        "F2" : 1.23,
+        "F3" : true,
+        "F4" : "foo"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 1,
+      "value" : {
+        "ID" : 1,
+        "F0" : 12,
+        "F1" : 1000,
+        "F2" : 1.23,
+        "F3" : true,
+        "F4" : "foo"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "ID" : 0,
+        "F0" : 21,
+        "F1" : 2000,
+        "F2" : 2.23,
+        "F3" : false,
+        "F4" : "bar"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 1,
+      "value" : {
+        "ID" : 1,
+        "F0" : 21,
+        "F1" : 2000,
+        "F2" : 2.23,
+        "F3" : false,
+        "F4" : "bar"
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "ID" : 0,
+        "L0" : 12,
+        "L1" : 1000,
+        "L2" : 1.23,
+        "L3" : true,
+        "L4" : "foo"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 1,
+      "value" : {
+        "ID" : 1,
+        "L0" : 12,
+        "L1" : 1000,
+        "L2" : 1.23,
+        "L3" : true,
+        "L4" : "foo"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "ID" : 0,
+        "L0" : 12,
+        "L1" : 1000,
+        "L2" : 1.23,
+        "L3" : true,
+        "L4" : "foo"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 1,
+      "value" : {
+        "ID" : 1,
+        "L0" : 12,
+        "L1" : 1000,
+        "L2" : 1.23,
+        "L3" : true,
+        "L4" : "foo"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ROWKEY BIGINT KEY, ID BIGINT, F0 INT, F1 BIGINT, F2 DOUBLE, F3 BOOLEAN, F4 STRING) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');", "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0) AS L0, EARLIEST_BY_OFFSET(F1) AS L1, EARLIEST_BY_OFFSET(F2) AS L2, EARLIEST_BY_OFFSET(F3) AS L3, EARLIEST_BY_OFFSET(F4) AS L4 FROM INPUT GROUP BY ID;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset/6.0.0_1588701853940/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset/6.0.0_1588701853940/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset/6.0.0_1589303205454/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset/6.0.0_1589303205454/plan.json
@@ -1,0 +1,161 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER, F1 BIGINT, F2 DOUBLE, F3 BOOLEAN, F4 STRING) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER, `F1` BIGINT, `F2` DOUBLE, `F3` BOOLEAN, `F4` STRING",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  EARLIEST_BY_OFFSET(INPUT.F0) L0,\n  EARLIEST_BY_OFFSET(INPUT.F1) L1,\n  EARLIEST_BY_OFFSET(INPUT.F2) L2,\n  EARLIEST_BY_OFFSET(INPUT.F3) L3,\n  EARLIEST_BY_OFFSET(INPUT.F4) L4\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER, `L1` BIGINT, `L2` DOUBLE, `L3` BOOLEAN, `L4` STRING",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER, `F1` BIGINT, `F2` DOUBLE, `F3` BOOLEAN, `F4` STRING"
+                },
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0", "F1 AS F1", "F2 AS F2", "F3 AS F3", "F4 AS F4" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0", "F1", "F2", "F3", "F4" ],
+            "aggregationFunctions" : [ "EARLIEST_BY_OFFSET(F0)", "EARLIEST_BY_OFFSET(F1)", "EARLIEST_BY_OFFSET(F2)", "EARLIEST_BY_OFFSET(F3)", "EARLIEST_BY_OFFSET(F4)" ]
+          },
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0", "KSQL_AGG_VARIABLE_1 AS L1", "KSQL_AGG_VARIABLE_2 AS L2", "KSQL_AGG_VARIABLE_3 AS L3", "KSQL_AGG_VARIABLE_4 AS L4" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset/6.0.0_1589303205454/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset/6.0.0_1589303205454/spec.json
@@ -1,0 +1,143 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1589303205454,
+  "path" : "query-validation-tests/earliest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<F0 INT, F1 BIGINT, F2 DOUBLE, F3 BOOLEAN, F4 VARCHAR> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : "STRUCT<ID BIGINT, F0 INT, F1 BIGINT, F2 DOUBLE, F3 BOOLEAN, F4 VARCHAR> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : "STRUCT<ID BIGINT, F0 INT, F1 BIGINT, F2 DOUBLE, F3 BOOLEAN, F4 VARCHAR, KSQL_AGG_VARIABLE_0 STRUCT<SEQ BIGINT, VAL INT>, KSQL_AGG_VARIABLE_1 STRUCT<SEQ BIGINT, VAL BIGINT>, KSQL_AGG_VARIABLE_2 STRUCT<SEQ BIGINT, VAL DOUBLE>, KSQL_AGG_VARIABLE_3 STRUCT<SEQ BIGINT, VAL BOOLEAN>, KSQL_AGG_VARIABLE_4 STRUCT<SEQ BIGINT, VAL VARCHAR>> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<L0 INT, L1 BIGINT, L2 DOUBLE, L3 BOOLEAN, L4 VARCHAR> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "earliest by offset",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 12,
+        "F1" : 1000,
+        "F2" : 1.23,
+        "F3" : true,
+        "F4" : "foo"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 1,
+      "value" : {
+        "F0" : 12,
+        "F1" : 1000,
+        "F2" : 1.23,
+        "F3" : true,
+        "F4" : "foo"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 21,
+        "F1" : 2000,
+        "F2" : 2.23,
+        "F3" : false,
+        "F4" : "bar"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 1,
+      "value" : {
+        "F0" : 21,
+        "F1" : 2000,
+        "F2" : 2.23,
+        "F3" : false,
+        "F4" : "bar"
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 12,
+        "L1" : 1000,
+        "L2" : 1.23,
+        "L3" : true,
+        "L4" : "foo"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 1,
+      "value" : {
+        "L0" : 12,
+        "L1" : 1000,
+        "L2" : 1.23,
+        "L3" : true,
+        "L4" : "foo"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 12,
+        "L1" : 1000,
+        "L2" : 1.23,
+        "L3" : true,
+        "L4" : "foo"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 1,
+      "value" : {
+        "L0" : 12,
+        "L1" : 1000,
+        "L2" : 1.23,
+        "L3" : true,
+        "L4" : "foo"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT, F1 BIGINT, F2 DOUBLE, F3 BOOLEAN, F4 STRING) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0) AS L0, EARLIEST_BY_OFFSET(F1) AS L1, EARLIEST_BY_OFFSET(F2) AS L2, EARLIEST_BY_OFFSET(F3) AS L3, EARLIEST_BY_OFFSET(F4) AS L4 FROM INPUT GROUP BY ID;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset/6.0.0_1589303205454/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset/6.0.0_1589303205454/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset_with_all_nulls/6.0.0_1588701854211/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset_with_all_nulls/6.0.0_1588701854211/plan.json
@@ -1,0 +1,164 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ROWKEY BIGINT KEY, ID BIGINT, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F0` INTEGER",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  EARLIEST_BY_OFFSET(INPUT.F0) L0\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `L0` INTEGER",
+      "keyField" : "ID",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F0` INTEGER"
+                },
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "EARLIEST_BY_OFFSET(F0)" ]
+          },
+          "selectExpressions" : [ "ID AS ID", "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset_with_all_nulls/6.0.0_1588701854211/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset_with_all_nulls/6.0.0_1588701854211/spec.json
@@ -1,0 +1,91 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1588701854211,
+  "path" : "query-validation-tests/earliest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<ID BIGINT, F0 INT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : "STRUCT<ID BIGINT, F0 INT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : "STRUCT<ID BIGINT, F0 INT, KSQL_AGG_VARIABLE_0 STRUCT<SEQ BIGINT, VAL INT>> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<ID BIGINT, L0 INT> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "earliest by offset with all nulls",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "ID" : 0,
+        "F0" : null
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "ID" : 0,
+        "F0" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "ID" : 0,
+        "L0" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "ID" : 0,
+        "L0" : null
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ROWKEY BIGINT KEY, ID BIGINT, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');", "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0) AS L0 FROM INPUT GROUP BY ID;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset_with_all_nulls/6.0.0_1588701854211/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset_with_all_nulls/6.0.0_1588701854211/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset_with_all_nulls/6.0.0_1589303205666/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset_with_all_nulls/6.0.0_1589303205666/plan.json
@@ -1,0 +1,161 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  EARLIEST_BY_OFFSET(INPUT.F0) L0\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "EARLIEST_BY_OFFSET(F0)" ]
+          },
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset_with_all_nulls/6.0.0_1589303205666/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset_with_all_nulls/6.0.0_1589303205666/spec.json
@@ -1,0 +1,87 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1589303205666,
+  "path" : "query-validation-tests/earliest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<F0 INT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : "STRUCT<ID BIGINT, F0 INT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : "STRUCT<ID BIGINT, F0 INT, KSQL_AGG_VARIABLE_0 STRUCT<SEQ BIGINT, VAL INT>> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<L0 INT> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "earliest by offset with all nulls",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : null
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0) AS L0 FROM INPUT GROUP BY ID;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset_with_all_nulls/6.0.0_1589303205666/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset_with_all_nulls/6.0.0_1589303205666/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset_with_nulls/6.0.0_1588701854095/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset_with_nulls/6.0.0_1588701854095/plan.json
@@ -1,0 +1,164 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ROWKEY BIGINT KEY, ID BIGINT, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', KEY='ID', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F0` INTEGER",
+      "keyField" : "ID",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  EARLIEST_BY_OFFSET(INPUT.F0) L0\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `L0` INTEGER",
+      "keyField" : "ID",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ROWKEY` BIGINT KEY, `ID` BIGINT, `F0` INTEGER"
+                },
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "EARLIEST_BY_OFFSET(F0)" ]
+          },
+          "selectExpressions" : [ "ID AS ID", "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.any.key.name.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset_with_nulls/6.0.0_1588701854095/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset_with_nulls/6.0.0_1588701854095/spec.json
@@ -1,0 +1,91 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1588701854095,
+  "path" : "query-validation-tests/earliest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<ID BIGINT, F0 INT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : "STRUCT<ID BIGINT, F0 INT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : "STRUCT<ID BIGINT, F0 INT, KSQL_AGG_VARIABLE_0 STRUCT<SEQ BIGINT, VAL INT>> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<ID BIGINT, L0 INT> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "earliest by offset with nulls",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "ID" : 0,
+        "F0" : 12
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "ID" : 0,
+        "F0" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "ID" : 0,
+        "L0" : 12
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "ID" : 0,
+        "L0" : 12
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ROWKEY BIGINT KEY, ID BIGINT, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');", "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0) AS L0 FROM INPUT GROUP BY ID;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset_with_nulls/6.0.0_1588701854095/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset_with_nulls/6.0.0_1588701854095/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset_with_nulls/6.0.0_1589303205588/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset_with_nulls/6.0.0_1589303205588/plan.json
@@ -1,0 +1,161 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  EARLIEST_BY_OFFSET(INPUT.F0) L0\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "EARLIEST_BY_OFFSET(F0)" ]
+          },
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset_with_nulls/6.0.0_1589303205588/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset_with_nulls/6.0.0_1589303205588/spec.json
@@ -1,0 +1,87 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1589303205588,
+  "path" : "query-validation-tests/earliest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<F0 INT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : "STRUCT<ID BIGINT, F0 INT> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : "STRUCT<ID BIGINT, F0 INT, KSQL_AGG_VARIABLE_0 STRUCT<SEQ BIGINT, VAL INT>> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<L0 INT> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "earliest by offset with nulls",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 12
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 12
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 12
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0) AS L0 FROM INPUT GROUP BY ID;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset_with_nulls/6.0.0_1589303205588/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset_with_nulls/6.0.0_1589303205588/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/earliest-offset-udaf.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/earliest-offset-udaf.json
@@ -1,0 +1,57 @@
+
+{
+  "comments": [
+    "Tests covering the use of the EARLIEST_BY_OFFSET aggregate function"
+  ],
+  "tests": [
+    {
+      "name": "earliest by offset",
+      "statements": [
+        "CREATE STREAM INPUT (ROWKEY BIGINT KEY, ID BIGINT, F0 INT, F1 BIGINT, F2 DOUBLE, F3 BOOLEAN, F4 STRING) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0) AS L0, EARLIEST_BY_OFFSET(F1) AS L1, EARLIEST_BY_OFFSET(F2) AS L2, EARLIEST_BY_OFFSET(F3) AS L3, EARLIEST_BY_OFFSET(F4) AS L4 FROM INPUT GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "F0": 12, "F1": 1000, "F2": 1.23, "F3": true, "F4": "foo"}},
+        {"topic": "test_topic", "key": 1, "value": {"ID": 1, "F0": 12, "F1": 1000, "F2": 1.23, "F3": true, "F4": "foo"}},
+        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "F0": 21, "F1": 2000, "F2": 2.23, "F3": false, "F4": "bar"}},
+        {"topic": "test_topic", "key": 1, "value": {"ID": 1, "F0": 21, "F1": 2000, "F2": 2.23, "F3": false, "F4": "bar"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"ID": 0, "L0": 12, "L1": 1000, "L2": 1.23, "L3": true, "L4": "foo"}},
+        {"topic": "OUTPUT", "key": 1, "value": {"ID": 1, "L0": 12, "L1": 1000, "L2": 1.23, "L3": true, "L4": "foo"}},
+        {"topic": "OUTPUT", "key": 0, "value": {"ID": 0, "L0": 12, "L1": 1000, "L2": 1.23, "L3": true, "L4": "foo"}},
+        {"topic": "OUTPUT", "key": 1, "value": {"ID": 1, "L0": 12, "L1": 1000, "L2": 1.23, "L3": true, "L4": "foo"}}
+      ]
+    },
+    {
+      "name": "earliest by offset with nulls",
+      "statements": [
+        "CREATE STREAM INPUT (ROWKEY BIGINT KEY, ID BIGINT, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0) AS L0 FROM INPUT GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "F0": 12}},
+        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "F0": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"ID": 0, "L0": 12}},
+        {"topic": "OUTPUT", "key": 0, "value": {"ID": 0, "L0": 12}}
+      ]
+    },
+    {
+      "name": "earliest by offset with all nulls",
+      "statements": [
+        "CREATE STREAM INPUT (ROWKEY BIGINT KEY, ID BIGINT, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0) AS L0 FROM INPUT GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "F0": null}},
+        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "F0": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"ID": 0, "L0": null}},
+        {"topic": "OUTPUT", "key": 0, "value": {"ID": 0, "L0": null}}
+      ]
+    }
+  ]
+}

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/earliest-offset-udaf.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/earliest-offset-udaf.json
@@ -7,50 +7,50 @@
     {
       "name": "earliest by offset",
       "statements": [
-        "CREATE STREAM INPUT (ROWKEY BIGINT KEY, ID BIGINT, F0 INT, F1 BIGINT, F2 DOUBLE, F3 BOOLEAN, F4 STRING) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT, F1 BIGINT, F2 DOUBLE, F3 BOOLEAN, F4 STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0) AS L0, EARLIEST_BY_OFFSET(F1) AS L1, EARLIEST_BY_OFFSET(F2) AS L2, EARLIEST_BY_OFFSET(F3) AS L3, EARLIEST_BY_OFFSET(F4) AS L4 FROM INPUT GROUP BY ID;"
       ],
       "inputs": [
-        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "F0": 12, "F1": 1000, "F2": 1.23, "F3": true, "F4": "foo"}},
-        {"topic": "test_topic", "key": 1, "value": {"ID": 1, "F0": 12, "F1": 1000, "F2": 1.23, "F3": true, "F4": "foo"}},
-        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "F0": 21, "F1": 2000, "F2": 2.23, "F3": false, "F4": "bar"}},
-        {"topic": "test_topic", "key": 1, "value": {"ID": 1, "F0": 21, "F1": 2000, "F2": 2.23, "F3": false, "F4": "bar"}}
+        {"topic": "test_topic", "key": 0, "value": {"F0": 12, "F1": 1000, "F2": 1.23, "F3": true, "F4": "foo"}},
+        {"topic": "test_topic", "key": 1, "value": {"F0": 12, "F1": 1000, "F2": 1.23, "F3": true, "F4": "foo"}},
+        {"topic": "test_topic", "key": 0, "value": {"F0": 21, "F1": 2000, "F2": 2.23, "F3": false, "F4": "bar"}},
+        {"topic": "test_topic", "key": 1, "value": {"F0": 21, "F1": 2000, "F2": 2.23, "F3": false, "F4": "bar"}}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"ID": 0, "L0": 12, "L1": 1000, "L2": 1.23, "L3": true, "L4": "foo"}},
-        {"topic": "OUTPUT", "key": 1, "value": {"ID": 1, "L0": 12, "L1": 1000, "L2": 1.23, "L3": true, "L4": "foo"}},
-        {"topic": "OUTPUT", "key": 0, "value": {"ID": 0, "L0": 12, "L1": 1000, "L2": 1.23, "L3": true, "L4": "foo"}},
-        {"topic": "OUTPUT", "key": 1, "value": {"ID": 1, "L0": 12, "L1": 1000, "L2": 1.23, "L3": true, "L4": "foo"}}
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": 12, "L1": 1000, "L2": 1.23, "L3": true, "L4": "foo"}},
+        {"topic": "OUTPUT", "key": 1, "value": {"L0": 12, "L1": 1000, "L2": 1.23, "L3": true, "L4": "foo"}},
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": 12, "L1": 1000, "L2": 1.23, "L3": true, "L4": "foo"}},
+        {"topic": "OUTPUT", "key": 1, "value": {"L0": 12, "L1": 1000, "L2": 1.23, "L3": true, "L4": "foo"}}
       ]
     },
     {
       "name": "earliest by offset with nulls",
       "statements": [
-        "CREATE STREAM INPUT (ROWKEY BIGINT KEY, ID BIGINT, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0) AS L0 FROM INPUT GROUP BY ID;"
       ],
       "inputs": [
-        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "F0": 12}},
-        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "F0": null}}
+        {"topic": "test_topic", "key": 0, "value": {"F0": 12}},
+        {"topic": "test_topic", "key": 0, "value": {"F0": null}}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"ID": 0, "L0": 12}},
-        {"topic": "OUTPUT", "key": 0, "value": {"ID": 0, "L0": 12}}
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": 12}},
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": 12}}
       ]
     },
     {
       "name": "earliest by offset with all nulls",
       "statements": [
-        "CREATE STREAM INPUT (ROWKEY BIGINT KEY, ID BIGINT, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0) AS L0 FROM INPUT GROUP BY ID;"
       ],
       "inputs": [
-        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "F0": null}},
-        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "F0": null}}
+        {"topic": "test_topic", "key": 0, "value": {"F0": null}},
+        {"topic": "test_topic", "key": 0, "value": {"F0": null}}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"ID": 0, "L0": null}},
-        {"topic": "OUTPUT", "key": 0, "value": {"ID": 0, "L0": null}}
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": null}},
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": null}}
       ]
     }
   ]


### PR DESCRIPTION
### Description 

Fixes https://github.com/confluentinc/ksql/issues/5268

Implements earliest_by_offset() UDAF which computes the earliest value for a column. Earliest being defined as offset order.

Note for the reviewer:
- The implementation is taken from the latest_by_offset() code https://github.com/confluentinc/ksql/pull/4782, and modified to return the earliest offset. Expect similar concerns and questions commented in the mentioned PR.

### Testing done 
Added new unit test and QTT test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

