### PR TITLE
feat(client): support push query termination in Java client

### DIFF
--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/Client.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/Client.java
@@ -64,6 +64,8 @@ public interface Client {
 
   Publisher<InsertAck> streamInserts(String streamName, Publisher<List<Object>> insertsPublisher);
 
+  CompletableFuture<Void> terminatePushQuery(String queryId);
+
   void close();
 
   static Client create(ClientOptions clientOptions) {


### PR DESCRIPTION
### Description 

^ via the `/close-query` endpoint. This PR also adds a test to check that `StreamedQueryResult` objects are properly completed when the underlying query is terminated.

### Testing done 

Unit tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

