### PR TITLE
docs: add analytics outside theme

### DIFF
--- a/docs/js/analytics.js
+++ b/docs/js/analytics.js
@@ -1,0 +1,5 @@
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-WRL2Z8Z');

--- a/docs/overrides/partials/integrations/analytics.html
+++ b/docs/overrides/partials/integrations/analytics.html
@@ -1,8 +1,0 @@
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','{{ config.google_analytics[0] }}');</script>
-
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ config.google_analytics[0] }}"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,6 @@ site_url: https://docs.ksqldb.io/en/latest/
 site_description: ksqlDB documentation
 site_author: Confluent
 copyright: Copyright &copy; 2020 <a href="https://www.confluent.io/">Confluent</a>.
-google_analytics: ['GTM-WRL2Z8Z', 'docs.ksqldb.io']
 
 repo_name: confluentinc/ksql
 repo_url: https://github.com/confluentinc/ksql
@@ -11,8 +10,7 @@ edit_uri: ""
 docs_dir: docs
 
 theme:
-    name: material
-    custom_dir: docs/overrides
+    name: material    
     favicon: img/favicon.ico # should match asset for main ksqldb.io site
     logo: img/logo.png # should match asset for main ksqldb.io site
     features:
@@ -23,6 +21,7 @@ extra_css:
 
 extra_javascript:
   - js/extra.js
+  - js/analytics.js
 
 nav:
   - Overview: index.md


### PR DESCRIPTION
### Description 
In #5321, the docs analytics implementation was moved to a template override. We have found that this can produce inconsistent output across build configurations. This PR moves the implementation to a script include, which should produce the same behavior across builds.

### Testing done 
Verified by building the docs locally and with a test docs site version.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

