### PR TITLE
chore: remove defunct alias support for PARTITION BY

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/RewrittenAnalysis.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/RewrittenAnalysis.java
@@ -124,9 +124,7 @@ public class RewrittenAnalysis implements ImmutableAnalysis {
     return original.getPartitionBy()
         .map(partitionBy -> new PartitionBy(
             partitionBy.getLocation(),
-            rewrite(partitionBy.getExpression()),
-            partitionBy.getAlias()
-                .map(this::rewrite)
+            rewrite(partitionBy.getExpression())
         ));
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/AstSanitizer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/AstSanitizer.java
@@ -35,7 +35,6 @@ import io.confluent.ksql.parser.tree.AstVisitor;
 import io.confluent.ksql.parser.tree.CreateStreamAsSelect;
 import io.confluent.ksql.parser.tree.GroupBy;
 import io.confluent.ksql.parser.tree.InsertInto;
-import io.confluent.ksql.parser.tree.PartitionBy;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.SingleColumn;
 import io.confluent.ksql.parser.tree.Statement;
@@ -185,30 +184,6 @@ public final class AstSanitizer {
         }
       }
       return super.visitGroupBy(node, context);
-    }
-
-    @Override
-    protected Optional<AstNode> visitPartitionBy(
-        final PartitionBy node,
-        final StatementRewriter.Context<Void> context
-    ) {
-      if (node.getAlias().isPresent()
-          && node.getExpression() instanceof ColumnReferenceExp) {
-
-        final ColumnName groupByColName = ((ColumnReferenceExp) node.getExpression())
-            .getColumnName();
-
-        if (node.getAlias().get().equals(groupByColName)) {
-          // Alias is a no-op - remove it:
-          return Optional.of(new PartitionBy(
-              node.getLocation(),
-              node.getExpression(),
-              Optional.empty()
-          ));
-        }
-      }
-
-      return super.visitPartitionBy(node, context);
     }
 
     private DataSource getSource(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/StatementRewriter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/StatementRewriter.java
@@ -447,8 +447,7 @@ public final class StatementRewriter<C> {
       return result
           .orElseGet(() -> new PartitionBy(
               node.getLocation(),
-              processExpression(node.getExpression(), context),
-              node.getAlias()
+              processExpression(node.getExpression(), context)
           ));
     }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -846,7 +846,6 @@ public class LogicalPlanner {
     return PartitionByParamsFactory.buildSchema(
         sourceSchema,
         partitionBy,
-        Optional.empty(),
         functionRegistry
     );
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/RepartitionNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/RepartitionNode.java
@@ -86,7 +86,6 @@ public class RepartitionNode extends PlanNode {
     return source.buildStream(builder)
         .selectKey(
             partitionBy,
-            Optional.empty(),
             builder.buildNodeContext(getId().toString())
         );
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -342,10 +342,9 @@ public class SchemaKStream<K> {
   @SuppressWarnings("unchecked")
   public SchemaKStream<Struct> selectKey(
       final Expression keyExpression,
-      final Optional<ColumnName> alias,
       final Stacker contextStacker
   ) {
-    if (repartitionNotNeeded(ImmutableList.of(keyExpression), alias)) {
+    if (repartitionNotNeeded(ImmutableList.of(keyExpression), Optional.empty())) {
       return (SchemaKStream<Struct>) this;
     }
 
@@ -356,7 +355,7 @@ public class SchemaKStream<K> {
 
     final ExecutionStep<KStreamHolder<Struct>> step = ksqlConfig
         .getBoolean(KsqlConfig.KSQL_ANY_KEY_NAME_ENABLED)
-        ? ExecutionStepFactory.streamSelectKey(contextStacker, sourceStep, keyExpression, alias)
+        ? ExecutionStepFactory.streamSelectKey(contextStacker, sourceStep, keyExpression)
         : ExecutionStepFactory.streamSelectKeyV1(contextStacker, sourceStep, keyExpression);
 
     return new SchemaKStream<>(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
@@ -144,10 +144,9 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
   @Override
   public SchemaKStream<Struct> selectKey(
       final Expression keyExpression,
-      final Optional<ColumnName> alias,
       final Stacker contextStacker
   ) {
-    if (repartitionNotNeeded(ImmutableList.of(keyExpression), alias)) {
+    if (repartitionNotNeeded(ImmutableList.of(keyExpression), Optional.empty())) {
       return (SchemaKStream<Struct>) this;
     }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/PullQueryValidatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/PullQueryValidatorTest.java
@@ -137,8 +137,7 @@ public class PullQueryValidatorTest {
     // Given:
     when(analysis.getPartitionBy()).thenReturn(Optional.of(new PartitionBy(
         Optional.empty(),
-        AN_EXPRESSION,
-        Optional.empty()
+        AN_EXPRESSION
     )));
 
     // When:

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/AstSanitizerTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/AstSanitizerTest.java
@@ -34,7 +34,6 @@ import io.confluent.ksql.parser.AstBuilder;
 import io.confluent.ksql.parser.DefaultKsqlParser;
 import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.tree.GroupBy;
-import io.confluent.ksql.parser.tree.PartitionBy;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Select;
 import io.confluent.ksql.parser.tree.SingleColumn;
@@ -312,19 +311,6 @@ public class AstSanitizerTest {
     assertThat(result.getSelect(), is(new Select(ImmutableList.of(
         new SingleColumn(column(TEST1_NAME, "COL1"), Optional.of(ColumnName.of("BOB")))
     ))));
-  }
-
-  @Test
-  public void shouldRemoveAliasFromPartitionByIfNoOp() {
-    // Given:
-    final Statement stmt = givenQuery("SELECT * FROM TEST1 PARTITION BY COL1 AS COL1;");
-
-    // When:
-    final Query result = (Query) AstSanitizer.sanitize(stmt, META_STORE);
-
-    // Then:
-    assertThat(result.getPartitionBy(), is(not(Optional.empty())));
-    assertThat(result.getPartitionBy().flatMap(PartitionBy::getAlias), is(Optional.empty()));
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/StatementRewriterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/StatementRewriterTest.java
@@ -810,8 +810,7 @@ public class StatementRewriterTest {
     // Given:
     final PartitionBy partitionBy = new PartitionBy(
         location,
-        expression,
-        Optional.of(COL2)
+        expression
     );
     when(expressionRewriter.apply(expression, context)).thenReturn(rewrittenExpression);
 
@@ -821,8 +820,7 @@ public class StatementRewriterTest {
     // Then:
     assertThat(rewritten, equalTo(new PartitionBy(
         location,
-        rewrittenExpression,
-        Optional.of(COL2)
+        rewrittenExpression
     )));
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
@@ -204,7 +204,7 @@ public class SchemaKStreamTest {
 
     // When:
     final SchemaKStream result = initialSchemaKStream
-        .selectKey(repartitionNode.getPartitionBy(), Optional.empty(), childContextStacker);
+        .selectKey(repartitionNode.getPartitionBy(), childContextStacker);
 
     // Then:
     assertThat(result, is(initialSchemaKStream));
@@ -219,7 +219,7 @@ public class SchemaKStreamTest {
 
     // When:
     final SchemaKStream result = initialSchemaKStream
-        .selectKey(repartitionNode.getPartitionBy(), Optional.empty(), childContextStacker);
+        .selectKey(repartitionNode.getPartitionBy(), childContextStacker);
 
     // Then:
     assertThat(result, is(initialSchemaKStream));
@@ -234,7 +234,7 @@ public class SchemaKStreamTest {
 
     // When:
     final SchemaKStream result = initialSchemaKStream
-        .selectKey(repartitionNode.getPartitionBy(), Optional.empty(), childContextStacker);
+        .selectKey(repartitionNode.getPartitionBy(), childContextStacker);
 
     // Then:
     assertThat(result.getKeyField(),
@@ -250,7 +250,7 @@ public class SchemaKStreamTest {
 
     // When:
     final SchemaKStream result = initialSchemaKStream
-        .selectKey(repartitionNode.getPartitionBy(), Optional.empty(), childContextStacker);
+        .selectKey(repartitionNode.getPartitionBy(), childContextStacker);
 
     // Then:
     assertThat(result.getKeyField(), is(KeyField.none()));
@@ -265,7 +265,7 @@ public class SchemaKStreamTest {
 
     // When:
     final SchemaKStream result = initialSchemaKStream
-        .selectKey(repartitionNode.getPartitionBy(), Optional.empty(), childContextStacker);
+        .selectKey(repartitionNode.getPartitionBy(), childContextStacker);
 
     // Then:
     assertThat(result.getKeyField(), is(KeyField.none()));
@@ -279,7 +279,7 @@ public class SchemaKStreamTest {
     final RepartitionNode repartitionNode = (RepartitionNode) logicalPlan.getSources().get(0).getSources().get(0);
 
     // When:
-    initialSchemaKStream.selectKey(repartitionNode.getPartitionBy(), Optional.empty(),
+    initialSchemaKStream.selectKey(repartitionNode.getPartitionBy(),
         childContextStacker
     );
   }
@@ -405,7 +405,7 @@ public class SchemaKStreamTest {
         new UnqualifiedColumnReferenceExp(ColumnName.of("COL2"));
 
     // When:
-    schemaKTable.selectKey(col2, Optional.empty(), childContextStacker);
+    schemaKTable.selectKey(col2, childContextStacker);
   }
 
   @Test
@@ -495,7 +495,7 @@ public class SchemaKStreamTest {
     // When:
     final SchemaKStream<?> rekeyedSchemaKStream = initialSchemaKStream.selectKey(
         new UnqualifiedColumnReferenceExp(ColumnName.of("COL1")),
-        Optional.empty(), childContextStacker);
+        childContextStacker);
 
     // Then:
     assertThat(rekeyedSchemaKStream.getKeyField(), is(expected));
@@ -509,7 +509,7 @@ public class SchemaKStreamTest {
     // When:
     final SchemaKStream<?> rekeyedSchemaKStream = initialSchemaKStream.selectKey(
         new UnqualifiedColumnReferenceExp(ColumnName.of("COL1")),
-        Optional.empty(), childContextStacker);
+        childContextStacker);
 
     // Then:
     assertThat(
@@ -532,7 +532,7 @@ public class SchemaKStreamTest {
     // When:
     final SchemaKStream<?> rekeyedSchemaKStream = initialSchemaKStream.selectKey(
         new UnqualifiedColumnReferenceExp(ColumnName.of("COL1")),
-        Optional.empty(), childContextStacker);
+        childContextStacker);
 
     // Then:
     assertThat(

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSelectKey.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSelectKey.java
@@ -18,12 +18,10 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.expression.tree.Expression;
-import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.testing.EffectivelyImmutable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import org.apache.kafka.connect.data.Struct;
 
 @Immutable
@@ -33,19 +31,16 @@ public class StreamSelectKey implements ExecutionStep<KStreamHolder<Struct>> {
   private final Expression keyExpression;
   @EffectivelyImmutable
   private final ExecutionStep<? extends KStreamHolder<?>> source;
-  private final Optional<ColumnName> alias;
 
   public StreamSelectKey(
       @JsonProperty(value = "properties", required = true) final ExecutionStepPropertiesV1 props,
       @JsonProperty(value = "source", required = true) final
       ExecutionStep<? extends KStreamHolder<?>> source,
-      @JsonProperty(value = "keyExpression", required = true) final Expression keyExpression,
-      @JsonProperty(value = "alias") final Optional<ColumnName> alias
+      @JsonProperty(value = "keyExpression", required = true) final Expression keyExpression
   ) {
     this.properties = Objects.requireNonNull(props, "props");
     this.source = Objects.requireNonNull(source, "source");
     this.keyExpression = Objects.requireNonNull(keyExpression, "keyExpression");
-    this.alias = Objects.requireNonNull(alias, "alias");
   }
 
   @Override
@@ -61,10 +56,6 @@ public class StreamSelectKey implements ExecutionStep<KStreamHolder<Struct>> {
 
   public Expression getKeyExpression() {
     return keyExpression;
-  }
-
-  public Optional<ColumnName> getAlias() {
-    return alias;
   }
 
   public ExecutionStep<? extends KStreamHolder<?>> getSource() {
@@ -86,12 +77,11 @@ public class StreamSelectKey implements ExecutionStep<KStreamHolder<Struct>> {
     }
     final StreamSelectKey that = (StreamSelectKey) o;
     return Objects.equals(properties, that.properties)
-        && Objects.equals(source, that.source)
-        && Objects.equals(alias, that.alias);
+        && Objects.equals(source, that.source);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(properties, source, alias);
+    return Objects.hash(properties, source);
   }
 }

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/plan/StreamSelectKeyTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/plan/StreamSelectKeyTest.java
@@ -16,8 +16,6 @@ package io.confluent.ksql.execution.plan;
 
 import com.google.common.testing.EqualsTester;
 import io.confluent.ksql.execution.expression.tree.Expression;
-import io.confluent.ksql.name.ColumnName;
-import java.util.Optional;
 import org.apache.kafka.connect.data.Struct;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,19 +36,16 @@ public class StreamSelectKeyTest {
   private Expression expression1;
   @Mock
   private Expression expression2;
-  @Mock
-  private ColumnName alias;
 
   @SuppressWarnings("UnstableApiUsage")
   @Test
   public void shouldImplementEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            new StreamSelectKey(properties1, source1, expression1, Optional.of(alias)),
-            new StreamSelectKey(properties1, source1, expression1, Optional.of(alias)))
-        .addEqualityGroup(new StreamSelectKey(properties2, source1, expression1, Optional.of(alias)))
-        .addEqualityGroup(new StreamSelectKey(properties1, source2, expression1, Optional.of(alias)))
-        .addEqualityGroup(new StreamSelectKey(properties1, source1, expression2, Optional.of(alias)))
-        .addEqualityGroup(new StreamSelectKey(properties1, source1, expression1, Optional.empty()));
+            new StreamSelectKey(properties1, source1, expression1),
+            new StreamSelectKey(properties1, source1, expression1))
+        .addEqualityGroup(new StreamSelectKey(properties2, source1, expression1))
+        .addEqualityGroup(new StreamSelectKey(properties1, source2, expression1))
+        .addEqualityGroup(new StreamSelectKey(properties1, source1, expression2));
   }
 }

--- a/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -76,7 +76,7 @@ query
       (WINDOW  windowExpression)?
       (WHERE where=booleanExpression)?
       (GROUP BY groupBy)?
-      (PARTITION BY partitionBy)?
+      (PARTITION BY partitionBy=valueExpression)?
       (HAVING having=booleanExpression)?
       (EMIT resultMaterialization)?
       limitClause?
@@ -150,10 +150,6 @@ windowUnit
     | MINUTES
     | SECONDS
     | MILLISECONDS
-    ;
-
-partitionBy
-    : valueExpression (AS? identifier)?
     ;
 
 groupBy

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -79,7 +79,6 @@ import io.confluent.ksql.parser.SqlBaseParser.LimitClauseContext;
 import io.confluent.ksql.parser.SqlBaseParser.ListConnectorsContext;
 import io.confluent.ksql.parser.SqlBaseParser.ListTypesContext;
 import io.confluent.ksql.parser.SqlBaseParser.NumberContext;
-import io.confluent.ksql.parser.SqlBaseParser.PartitionByContext;
 import io.confluent.ksql.parser.SqlBaseParser.RegisterTypeContext;
 import io.confluent.ksql.parser.SqlBaseParser.RetentionClauseContext;
 import io.confluent.ksql.parser.SqlBaseParser.SourceNameContext;
@@ -409,6 +408,10 @@ public class AstBuilder {
 
       final OptionalInt limit = getLimit(context.limitClause());
 
+      final Optional<PartitionBy> partitionBy =
+          visitIfPresent(context.partitionBy, Expression.class)
+              .map(e -> new PartitionBy(getLocation(context.PARTITION()), e));
+
       return new Query(
           getLocation(context),
           select,
@@ -416,7 +419,7 @@ public class AstBuilder {
           visitIfPresent(context.windowExpression(), WindowExpression.class),
           visitIfPresent(context.where, Expression.class),
           visitIfPresent(context.groupBy(), GroupBy.class),
-          visitIfPresent(context.partitionBy(), PartitionBy.class),
+          partitionBy,
           visitIfPresent(context.having, Expression.class),
           resultMaterialization,
           pullQuery,
@@ -556,17 +559,6 @@ public class AstBuilder {
       return new Pair<>(Long.parseLong(joinWindowSize.number().getText()),
           WindowExpression.getWindowUnit(
               joinWindowSize.windowUnit().getText().toUpperCase()));
-    }
-
-    @Override
-    public Node visitPartitionBy(final PartitionByContext ctx) {
-      final Optional<ColumnName> alias = Optional.ofNullable(ctx.identifier())
-          .map(ParserUtil::getIdentifierText)
-          .map(ColumnName::of);
-
-      final Expression expression = (Expression) visit(ctx.valueExpression());
-
-      return new PartitionBy(getLocation(ctx), expression, alias);
     }
 
     @Override

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
@@ -415,12 +415,7 @@ public final class SqlFormatter {
     protected Void visitPartitionBy(final PartitionBy node, final Integer indent) {
       final String expression = formatExpression(node.getExpression());
 
-      final String alias = node.getAlias()
-          .map(SqlFormatter::escapedName)
-          .map(text -> " AS " + text)
-          .orElse("");
-
-      append(indent, "PARTITION BY " + expression + alias)
+      append(indent, "PARTITION BY " + expression)
           .append('\n');
 
       return null;

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/PartitionBy.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/PartitionBy.java
@@ -19,7 +19,6 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.expression.tree.Expression;
-import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.parser.NodeLocation;
 import java.util.Objects;
 import java.util.Optional;
@@ -28,24 +27,17 @@ import java.util.Optional;
 public class PartitionBy extends AstNode {
 
   private final Expression expression;
-  private final Optional<ColumnName> alias;
 
   public PartitionBy(
       final Optional<NodeLocation> location,
-      final Expression partitionBy,
-      final Optional<ColumnName> alias
+      final Expression partitionBy
   ) {
     super(location);
     this.expression = requireNonNull(partitionBy, "partitionBy");
-    this.alias = requireNonNull(alias, "alias");
   }
 
   public Expression getExpression() {
     return expression;
-  }
-
-  public Optional<ColumnName> getAlias() {
-    return alias;
   }
 
   @Override
@@ -62,20 +54,18 @@ public class PartitionBy extends AstNode {
       return false;
     }
     final PartitionBy groupBy = (PartitionBy) o;
-    return Objects.equals(expression, groupBy.expression)
-        && Objects.equals(alias, groupBy.alias);
+    return Objects.equals(expression, groupBy.expression);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(expression, alias);
+    return Objects.hash(expression);
   }
 
   @Override
   public String toString() {
     return "PartitionBy{"
         + "expression=" + expression
-        + ", alias=" + alias
         + '}';
   }
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/PartitionByTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/PartitionByTest.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.parser.tree;
 
 import com.google.common.testing.EqualsTester;
 import io.confluent.ksql.execution.expression.tree.Expression;
-import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.parser.NodeLocation;
 import java.util.Optional;
 import org.junit.Test;
@@ -28,7 +27,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class PartitionByTest {
 
-  private static final ColumnName COL0 = ColumnName.of("Bob");
   private static final NodeLocation LOCATION = new NodeLocation(1, 4);
 
   @Mock
@@ -41,15 +39,12 @@ public class PartitionByTest {
   public void shouldImplementHashCodeAndEqualsProperty() {
     new EqualsTester()
         .addEqualityGroup(
-            new PartitionBy(Optional.empty(), exp1, Optional.of(COL0)),
-            new PartitionBy(Optional.empty(), exp1, Optional.of(COL0)),
-            new PartitionBy(Optional.of(LOCATION), exp1, Optional.of(COL0))
+            new PartitionBy(Optional.empty(), exp1),
+            new PartitionBy(Optional.empty(), exp1),
+            new PartitionBy(Optional.of(LOCATION), exp1)
         )
         .addEqualityGroup(
-            new PartitionBy(Optional.empty(), exp2, Optional.of(COL0))
-        )
-        .addEqualityGroup(
-            new PartitionBy(Optional.empty(), exp1, Optional.empty())
+            new PartitionBy(Optional.empty(), exp2)
         )
         .testEquals();
   }

--- a/ksqldb-rest-app/src/test/resources/ksql-plan-schema/schema.json
+++ b/ksqldb-rest-app/src/test/resources/ksql-plan-schema/schema.json
@@ -449,9 +449,6 @@
         },
         "keyExpression" : {
           "type" : "string"
-        },
-        "alias" : {
-          "type" : "string"
         }
       },
       "title" : "streamSelectKeyV2",

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
@@ -252,13 +252,12 @@ public final class ExecutionStepFactory {
   public static StreamSelectKey streamSelectKey(
       final QueryContext.Stacker stacker,
       final ExecutionStep<? extends KStreamHolder<?>> source,
-      final Expression fieldName,
-      final Optional<ColumnName> alias
+      final Expression fieldName
   ) {
     final ExecutionStepPropertiesV1 props =
         new ExecutionStepPropertiesV1(stacker.getQueryContext());
 
-    return new StreamSelectKey(props, source, fieldName, alias);
+    return new StreamSelectKey(props, source, fieldName);
   }
 
   public static <K> TableSink<K> tableSink(

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/PartitionByParamsFactory.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/PartitionByParamsFactory.java
@@ -67,13 +67,11 @@ public final class PartitionByParamsFactory {
   public static PartitionByParams build(
       final LogicalSchema sourceSchema,
       final Expression partitionBy,
-      final Optional<ColumnName> alias,
       final KsqlConfig ksqlConfig,
       final FunctionRegistry functionRegistry,
       final ProcessingLogger logger
   ) {
-    final Optional<ColumnName> partitionByCol =
-        getPartitionByColumnName(sourceSchema, partitionBy, alias);
+    final Optional<ColumnName> partitionByCol = getPartitionByColumnName(sourceSchema, partitionBy);
 
     final Function<GenericRow, Object> evaluator = buildExpressionEvaluator(
         sourceSchema,
@@ -95,11 +93,10 @@ public final class PartitionByParamsFactory {
   public static LogicalSchema buildSchema(
       final LogicalSchema sourceSchema,
       final Expression partitionBy,
-      final Optional<ColumnName> alias,
       final FunctionRegistry functionRegistry
   ) {
     final Optional<ColumnName> partitionByCol =
-        getPartitionByColumnName(sourceSchema, partitionBy, alias);
+        getPartitionByColumnName(sourceSchema, partitionBy);
 
     return buildSchema(sourceSchema, partitionBy, functionRegistry, partitionByCol);
   }
@@ -136,14 +133,8 @@ public final class PartitionByParamsFactory {
 
   private static Optional<ColumnName> getPartitionByColumnName(
       final LogicalSchema sourceSchema,
-      final Expression partitionBy,
-      final Optional<ColumnName> alias
+      final Expression partitionBy
   ) {
-    if (alias.isPresent()) {
-      // User supplied a name:
-      return alias;
-    }
-
     if (partitionBy instanceof ColumnReferenceExp) {
       // PARTITION BY column:
       final ColumnName columnName = ((ColumnReferenceExp) partitionBy).getColumnName();

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StepSchemaResolver.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StepSchemaResolver.java
@@ -234,7 +234,6 @@ public final class StepSchemaResolver {
     return PartitionByParamsFactory.buildSchema(
         sourceSchema,
         step.getKeyExpression(),
-        step.getAlias(),
         functionRegistry
     );
   }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilder.java
@@ -25,10 +25,8 @@ import io.confluent.ksql.execution.plan.KeySerdeFactory;
 import io.confluent.ksql.execution.plan.StreamSelectKey;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
-import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.util.KsqlConfig;
-import java.util.Optional;
 import java.util.function.BiFunction;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.KeyValue;
@@ -63,7 +61,6 @@ public final class StreamSelectKeyBuilder {
     final PartitionByParams params = paramsBuilder.build(
         sourceSchema,
         selectKey.getKeyExpression(),
-        selectKey.getAlias(),
         queryBuilder.getKsqlConfig(),
         queryBuilder.getFunctionRegistry(),
         logger
@@ -88,7 +85,6 @@ public final class StreamSelectKeyBuilder {
     PartitionByParams build(
         LogicalSchema sourceSchema,
         Expression partitionBy,
-        Optional<ColumnName> alias,
         KsqlConfig ksqlConfig,
         FunctionRegistry functionRegistry,
         ProcessingLogger logger

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/PartitionByParamsFactoryTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/PartitionByParamsFactoryTest.java
@@ -138,7 +138,6 @@ public class PartitionByParamsFactoryTest {
     final LogicalSchema resultSchema = PartitionByParamsFactory.buildSchema(
         SCHEMA,
         partitionBy,
-        Optional.empty(),
         functionRegistry
     );
 
@@ -166,7 +165,6 @@ public class PartitionByParamsFactoryTest {
     final LogicalSchema resultSchema = PartitionByParamsFactory.buildSchema(
         SCHEMA,
         partitionBy,
-        Optional.empty(),
         functionRegistry
     );
 
@@ -195,7 +193,6 @@ public class PartitionByParamsFactoryTest {
     final LogicalSchema resultSchema = PartitionByParamsFactory.buildSchema(
         SCHEMA,
         partitionBy,
-        Optional.empty(),
         functionRegistry
     );
 
@@ -208,31 +205,6 @@ public class PartitionByParamsFactoryTest {
         .valueColumn(SystemColumns.ROWTIME_NAME, SqlTypes.BIGINT)
         .valueColumn(COL0, SqlTypes.STRING)
         .valueColumn(ColumnName.of("KSQL_COL_0"), SqlTypes.INTEGER)
-        .build()));
-  }
-
-  @Test
-  public void shouldBuildResultSchemaUsingSuppliedAlias() {
-    // Given:
-    final Expression partitionBy = new UnqualifiedColumnReferenceExp(COL1);
-    final ColumnName newKeyName = ColumnName.of("NEW_KEY");
-
-    // When:
-    final LogicalSchema resultSchema = PartitionByParamsFactory.buildSchema(
-        SCHEMA,
-        partitionBy,
-        Optional.of(newKeyName),
-        functionRegistry
-    );
-
-    // Then:
-    assertThat(resultSchema, is(LogicalSchema.builder()
-        .keyColumn(newKeyName, SqlTypes.INTEGER)
-        .valueColumn(COL1, SqlTypes.INTEGER)
-        .valueColumn(COL2, SqlTypes.INTEGER)
-        .valueColumn(COL3, COL3_TYPE)
-        .valueColumn(SystemColumns.ROWTIME_NAME, SqlTypes.BIGINT)
-        .valueColumn(COL0, SqlTypes.STRING)
         .build()));
   }
 
@@ -314,7 +286,7 @@ public class PartitionByParamsFactoryTest {
 
   private PartitionByParams partitionBy(final Expression expression) {
     return PartitionByParamsFactory
-        .build(SCHEMA, expression, Optional.empty(), KSQL_CONFIG, functionRegistry, logger);
+        .build(SCHEMA, expression,  KSQL_CONFIG, functionRegistry, logger);
   }
 
   public static class FailingUdf implements Kudf {

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StepSchemaResolverTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StepSchemaResolverTest.java
@@ -353,8 +353,7 @@ public class StepSchemaResolverTest {
     final StreamSelectKey step = new StreamSelectKey(
         PROPERTIES,
         streamSource,
-        keyExpression,
-        Optional.empty()
+        keyExpression
     );
 
     // When:
@@ -363,30 +362,6 @@ public class StepSchemaResolverTest {
     // Then:
     assertThat(result, is(LogicalSchema.builder()
         .keyColumn(keyExpression.getColumnName(), SqlTypes.INTEGER)
-        .valueColumns(SCHEMA.value())
-        .build()
-    ));
-  }
-
-  @Test
-  public void shouldResolveSchemaForStreamSelectKeyV2WithAlias() {
-    // Given:
-    final UnqualifiedColumnReferenceExp keyExpression =
-        new UnqualifiedColumnReferenceExp(ColumnName.of("ORANGE"));
-
-    final StreamSelectKey step = new StreamSelectKey(
-        PROPERTIES,
-        streamSource,
-        keyExpression,
-        Optional.of(ColumnName.of("RED"))
-    );
-
-    // When:
-    final LogicalSchema result = resolver.resolve(step, SCHEMA);
-
-    // Then:
-    assertThat(result, is(LogicalSchema.builder()
-        .keyColumn(ColumnName.of("RED"), SqlTypes.INTEGER)
         .valueColumns(SCHEMA.value())
         .build()
     ));

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderTest.java
@@ -43,7 +43,6 @@ import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.util.KsqlConfig;
-import java.util.Optional;
 import java.util.function.BiFunction;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.KeyValue;
@@ -106,8 +105,6 @@ public class StreamSelectKeyBuilderTest {
   private Struct aKey;
   @Mock
   private GenericRow aValue;
-  @Mock
-  private Optional<ColumnName> alias;
   @Captor
   private ArgumentCaptor<KeyValueMapper<Struct, GenericRow, KeyValue<Struct, GenericRow>>> mapperCaptor;
   @Captor
@@ -125,7 +122,7 @@ public class StreamSelectKeyBuilderTest {
     when(queryBuilder.getFunctionRegistry()).thenReturn(functionRegistry);
     when(queryBuilder.getKsqlConfig()).thenReturn(CONFIG);
 
-    when(paramBuilder.build(any(), any(), any(), any(), any(), any())).thenReturn(params);
+    when(paramBuilder.build(any(), any(), any(), any(), any())).thenReturn(params);
 
     when(params.getMapper()).thenReturn(mapper);
     when(params.getSchema()).thenReturn(RESULT_SCHEMA);
@@ -138,8 +135,7 @@ public class StreamSelectKeyBuilderTest {
     selectKey = new StreamSelectKey(
         new ExecutionStepPropertiesV1(queryContext),
         sourceStep,
-        KEY,
-        alias
+        KEY
     );
   }
 
@@ -153,7 +149,6 @@ public class StreamSelectKeyBuilderTest {
     verify(paramBuilder).build(
         SOURCE_SCHEMA,
         KEY,
-        alias,
         CONFIG,
         functionRegistry,
         processingLogger


### PR DESCRIPTION
### Description 

The KLIP-24 work removes the need for alias support on partition by clauses, e.g. `PARTITION BY x AS y`.

Note: this feature was never enabled in a released version.

### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

