### PR TITLE
chore(client): first class decimal support in client interfaces

### DIFF
--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/KsqlArray.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/KsqlArray.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.api.client;
 
 import io.vertx.core.json.JsonArray;
+import java.math.BigDecimal;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -84,6 +85,10 @@ public class KsqlArray {
     return delegate.getBoolean(pos);
   }
 
+  public BigDecimal getDecimal(final int pos) {
+    return new BigDecimal(getValue(pos).toString());
+  }
+
   public KsqlArray getKsqlArray(final int pos) {
     return new KsqlArray(delegate.getJsonArray(pos));
   }
@@ -121,6 +126,11 @@ public class KsqlArray {
   }
 
   public KsqlArray add(final Boolean value) {
+    delegate.add(value);
+    return this;
+  }
+
+  public KsqlArray add(final BigDecimal value) {
     delegate.add(value);
     return this;
   }

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/KsqlObject.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/KsqlObject.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.api.client;
 
 import io.vertx.core.json.JsonObject;
+import java.math.BigDecimal;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -90,6 +91,10 @@ public class KsqlObject {
     return delegate.getBoolean(key);
   }
 
+  public BigDecimal getDecimal(final String key) {
+    return new BigDecimal(getValue(key).toString());
+  }
+
   public KsqlArray getKsqlArray(final String key) {
     return new KsqlArray(delegate.getJsonArray(key));
   }
