### PR TITLE
fix: improve error message on key field type mismatch

### DIFF
--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateSourceCommand.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateSourceCommand.java
@@ -89,7 +89,7 @@ public abstract class CreateSourceCommand implements DdlCommand {
     return windowInfo;
   }
 
-  private static void validate(final LogicalSchema schema, final Optional<ColumnName> keyField) {
+  private void validate(final LogicalSchema schema, final Optional<ColumnName> keyField) {
     if (schema.valueContainsAny(SystemColumns.systemColumnNames())) {
       throw new IllegalArgumentException("Schema contains system columns in value schema");
     }
@@ -106,17 +106,21 @@ public abstract class CreateSourceCommand implements DdlCommand {
       final SqlType keyType = schema.key().get(0).type();
 
       if (!keyFieldType.equals(keyType)) {
+        final String primaryKey = this instanceof CreateTableCommand
+            ? "PRIMARY KEY"
+            : "KEY";
+
         throw new KsqlException("The KEY field ("
             + keyField.get().text()
             + ") identified in the WITH clause is of a different type to the actual key column."
             + System.lineSeparator()
-            + "Use of the KEY field is deprecated. Remove the KEY field from the WITH clause and "
-            + "specify the name of the key column by adding "
-            + "'" + keyField.get().text() + " " + keyFieldType + " KEY' to the schema."
+            + "Either change the type of the KEY field to match ROWKEY, "
+            + "or explicitly set ROWKEY to the type of the KEY field by adding "
+            + "'ROWKEY " + keyFieldType + " " + primaryKey + "' in the schema."
             + System.lineSeparator()
             + "KEY field type: " + keyFieldType
             + System.lineSeparator()
-            + "key column type: " + keyType
+            + "ROWKEY type: " + keyType
         );
       }
     }

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/ddl/commands/CreateSourceCommandTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/ddl/commands/CreateSourceCommandTest.java
@@ -93,12 +93,12 @@ public class CreateSourceCommandTest {
         "The KEY field (keyField) identified in the "
             + "WITH clause is of a different type to the actual key column."));
     assertThat(e.getMessage(), containsString(
-        "Use of the KEY field is deprecated. Remove the KEY field from the WITH clause and "
-            + "specify the name of the key column by adding 'keyField STRING KEY' to the schema."));
+        "Either change the type of the KEY field to match ROWKEY, or explicitly set "
+            + "ROWKEY to the type of the KEY field by adding 'ROWKEY STRING KEY' in the schema."));
     assertThat(e.getMessage(), containsString(
         "KEY field type: STRING"));
     assertThat(e.getMessage(), containsString(
-        "key column type: INTEGER"));
+        "ROWKEY type: INTEGER"));
   }
 
   @Test

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/key-field.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/key-field.json
@@ -831,7 +831,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "The KEY field (FOO) identified in the WITH clause is of a different type to the actual key column.\nUse of the KEY field is deprecated. Remove the KEY field from the WITH clause and specify the name of the key column by adding 'FOO INTEGER KEY' to the schema.\nKEY field type: INTEGER\nkey column type: STRING"
+        "message": "The KEY field (FOO) identified in the WITH clause is of a different type to the actual key column.\nEither change the type of the KEY field to match ROWKEY, or explicitly set ROWKEY to the type of the KEY field by adding 'ROWKEY INTEGER KEY' in the schema.\nKEY field type: INTEGER\nROWKEY type: STRING"
       }
     },
     {


### PR DESCRIPTION

### Description 

fixes: https://github.com/confluentinc/ksql/issues/5333

The error message being returned to the user if the key field identified via `WITH(KEY)` syntax had a different SQL type to ROWKEY column was misleading as it talked about `WITH(KEY)` being deprecated and didn't mention `PRIMARY KEY`s on tables.  This is mainly due to the 'any key name' feature being pulled from the 0.9 release.  This change reverts the error message to the old version and adds in the PRIMARY KEY bit.

### Testing done 

test updated.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

