### PR TITLE
fix: always represent double/decimal as decimal in qtt

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/RecordNode.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/RecordNode.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.JsonSerializer;
@@ -42,6 +43,7 @@ import java.util.Optional;
 public final class RecordNode {
 
   private static final ObjectMapper objectMapper = new ObjectMapper()
+      .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
       .setNodeFactory(JsonNodeFactory.withExactBigDecimals(true));
 
   private final String topicName;

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_JSON_scale_in_data_less_than_scale_in_type/6.0.0_1583419431528/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_JSON_scale_in_data_less_than_scale_in_type/6.0.0_1583419431528/spec.json
@@ -79,7 +79,7 @@
       "topic" : "OUTPUT",
       "key" : "",
       "value" : {
-        "DEC" : 0.00010
+        "DEC" : 0.0001
       }
     } ],
     "topics" : [ {

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_JSON_should_not_trim_trailing_zeros/6.0.0_1589330376226/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_JSON_should_not_trim_trailing_zeros/6.0.0_1589330376226/plan.json
@@ -1,0 +1,124 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID STRING KEY, DEC DECIMAL(6, 4)) WITH (KAFKA_TOPIC='test', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` STRING KEY, `DEC` DECIMAL(6, 4)",
+      "topicName" : "test",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `DEC` DECIMAL(6, 4)",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY, `DEC` DECIMAL(6, 4)"
+          },
+          "selectExpressions" : [ "DEC AS DEC" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_JSON_should_not_trim_trailing_zeros/6.0.0_1589330376226/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_JSON_should_not_trim_trailing_zeros/6.0.0_1589330376226/spec.json
@@ -1,85 +1,37 @@
 {
   "version" : "6.0.0",
-  "timestamp" : 1588893908853,
+  "timestamp" : 1589330376226,
   "path" : "query-validation-tests/decimal.json",
   "schemas" : {
     "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<DEC DECIMAL(6, 4)> NOT NULL",
     "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<DEC DECIMAL(6, 4)> NOT NULL"
   },
   "testCase" : {
-    "name" : "JSON scale in data less than scale in type",
+    "name" : "JSON should not trim trailing zeros",
     "inputs" : [ {
       "topic" : "test",
       "key" : "",
       "value" : {
-        "DEC" : 10
+        "DEC" : 10.0
       }
     }, {
       "topic" : "test",
       "key" : "",
       "value" : {
-        "DEC" : 1
-      }
-    }, {
-      "topic" : "test",
-      "key" : "",
-      "value" : {
-        "DEC" : 0.1
-      }
-    }, {
-      "topic" : "test",
-      "key" : "",
-      "value" : {
-        "DEC" : 0.01
-      }
-    }, {
-      "topic" : "test",
-      "key" : "",
-      "value" : {
-        "DEC" : 0.001
-      }
-    }, {
-      "topic" : "test",
-      "key" : "",
-      "value" : {
-        "DEC" : 0.0001
+        "DEC" : 1.0000
       }
     } ],
     "outputs" : [ {
       "topic" : "OUTPUT",
       "key" : "",
       "value" : {
-        "DEC" : 10
+        "DEC" : 10.0
       }
     }, {
       "topic" : "OUTPUT",
       "key" : "",
       "value" : {
-        "DEC" : 1
-      }
-    }, {
-      "topic" : "OUTPUT",
-      "key" : "",
-      "value" : {
-        "DEC" : 0.1
-      }
-    }, {
-      "topic" : "OUTPUT",
-      "key" : "",
-      "value" : {
-        "DEC" : 0.01
-      }
-    }, {
-      "topic" : "OUTPUT",
-      "key" : "",
-      "value" : {
-        "DEC" : 0.001
-      }
-    }, {
-      "topic" : "OUTPUT",
-      "key" : "",
-      "value" : {
-        "DEC" : 0.0001
+        "DEC" : 1.0000
       }
     } ],
     "topics" : [ {

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_JSON_should_not_trim_trailing_zeros/6.0.0_1589330376226/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_JSON_should_not_trim_trailing_zeros/6.0.0_1589330376226/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/decimal.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/decimal.json
@@ -64,7 +64,7 @@
         {"topic": "OUTPUT", "value": {"DEC": 0.1}},
         {"topic": "OUTPUT", "value": {"DEC": 0.01}},
         {"topic": "OUTPUT", "value": {"DEC": 0.001}},
-        {"topic": "OUTPUT", "value": {"DEC": 0.00010}}
+        {"topic": "OUTPUT", "value": {"DEC": 0.0001}}
       ],
       "post": {
         "sources": [
@@ -74,7 +74,6 @@
       }
     },
     {
-      "enabled": false,
       "name": "JSON should not trim trailing zeros",
       "comment": "Disabled until https://github.com/confluentinc/ksql/issues/4710 is done",
       "statements": [
@@ -91,8 +90,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "INPUT", "type": "stream", "schema": "ROWKEY STRING KEY, DEC DECIMAL(6,4)"},
-          {"name": "OUTPUT", "type": "stream", "schema": "ROWKEY STRING KEY, DEC DECIMAL(6,4)"}
+          {"name": "INPUT", "type": "stream", "schema": "ID STRING KEY, DEC DECIMAL(6,4)"},
+          {"name": "OUTPUT", "type": "stream", "schema": "ID STRING KEY, DEC DECIMAL(6,4)"}
         ]
       }
     },


### PR DESCRIPTION
### Description 

This patch changes how we represent decimal/double in our qtt to always
represent these as decimals internally (e.g. in the Record/RecordNode).
Storing them as doubles can result in the scale not being preserved for
decimals. This mostly works pretty seamlessly, except when writing
kafka-serialized doubles to source topics. In this case, we have to
convert the value to a double before passing to the serializer.

With this change, we can also re-enable the trailing zeroes qtt
