### PR TITLE
chore: Revert "build ksqlDB against 6.0.0 (#5339)"

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/RecordNode.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/RecordNode.java
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import io.confluent.ksql.test.tools.Record;
@@ -41,8 +40,7 @@ import java.util.Optional;
 @JsonSerialize(using = RecordNode.Serializer.class)
 public final class RecordNode {
 
-  private static final ObjectMapper objectMapper = new ObjectMapper()
-      .setNodeFactory(JsonNodeFactory.withExactBigDecimals(true));
+  private static final ObjectMapper objectMapper = new ObjectMapper();
 
   private final String topicName;
   private final Optional<Object> key;

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_JSON_scale_in_data_less_than_scale_in_type/6.0.0_1583419431528/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_JSON_scale_in_data_less_than_scale_in_type/6.0.0_1583419431528/spec.json
@@ -79,7 +79,7 @@
       "topic" : "OUTPUT",
       "key" : "",
       "value" : {
-        "DEC" : 0.00010
+        "DEC" : 0.0001
       }
     } ],
     "topics" : [ {

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_JSON_scale_in_data_less_than_scale_in_type/6.0.0_1588893908853/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_JSON_scale_in_data_less_than_scale_in_type/6.0.0_1588893908853/spec.json
@@ -79,7 +79,7 @@
       "topic" : "OUTPUT",
       "key" : "",
       "value" : {
-        "DEC" : 0.00010
+        "DEC" : 0.0001
       }
     } ],
     "topics" : [ {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/decimal.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/decimal.json
@@ -64,7 +64,7 @@
         {"topic": "OUTPUT", "value": {"DEC": 0.1}},
         {"topic": "OUTPUT", "value": {"DEC": 0.01}},
         {"topic": "OUTPUT", "value": {"DEC": 0.001}},
-        {"topic": "OUTPUT", "value": {"DEC": 0.00010}}
+        {"topic": "OUTPUT", "value": {"DEC": 0.0001}}
       ],
       "post": {
         "sources": [

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonSerializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonSerializerTest.java
@@ -333,6 +333,11 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldSerializeDecimalsWithoutStrippingTrailingZeros() {
+    // Get rid of this once currentlyDoesStripTrailingZerosButShouldNot is removed
+    if (!useSchemas) {
+      return;
+    }
+
     // Given:
     givenSerializerForSchema(DecimalUtil.builder(3, 1).build());
 
@@ -341,6 +346,27 @@ public class KsqlJsonSerializerTest {
 
     // Then:
     assertThat(asJsonString(bytes), is("12.0"));
+  }
+
+  /*
+  When this test starts failing it's because https://issues.apache.org/jira/browse/KAFKA-9667
+  has been fixed. This test should be removed. The above test, and the matching test in decimal.json
+  should also be enabled. (Search for https://github.com/confluentinc/ksql/issues/4710 in the code).
+   */
+  @Test
+  public void currentlyDoesStripTrailingZerosButShouldNot() {
+    if (useSchemas) {
+      return;
+    }
+
+    // Given:
+    givenSerializerForSchema(DecimalUtil.builder(3, 1).build());
+
+    // When:
+    final byte[] bytes = serializer.serialize(SOME_TOPIC, new BigDecimal("12.0"));
+
+    // Then:
+    assertThat(asJsonString(bytes), is("12"));
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,9 @@
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <skip.docker.build>true</skip.docker.build>
         <skip.docker.test>true</skip.docker.test>
+        <kafka.version>5.5.0-ccs</kafka.version>
+        <ce.kafka.version>5.5.0-ce</ce.kafka.version>
+        <confluent.version>5.5.0</confluent.version>
         <compile.warnings-flag>-Werror</compile.warnings-flag>
         <!-- Only used to provide login module implementation for tests -->
         <jetty.version>9.4.28.v20200408</jetty.version>


### PR DESCRIPTION
This reverts commit 67ea30b2e1e4d5ef2dd110a71e22f68072682eeb.

### Description 

Reverting this commit as it breaks master. It seems to change the version of Kafka/KS that we build against, and the current ksqlDb master code does not build against that version. Specifically the ProcessorContext interface has changed from generic (old version) to non generic (newer version) - this results in compiler warnings and our build is configured to fail on warnings.

### Testing done 

N/A

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

