### PR TITLE
chore: build ksqlDB against 6.0.0

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactory.java
@@ -29,15 +29,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 import javax.net.ssl.SSLContext;
-import org.apache.kafka.common.network.Mode;
-import org.apache.kafka.common.security.ssl.SslFactory;
+import org.apache.kafka.common.security.auth.SslEngineFactory;
+import org.apache.kafka.common.security.ssl.DefaultSslEngineFactory;
 
 /**
  * Configurable Schema Registry client factory, enabling SSL.
  */
 public class KsqlSchemaRegistryClientFactory {
 
-  private final SslFactory sslFactory;
+  private final SSLContext sslContext;
   private final Supplier<RestService> serviceSupplier;
   private final Map<String, Object> schemaRegistryClientConfigs;
   private final SchemaRegistryClientFactory schemaRegistryClientFactory;
@@ -56,17 +56,17 @@ public class KsqlSchemaRegistryClientFactory {
       final KsqlConfig config,
       final Map<String, String> schemaRegistryHttpHeaders
   ) {
-    this(config, newSchemaRegistrySslFactory(config), schemaRegistryHttpHeaders);
+    this(config, newSslContext(config), schemaRegistryHttpHeaders);
   }
 
   public KsqlSchemaRegistryClientFactory(
       final KsqlConfig config,
-      final SslFactory sslFactory,
+      final SSLContext sslContext,
       final Map<String, String> schemaRegistryHttpHeaders
   ) {
     this(config,
         () -> new RestService(config.getString(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY)),
-        sslFactory,
+        sslContext,
         CachedSchemaRegistryClient::new,
         schemaRegistryHttpHeaders
     );
@@ -78,10 +78,10 @@ public class KsqlSchemaRegistryClientFactory {
   @VisibleForTesting
   KsqlSchemaRegistryClientFactory(final KsqlConfig config,
                                   final Supplier<RestService> serviceSupplier,
-                                  final SslFactory sslFactory,
+                                  final SSLContext sslContext,
                                   final SchemaRegistryClientFactory schemaRegistryClientFactory,
                                   final Map<String, String> httpHeaders) {
-    this.sslFactory = sslFactory;
+    this.sslContext = sslContext;
     this.serviceSupplier = serviceSupplier;
     this.schemaRegistryClientConfigs = config.originalsWithPrefix(
         KsqlConfig.KSQL_SCHEMA_REGISTRY_PREFIX);
@@ -92,16 +92,19 @@ public class KsqlSchemaRegistryClientFactory {
   }
 
   /**
-   * Creates an SslFactory configured to be used with the KsqlSchemaRegistryClient.
+   * Creates an SslContext configured to be used with the KsqlSchemaRegistryClient.
    */
-  public static SslFactory newSchemaRegistrySslFactory(final KsqlConfig config) {
-    final SslFactory sslFactory = new SslFactory(Mode.CLIENT);
-    configureSslFactory(config, sslFactory);
-    return sslFactory;
+  public static SSLContext newSslContext(final KsqlConfig config) {
+    final DefaultSslEngineFactory sslFactory = new DefaultSslEngineFactory();
+    configureSslEngineFactory(config, sslFactory);
+    return sslFactory.sslContext();
   }
 
   @VisibleForTesting
-  static void configureSslFactory(final KsqlConfig config, final SslFactory sslFactory) {
+  static void configureSslEngineFactory(
+      final KsqlConfig config,
+      final SslEngineFactory sslFactory
+  ) {
     sslFactory
         .configure(config.valuesWithPrefixOverride(KsqlConfig.KSQL_SCHEMA_REGISTRY_PREFIX));
   }
@@ -112,7 +115,6 @@ public class KsqlSchemaRegistryClientFactory {
     }
   
     final RestService restService = serviceSupplier.get();
-    final SSLContext sslContext = sslFactory.sslEngineBuilder().sslContext();
     if (sslContext != null) {
       restService.setSslSocketFactory(sslContext.getSocketFactory());
     }

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/RecordNode.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/RecordNode.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import io.confluent.ksql.test.tools.Record;
@@ -40,7 +41,8 @@ import java.util.Optional;
 @JsonSerialize(using = RecordNode.Serializer.class)
 public final class RecordNode {
 
-  private static final ObjectMapper objectMapper = new ObjectMapper();
+  private static final ObjectMapper objectMapper = new ObjectMapper()
+      .setNodeFactory(JsonNodeFactory.withExactBigDecimals(true));
 
   private final String topicName;
   private final Optional<Object> key;

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_JSON_scale_in_data_less_than_scale_in_type/6.0.0_1583419431528/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_JSON_scale_in_data_less_than_scale_in_type/6.0.0_1583419431528/spec.json
@@ -79,7 +79,7 @@
       "topic" : "OUTPUT",
       "key" : "",
       "value" : {
-        "DEC" : 0.0001
+        "DEC" : 0.00010
       }
     } ],
     "topics" : [ {

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_JSON_scale_in_data_less_than_scale_in_type/6.0.0_1588893908853/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_JSON_scale_in_data_less_than_scale_in_type/6.0.0_1588893908853/spec.json
@@ -79,7 +79,7 @@
       "topic" : "OUTPUT",
       "key" : "",
       "value" : {
-        "DEC" : 0.0001
+        "DEC" : 0.00010
       }
     } ],
     "topics" : [ {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/decimal.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/decimal.json
@@ -64,7 +64,7 @@
         {"topic": "OUTPUT", "value": {"DEC": 0.1}},
         {"topic": "OUTPUT", "value": {"DEC": 0.01}},
         {"topic": "OUTPUT", "value": {"DEC": 0.001}},
-        {"topic": "OUTPUT", "value": {"DEC": 0.0001}}
+        {"topic": "OUTPUT", "value": {"DEC": 0.00010}}
       ],
       "post": {
         "sources": [

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonSerializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonSerializerTest.java
@@ -333,11 +333,6 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldSerializeDecimalsWithoutStrippingTrailingZeros() {
-    // Get rid of this once currentlyDoesStripTrailingZerosButShouldNot is removed
-    if (!useSchemas) {
-      return;
-    }
-
     // Given:
     givenSerializerForSchema(DecimalUtil.builder(3, 1).build());
 
@@ -346,27 +341,6 @@ public class KsqlJsonSerializerTest {
 
     // Then:
     assertThat(asJsonString(bytes), is("12.0"));
-  }
-
-  /*
-  When this test starts failing it's because https://issues.apache.org/jira/browse/KAFKA-9667
-  has been fixed. This test should be removed. The above test, and the matching test in decimal.json
-  should also be enabled. (Search for https://github.com/confluentinc/ksql/issues/4710 in the code).
-   */
-  @Test
-  public void currentlyDoesStripTrailingZerosButShouldNot() {
-    if (useSchemas) {
-      return;
-    }
-
-    // Given:
-    givenSerializerForSchema(DecimalUtil.builder(3, 1).build());
-
-    // When:
-    final byte[] bytes = serializer.serialize(SOME_TOPIC, new BigDecimal("12.0"));
-
-    // Then:
-    assertThat(asJsonString(bytes), is("12"));
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -125,9 +125,6 @@
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <skip.docker.build>true</skip.docker.build>
         <skip.docker.test>true</skip.docker.test>
-        <kafka.version>5.5.0-ccs</kafka.version>
-        <ce.kafka.version>5.5.0-ce</ce.kafka.version>
-        <confluent.version>5.5.0</confluent.version>
         <compile.warnings-flag>-Werror</compile.warnings-flag>
         <!-- Only used to provide login module implementation for tests -->
         <jetty.version>9.4.28.v20200408</jetty.version>


### PR DESCRIPTION
- drop cp/kaka versions from pom.xml and just use the ones from common
- fix usage of ssl factory

