### PR TITLE
test: fix racy client test (MINOR)

### DIFF
--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertThrows;
 
 import io.confluent.ksql.api.BaseApiTest;
 import io.confluent.ksql.api.TestQueryPublisher;
+import io.confluent.ksql.api.client.impl.StreamedQueryResultImpl;
 import io.confluent.ksql.api.client.util.RowUtil;
 import io.confluent.ksql.api.server.KsqlApiException;
 import io.confluent.ksql.api.server.PushQueryId;
@@ -289,19 +290,21 @@ public class ClientTest extends BaseApiTest {
       streamedQueryResult.poll();
     }
 
-    CountDownLatch latch = new CountDownLatch(1);
+    CountDownLatch pollStarted = new CountDownLatch(1);
+    CountDownLatch pollReturned = new CountDownLatch(1);
     new Thread(() -> {
       // This poll() call blocks as there are no more rows to be returned
-      final Row row = streamedQueryResult.poll();
+      final Row row = StreamedQueryResultImpl.pollWithCallback(streamedQueryResult, () -> pollStarted.countDown());
       assertThat(row, is(nullValue()));
-      latch.countDown();
+      pollReturned.countDown();
     }).start();
+    awaitLatch(pollStarted);
 
     // When
     sendQueryPublisherError();
 
     // Then: poll() call terminates because of the error
-    assertThat(latch.await(2000, TimeUnit.MILLISECONDS), is(true));
+    awaitLatch(pollReturned);
   }
 
   @Test
@@ -512,7 +515,7 @@ public class ClientTest extends BaseApiTest {
       }
     };
     publisher.subscribe(subscriber);
-    assertThat(latch.await(2000, TimeUnit.MILLISECONDS), is(true));
+    awaitLatch(latch);
     return subscriber;
   }
 
@@ -521,6 +524,10 @@ public class ClientTest extends BaseApiTest {
     for (int i = 0; i < DEFAULT_JSON_ROWS.size(); i++) {
       verifyRowWithIndex(rows.get(i), i);
     }
+  }
+
+  private static void awaitLatch(CountDownLatch latch) throws Exception {
+    assertThat(latch.await(2000, TimeUnit.MILLISECONDS), is(true));
   }
 
   private static void verifyRowWithIndex(final Row row, final int index) {

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/StreamedQueryResultImplTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/StreamedQueryResultImplTest.java
@@ -110,17 +110,19 @@ public class StreamedQueryResultImplTest {
     // Poll for a minimal amount of time to ensure PollableSubscriber is subscribed
     queryResult.poll(1, TimeUnit.NANOSECONDS);
 
-    CountDownLatch latch = new CountDownLatch(1);
+    CountDownLatch pollStarted = new CountDownLatch(1);
+    CountDownLatch pollReturned = new CountDownLatch(1);
     new Thread(() -> {
-      queryResult.poll();
-      latch.countDown();
+      StreamedQueryResultImpl.pollWithCallback(queryResult, () -> pollStarted.countDown());
+      pollReturned.countDown();
     }).start();
+    awaitLatch(pollStarted);
 
     // When
     handleQueryResultError();
 
     // Then
-    awaitLatch(latch);
+    awaitLatch(pollReturned);
   }
 
   @Test


### PR DESCRIPTION
### Description 

A recently added test:
```
  @Test
  public void shouldReturnFromPollOnError() throws Exception {
    // Given
    // Poll for a minimal amount of time to ensure PollableSubscriber is subscribed
    queryResult.poll(1, TimeUnit.NANOSECONDS);

    CountDownLatch latch = new CountDownLatch(1);
    new Thread(() -> {
      queryResult.poll();
      latch.countDown();
    }).start();

    // When
    handleQueryResultError();

    // Then
    awaitLatch(latch);
  }
```
is flaky due to the following race condition: if `handleQueryResultError();` executes before the call to `queryResult.poll();` begins, then `queryResult.poll();` will fail and the test will fail. However, ensuring that the call to `queryResult.poll();` begins before `handleQueryResultError();` is called is nontrivial since `queryResult.poll();` is a blocking call that will only terminate once `handleQueryResultError();` has executed. (The purpose of the test is to ensure that `handleQueryResultError();` indeed causes `queryResult.poll();` to unblock.)

This PR fixes the race condition by adding a test-only version of `queryResult.poll()` that executes a callback once sufficiently far into the `poll()` call. This feels really ugly / hacky, and is also somewhat brittle since the test is no longer exercising exactly the method it's testing, but I can't think of a better solution. Suggestions appreciated!

### Testing done 

Tests continue to pass, flakiness is resolved.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

