### PR TITLE
docs: cherry-pick: update copyright date to 2020 (DOCS-4284)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: ksqlDB
 site_url: https://docs.ksqldb.io/en/latest/
 site_description: ksqlDB documentation
 site_author: Confluent
-copyright: Copyright &copy; 2019 <a href="https://www.confluent.io/">Confluent</a>.
+copyright: Copyright &copy; 2020 <a href="https://www.confluent.io/">Confluent</a>.
 google_analytics: ['UA-56447542-10', 'docs.ksqldb.io']
 
 repo_name: confluentinc/ksql


### PR DESCRIPTION
From https://github.com/confluentinc/ksql/pull/5309.