### PR TITLE
refactor: unify TransientQuery metadata

### DIFF
--- a/ksqldb-api-reactive-streams-tck/src/test/java/io/confluent/ksql/api/tck/BlockingQueryPublisherVerificationTest.java
+++ b/ksqldb-api-reactive-streams-tck/src/test/java/io/confluent/ksql/api/tck/BlockingQueryPublisherVerificationTest.java
@@ -75,7 +75,7 @@ public class BlockingQueryPublisherVerificationTest extends PublisherVerificatio
     private final TransientQueryQueue queue;
 
     public TestQueryHandle(final long elements) {
-      final OptionalInt limit = elements == 0 || elements == Long.MAX_VALUE
+      final OptionalInt limit = elements == Long.MAX_VALUE
           ? OptionalInt.empty()
           : OptionalInt.of((int) elements);
 

--- a/ksqldb-api-reactive-streams-tck/src/test/java/io/confluent/ksql/api/tck/BlockingQueryPublisherVerificationTest.java
+++ b/ksqldb-api-reactive-streams-tck/src/test/java/io/confluent/ksql/api/tck/BlockingQueryPublisherVerificationTest.java
@@ -18,6 +18,8 @@ package io.confluent.ksql.api.tck;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.api.endpoints.BlockingQueryPublisher;
 import io.confluent.ksql.api.server.PushQueryHandle;
+import io.confluent.ksql.query.BlockingRowQueue;
+import io.confluent.ksql.query.TransientQueryQueue;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
 import io.vertx.core.WorkerExecutor;
@@ -45,10 +47,11 @@ public class BlockingQueryPublisherVerificationTest extends PublisherVerificatio
   public Publisher<GenericRow> createPublisher(long elements) {
     final Context context = vertx.getOrCreateContext();
     BlockingQueryPublisher publisher = new BlockingQueryPublisher(context, workerExecutor);
-    publisher.setQueryHandle(new TestQueryHandle(elements));
+    final TestQueryHandle queryHandle = new TestQueryHandle(elements);
+    publisher.setQueryHandle(queryHandle);
     if (elements < Integer.MAX_VALUE) {
       for (long l = 0; l < elements; l++) {
-        publisher.accept(generateRow(l));
+        queryHandle.queue.acceptRow(generateRow(l));
       }
     }
     return publisher;
@@ -59,7 +62,7 @@ public class BlockingQueryPublisherVerificationTest extends PublisherVerificatio
     return null;
   }
 
-  private GenericRow generateRow(long num) {
+  private static GenericRow generateRow(long num) {
     List<Object> l = new ArrayList<>();
     l.add("foo" + num);
     l.add(num);
@@ -69,10 +72,14 @@ public class BlockingQueryPublisherVerificationTest extends PublisherVerificatio
 
   private static class TestQueryHandle implements PushQueryHandle {
 
-    private final long elements;
+    private final TransientQueryQueue queue;
 
     public TestQueryHandle(final long elements) {
-      this.elements = elements;
+      final OptionalInt limit = elements == 0 || elements == Long.MAX_VALUE
+          ? OptionalInt.empty()
+          : OptionalInt.of((int) elements);
+
+      this.queue = new TransientQueryQueue(limit);
     }
 
     @Override
@@ -86,19 +93,16 @@ public class BlockingQueryPublisherVerificationTest extends PublisherVerificatio
     }
 
     @Override
-    public OptionalInt getLimit() {
-      return elements != Long.MAX_VALUE ? OptionalInt.of((int) elements) : OptionalInt.empty();
-    }
-
-    @Override
     public void start() {
     }
 
     @Override
     public void stop() {
+    }
 
+    @Override
+    public BlockingRowQueue getQueue() {
+      return queue;
     }
   }
-
-
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/KsqlExecutionContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/KsqlExecutionContext.java
@@ -32,7 +32,6 @@ import io.confluent.ksql.util.TransientQueryMetadata;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Consumer;
 
 /**
  * The context in which statements can be executed.
@@ -108,19 +107,11 @@ public interface KsqlExecutionContext {
 
   /**
    * Executes a query using the supplied service context.
+   * @return the query metadata
    */
   TransientQueryMetadata executeQuery(
       ServiceContext serviceContext,
       ConfiguredStatement<Query> statement
-  );
-
-  /**
-   * Executes a query using the supplied service context.
-   */
-  QueryMetadata executeQuery(
-      ServiceContext serviceContext,
-      ConfiguredStatement<Query> statement,
-      Consumer<GenericRow> rowConsumer
   );
 
   /**
@@ -147,7 +138,6 @@ public interface KsqlExecutionContext {
    * @return The execution result.
    */
   ExecuteResult execute(ServiceContext serviceContext, ConfiguredStatement<?> statement);
-
 
   /**
    * Holds the union of possible results from an {@link #execute} call.

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.engine;
 import static io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.KsqlExecutionContext.ExecuteResult;
 import io.confluent.ksql.execution.ddl.commands.CreateSourceCommand;
 import io.confluent.ksql.execution.ddl.commands.CreateStreamCommand;
@@ -53,13 +52,11 @@ import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.PlanSummary;
-import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Consumer;
 
 /**
  * Executor of {@code PreparedStatement} within a specific {@code EngineContext} and using a
@@ -136,28 +133,6 @@ final class EngineExecutor {
             plans.physicalPlan.getPhysicalPlan()),
         outputNode.getSchema(),
         outputNode.getLimit()
-    );
-  }
-
-  QueryMetadata executeQuery(final ConfiguredStatement<Query> statement,
-      final Consumer<GenericRow> rowConsumer) {
-    final ExecutorPlans plans = planQuery(statement, statement.getStatement(), Optional.empty());
-    final OutputNode outputNode = plans.logicalPlan.getNode().get();
-    final QueryExecutor executor = engineContext.createQueryExecutor(
-        ksqlConfig,
-        overriddenProperties,
-        serviceContext
-    );
-    return executor.buildTransientQuery(
-        statement.getStatementText(),
-        plans.physicalPlan.getQueryId(),
-        getSourceNames(outputNode),
-        plans.physicalPlan.getPhysicalPlan(),
-        buildPlanSummary(
-            plans.physicalPlan.getQueryId(),
-            plans.physicalPlan.getPhysicalPlan()),
-        outputNode.getSchema(),
-        rowConsumer
     );
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.engine;
 
 import com.google.common.collect.ImmutableList;
-import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.ServiceInfo;
 import io.confluent.ksql.function.FunctionRegistry;
@@ -52,7 +51,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -232,24 +230,6 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
       // add the statement text to the KsqlException
       throw new KsqlStatementException(e.getMessage(), statement.getStatementText(), e.getCause());
     }
-  }
-
-  @Override
-  public QueryMetadata executeQuery(
-      final ServiceContext serviceContext,
-      final ConfiguredStatement<Query> statement,
-      final Consumer<GenericRow> rowConsumer
-  ) {
-    final QueryMetadata query = EngineExecutor
-        .create(
-            primaryContext,
-            serviceContext,
-            statement.getConfig(),
-            statement.getConfigOverrides()
-        )
-        .executeQuery(statement, rowConsumer);
-    registerQuery(query);
-    return query;
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.engine;
 
 import com.google.common.collect.ImmutableList;
-import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.logging.processing.NoopProcessingLogContext;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
@@ -34,7 +33,6 @@ import io.confluent.ksql.util.Sandbox;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Consumer;
 
 /**
  * An execution context that can execute statements without changing the core engine's state
@@ -149,16 +147,5 @@ final class SandboxedExecutionContext implements KsqlExecutionContext {
         statement.getConfig(),
         statement.getConfigOverrides()
     ).executeQuery(statement);
-  }
-
-  @Override
-  public QueryMetadata executeQuery(final ServiceContext serviceContext,
-      final ConfiguredStatement<Query> statement, final Consumer<GenericRow> rowConsumer) {
-    return EngineExecutor.create(
-        engineContext,
-        serviceContext,
-        statement.getConfig(),
-        statement.getConfigOverrides()
-    ).executeQuery(statement, rowConsumer);
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/BlockingRowQueue.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/BlockingRowQueue.java
@@ -19,7 +19,6 @@ import io.confluent.ksql.GenericRow;
 import java.util.Collection;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
-import org.apache.kafka.streams.KeyValue;
 
 /**
  * The queue between the Kafka-streams topology and the client connection.
@@ -40,19 +39,36 @@ public interface BlockingRowQueue {
   void setLimitHandler(LimitHandler limitHandler);
 
   /**
-   * Poll the queue for a single row
+   * Sets the called back that will be called any time a new row is accepted into the queue.
    *
+   * @param callback the callback.
+   */
+  void setQueuedCallback(Runnable callback);
+
+  /**
+   * Poll the queue for a single row, with a timeout.
+   *
+   * @return the next row
    * @see BlockingQueue#poll(long, TimeUnit)
    */
-  KeyValue<String, GenericRow> poll(long timeout, TimeUnit unit)
+  GenericRow poll(long timeout, TimeUnit unit)
       throws InterruptedException;
+
+  /**
+   * Poll the queue for a single row.
+   *
+   * @return the next row
+   * @see BlockingQueue#poll()
+   */
+  GenericRow poll();
 
   /**
    * Drain the queue to the supplied {@code collection}.
    *
+   * @param collection the collection to add drained rows to.
    * @see BlockingQueue#drainTo(Collection)
    */
-  void drainTo(Collection<? super KeyValue<String, GenericRow>> collection);
+  void drainTo(Collection<? super GenericRow> collection);
 
   /**
    * The size of the queue.
@@ -60,6 +76,11 @@ public interface BlockingRowQueue {
    * @see BlockingQueue#size()
    */
   int size();
+
+  /**
+   * @return {@code true} if the queue is empty, false otherwise.
+   */
+  boolean isEmpty();
 
   /**
    * Close the queue.

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/LimitedQueueCallback.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/LimitedQueueCallback.java
@@ -32,7 +32,7 @@ public final class LimitedQueueCallback implements LimitQueueCallback {
   };
 
   LimitedQueueCallback(final int limit) {
-    if (limit <= 0) {
+    if (limit < 0) {
       throw new IllegalArgumentException("limit must be positive, was:" + limit);
     }
     this.remaining = new AtomicInteger(limit);
@@ -42,6 +42,9 @@ public final class LimitedQueueCallback implements LimitQueueCallback {
   @Override
   public void setLimitHandler(final LimitHandler limitHandler) {
     this.limitHandler = Objects.requireNonNull(limitHandler, "limitHandler");
+    if (remaining.get() == 0) {
+      limitHandler.limitReached();
+    }
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.util;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.internal.QueryStateListener;
@@ -59,7 +60,8 @@ public abstract class QueryMetadata {
   private boolean everStarted = false;
 
   // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
-  public QueryMetadata(
+  @VisibleForTesting
+  QueryMetadata(
       final String statementString,
       final KafkaStreams kafkaStreams,
       final LogicalSchema logicalSchema,

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
@@ -57,7 +57,6 @@ import org.apache.kafka.clients.producer.ProducerInterceptor;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.Configurable;
-import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.test.IntegrationTest;
 import org.apache.kafka.test.TestUtils;
@@ -214,7 +213,7 @@ public class EndToEndIntegrationTest {
     final TransientQueryMetadata queryMetadata = executeStatement(
         "SELECT * from pageviews_female EMIT CHANGES;");
 
-    final List<KeyValue<String, GenericRow>> results = new ArrayList<>();
+    final List<GenericRow> results = new ArrayList<>();
     final BlockingRowQueue rowQueue = queryMetadata.getRowQueue();
 
     // From the mock data, we expect exactly 3 page views from female users.
@@ -224,7 +223,7 @@ public class EndToEndIntegrationTest {
     TestUtils.waitForCondition(() -> {
       try {
         log.debug("polling from pageviews_female");
-        final KeyValue<String, GenericRow> nextRow = rowQueue.poll(1, TimeUnit.SECONDS);
+        final GenericRow nextRow = rowQueue.poll(1, TimeUnit.SECONDS);
         if (nextRow != null) {
           results.add(nextRow);
         } else {
@@ -244,8 +243,8 @@ public class EndToEndIntegrationTest {
     final List<String> actualPages = new ArrayList<>();
     final List<String> actualUsers = new ArrayList<>();
 
-    for (final KeyValue<String, GenericRow> result : results) {
-      final List<Object> columns = result.value.values();
+    for (final GenericRow result : results) {
+      final List<Object> columns = result.values();
       log.debug("pageview join: {}", columns);
 
       assertThat(columns, hasSize(4));
@@ -408,12 +407,10 @@ public class EndToEndIntegrationTest {
         30_000,
         expectedRows + " rows were not available after 30 seconds");
 
-    final List<KeyValue<String, GenericRow>> rows = new ArrayList<>();
+    final List<GenericRow> rows = new ArrayList<>();
     rowQueue.drainTo(rows);
 
-    return rows.stream()
-        .map(kv -> kv.value)
-        .collect(Collectors.toList());
+    return rows;
   }
 
   public static class DummyConsumerInterceptor implements ConsumerInterceptor {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/LimitedQueueCallbackTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/LimitedQueueCallbackTest.java
@@ -82,6 +82,18 @@ public class LimitedQueueCallbackTest {
   }
 
   @Test
+  public void shouldCallLimitHandlerImmediatelyIfLimitZero() {
+    // Given:
+    callback = new LimitedQueueCallback(0);
+
+    // When:
+    callback.setLimitHandler(limitHandler);
+
+    // Then:
+    verify(limitHandler).limitReached();
+  }
+
+  @Test
   public void shouldBeThreadSafe() {
     // Given:
     final int theLimit = 100;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/TransientQueryQueueTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/TransientQueryQueueTest.java
@@ -18,14 +18,12 @@ package io.confluent.ksql.query;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.query.TransientQueryQueue.QueuePopulator;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.OptionalInt;
@@ -33,20 +31,15 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
-import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.kstream.KStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-@SuppressWarnings("unchecked")
 @RunWith(MockitoJUnitRunner.class)
 public class TransientQueryQueueTest {
 
@@ -60,11 +53,6 @@ public class TransientQueryQueueTest {
 
   @Mock
   private LimitHandler limitHandler;
-  @Mock
-  private KStream<String, GenericRow> kStreamsApp;
-  @Captor
-  private ArgumentCaptor<QueuePopulator<String>> queuePopulatorCaptor;
-  private QueuePopulator<String> queuePopulator;
   private TransientQueryQueue queue;
   private ScheduledExecutorService executorService;
 
@@ -83,20 +71,17 @@ public class TransientQueryQueueTest {
   @Test
   public void shouldQueue() {
     // When:
-    queuePopulator.apply("key1", ROW_ONE);
-    queuePopulator.apply("key2", ROW_TWO);
+    queue.acceptRow(ROW_ONE);
+    queue.acceptRow(ROW_TWO);
 
     // Then:
-    assertThat(drainValues(), contains(
-        new KeyValue<>("key1", ROW_ONE),
-        new KeyValue<>("key2", ROW_TWO)
-    ));
+    assertThat(drainValues(), contains(ROW_ONE, ROW_TWO));
   }
 
   @Test
   public void shouldNotQueueNullValues() {
     // When:
-    queuePopulator.apply("key1", null);
+    queue.acceptRow(null);
 
     // Then:
     assertThat(queue.size(), is(0));
@@ -106,7 +91,7 @@ public class TransientQueryQueueTest {
   public void shouldQueueUntilLimitReached() {
     // When:
     IntStream.range(0, SOME_LIMIT + 2)
-        .forEach(idx -> queuePopulator.apply("key1", ROW_ONE));
+        .forEach(idx -> queue.acceptRow(ROW_ONE));
 
     // Then:
     assertThat(queue.size(), is(SOME_LIMIT));
@@ -115,22 +100,22 @@ public class TransientQueryQueueTest {
   @Test
   public void shouldPoll() throws Exception {
     // Given:
-    queuePopulator.apply("key1", ROW_ONE);
-    queuePopulator.apply("key2", ROW_TWO);
+    queue.acceptRow(ROW_ONE);
+    queue.acceptRow(ROW_TWO);
 
     // When:
-    final KeyValue<String, GenericRow> result = queue.poll(1, TimeUnit.SECONDS);
+    final GenericRow result = queue.poll(1, TimeUnit.SECONDS);
 
     // Then:
-    assertThat(result, is(new KeyValue<>("key1", ROW_ONE)));
-    assertThat(drainValues(), contains(new KeyValue<>("key2", ROW_TWO)));
+    assertThat(result, is(ROW_ONE));
+    assertThat(drainValues(), contains(ROW_TWO));
   }
 
   @Test
   public void shouldNotCallLimitHandlerIfLimitNotReached() {
     // When:
     IntStream.range(0, SOME_LIMIT - 1)
-        .forEach(idx -> queuePopulator.apply("key1", ROW_ONE));
+        .forEach(idx -> queue.acceptRow(ROW_ONE));
 
     // Then:
     verify(limitHandler, never()).limitReached();
@@ -140,7 +125,7 @@ public class TransientQueryQueueTest {
   public void shouldCallLimitHandlerAsLimitReached() {
     // When:
     IntStream.range(0, SOME_LIMIT)
-        .forEach(idx -> queuePopulator.apply("key1", ROW_ONE));
+        .forEach(idx -> queue.acceptRow(ROW_ONE));
 
     // Then:
     verify(limitHandler).limitReached();
@@ -150,7 +135,7 @@ public class TransientQueryQueueTest {
   public void shouldCallLimitHandlerOnlyOnce() {
     // When:
     IntStream.range(0, SOME_LIMIT + 1)
-        .forEach(idx -> queuePopulator.apply("key1", ROW_ONE));
+        .forEach(idx -> queue.acceptRow(ROW_ONE));
 
     // Then:
     verify(limitHandler, times(1)).limitReached();
@@ -162,12 +147,12 @@ public class TransientQueryQueueTest {
     givenQueue(OptionalInt.empty());
 
     IntStream.range(0, MAX_LIMIT)
-        .forEach(idx -> queuePopulator.apply("key1", ROW_ONE));
+        .forEach(idx -> queue.acceptRow(ROW_ONE));
 
     givenWillCloseQueueAsync();
 
     // When:
-    queuePopulator.apply("should not be queued", ROW_TWO);
+    queue.acceptRow(ROW_TWO);
 
     // Then: did not block and:
     assertThat(queue.size(), is(MAX_LIMIT));
@@ -179,17 +164,13 @@ public class TransientQueryQueueTest {
   }
 
   private void givenQueue(final OptionalInt limit) {
-    clearInvocations(kStreamsApp);
-    queue = new TransientQueryQueue(kStreamsApp, limit, MAX_LIMIT, 1);
+    queue = new TransientQueryQueue(limit, MAX_LIMIT, 1);
 
     queue.setLimitHandler(limitHandler);
-
-    verify(kStreamsApp).foreach(queuePopulatorCaptor.capture());
-    queuePopulator = queuePopulatorCaptor.getValue();
   }
 
-  private List<KeyValue<String, GenericRow>> drainValues() {
-    final List<KeyValue<String, GenericRow>> entries = new ArrayList<>();
+  private List<GenericRow> drainValues() {
+    final List<GenericRow> entries = new ArrayList<>();
     queue.drainTo(entries);
     return entries;
   }

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
@@ -431,6 +431,23 @@
         "message": "Window bounds column WINDOWSTART can only be used in the SELECT clause of windowed aggregations",
         "status": 400
       }
+    },
+    {
+      "name": "Zero limit",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "SELECT * FROM INPUT EMIT CHANGES LIMIT 0;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": "11", "value": {"id": 100}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`K` STRING, `ID` INTEGER"}},
+          {"finalMessage":"Limit Reached"}
+        ]}
+      ]
     }
   ]
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/PushQueryHandle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/PushQueryHandle.java
@@ -15,8 +15,8 @@
 
 package io.confluent.ksql.api.server;
 
+import io.confluent.ksql.query.BlockingRowQueue;
 import java.util.List;
-import java.util.OptionalInt;
 
 /**
  * Handle to a push query running in the engine
@@ -27,9 +27,9 @@ public interface PushQueryHandle {
 
   List<String> getColumnTypes();
 
-  OptionalInt getLimit();
-
   void start();
 
   void stop();
+
+  BlockingRowQueue getQueue();
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PushQueryPublisher.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PushQueryPublisher.java
@@ -30,7 +30,6 @@ import io.confluent.ksql.util.TransientQueryMetadata;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.apache.kafka.streams.KeyValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -87,12 +86,13 @@ class PushQueryPublisher implements Flow.Publisher<Collection<StreamedRow>> {
 
     @Override
     public Collection<StreamedRow> poll() {
-      final List<KeyValue<String, GenericRow>> rows = Lists.newLinkedList();
+      final List<GenericRow> rows = Lists.newLinkedList();
       queryMetadata.getRowQueue().drainTo(rows);
       if (rows.isEmpty()) {
         return null;
       } else {
-        return rows.stream().map(row -> StreamedRow.row(row.value))
+        return rows.stream()
+            .map(StreamedRow::row)
             .collect(Collectors.toCollection(Lists::newLinkedList));
       }
     }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriter.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import org.apache.kafka.streams.KeyValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,12 +71,12 @@ class QueryStreamWriter implements StreamingOutput {
       write(out, buildHeader());
 
       while (!connectionClosed && queryMetadata.isRunning() && !limitReached) {
-        final KeyValue<String, GenericRow> value = queryMetadata.getRowQueue().poll(
+        final GenericRow value = queryMetadata.getRowQueue().poll(
             disconnectCheckInterval,
             TimeUnit.MILLISECONDS
         );
         if (value != null) {
-          write(out, StreamedRow.row(value.value));
+          write(out, StreamedRow.row(value));
         } else {
           // If no new rows have been written, the user may have terminated the connection without
           // us knowing. Check by trying to write a single newline.
@@ -151,11 +150,11 @@ class QueryStreamWriter implements StreamingOutput {
   }
 
   private void drain(final OutputStream out) throws IOException {
-    final List<KeyValue<String, GenericRow>> rows = Lists.newArrayList();
+    final List<GenericRow> rows = Lists.newArrayList();
     queryMetadata.getRowQueue().drainTo(rows);
 
-    for (final KeyValue<String, GenericRow> row : rows) {
-      write(out, StreamedRow.row(row.value));
+    for (final GenericRow row : rows) {
+      write(out, StreamedRow.row(row));
     }
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -298,7 +298,8 @@ public class StreamedQueryResource implements KsqlConfigurable {
         query,
         disconnectCheckInterval.toMillis(),
         OBJECT_MAPPER,
-        connectionClosedFuture);
+        connectionClosedFuture
+    );
 
     log.info("Streaming query '{}'", statement.getStatementText());
     return EndpointResponse.ok(queryStreamWriter);


### PR DESCRIPTION
### Description 

A change went in a while ago that created a transient query without creating `TransientQueryMetadata`. Instead is inline-subclassed the abstract `QueryMetadata` class, and replicated the logic for handling limits.

The direct subclassing of `QueryMetadata` is not ideal. All transient queries should be `TransientQueryMetadata`.

The replication of the limit handling logical is also not ideal.

This change fixes both of these issues.


### Testing done 

`mvn verify`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

