### PR TITLE
docs: use GTM for analytics

### DIFF
--- a/docs/overrides/partials/integrations/analytics.html
+++ b/docs/overrides/partials/integrations/analytics.html
@@ -1,0 +1,8 @@
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','{{ config.google_analytics[0] }}');</script>
+
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ config.google_analytics[0] }}"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://docs.ksqldb.io/en/latest/
 site_description: ksqlDB documentation
 site_author: Confluent
 copyright: Copyright &copy; 2020 <a href="https://www.confluent.io/">Confluent</a>.
-google_analytics: ['UA-56447542-10', 'docs.ksqldb.io']
+google_analytics: ['GTM-WRL2Z8Z', 'docs.ksqldb.io']
 
 repo_name: confluentinc/ksql
 repo_url: https://github.com/confluentinc/ksql
@@ -12,6 +12,7 @@ docs_dir: docs
 
 theme:
     name: material
+    custom_dir: docs/overrides
     favicon: img/favicon.ico # should match asset for main ksqldb.io site
     logo: img/logo.png # should match asset for main ksqldb.io site
     features:


### PR DESCRIPTION
### Description 
Updates docs site analytics to match ksqldb.io's configuration. This overrides a specific mkdocs-material partial to insert the code.

The mkdocs configuration now specifies a Google Tag Manager account. I did not change the property name from `google_analytics` because it would have involved a cascade of overrides to the theme files.

### Testing done 
Tested with a local docs build and GTM preview mode.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

