### PR TITLE
chore: add internal request property to healthcheck requests

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgent.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgent.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.rest.server.ServerUtil;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.SimpleKsqlClient;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlRequestConfig;
 import io.confluent.ksql.util.ReservedInternalTopics;
 import java.net.URI;
 import java.util.Collections;
@@ -99,7 +100,10 @@ public class HealthCheckAgent {
     public HealthCheckResponseDetail check(final HealthCheckAgent healthCheckAgent) {
       final RestResponse<KsqlEntityList> response =
           healthCheckAgent.ksqlClient
-              .makeKsqlRequest(healthCheckAgent.serverEndpoint, ksqlStatement, ImmutableMap.of());
+              .makeKsqlRequest(
+                  healthCheckAgent.serverEndpoint,
+                  ksqlStatement,
+                  ImmutableMap.of(KsqlRequestConfig.KSQL_REQUEST_INTERNAL_REQUEST, true));
       return new HealthCheckResponseDetail(response.isSuccessful());
     }
   }


### PR DESCRIPTION
### Description 
The healthcheck agent should be issuing requests that indicate it's an internal request, this is so that the `show queries` request doesn't trigger a scatter gather.

### Testing done 
unit test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