@@ -123,6 +128,11 @@ public class KsqlObject {
   }
 
   public KsqlObject put(final String key, final Boolean value) {
+    delegate.put(key, value);
+    return this;
+  }
+
+  public KsqlObject put(final String key, final BigDecimal value) {
     delegate.put(key, value);
     return this;
   }

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/Row.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/Row.java
@@ -29,6 +29,22 @@ public interface Row {
   KsqlArray values();
 
   /**
+   * Whether the value for a particular column of the Row is null.
+   *
+   * @param columnIndex index of column (1-indexed).
+   * @return whether the column value is null.
+   */
+  boolean isNull(int columnIndex);
+
+  /**
+   * Whether the value for a particular column of the Row is null.
+   *
+   * @param columnName name of column.
+   * @return whether the column value is null.
+   */
+  boolean isNull(String columnName);
+
+  /**
    * Get the value for a particular column of the Row as an Object.
    *
    * @param columnIndex index of column (1-indexed).

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/Row.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/Row.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.api.client;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 /**
@@ -139,6 +140,22 @@ public interface Row {
    * @return column value.
    */
   Boolean getBoolean(String columnName);
+
+  /**
+   * Get the value for a particular column of the Row as a BigDecimal.
+   *
+   * @param columnIndex index of column (1-indexed).
+   * @return column value.
+   */
+  BigDecimal getDecimal(int columnIndex);
+
+  /**
+   * Get the value for a particular column of the Row as a BigDecimal.
+   *
+   * @param columnName name of column.
+   * @return column value.
+   */
+  BigDecimal getDecimal(String columnName);
 
   /**
    * Get the value for a particular column of the Row as a KsqlObject.

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/RowImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/RowImpl.java
@@ -59,6 +59,16 @@ public class RowImpl implements Row {
   }
 
   @Override
+  public boolean isNull(final int columnIndex) {
+    return getValue(columnIndex) == null;
+  }
+
+  @Override
+  public boolean isNull(final String columnName) {
+    return isNull(indexFromName(columnName));
+  }
+
+  @Override
   public Object getValue(final int columnIndex) {
     return values.getValue(columnIndex - 1);
   }

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/RowImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/RowImpl.java
@@ -20,6 +20,7 @@ import io.confluent.ksql.api.client.KsqlArray;
 import io.confluent.ksql.api.client.KsqlObject;
 import io.confluent.ksql.api.client.Row;
 import io.vertx.core.json.JsonArray;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -126,6 +127,16 @@ public class RowImpl implements Row {
   @Override
   public Boolean getBoolean(final String columnName) {
     return getBoolean(indexFromName(columnName));
+  }
+
+  @Override
+  public BigDecimal getDecimal(final int columnIndex) {
+    return values.getDecimal(columnIndex - 1);
+  }
+
+  @Override
+  public BigDecimal getDecimal(final String columnName) {
+    return getDecimal(indexFromName(columnName));
   }
 
   @Override

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/util/RowUtil.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/util/RowUtil.java
@@ -42,7 +42,12 @@ public final class RowUtil {
 
   private static ColumnType columnTypeFromString(final String columnType) {
     final int bracketInd = columnType.indexOf('<');
-    final String primaryType = bracketInd == -1 ? columnType : columnType.substring(0, bracketInd);
+    final int parenInd = columnType.indexOf('(');
+
+    final String primaryType = columnType.substring(0, Math.min(
+        bracketInd == -1 ? columnType.length() : bracketInd,
+        parenInd == -1 ? columnType.length() : parenInd
+    ));
     return new ColumnTypeImpl(primaryType);
   }
 }

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/RowImplTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/RowImplTest.java
@@ -17,11 +17,17 @@ package io.confluent.ksql.api.client.impl;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.api.client.ColumnType;
+import io.confluent.ksql.api.client.KsqlArray;
+import io.confluent.ksql.api.client.KsqlObject;
 import io.confluent.ksql.api.client.util.RowUtil;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import org.junit.Before;
@@ -29,11 +35,22 @@ import org.junit.Test;
 
 public class RowImplTest {
 
-  private static final List<String> COLUMN_NAMES = ImmutableList.of("f_str", "f_int", "f_long", "f_double", "f_bool");
+  private static final List<String> COLUMN_NAMES =
+      ImmutableList.of("f_str", "f_int", "f_long", "f_double", "f_bool", "f_decimal", "f_array", "f_map", "f_struct", "f_null");
   private static final List<ColumnType> COLUMN_TYPES = RowUtil.columnTypesFromStrings(
-      ImmutableList.of("STRING", "INTEGER", "BIGINT", "DOUBLE", "BOOLEAN"));
+      ImmutableList.of("STRING", "INTEGER", "BIGINT", "DOUBLE", "BOOLEAN", "DECIMAL", "ARRAY", "MAP", "STRUCT", "INTEGER"));
   private static final Map<String, Integer> COLUMN_NAME_TO_INDEX = RowUtil.valueToIndexMap(COLUMN_NAMES);
-  private static final JsonArray VALUES = new JsonArray(ImmutableList.of("foo", 2, 1234L, 34.43, false));
+  private static final JsonArray VALUES = new JsonArray()
+      .add("foo")
+      .add(2)
+      .add(1234L)
+      .add(34.43)
+      .add(false)
+      .add(12.21) // server endpoint returns decimals as doubles
+      .add(new JsonArray("[\"e1\",\"e2\"]"))
+      .add(new JsonObject("{\"k1\":\"v1\",\"k2\":\"v2\"}"))
+      .add(new JsonObject("{\"f1\":\"baz\",\"f2\":12}"))
+      .addNull();
 
   private RowImpl row;
 
@@ -49,6 +66,11 @@ public class RowImplTest {
     assertThat(row.getValue(3), is(1234L));
     assertThat(row.getValue(4), is(34.43));
     assertThat(row.getValue(5), is(false));
+    assertThat(row.getValue(6), is(12.21));
+    assertThat(row.getValue(7), is(new JsonArray("[\"e1\",\"e2\"]")));
+    assertThat(row.getValue(8), is(new JsonObject("{\"k1\":\"v1\",\"k2\":\"v2\"}")));
+    assertThat(row.getValue(9), is(new JsonObject("{\"f1\":\"baz\",\"f2\":12}")));
+    assertThat(row.getValue(10), is(nullValue()));
   }
 
   @Test
@@ -75,5 +97,28 @@ public class RowImplTest {
   @Test
   public void shouldGetBoolean() {
     assertThat(row.getBoolean("f_bool"), is(false));
+  }
+
+  @Test
+  public void shouldGetDecimal() {
+    assertThat(row.getDecimal("f_decimal"), is(new BigDecimal("12.21")));
+  }
+
+  @Test
+  public void shouldGetKsqlArray() {
+    assertThat(row.getKsqlArray("f_array"), is(new KsqlArray(ImmutableList.of("e1", "e2"))));
+  }
+
+  @Test
+  public void shouldGetKsqlObject() {
+    assertThat(row.getKsqlObject("f_map"), is(new KsqlObject(ImmutableMap.of("k1", "v1", "k2", "v2"))));
+    assertThat(row.getKsqlObject("f_struct"), is(new KsqlObject(ImmutableMap.of("f1", "baz", "f2", 12))));
+  }
+
+  @Test
+  public void shouldReturnNull() {
+    assertThat(row.isNull("f_null"), is(true));
+    assertThat(row.isNull("f_bool"), is(false));
+    assertThat(row.isNull("f_struct"), is(false));
   }
 }

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/util/RowUtilTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/util/RowUtilTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.client.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.api.client.ColumnType;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Test;
+
+public class RowUtilTest {
+
+  @Test
+  public void shouldGetColumnTypesFromStrings() {
+    // Given
+    final List<String> stringTypes = ImmutableList.of(
+        "STRING",
+        "INTEGER",
+        "BIGINT",
+        "BOOLEAN",
+        "DOUBLE",
+        "ARRAY<STRING>",
+        "MAP<STRING, STRING>",
+        "DECIMAL(4, 2)",
+        "STRUCT<`F1` STRING, `F2` INTEGER>"
+    );
+
+    // When
+    final List<ColumnType> columnTypes = RowUtil.columnTypesFromStrings(stringTypes);
+
+    // Then
+    assertThat(
+        columnTypes.stream()
+            .map(t -> t.getType().toString())
+            .collect(Collectors.toList()),
+        contains(
+            "STRING",
+            "INTEGER",
+            "BIGINT",
+            "BOOLEAN",
+            "DOUBLE",
+            "ARRAY",
+            "MAP",
+            "DECIMAL",
+            "STRUCT"
+    ));
+  }
+}


### PR DESCRIPTION
### Description 

This PR is stacked on https://github.com/confluentinc/ksql/pull/5327 -- only the new commits should be reviewed.

This PR adds support for the decimal type in various interfaces, and also adds the `Row#isNull()` method based on feedback from https://github.com/confluentinc/ksql/pull/5236. Additional unit test coverage was added to `RowImplTest.java` (and will be carried over into integration test coverage in `ClientTest.java` in a future PR).

### Testing done 

Manual + added unit tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

