### PR TITLE
docs: add upgrade note at the top of changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Upgrading
 
-If you're upgrading from a ksqlDB version < 0.7, please make sure to read and follow these [upgrade instructions](./docs-md/operate-and-deploy/installation/upgrading.md).
+If you're upgrading from a ksqlDB version before 0.7, follow these [upgrade instructions](./docs-md/operate-and-deploy/installation/upgrading.md).
 
 ## [0.8.1](https://github.com/confluentinc/ksql/releases/tag/v0.8.1-ksqldb) (2020-03-30)
 
@@ -618,4 +618,3 @@ This change splits "SHOW TOPICS" into two commands:
 
 Release notes for KSQL releases prior to ksqlDB v0.6.0 can be found at
 [docs/changelog.rst](https://github.com/confluentinc/ksql/blob/5.4.1-post/docs/changelog.rst).
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Upgrading
+
+If you're upgrading from a ksqlDB version < 0.7, please make sure to read and follow these [upgrade instructions](./docs-md/operate-and-deploy/installation/upgrading.md).
+
 ## [0.8.1](https://github.com/confluentinc/ksql/releases/tag/v0.8.1-ksqldb) (2020-03-30)
 
 ### Bug Fixes


### PR DESCRIPTION
### Description 
Add a note at the top of the Changelog to warn users who upgrade from ksqlDB < 0.7 to read and follow the upgrade instructions.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

