### PR TITLE
chore: remove defunct alias support on GROUP BY

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/RewrittenAnalysis.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/RewrittenAnalysis.java
@@ -135,9 +135,7 @@ public class RewrittenAnalysis implements ImmutableAnalysis {
     return original.getGroupBy()
         .map(groupBy -> new GroupBy(
             groupBy.getLocation(),
-            rewriteList(groupBy.getGroupingExpressions()),
-            groupBy.getAlias()
-                .map(this::rewrite)
+            rewriteList(groupBy.getGroupingExpressions())
         ));
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/AstSanitizer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/AstSanitizer.java
@@ -33,7 +33,6 @@ import io.confluent.ksql.parser.NodeLocation;
 import io.confluent.ksql.parser.tree.AstNode;
 import io.confluent.ksql.parser.tree.AstVisitor;
 import io.confluent.ksql.parser.tree.CreateStreamAsSelect;
-import io.confluent.ksql.parser.tree.GroupBy;
 import io.confluent.ksql.parser.tree.InsertInto;
 import io.confluent.ksql.parser.tree.PartitionBy;
 import io.confluent.ksql.parser.tree.Query;
@@ -43,7 +42,6 @@ import io.confluent.ksql.schema.ksql.ColumnAliasGenerator;
 import io.confluent.ksql.schema.ksql.ColumnNames;
 import io.confluent.ksql.schema.utils.FormatOptions;
 import io.confluent.ksql.util.KsqlException;
-import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
 
@@ -159,32 +157,6 @@ public final class AstSanitizer {
       return Optional.of(
           new SingleColumn(singleColumn.getLocation(), expression, Optional.of(alias))
       );
-    }
-
-    @Override
-    protected Optional<AstNode> visitGroupBy(
-        final GroupBy node,
-        final StatementRewriter.Context<Void> context
-    ) {
-      final List<Expression> groupingExpressions = node.getGroupingExpressions();
-
-      if (node.getAlias().isPresent()
-          && groupingExpressions.size() == 1
-          && groupingExpressions.get(0) instanceof ColumnReferenceExp) {
-
-        final ColumnName groupByColName = ((ColumnReferenceExp) groupingExpressions.get(0))
-            .getColumnName();
-
-        if (node.getAlias().get().equals(groupByColName)) {
-          // Alias is a no-op - remove it:
-          return Optional.of(new GroupBy(
-              node.getLocation(),
-              groupingExpressions,
-              Optional.empty()
-          ));
-        }
-      }
-      return super.visitGroupBy(node, context);
     }
 
     @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/StatementRewriter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/StatementRewriter.java
@@ -463,7 +463,7 @@ public final class StatementRewriter<C> {
           .map(exp -> processExpression(exp, context))
           .collect(Collectors.toList());
 
-      return new GroupBy(node.getLocation(), rewrittenGroupings, node.getAlias());
+      return new GroupBy(node.getLocation(), rewrittenGroupings);
     }
 
     @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -767,14 +767,12 @@ public class LogicalPlanner {
     if (groupByExps.size() != 1) {
       if (ksqlConfig.getBoolean(KsqlConfig.KSQL_ANY_KEY_NAME_ENABLED)) {
 
-        keyName = Optional.of(groupBy.getAlias()
-            .orElseGet(() -> ColumnNames.nextKsqlColAlias(
-                sourceSchema,
-                LogicalSchema.builder()
-                    .valueColumns(projectionSchema.value())
-                    .build()
-            ))
-        );
+        keyName = Optional.of(ColumnNames.nextKsqlColAlias(
+            sourceSchema,
+            LogicalSchema.builder()
+                .valueColumns(projectionSchema.value())
+                .build()
+        ));
 
         keyColumnNames = groupBy.getGroupingExpressions().stream()
             .map(selectResolver)
@@ -790,11 +788,7 @@ public class LogicalPlanner {
       final Expression expression = groupByExps.get(0);
 
       if (ksqlConfig.getBoolean(KsqlConfig.KSQL_ANY_KEY_NAME_ENABLED)) {
-        if (groupBy.getAlias().isPresent()) {
-          keyName = Optional.of(groupBy.getAlias().get());
-        } else {
-          keyName = selectResolver.apply(expression);
-        }
+        keyName = selectResolver.apply(expression);
       } else {
         keyName = Optional.of(exactlyMatchesKeyColumns(expression, sourceSchema)
             ? ((ColumnReferenceExp) expression).getColumnName()

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
@@ -268,7 +268,6 @@ public class AggregateNode extends PlanNode implements VerifiableNode {
     return preSelected.groupBy(
         valueFormat,
         groupBy.getGroupingExpressions(),
-        groupBy.getAlias(),
         contextStacker.push(GROUP_BY_OP_NAME)
     );
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
@@ -147,7 +147,7 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
       final Optional<ColumnName> alias,
       final Stacker contextStacker
   ) {
-    if (repartitionNotNeeded(ImmutableList.of(keyExpression), alias)) {
+    if (repartitionNotNeeded(ImmutableList.of(keyExpression))) {
       return (SchemaKStream<Struct>) this;
     }
 
@@ -170,7 +170,6 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
   public SchemaKGroupedTable groupBy(
       final ValueFormat valueFormat,
       final List<Expression> groupByExpressions,
-      final Optional<ColumnName> alias,
       final Stacker contextStacker
   ) {
     final KeyFormat groupedKeyFormat = KeyFormat.nonWindowed(keyFormat.getFormatInfo());
@@ -184,8 +183,7 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
         contextStacker,
         sourceTableStep,
         Formats.of(groupedKeyFormat, valueFormat, SerdeOption.none()),
-        groupByExpressions,
-        alias
+        groupByExpressions
     );
 
     return new SchemaKGroupedTable(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/AggregateAnalyzerTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/AggregateAnalyzerTest.java
@@ -425,9 +425,8 @@ public class AggregateAnalyzerTest {
     when(analysis.getGroupBy())
         .thenReturn(Optional.of(new GroupBy(
             Optional.empty(),
-            ImmutableList.copyOf(expressions),
-            Optional.empty())
-        ));
+            ImmutableList.copyOf(expressions)
+        )));
   }
 
   private void givenHavingExpression(final Expression expression) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/PullQueryValidatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/PullQueryValidatorTest.java
@@ -118,8 +118,7 @@ public class PullQueryValidatorTest {
     // Given:
     when(analysis.getGroupBy()).thenReturn(Optional.of(new GroupBy(
         Optional.empty(),
-        ImmutableList.of(AN_EXPRESSION),
-        Optional.empty()
+        ImmutableList.of(AN_EXPRESSION)
     )));
 
     // When:

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/AstSanitizerTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/AstSanitizerTest.java
@@ -33,7 +33,6 @@ import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.AstBuilder;
 import io.confluent.ksql.parser.DefaultKsqlParser;
 import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
-import io.confluent.ksql.parser.tree.GroupBy;
 import io.confluent.ksql.parser.tree.PartitionBy;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Select;
@@ -325,19 +324,6 @@ public class AstSanitizerTest {
     // Then:
     assertThat(result.getPartitionBy(), is(not(Optional.empty())));
     assertThat(result.getPartitionBy().flatMap(PartitionBy::getAlias), is(Optional.empty()));
-  }
-
-  @Test
-  public void shouldRemoveAliasFromGroupByIfNoOp() {
-    // Given:
-    final Statement stmt = givenQuery("SELECT COUNT(1) FROM TEST1 GROUP BY COL1 AS COL1;");
-
-    // When:
-    final Query result = (Query) AstSanitizer.sanitize(stmt, META_STORE);
-
-    // Then:
-    assertThat(result.getGroupBy(), is(not(Optional.empty())));
-    assertThat(result.getGroupBy().flatMap(GroupBy::getAlias), is(Optional.empty()));
   }
 
   private static Statement givenQuery(final String sql) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/StatementRewriterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/StatementRewriterTest.java
@@ -783,8 +783,7 @@ public class StatementRewriterTest {
     final Expression rewrittenExp2 = mock(Expression.class);
     final GroupBy groupBy = new GroupBy(
         location,
-        ImmutableList.of(exp1, exp2),
-        Optional.of(COL2)
+        ImmutableList.of(exp1, exp2)
     );
     when(expressionRewriter.apply(exp1, context)).thenReturn(rewrittenExp1);
     when(expressionRewriter.apply(exp2, context)).thenReturn(rewrittenExp2);
@@ -798,8 +797,7 @@ public class StatementRewriterTest {
         equalTo(
             new GroupBy(
                 location,
-                ImmutableList.of(rewrittenExp1, rewrittenExp2),
-                Optional.of(COL2)
+                ImmutableList.of(rewrittenExp1, rewrittenExp2)
             )
         )
     );

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
@@ -555,7 +555,7 @@ public class SchemaKStreamTest {
     final SchemaKGroupedStream groupedSchemaKStream = initialSchemaKStream.groupBy(
         valueFormat,
         groupBy,
-        Optional.empty(), childContextStacker
+        childContextStacker
     );
 
     // Then:
@@ -574,7 +574,7 @@ public class SchemaKStreamTest {
     final SchemaKGroupedStream groupedSchemaKStream = initialSchemaKStream.groupBy(
         valueFormat,
         groupBy,
-        Optional.empty(), childContextStacker
+        childContextStacker
     );
 
     // Then:
@@ -604,7 +604,7 @@ public class SchemaKStreamTest {
     final SchemaKGroupedStream groupedSchemaKStream = initialSchemaKStream.groupBy(
         valueFormat,
         groupBy,
-        Optional.empty(), childContextStacker
+        childContextStacker
     );
 
     // Then:
@@ -627,7 +627,7 @@ public class SchemaKStreamTest {
     final SchemaKGroupedStream groupedSchemaKStream = initialSchemaKStream.groupBy(
         valueFormat,
         groupBy,
-        Optional.empty(), childContextStacker
+        childContextStacker
     );
 
     // Then:
@@ -640,8 +640,8 @@ public class SchemaKStreamTest {
                 initialSchemaKStream.getSourceStep(),
                 io.confluent.ksql.execution.plan.Formats
                     .of(expectedKeyFormat, valueFormat, SerdeOption.none()),
-                groupBy,
-                Optional.empty())
+                groupBy
+            )
         )
     );
   }
@@ -658,7 +658,7 @@ public class SchemaKStreamTest {
     final SchemaKGroupedStream groupedSchemaKStream = initialSchemaKStream.groupBy(
         valueFormat,
         groupBy,
-        Optional.empty(), childContextStacker
+        childContextStacker
     );
 
     // Then:
@@ -681,7 +681,7 @@ public class SchemaKStreamTest {
     final SchemaKGroupedStream groupedSchemaKStream = initialSchemaKStream.groupBy(
         valueFormat,
         groupBy,
-        Optional.empty(), childContextStacker
+        childContextStacker
     );
 
     // Then:
@@ -699,7 +699,7 @@ public class SchemaKStreamTest {
     final SchemaKGroupedStream groupedSchemaKStream = initialSchemaKStream.groupBy(
         valueFormat,
         ImmutableList.of(groupBy),
-        Optional.empty(), childContextStacker
+        childContextStacker
     );
 
     // Then:

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
@@ -479,7 +479,6 @@ public class SchemaKTableTest {
     final SchemaKGroupedTable groupedSchemaKTable = initialSchemaKTable.groupBy(
         valueFormat,
         groupByExpressions,
-        Optional.empty(),
         childContextStacker
     );
 
@@ -495,13 +494,11 @@ public class SchemaKTableTest {
     final PlanNode logicalPlan = buildLogicalPlan(selectQuery);
     initialSchemaKTable = buildSchemaKTableFromPlan(logicalPlan);
     final List<Expression> groupByExpressions = Arrays.asList(TEST_2_COL_2, TEST_2_COL_1);
-    final Optional<ColumnName> alias = Optional.of(ColumnName.of("COL1"));
 
     // When:
     final SchemaKGroupedTable groupedSchemaKTable = initialSchemaKTable.groupBy(
         valueFormat,
         groupByExpressions,
-        alias,
         childContextStacker
     );
 
@@ -514,8 +511,7 @@ public class SchemaKTableTest {
                 initialSchemaKTable.getSourceTableStep(),
                 io.confluent.ksql.execution.plan.Formats
                     .of(initialSchemaKTable.keyFormat, valueFormat, SerdeOption.none()),
-                groupByExpressions,
-                alias
+                groupByExpressions
             )
         )
     );
@@ -533,7 +529,6 @@ public class SchemaKTableTest {
     final SchemaKGroupedTable groupedSchemaKTable = initialSchemaKTable.groupBy(
         valueFormat,
         groupByExpressions,
-        Optional.empty(),
         childContextStacker
     );
 
@@ -565,7 +560,7 @@ public class SchemaKTableTest {
 
     // When:
     final SchemaKGroupedTable result =
-        schemaKTable.groupBy(valueFormat, groupByExpressions, Optional.empty(), childContextStacker);
+        schemaKTable.groupBy(valueFormat, groupByExpressions, childContextStacker);
 
     // Then:
     result.getSourceTableStep().build(planBuilder);
@@ -601,7 +596,7 @@ public class SchemaKTableTest {
 
     // Call groupBy and extract the captured mapper
     final SchemaKGroupedTable result = initialSchemaKTable.groupBy(
-        valueFormat, groupByExpressions, Optional.empty(), childContextStacker);
+        valueFormat, groupByExpressions, childContextStacker);
     result.getSourceTableStep().build(planBuilder);
     verify(mockKTable, mockKGroupedTable);
     final KeyValueMapper keySelector = capturedKeySelector.getValue();
@@ -848,7 +843,7 @@ public class SchemaKTableTest {
 
     // When:
     final SchemaKGroupedTable result = selected
-        .groupBy(valueFormat, groupByExprs, Optional.empty(), childContextStacker);
+        .groupBy(valueFormat, groupByExprs, childContextStacker);
 
     // Then:
     assertThat(result.getKeyField(),

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/StreamGroupBy.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/StreamGroupBy.java
@@ -21,11 +21,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.expression.tree.Expression;
-import io.confluent.ksql.name.ColumnName;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 @Immutable
 public class StreamGroupBy<K> implements ExecutionStep<KGroupedStreamHolder> {
@@ -34,28 +32,21 @@ public class StreamGroupBy<K> implements ExecutionStep<KGroupedStreamHolder> {
   private final ExecutionStep<KStreamHolder<K>> source;
   private final Formats internalFormats;
   private final ImmutableList<Expression> groupByExpressions;
-  private final Optional<ColumnName> alias;
 
   public StreamGroupBy(
       @JsonProperty(value = "properties", required = true) final ExecutionStepPropertiesV1 props,
       @JsonProperty(value = "source", required = true) final ExecutionStep<KStreamHolder<K>> source,
       @JsonProperty(value = "internalFormats", required = true) final Formats internalFormats,
-      @JsonProperty(value = "groupByExpressions", required = true) final List<Expression> groupBys,
-      @JsonProperty(value = "alias") final Optional<ColumnName> alias
+      @JsonProperty(value = "groupByExpressions", required = true) final List<Expression> groupBys
   ) {
     this.properties = requireNonNull(props, "props");
     this.internalFormats = requireNonNull(internalFormats, "internalFormats");
     this.source = requireNonNull(source, "source");
     this.groupByExpressions = ImmutableList.copyOf(requireNonNull(groupBys, "groupBys"));
-    this.alias = requireNonNull(alias, "alias");
   }
 
   public List<Expression> getGroupByExpressions() {
     return groupByExpressions;
-  }
-
-  public Optional<ColumnName> getAlias() {
-    return alias;
   }
 
   @Override
@@ -94,12 +85,11 @@ public class StreamGroupBy<K> implements ExecutionStep<KGroupedStreamHolder> {
     return Objects.equals(properties, that.properties)
         && Objects.equals(source, that.source)
         && Objects.equals(internalFormats, that.internalFormats)
-        && Objects.equals(groupByExpressions, that.groupByExpressions)
-        && Objects.equals(alias, that.alias);
+        && Objects.equals(groupByExpressions, that.groupByExpressions);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(properties, source, internalFormats, groupByExpressions, alias);
+    return Objects.hash(properties, source, internalFormats, groupByExpressions);
   }
 }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/TableGroupBy.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/TableGroupBy.java
@@ -21,11 +21,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.expression.tree.Expression;
-import io.confluent.ksql.name.ColumnName;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 @Immutable
 public class TableGroupBy<K> implements ExecutionStep<KGroupedTableHolder> {
@@ -33,22 +31,17 @@ public class TableGroupBy<K> implements ExecutionStep<KGroupedTableHolder> {
   private final ExecutionStep<KTableHolder<K>> source;
   private final Formats internalFormats;
   private final ImmutableList<Expression> groupByExpressions;
-  private final Optional<ColumnName> alias;
 
   public TableGroupBy(
       @JsonProperty(value = "properties", required = true) final ExecutionStepPropertiesV1 props,
       @JsonProperty(value = "source", required = true) final ExecutionStep<KTableHolder<K>> source,
       @JsonProperty(value = "internalFormats", required = true) final Formats internalFormats,
-      @JsonProperty(value = "groupByExpressions", required = true)
-      final List<Expression> groupByExpressions,
-      @JsonProperty(value = "alias") final Optional<ColumnName> alias
+      @JsonProperty(value = "groupByExpressions", required = true) final List<Expression> groupBys
   ) {
     this.properties = requireNonNull(props, "props");
     this.source = requireNonNull(source, "source");
     this.internalFormats = requireNonNull(internalFormats, "internalFormats");
-    this.groupByExpressions = ImmutableList
-        .copyOf(requireNonNull(groupByExpressions, "groupByExpressions"));
-    this.alias = requireNonNull(alias, "alias");
+    this.groupByExpressions = ImmutableList.copyOf(requireNonNull(groupBys, "groupBys"));
   }
 
   @Override
@@ -68,10 +61,6 @@ public class TableGroupBy<K> implements ExecutionStep<KGroupedTableHolder> {
 
   public List<Expression> getGroupByExpressions() {
     return groupByExpressions;
-  }
-
-  public Optional<ColumnName> getAlias() {
-    return alias;
   }
 
   public ExecutionStep<KTableHolder<K>> getSource() {

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/plan/StreamGroupByTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/plan/StreamGroupByTest.java
@@ -61,7 +61,6 @@ public class StreamGroupByTest {
         .addEqualityGroup(new StreamGroupBy<>(properties2, source1, formats1, expression1))
         .addEqualityGroup(new StreamGroupBy<>(properties1, source2, formats1, expression1))
         .addEqualityGroup(new StreamGroupBy<>(properties1, source1, formats2, expression1))
-        .addEqualityGroup(new StreamGroupBy<>(properties1, source1, formats1, expression2))
-        .addEqualityGroup(new StreamGroupBy<>(properties1, source1, formats1, expression1));
+        .addEqualityGroup(new StreamGroupBy<>(properties1, source1, formats1, expression2));
   }
 }

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/plan/StreamGroupByTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/plan/StreamGroupByTest.java
@@ -19,9 +19,7 @@ import static org.mockito.Mockito.mock;
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
 import io.confluent.ksql.execution.expression.tree.Expression;
-import io.confluent.ksql.name.ColumnName;
 import java.util.List;
-import java.util.Optional;
 import org.apache.kafka.connect.data.Struct;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,8 +41,6 @@ public class StreamGroupByTest {
   private Formats formats1;
   @Mock
   private Formats formats2;
-  @Mock
-  private ColumnName alias;
 
   private List<Expression> expression1;
   private List<Expression> expression2;
@@ -60,12 +56,12 @@ public class StreamGroupByTest {
   public void shouldImplementEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            new StreamGroupBy<>(properties1, source1, formats1, expression1, Optional.of(alias)),
-            new StreamGroupBy<>(properties1, source1, formats1, expression1, Optional.of(alias)))
-        .addEqualityGroup(new StreamGroupBy<>(properties2, source1, formats1, expression1, Optional.of(alias)))
-        .addEqualityGroup(new StreamGroupBy<>(properties1, source2, formats1, expression1, Optional.of(alias)))
-        .addEqualityGroup(new StreamGroupBy<>(properties1, source1, formats2, expression1, Optional.of(alias)))
-        .addEqualityGroup(new StreamGroupBy<>(properties1, source1, formats1, expression2, Optional.of(alias)))
-        .addEqualityGroup(new StreamGroupBy<>(properties1, source1, formats1, expression1, Optional.empty()));
+            new StreamGroupBy<>(properties1, source1, formats1, expression1),
+            new StreamGroupBy<>(properties1, source1, formats1, expression1))
+        .addEqualityGroup(new StreamGroupBy<>(properties2, source1, formats1, expression1))
+        .addEqualityGroup(new StreamGroupBy<>(properties1, source2, formats1, expression1))
+        .addEqualityGroup(new StreamGroupBy<>(properties1, source1, formats2, expression1))
+        .addEqualityGroup(new StreamGroupBy<>(properties1, source1, formats1, expression2))
+        .addEqualityGroup(new StreamGroupBy<>(properties1, source1, formats1, expression1));
   }
 }

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/plan/TableGroupByTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/plan/TableGroupByTest.java
@@ -61,7 +61,6 @@ public class TableGroupByTest {
         .addEqualityGroup(new TableGroupBy<>(properties2, source1, formats1, expression1))
         .addEqualityGroup(new TableGroupBy<>(properties1, source2, formats1, expression1))
         .addEqualityGroup(new TableGroupBy<>(properties1, source1, formats2, expression1))
-        .addEqualityGroup(new TableGroupBy<>(properties1, source1, formats1, expression2))
-        .addEqualityGroup(new TableGroupBy<>(properties1, source1, formats1, expression1));
+        .addEqualityGroup(new TableGroupBy<>(properties1, source1, formats1, expression2));
   }
 }

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/plan/TableGroupByTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/plan/TableGroupByTest.java
@@ -19,9 +19,7 @@ import static org.mockito.Mockito.mock;
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
 import io.confluent.ksql.execution.expression.tree.Expression;
-import io.confluent.ksql.name.ColumnName;
 import java.util.List;
-import java.util.Optional;
 import org.apache.kafka.connect.data.Struct;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,8 +41,6 @@ public class TableGroupByTest {
   private Formats formats1;
   @Mock
   private Formats formats2;
-  @Mock
-  private ColumnName alias;
 
   private List<Expression> expression1;
   private List<Expression> expression2;
@@ -60,12 +56,12 @@ public class TableGroupByTest {
   public void shouldImplementEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            new TableGroupBy<>(properties1, source1, formats1, expression1, Optional.of(alias)),
-            new TableGroupBy<>(properties1, source1, formats1, expression1, Optional.of(alias)))
-        .addEqualityGroup(new TableGroupBy<>(properties2, source1, formats1, expression1, Optional.of(alias)))
-        .addEqualityGroup(new TableGroupBy<>(properties1, source2, formats1, expression1, Optional.of(alias)))
-        .addEqualityGroup(new TableGroupBy<>(properties1, source1, formats2, expression1, Optional.of(alias)))
-        .addEqualityGroup(new TableGroupBy<>(properties1, source1, formats1, expression2, Optional.of(alias)))
-        .addEqualityGroup(new TableGroupBy<>(properties1, source1, formats1, expression1, Optional.empty()));
+            new TableGroupBy<>(properties1, source1, formats1, expression1),
+            new TableGroupBy<>(properties1, source1, formats1, expression1))
+        .addEqualityGroup(new TableGroupBy<>(properties2, source1, formats1, expression1))
+        .addEqualityGroup(new TableGroupBy<>(properties1, source2, formats1, expression1))
+        .addEqualityGroup(new TableGroupBy<>(properties1, source1, formats2, expression1))
+        .addEqualityGroup(new TableGroupBy<>(properties1, source1, formats1, expression2))
+        .addEqualityGroup(new TableGroupBy<>(properties1, source1, formats1, expression1));
   }
 }

--- a/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -157,9 +157,8 @@ partitionBy
     ;
 
 groupBy
-    : valueExpression (AS? identifier)?
-    | valueExpression (',' valueExpression)*
-    | '(' (valueExpression (',' valueExpression)*)? ')' (AS? identifier)?
+    : valueExpression (',' valueExpression)*
+    | '(' (valueExpression (',' valueExpression)*)? ')'
     ;
 
 values

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -571,13 +571,9 @@ public class AstBuilder {
 
     @Override
     public Node visitGroupBy(final SqlBaseParser.GroupByContext ctx) {
-      final Optional<ColumnName> alias = Optional.ofNullable(ctx.identifier())
-          .map(ParserUtil::getIdentifierText)
-          .map(ColumnName::of);
-
       final List<Expression> expressions = visit(ctx.valueExpression(), Expression.class);
 
-      return new GroupBy(getLocation(ctx), expressions, alias);
+      return new GroupBy(getLocation(ctx), expressions);
     }
 
     @Override

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
@@ -428,22 +428,11 @@ public final class SqlFormatter {
 
     @Override
     protected Void visitGroupBy(final GroupBy node, final Integer indent) {
-      final boolean surroundWithBrackets = node.getAlias().isPresent()
-          && node.getGroupingExpressions().size() > 1;
-
-      final String prefix = surroundWithBrackets ? "(" : "";
-      final String suffix = surroundWithBrackets ? ")" : "";
-
       final String expressions = node.getGroupingExpressions().stream()
           .map(SqlFormatter::formatExpression)
-          .collect(Collectors.joining(", ", prefix, suffix));
+          .collect(Collectors.joining(", "));
 
-      final String alias = node.getAlias()
-          .map(SqlFormatter::escapedName)
-          .map(text -> " AS " + text)
-          .orElse("");
-
-      append(indent, "GROUP BY " + expressions + alias)
+      append(indent, "GROUP BY " + expressions)
           .append('\n');
 
       return null;

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/GroupBy.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/GroupBy.java
@@ -20,7 +20,6 @@ import static java.util.Objects.requireNonNull;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.expression.tree.Expression;
-import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.parser.NodeLocation;
 import io.confluent.ksql.util.KsqlException;
 import java.util.HashSet;
@@ -32,17 +31,14 @@ import java.util.Optional;
 public class GroupBy extends AstNode {
 
   private final ImmutableList<Expression> groupingExpressions;
-  private final Optional<ColumnName> alias;
 
   public GroupBy(
       final Optional<NodeLocation> location,
-      final List<Expression> groupingExpressions,
-      final Optional<ColumnName> alias
+      final List<Expression> groupingExpressions
   ) {
     super(location);
     this.groupingExpressions = ImmutableList
         .copyOf(requireNonNull(groupingExpressions, "groupingElements"));
-    this.alias = requireNonNull(alias, "alias");
 
     final HashSet<Object> groupBys = new HashSet<>(groupingExpressions.size());
 
@@ -61,10 +57,6 @@ public class GroupBy extends AstNode {
     return groupingExpressions;
   }
 
-  public Optional<ColumnName> getAlias() {
-    return alias;
-  }
-
   @Override
   protected <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
     return visitor.visitGroupBy(this, context);
@@ -79,20 +71,18 @@ public class GroupBy extends AstNode {
       return false;
     }
     final GroupBy groupBy = (GroupBy) o;
-    return Objects.equals(groupingExpressions, groupBy.groupingExpressions)
-        && Objects.equals(alias, groupBy.alias);
+    return Objects.equals(groupingExpressions, groupBy.groupingExpressions);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(groupingExpressions, alias);
+    return Objects.hash(groupingExpressions);
   }
 
   @Override
   public String toString() {
     return "GroupBy{"
         + "groupingExpressions=" + groupingExpressions
-        + ", alias=" + alias
         + '}';
   }
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/GroupByTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/GroupByTest.java
@@ -54,9 +54,6 @@ public class GroupByTest {
         .addEqualityGroup(
             new GroupBy(Optional.empty(), ImmutableList.of(exp1))
         )
-        .addEqualityGroup(
-            new GroupBy(Optional.empty(), ImmutableList.of(exp1, exp2))
-        )
         .testEquals();
   }
 

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/GroupByTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/GroupByTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertThrows;
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
 import io.confluent.ksql.execution.expression.tree.Expression;
-import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.parser.NodeLocation;
 import io.confluent.ksql.util.KsqlException;
 import java.util.List;
@@ -36,7 +35,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class GroupByTest {
 
-  private static final ColumnName COL0 = ColumnName.of("Bob");
   private static final NodeLocation LOCATION = new NodeLocation(1, 4);
 
   @Mock
@@ -49,15 +47,15 @@ public class GroupByTest {
   public void shouldImplementHashCodeAndEqualsProperty() {
     new EqualsTester()
         .addEqualityGroup(
-            new GroupBy(Optional.empty(), ImmutableList.of(exp1, exp2), Optional.of(COL0)),
-            new GroupBy(Optional.empty(), ImmutableList.of(exp1, exp2), Optional.of(COL0)),
-            new GroupBy(Optional.of(LOCATION), ImmutableList.of(exp1, exp2), Optional.of(COL0))
+            new GroupBy(Optional.empty(), ImmutableList.of(exp1, exp2)),
+            new GroupBy(Optional.empty(), ImmutableList.of(exp1, exp2)),
+            new GroupBy(Optional.of(LOCATION), ImmutableList.of(exp1, exp2))
         )
         .addEqualityGroup(
-            new GroupBy(Optional.empty(), ImmutableList.of(exp1), Optional.of(COL0))
+            new GroupBy(Optional.empty(), ImmutableList.of(exp1))
         )
         .addEqualityGroup(
-            new GroupBy(Optional.empty(), ImmutableList.of(exp1, exp2), Optional.empty())
+            new GroupBy(Optional.empty(), ImmutableList.of(exp1, exp2))
         )
         .testEquals();
   }
@@ -67,7 +65,7 @@ public class GroupByTest {
     // Given:
     final List<Expression> original = ImmutableList.of(exp1, exp2);
 
-    final GroupBy groupBy = new GroupBy(Optional.empty(), original, Optional.empty());
+    final GroupBy groupBy = new GroupBy(Optional.empty(), original);
 
     // When:
     final List<Expression> result = groupBy.getGroupingExpressions();
@@ -84,7 +82,7 @@ public class GroupByTest {
     // When:
     final KsqlException e = assertThrows(
         KsqlException.class,
-        () -> new GroupBy(Optional.empty(), withDuplicate, Optional.empty())
+        () -> new GroupBy(Optional.empty(), withDuplicate)
     );
 
     // Then:
@@ -99,7 +97,7 @@ public class GroupByTest {
     // When:
     final KsqlException e = assertThrows(
         KsqlException.class,
-        () -> new GroupBy(Optional.empty(), empty, Optional.empty())
+        () -> new GroupBy(Optional.empty(), empty)
     );
 
     // Then:

--- a/ksqldb-rest-app/src/test/resources/ksql-plan-schema/schema.json
+++ b/ksqldb-rest-app/src/test/resources/ksql-plan-schema/schema.json
@@ -355,9 +355,6 @@
           "items" : {
             "type" : "string"
           }
-        },
-        "alias" : {
-          "type" : "string"
         }
       },
       "title" : "streamGroupByV1",
@@ -560,9 +557,6 @@
           "type" : "string",
           "enum" : [ "INNER", "LEFT", "OUTER" ]
         },
-        "keyColName" : {
-          "type" : "string"
-        },
         "leftInternalFormats" : {
           "$ref" : "#/definitions/Formats"
         },
@@ -580,6 +574,9 @@
         },
         "afterMillis" : {
           "type" : "integer"
+        },
+        "keyColName" : {
+          "type" : "string"
         }
       },
       "title" : "streamStreamJoinV1",
@@ -601,9 +598,6 @@
           "type" : "string",
           "enum" : [ "INNER", "LEFT", "OUTER" ]
         },
-        "keyColName" : {
-          "type" : "string"
-        },
         "internalFormats" : {
           "$ref" : "#/definitions/Formats"
         },
@@ -612,6 +606,9 @@
         },
         "rightSource" : {
           "$ref" : "#/definitions/ExecutionStep"
+        },
+        "keyColName" : {
+          "type" : "string"
         }
       },
       "title" : "streamTableJoinV1",
@@ -792,9 +789,6 @@
           "items" : {
             "type" : "string"
           }
-        },
-        "alias" : {
-          "type" : "string"
         }
       },
       "title" : "tableGroupByV1",
@@ -869,14 +863,14 @@
           "type" : "string",
           "enum" : [ "INNER", "LEFT", "OUTER" ]
         },
-        "keyColName" : {
-          "type" : "string"
-        },
         "leftSource" : {
           "$ref" : "#/definitions/ExecutionStep"
         },
         "rightSource" : {
           "$ref" : "#/definitions/ExecutionStep"
+        },
+        "keyColName" : {
+          "type" : "string"
         }
       },
       "title" : "tableTableJoinV1",

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
@@ -363,16 +363,14 @@ public final class ExecutionStepFactory {
       final Stacker stacker,
       final ExecutionStep<KStreamHolder<K>> sourceStep,
       final Formats format,
-      final List<Expression> groupingExpressions,
-      final Optional<ColumnName> alias
+      final List<Expression> groupingExpressions
   ) {
     final QueryContext queryContext = stacker.getQueryContext();
     return new StreamGroupBy<>(
         new ExecutionStepPropertiesV1(queryContext),
         sourceStep,
         format,
-        groupingExpressions,
-        alias
+        groupingExpressions
     );
   }
 
@@ -406,16 +404,14 @@ public final class ExecutionStepFactory {
       final QueryContext.Stacker stacker,
       final ExecutionStep<KTableHolder<K>> sourceStep,
       final Formats format,
-      final List<Expression> groupingExpressions,
-      final Optional<ColumnName> alias
+      final List<Expression> groupingExpressions
   ) {
     final QueryContext queryContext = stacker.getQueryContext();
     return new TableGroupBy<>(
         new ExecutionStepPropertiesV1(queryContext),
         sourceStep,
         format,
-        groupingExpressions,
-        alias
+        groupingExpressions
     );
   }
 }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/GroupByParamsFactory.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/GroupByParamsFactory.java
@@ -39,7 +39,6 @@ import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import org.apache.kafka.connect.data.Struct;
@@ -55,31 +54,25 @@ final class GroupByParamsFactory {
   public static LogicalSchema buildSchema(
       final LogicalSchema sourceSchema,
       final List<ExpressionMetadata> groupBys,
-      final Optional<ColumnName> alias,
       final KsqlConfig ksqlConfig
   ) {
-    Objects.requireNonNull(alias, "alias");
-
     final ProcessingLogger logger = NoopProcessingLogContext.NOOP_LOGGER;
 
-    return buildGrouper(sourceSchema, groupBys, alias, logger, ksqlConfig)
+    return buildGrouper(sourceSchema, groupBys, logger, ksqlConfig)
         .getSchema();
   }
 
   public static GroupByParams build(
       final LogicalSchema sourceSchema,
       final List<ExpressionMetadata> groupBys,
-      final Optional<ColumnName> alias,
       final ProcessingLogger logger,
       final KsqlConfig ksqlConfig
   ) {
-    Objects.requireNonNull(alias, "alias");
-
     if (groupBys.isEmpty()) {
       throw new IllegalArgumentException("No GROUP BY groupBys");
     }
 
-    final Grouper grouper = buildGrouper(sourceSchema, groupBys, alias, logger, ksqlConfig);
+    final Grouper grouper = buildGrouper(sourceSchema, groupBys, logger, ksqlConfig);
 
     return new GroupByParams(grouper.getSchema(), grouper::apply);
   }
@@ -87,13 +80,12 @@ final class GroupByParamsFactory {
   private static Grouper buildGrouper(
       final LogicalSchema sourceSchema,
       final List<ExpressionMetadata> groupBys,
-      final Optional<ColumnName> alias,
       final ProcessingLogger logger,
       final KsqlConfig ksqlConfig
   ) {
     return groupBys.size() == 1
-        ? new SingleExpressionGrouper(sourceSchema, groupBys.get(0), alias, logger, ksqlConfig)
-        : new MultiExpressionGrouper(sourceSchema, groupBys, alias, logger, ksqlConfig);
+        ? new SingleExpressionGrouper(sourceSchema, groupBys.get(0), logger, ksqlConfig)
+        : new MultiExpressionGrouper(sourceSchema, groupBys, logger, ksqlConfig);
   }
 
   private static LogicalSchema buildSchemaWithKeyType(
@@ -156,11 +148,10 @@ final class GroupByParamsFactory {
     SingleExpressionGrouper(
         final LogicalSchema sourceSchema,
         final ExpressionMetadata groupBy,
-        final Optional<ColumnName> alias,
         final ProcessingLogger logger,
         final KsqlConfig ksqlConfig
     ) {
-      this.schema = singleExpressionSchema(sourceSchema, groupBy, alias, ksqlConfig);
+      this.schema = singleExpressionSchema(sourceSchema, groupBy, ksqlConfig);
       this.groupBy = requireNonNull(groupBy, "groupBy");
       this.keyBuilder = keyBuilder(schema);
       this.logger = Objects.requireNonNull(logger, "logger");
@@ -183,7 +174,6 @@ final class GroupByParamsFactory {
     private static LogicalSchema singleExpressionSchema(
         final LogicalSchema sourceSchema,
         final ExpressionMetadata groupBy,
-        final Optional<ColumnName> alias,
         final KsqlConfig ksqlConfig
     ) {
       final SqlType keyType = groupBy.getExpressionType();
@@ -195,9 +185,7 @@ final class GroupByParamsFactory {
       final ColumnName singleColumnName;
 
       if (ksqlConfig.getBoolean(KsqlConfig.KSQL_ANY_KEY_NAME_ENABLED)) {
-        if (alias.isPresent()) {
-          singleColumnName = alias.get();
-        } else if (groupByExp instanceof ColumnReferenceExp) {
+        if (groupByExp instanceof ColumnReferenceExp) {
           singleColumnName = ((ColumnReferenceExp) groupByExp).getColumnName();
         } else {
           singleColumnName = keyAliasGenerator.uniqueAliasFor(groupByExp);
@@ -220,11 +208,10 @@ final class GroupByParamsFactory {
     MultiExpressionGrouper(
         final LogicalSchema sourceSchema,
         final List<ExpressionMetadata> groupBys,
-        final Optional<ColumnName> alias,
         final ProcessingLogger logger,
         final KsqlConfig ksqlConfig
     ) {
-      this.schema = multiExpressionSchema(sourceSchema, alias, ksqlConfig);
+      this.schema = multiExpressionSchema(sourceSchema, ksqlConfig);
       this.groupBys = ImmutableList.copyOf(requireNonNull(groupBys, "groupBys"));
       this.keyBuilder = keyBuilder(schema);
       this.logger = Objects.requireNonNull(logger, "logger");
@@ -261,13 +248,11 @@ final class GroupByParamsFactory {
 
   private static LogicalSchema multiExpressionSchema(
       final LogicalSchema sourceSchema,
-      final Optional<ColumnName> alias,
       final KsqlConfig ksqlConfig
   ) {
-    final ColumnName keyName = alias
-        .orElseGet(() -> ksqlConfig.getBoolean(KsqlConfig.KSQL_ANY_KEY_NAME_ENABLED)
-            ? ColumnNames.nextKsqlColAlias(sourceSchema)
-            : SystemColumns.ROWKEY_NAME);
+    final ColumnName keyName = ksqlConfig.getBoolean(KsqlConfig.KSQL_ANY_KEY_NAME_ENABLED)
+        ? ColumnNames.nextKsqlColAlias(sourceSchema)
+        : SystemColumns.ROWKEY_NAME;
 
     return buildSchemaWithKeyType(sourceSchema, keyName, SqlTypes.STRING);
   }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StepSchemaResolver.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StepSchemaResolver.java
@@ -185,7 +185,7 @@ public final class StepSchemaResolver {
     );
 
     return GroupByParamsFactory
-        .buildSchema(sourceSchema, compiledGroupBy, streamGroupBy.getAlias(), ksqlConfig);
+        .buildSchema(sourceSchema, compiledGroupBy, ksqlConfig);
   }
 
   private LogicalSchema handleTableGroupBy(
@@ -201,7 +201,7 @@ public final class StepSchemaResolver {
     );
 
     return GroupByParamsFactory
-        .buildSchema(sourceSchema, compiledGroupBy, tableGroupBy.getAlias(), ksqlConfig);
+        .buildSchema(sourceSchema, compiledGroupBy, ksqlConfig);
   }
 
   private LogicalSchema handleStreamSelect(

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamGroupByBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamGroupByBuilder.java
@@ -29,12 +29,10 @@ import io.confluent.ksql.execution.plan.KStreamHolder;
 import io.confluent.ksql.execution.plan.StreamGroupBy;
 import io.confluent.ksql.execution.plan.StreamGroupByKey;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
-import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.List;
-import java.util.Optional;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.kstream.Grouped;
@@ -100,7 +98,7 @@ public final class StreamGroupByBuilder {
     final ProcessingLogger logger = queryBuilder.getProcessingLogger(queryContext);
 
     final GroupByParams params = paramsFactory
-        .build(sourceSchema, groupBy, step.getAlias(), logger, queryBuilder.getKsqlConfig());
+        .build(sourceSchema, groupBy, logger, queryBuilder.getKsqlConfig());
 
     final Grouped<Struct, GenericRow> grouped = buildGrouped(
         formats,
@@ -146,7 +144,6 @@ public final class StreamGroupByBuilder {
     GroupByParams build(
         LogicalSchema sourceSchema,
         List<ExpressionMetadata> groupBys,
-        Optional<ColumnName> alias,
         ProcessingLogger logger,
         KsqlConfig ksqlConfig
     );

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableGroupByBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableGroupByBuilder.java
@@ -28,12 +28,10 @@ import io.confluent.ksql.execution.plan.KGroupedTableHolder;
 import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.TableGroupBy;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
-import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Function;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.connect.data.Struct;
@@ -85,7 +83,7 @@ public final class TableGroupByBuilder {
     final ProcessingLogger logger = queryBuilder.getProcessingLogger(queryContext);
 
     final GroupByParams params = paramsFactory
-        .build(sourceSchema, groupBy, step.getAlias(), logger, queryBuilder.getKsqlConfig());
+        .build(sourceSchema, groupBy, logger, queryBuilder.getKsqlConfig());
 
     final PhysicalSchema physicalSchema = PhysicalSchema.from(
         params.getSchema(),
@@ -134,7 +132,6 @@ public final class TableGroupByBuilder {
     GroupByParams build(
         LogicalSchema sourceSchema,
         List<ExpressionMetadata> groupBys,
-        Optional<ColumnName> alias,
         ProcessingLogger logger,
         KsqlConfig ksqlConfig
     );

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StepSchemaResolverTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StepSchemaResolverTest.java
@@ -245,8 +245,7 @@ public class StepSchemaResolverTest {
         PROPERTIES,
         streamSource,
         formats,
-        ImmutableList.of(new UnqualifiedColumnReferenceExp(Optional.empty(), ORANGE_COL)),
-        Optional.empty()
+        ImmutableList.of(new UnqualifiedColumnReferenceExp(Optional.empty(), ORANGE_COL))
     );
 
     // When:
@@ -268,8 +267,7 @@ public class StepSchemaResolverTest {
         PROPERTIES,
         streamSource,
         formats,
-        ImmutableList.of(new UnqualifiedColumnReferenceExp(Optional.empty(), ORANGE_COL)),
-        Optional.empty()
+        ImmutableList.of(new UnqualifiedColumnReferenceExp(Optional.empty(), ORANGE_COL))
     );
 
     // When:
@@ -278,29 +276,6 @@ public class StepSchemaResolverTest {
     // Then:
     assertThat(result, is(LogicalSchema.builder()
         .keyColumn(ORANGE_COL, SqlTypes.INTEGER)
-        .valueColumns(SCHEMA.value())
-        .build()));
-  }
-
-  @Test
-  public void shouldResolveSchemaForAliasedStreamGroupBy() {
-    // Given:
-    when(config.getBoolean(KsqlConfig.KSQL_ANY_KEY_NAME_ENABLED)).thenReturn(true);
-
-    final StreamGroupBy<?> step = new StreamGroupBy<>(
-        PROPERTIES,
-        streamSource,
-        formats,
-        ImmutableList.of(new UnqualifiedColumnReferenceExp(Optional.empty(), ORANGE_COL)),
-        Optional.of(ColumnName.of("NEW_KEY"))
-    );
-
-    // When:
-    final LogicalSchema result = resolver.resolve(step, SCHEMA);
-
-    // Then:
-    assertThat(result, is(LogicalSchema.builder()
-        .keyColumn(ColumnName.of("NEW_KEY"), SqlTypes.INTEGER)
         .valueColumns(SCHEMA.value())
         .build()));
   }
@@ -459,8 +434,7 @@ public class StepSchemaResolverTest {
         PROPERTIES,
         tableSource,
         formats,
-        ImmutableList.of(new UnqualifiedColumnReferenceExp(Optional.empty(), ORANGE_COL)),
-        Optional.empty()
+        ImmutableList.of(new UnqualifiedColumnReferenceExp(Optional.empty(), ORANGE_COL))
     );
 
     // When:
@@ -482,8 +456,7 @@ public class StepSchemaResolverTest {
         PROPERTIES,
         tableSource,
         formats,
-        ImmutableList.of(new UnqualifiedColumnReferenceExp(Optional.empty(), ORANGE_COL)),
-        Optional.empty()
+        ImmutableList.of(new UnqualifiedColumnReferenceExp(Optional.empty(), ORANGE_COL))
     );
 
     // When:
@@ -492,29 +465,6 @@ public class StepSchemaResolverTest {
     // Then:
     assertThat(result, is(LogicalSchema.builder()
         .keyColumn(ORANGE_COL, SqlTypes.INTEGER)
-        .valueColumns(SCHEMA.value())
-        .build()));
-  }
-
-  @Test
-  public void shouldResolveSchemaForAliasedTableGroupBy() {
-    // Given:
-    when(config.getBoolean(KsqlConfig.KSQL_ANY_KEY_NAME_ENABLED)).thenReturn(true);
-
-    final TableGroupBy<?> step = new TableGroupBy<>(
-        PROPERTIES,
-        tableSource,
-        formats,
-        ImmutableList.of(new UnqualifiedColumnReferenceExp(Optional.empty(), ORANGE_COL)),
-        Optional.of(ColumnName.of("NEW_KEY"))
-    );
-
-    // When:
-    final LogicalSchema result = resolver.resolve(step, SCHEMA);
-
-    // Then:
-    assertThat(result, is(LogicalSchema.builder()
-        .keyColumn(ColumnName.of("NEW_KEY"), SqlTypes.INTEGER)
         .valueColumns(SCHEMA.value())
         .build()));
   }

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderTest.java
@@ -38,7 +38,6 @@ import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Function;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.connect.data.Struct;
@@ -123,8 +122,6 @@ public class StreamGroupByBuilderTest {
   @Mock
   private ProcessingLogger processingLogger;
   @Mock
-  private Optional<ColumnName> alias;
-  @Mock
   private KStreamHolder<Struct> streamHolder;
   @Mock
   private ParamsFactory paramsFactory;
@@ -146,7 +143,7 @@ public class StreamGroupByBuilderTest {
     when(streamHolder.getSchema()).thenReturn(SCHEMA);
     when(streamHolder.getStream()).thenReturn(sourceStream);
 
-    when(paramsFactory.build(any(), any(), any(), any(), any())).thenReturn(groupByParams);
+    when(paramsFactory.build(any(), any(), any(), any())).thenReturn(groupByParams);
 
     when(groupByParams.getSchema()).thenReturn(REKEYED_SCHEMA);
     when(groupByParams.getMapper()).thenReturn(mapper);
@@ -166,8 +163,7 @@ public class StreamGroupByBuilderTest {
         PROPERTIES,
         sourceStep,
         FORMATS,
-        GROUP_BY_EXPRESSIONS,
-        alias
+        GROUP_BY_EXPRESSIONS
     );
 
     groupByKey = new StreamGroupByKey(PROPERTIES, sourceStep, FORMATS);
@@ -196,7 +192,6 @@ public class StreamGroupByBuilderTest {
     verify(paramsFactory).build(
         eq(SCHEMA),
         any(),
-        eq(alias),
         eq(processingLogger),
         eq(ksqlConfig)
     );
@@ -284,7 +279,7 @@ public class StreamGroupByBuilderTest {
     builder.build(streamHolder, groupByKey);
 
     // Then:
-    verify(paramsFactory, never()).build(any(), any(), any(), any(), any());
+    verify(paramsFactory, never()).build(any(), any(), any(), any());
   }
 
   @Test

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableGroupByBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableGroupByBuilderTest.java
@@ -35,7 +35,6 @@ import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Function;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.connect.data.Struct;
@@ -116,8 +115,6 @@ public class TableGroupByBuilderTest {
   @Mock
   private ProcessingLogger processingLogger;
   @Mock
-  private Optional<ColumnName> alias;
-  @Mock
   private ParamsFactory paramsFactory;
   @Mock
   private KTableHolder<Struct> tableHolder;
@@ -140,7 +137,7 @@ public class TableGroupByBuilderTest {
     when(tableHolder.getSchema()).thenReturn(SCHEMA);
     when(tableHolder.getTable()).thenReturn(sourceTable);
 
-    when(paramsFactory.build(any(), any(), any(), any(), any())).thenReturn(groupByParams);
+    when(paramsFactory.build(any(), any(), any(), any())).thenReturn(groupByParams);
 
     when(groupByParams.getSchema()).thenReturn(REKEYED_SCHEMA);
     when(groupByParams.getMapper()).thenReturn(mapper);
@@ -159,8 +156,7 @@ public class TableGroupByBuilderTest {
         PROPERTIES,
         sourceStep,
         FORMATS,
-        GROUPBY_EXPRESSIONS,
-        alias
+        GROUPBY_EXPRESSIONS
     );
 
     builder = new TableGroupByBuilder(queryBuilder, groupedFactory, paramsFactory);
@@ -187,7 +183,6 @@ public class TableGroupByBuilderTest {
     verify(paramsFactory).build(
         eq(SCHEMA),
         any(),
-        eq(alias),
         eq(processingLogger),
         eq(ksqlConfig)
     );


### PR DESCRIPTION
### Description 

Klip-24 removes the need for aliasing support in group bys, i.e. `GROUP BY x AS y`.

Note: this feature was never turned on in a released version.

### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

