### PR TITLE
docs: cherry-pick: fix statement about key requirement in CREATE TABLE (DOCS-4268)

### DIFF
--- a/docs/developer-guide/ksqldb-reference/create-table.md
+++ b/docs/developer-guide/ksqldb-reference/create-table.md
@@ -25,10 +25,6 @@ ksqlDB adds the implicit columns `ROWTIME` and `ROWKEY` to every stream
 and table, which represent the corresponding Kafka message timestamp and
 message key, respectively. The timestamp has milliseconds accuracy.
 
-When creating a table from a Kafka topic, ksqlDB requries the message key
-to be a `VARCHAR` aka `STRING`. If the message key is not of this type
-follow the instructions in [Key Requirements](../syntax-reference.md#key-requirements).
-
 The WITH clause supports the following properties:
 
 |        Property         |                                            Description                                            |


### PR DESCRIPTION
From https://github.com/confluentinc/ksql/pull/5229.