### PR TITLE
docs: improved docs around listener config

### DIFF
--- a/docs/operate-and-deploy/installation/server-config/config-reference.md
+++ b/docs/operate-and-deploy/installation/server-config/config-reference.md
@@ -423,7 +423,7 @@ is `KSQL_LISTENERS`.
 The `ksql.internal.listener` setting controls the address bound for use by internal,
 intra-cluster communication.
 
-If not set, the internal listener default to the first listener defined by `listeners`.
+If not set, the internal listener defaults to the first listener defined by `listeners`.
 
 This setting is most often useful in a IaaS environment to separate external-facing
 traffic from internal traffic.

--- a/docs/operate-and-deploy/installation/server-config/config-reference.md
+++ b/docs/operate-and-deploy/installation/server-config/config-reference.md
@@ -432,7 +432,7 @@ traffic from internal traffic.
 
 This is the URL used for inter-node communication.  Unlike `listeners` or `ksql.internal.listener`,
 this configuration doesn't create a listener. Instead, it is used to set an externally routable
-url that other ksqlDB nodes will use to communicate with this node. It only needs to be set if
+URL that other ksqlDB nodes will use to communicate with this node. It only needs to be set if
 the internal listener is not externally resolvable or routable.
 
 If not set, the default is to use the internal listener, as controlled by `ksql.internal.listener`.

--- a/docs/operate-and-deploy/installation/server-config/config-reference.md
+++ b/docs/operate-and-deploy/installation/server-config/config-reference.md
@@ -406,6 +406,9 @@ listeners=http://[::]:8088
 
 # Bind only to localhost.
 listeners=http://localhost:8088
+
+# Bind to specific hostname or ip.
+listeners=http://server1245:8088
 ```
 
 You can configure ksqlDB Server to use HTTPS. For more information, see
@@ -415,19 +418,32 @@ The corresponding environment variable in the
 [ksqlDB Server image](https://hub.docker.com/r/confluentinc/ksqldb-server/)
 is `KSQL_LISTENERS`.
 
-### ksql.advertised.listener
-
-This is the url used for inter-node communication.  Unlike `listeners` or `ksql.internal.listener`, this configuration doesn't create a listener.
-
 ### ksql.internal.listener
 
-The `ksql.internal.listener ` setting controls the address bound for use by internal,
-intra-cluster endpoints.  These include forwarded pull queries, heartbeating, and lag reporting.
+The `ksql.internal.listener` setting controls the address bound for use by internal,
+intra-cluster communication.
 
-If not set, the system will use `listeners` to expose internal endpoints.
+If not set, the internal listener default to the first listener defined by `listeners`.
 
 This setting is most often useful in a IaaS environment to separate external-facing
-trafic from internal traffic.
+traffic from internal traffic.
+
+### ksql.advertised.listener
+
+This is the url used for inter-node communication.  Unlike `listeners` or `ksql.internal.listener`,
+this configuration doesn't create a listener. Instead, it is used to set an externally routable
+url that other ksqlDB nodes will use to communicate with this node. It only needs to be set if
+the internal listener is not externally resolvable or routable.
+
+If not set, the default is to use the internal listener, as controlled by `ksql.internal.listener`.
+
+If the `ksql.internal.listener` resolves, either by being explicitly set or from the default first
+url in `listeners`, to a url using `localhost`, a wildcard ip such as `0.0.0.0`, or a hostname that
+other ksqlDB nodes can either not resolve, or can not route requests to, then
+`ksql.advertised.listeners` should be set to a url that can.
+
+See [Configuring Listeners of a ksqlDB Cluster](./index.md#configuringlisteners-of-a-ksqldb-cluster)
+for more info.
 
 ### ksql.metrics.tags.custom
 

--- a/docs/operate-and-deploy/installation/server-config/config-reference.md
+++ b/docs/operate-and-deploy/installation/server-config/config-reference.md
@@ -435,7 +435,7 @@ this configuration doesn't create a listener. Instead, it is used to set an exte
 URL that other ksqlDB nodes will use to communicate with this node. It only needs to be set if
 the internal listener is not externally resolvable or routable.
 
-If not set, the default is to use the internal listener, as controlled by `ksql.internal.listener`.
+If not set, the default behavior is to use the internal listener, which is controlled by `ksql.internal.listener`.
 
 If the `ksql.internal.listener` resolves, either by being explicitly set or from the default first
 url in `listeners`, to a url using `localhost`, a wildcard ip such as `0.0.0.0`, or a hostname that

--- a/docs/operate-and-deploy/installation/server-config/config-reference.md
+++ b/docs/operate-and-deploy/installation/server-config/config-reference.md
@@ -437,14 +437,11 @@ the internal listener is not externally resolvable or routable.
 
 If not set, the default behavior is to use the internal listener, which is controlled by `ksql.internal.listener`.
 
-If `ksql.internal.listener` resolves to a URL that uses `localhost`,  a wildcard IP address, like `0.0.0.0`, or a
-hostname that other ksqlDB nodes either can't resolve or can't route requests to, 
-set `ksql.advertised.listeners` to a URL that ksqlDB nodes can resolve.
-other ksqlDB nodes can either not resolve, or can not route requests to, then
-`ksql.advertised.listeners` should be set to a url that can.
+If `ksql.internal.listener` resolves to a URL that uses `localhost`, a wildcard IP address,
+like `0.0.0.0`, or a hostname that other ksqlDB nodes either can't resolve or can't route requests
+to, set `ksql.advertised.listeners` to a URL that ksqlDB nodes can resolve.
 
-See [Configuring Listeners of a ksqlDB Cluster](./index.md#configuringlisteners-of-a-ksqldb-cluster)
-for more info.
+For more information, see [Configuring Listeners of a ksqlDB Cluster](./index.md#configuring-listeners-of-a-ksqldb-cluster)
 
 ### ksql.metrics.tags.custom
 

--- a/docs/operate-and-deploy/installation/server-config/config-reference.md
+++ b/docs/operate-and-deploy/installation/server-config/config-reference.md
@@ -437,7 +437,8 @@ the internal listener is not externally resolvable or routable.
 
 If not set, the default behavior is to use the internal listener, which is controlled by `ksql.internal.listener`.
 
-If the `ksql.internal.listener` resolves, either by being explicitly set or from the default first
+If `ksql.internal.listener` resolves to a URL that uses `localhost`,  a wildcard IP address, like `0.0.0.0`, or a
+hostname that other ksqlDB nodes either can't resolve or can't route requests to, 
 url in `listeners`, to a url using `localhost`, a wildcard ip such as `0.0.0.0`, or a hostname that
 other ksqlDB nodes can either not resolve, or can not route requests to, then
 `ksql.advertised.listeners` should be set to a url that can.

--- a/docs/operate-and-deploy/installation/server-config/config-reference.md
+++ b/docs/operate-and-deploy/installation/server-config/config-reference.md
@@ -439,7 +439,7 @@ If not set, the default behavior is to use the internal listener, which is contr
 
 If `ksql.internal.listener` resolves to a URL that uses `localhost`,  a wildcard IP address, like `0.0.0.0`, or a
 hostname that other ksqlDB nodes either can't resolve or can't route requests to, 
-url in `listeners`, to a url using `localhost`, a wildcard ip such as `0.0.0.0`, or a hostname that
+set `ksql.advertised.listeners` to a URL that ksqlDB nodes can resolve.
 other ksqlDB nodes can either not resolve, or can not route requests to, then
 `ksql.advertised.listeners` should be set to a url that can.
 

--- a/docs/operate-and-deploy/installation/server-config/config-reference.md
+++ b/docs/operate-and-deploy/installation/server-config/config-reference.md
@@ -430,7 +430,7 @@ traffic from internal traffic.
 
 ### ksql.advertised.listener
 
-This is the url used for inter-node communication.  Unlike `listeners` or `ksql.internal.listener`,
+This is the URL used for inter-node communication.  Unlike `listeners` or `ksql.internal.listener`,
 this configuration doesn't create a listener. Instead, it is used to set an externally routable
 url that other ksqlDB nodes will use to communicate with this node. It only needs to be set if
 the internal listener is not externally resolvable or routable.

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -427,7 +427,7 @@ ksql.advertised.listener=http://host1.internal.example.com:8099
 !!! note
     Only the `ksql.advertised.listener` needs to be resolvable and routable from servers running
     other nodes in the cluster. The `listener` configuration can be non-resolvable and non-routable,
-    as clients' can connect using whatever url you choose, and `ksql.internal.listener` is only used
+    because clients can connect using whatever URL you choose, and `ksql.internal.listener` is only used
     to start the listener.
 
 In this setup, the node shares the url in the `ksql.advertised.listener` config as its

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -409,7 +409,7 @@ communication will use a different listener to client communication.
 
 Where the internal IP or hostname used in the `ksql.internal.listener` configuration is not
 externally resolvable and routable, for example where it uses `localhost` or wildcard IPs such as
-`0.0.0.0` or `[::]`, both `ksql.internal.listener` and `ksql.advertised.listener` need to configured
+`0.0.0.0` or `[::]`, you must configure both `ksql.internal.listener` and `ksql.advertised.listener`
 to set the internal listener:
 
 ```properties

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -399,7 +399,7 @@ ksql.internal.listener=https://192.168.1.102:8088
 !!! note
     Only the `ksql.internal.listener` needs to be resolvable and routable from servers running other
     nodes in the cluster. The `listener` configuration can be non-resolvable and non-routable, because
-    clients' can connect using whatever url you choose.
+    clients can connect using whatever URL you choose.
 
 In this setup, the node shares the URL in the `ksql.internal.listener` config as its
 internal endpoint, which other nodes use for inter-node communication. Inter-node

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -373,7 +373,7 @@ communication will use the same listener as client communication.
 ### Dual listeners
 
 You may choose to configure internal communication to use a different listener to client
-ommunication, which allows for port filtering rules to deny clients access the internal listener, or
+communication, which enables port filtering rules to deny clients access the internal listener or
 the use of a different network interface for internal communication, for security or QoS reasons.
 
 This can be achieved by setting the `ksql.internal.listener` configuration to start a second

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -351,7 +351,7 @@ use the same listener as client communication.
 #### Single non-routable listener
 
 It's common to set up a service using special hostnames, like `localhost`, or wildcard addresses,
-such as `0.0.0.0` or `[::]`. These have special meanings and are not appropriate for
+like `0.0.0.0` or `[::]`. These special hostnames have special meanings and are not appropriate for
 inter-node communication, as they are not routable from other machines. Similarly, if your
 network is setup such that the IP or hostname you bind isn't resolvable or routable.
 

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -356,7 +356,7 @@ inter-node communication, because they're not routable from other machines. This
 network is set up such that the IP or hostname you bind isn't resolvable or routable.
 
 If you choose to use a non-routable listener, you must set `ksql.advertised.listener` and specify a
-url that is externally accessible and which will resolve to an endpoint defined in `listeners`.
+URL that is externally accessible and which resolves to an endpoint defined in `listeners`.
 
 ```properties
 # Non-routable wildcard ip:

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -352,7 +352,7 @@ use the same listener as client communication.
 
 It's common to set up a service using special hostnames, like `localhost`, or wildcard addresses,
 like `0.0.0.0` or `[::]`. These special hostnames have special meanings and are not appropriate for
-inter-node communication, as they are not routable from other machines. Similarly, if your
+inter-node communication, because they're not routable from other machines. This is also the case if your
 network is setup such that the IP or hostname you bind isn't resolvable or routable.
 
 If you choose to use a non-routable listener, you must set `ksql.advertised.listener` and specify a

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -420,7 +420,7 @@ listeners=https://0.0.0.0:8088
 # Note: port 8099 could be locked down using port forward or other network tools.
 ksql.internal.listener=https://0.0.0.0:8099
 
-# Url that other nodes can resolve and use to route requests to this node:
+# URL that other nodes can resolve and use to route requests to this node:
 ksql.advertised.listener=http://host1.internal.example.com:8099
 ```
 

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -377,7 +377,7 @@ communication, which enables port filtering rules to deny clients access the int
 the use of a different network interface for internal communication, for security or QoS reasons.
 
 This can be achieved by setting the `ksql.internal.listener` configuration to start a second
-listener that will exclusively used for inter-node communication.
+listener that is used exclusively for inter-node communication.
 
 If running dual listeners to improve security, you may also wish to enable
 [authentication and other security measures](security.md).

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -366,7 +366,7 @@ listeners=http://0.0.0.0:8088
 ksql.advertised.listener=http://host1.internal.example.com:8088
 ```
 
-In this setup, the node will share the url in the `ksql.advertised.listener` config as its
+In this setup, the node shares the URL in the `ksql.advertised.listener` config as its
 internal endpoint, which other nodes will use for inter-node communication. Inter-node
 communication will use the same listener as client communication.
 

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -398,7 +398,7 @@ ksql.internal.listener=https://192.168.1.102:8088
 
 !!! note
     Only the `ksql.internal.listener` needs to be resolvable and routable from servers running other
-    nodes in the cluster. The `listener` configuration can be non-resolvable and non-routable, as
+    nodes in the cluster. The `listener` configuration can be non-resolvable and non-routable, because
     clients' can connect using whatever url you choose.
 
 In this setup, the node will share the url in the `ksql.internal.listener` config as its

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -355,7 +355,7 @@ such as `0.0.0.0` or `[::]`. These have special meanings and are not appropriate
 inter-node communication, as they are not routable from other machines. Similarly, if your
 network is setup such that the IP or hostname you bind isn't resolvable or routable.
 
-If you choose to use a non-routable listener, you must set `ksql.advertised.listener`, specifying a
+If you choose to use a non-routable listener, you must set `ksql.advertised.listener` and specify a
 url that is externally accessible and which will resolve to an endpoint defined in `listeners`.
 
 ```properties

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -407,7 +407,7 @@ communication uses a different listener to client communication.
 
 #### Dual non-routable listeners
 
-Where the internal IP or hostname used in the `ksql.internal.listener` configuration is not
+If the internal IP address or hostname used in the `ksql.internal.listener` configuration is not
 externally resolvable and routable, for example where it uses `localhost` or wildcard IPs such as
 `0.0.0.0` or `[::]`, you must configure both `ksql.internal.listener` and `ksql.advertised.listener`
 to set the internal listener:

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -385,7 +385,7 @@ If you're running dual listeners to improve security, you may also wish to enabl
 #### Dual routable listeners
 
 If the internal IP address or hostname used in the `ksql.internal.listener` configuration is externally
-resolvable and routable, only `ksql.internal.listener` needs to configured to set the internal
+resolvable and routable, you only need to configure `ksql.internal.listener` to set the internal
 listener, for example:
 
 ```properties

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -430,6 +430,6 @@ ksql.advertised.listener=http://host1.internal.example.com:8099
     as clients' can connect using whatever url you choose, and `ksql.internal.listener` is only used
     to start the listener.
 
-In this setup, the node will share the url in the `ksql.advertised.listener` config as its
+In this setup, the node shares the url in the `ksql.advertised.listener` config as its
 internal endpoint, which other nodes use for inter-node communication. Inter-node
 communication will use a different listener to client communication.

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -403,7 +403,7 @@ ksql.internal.listener=https://192.168.1.102:8088
 
 In this setup, the node will share the url in the `ksql.internal.listener` config as its
 internal endpoint, which other nodes will use for inter-node communication. Inter-node
-communication will use a different listener to client communication.
+communication uses a different listener to client communication.
 
 #### Dual non-routable listeners
 

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -368,7 +368,7 @@ ksql.advertised.listener=http://host1.internal.example.com:8088
 
 In this setup, the node shares the URL in the `ksql.advertised.listener` config as its
 internal endpoint, which other nodes use for inter-node communication. Inter-node
-communication will use the same listener as client communication.
+communication use the same listener as client communication.
 
 ### Dual listeners
 

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -402,7 +402,7 @@ ksql.internal.listener=https://192.168.1.102:8088
     clients' can connect using whatever url you choose.
 
 In this setup, the node shares the URL in the `ksql.internal.listener` config as its
-internal endpoint, which other nodes will use for inter-node communication. Inter-node
+internal endpoint, which other nodes use for inter-node communication. Inter-node
 communication uses a different listener to client communication.
 
 #### Dual non-routable listeners

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -431,5 +431,5 @@ ksql.advertised.listener=http://host1.internal.example.com:8099
     to start the listener.
 
 In this setup, the node will share the url in the `ksql.advertised.listener` config as its
-internal endpoint, which other nodes will use for inter-node communication. Inter-node
+internal endpoint, which other nodes use for inter-node communication. Inter-node
 communication will use a different listener to client communication.

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -353,7 +353,7 @@ use the same listener as client communication.
 It's common to set up a service using special hostnames, like `localhost`, or wildcard addresses,
 like `0.0.0.0` or `[::]`. These special hostnames have special meanings and are not appropriate for
 inter-node communication, because they're not routable from other machines. This is also the case if your
-network is setup such that the IP or hostname you bind isn't resolvable or routable.
+network is set up such that the IP or hostname you bind isn't resolvable or routable.
 
 If you choose to use a non-routable listener, you must set `ksql.advertised.listener` and specify a
 url that is externally accessible and which will resolve to an endpoint defined in `listeners`.

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -345,7 +345,7 @@ listeners=https://192.168.1.101:8088
 ```
 
 In this setup, the node shares the first URL in the `listeners` config as its internal
-endpoint, which other nodes will use for inter-node communication. Inter-node communication will
+endpoint, which other nodes use for inter-node communication. Inter-node communication
 use the same listener as client communication.
 
 #### Single non-routable listener

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -344,7 +344,7 @@ listeners=https://ksqlHost56:8088
 listeners=https://192.168.1.101:8088
 ```
 
-In this setup, the node will share the first url in the `listeners` config as its internal
+In this setup, the node shares the first URL in the `listeners` config as its internal
 endpoint, which other nodes will use for inter-node communication. Inter-node communication will
 use the same listener as client communication.
 

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -432,4 +432,4 @@ ksql.advertised.listener=http://host1.internal.example.com:8099
 
 In this setup, the node shares the url in the `ksql.advertised.listener` config as its
 internal endpoint, which other nodes use for inter-node communication. Inter-node
-communication will use a different listener to client communication.
+communication uses a different listener to client communication.

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -362,7 +362,7 @@ url that is externally accessible and which will resolve to an endpoint defined 
 # Non-routable wildcard ip:
 listeners=http://0.0.0.0:8088
 
-# External accessible name that will resolve to the IP of the machine:
+# Externally accessible name that resolves to the IP of the machine:
 ksql.advertised.listener=http://host1.internal.example.com:8088
 ```
 

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -324,7 +324,7 @@ ksql.service.id=my_application_
 Once formed, many operations can be run using the client APIs exposed on `listeners`.
 
 In order to utilize pull queries and their high availability functionality, the nodes within the
-cluster must be able to communication with each other. KsqlDB supports setups with either a single
+cluster must be able to communicate with each other. ksqlDB supports setups with either a single
 shared listener for both client and internal communication, or dual single-purpose listeners. The
 following describes how to configure listeners depending on the nature of your environment and
 requirements.

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -379,7 +379,7 @@ the use of a different network interface for internal communication, for securit
 This can be achieved by setting the `ksql.internal.listener` configuration to start a second
 listener that is used exclusively for inter-node communication.
 
-If running dual listeners to improve security, you may also wish to enable
+If you're running dual listeners to improve security, you may also wish to enable
 [authentication and other security measures](security.md).
 
 #### Dual routable listeners

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -310,83 +310,126 @@ Start the ksqlDB server with the configuration file specified.
 <path-to-confluent>/bin/ksql-server-start <path-to-confluent>/etc/ksqldb/ksql-server.properties
 ```
 
-Configuring Listeners for a ksqlDB Cluster
---------------------------------
+Configuring Listeners of a ksqlDB Cluster
+------------------------------------------
 
 Multiple hosts are required to scale ksqlDB processing power and to do that, they must
 form a cluster.  ksqlDB requires all hosts of a cluster to use the same `ksql.service.id`.
 
 ```properties
-bootstrap.servers=localhost:9092
+bootstrap.servers=kafkaBroker1:9092,kafkaBroker2:9092
 ksql.service.id=my_application_
 ```
 
 Once formed, many operations can be run using the client APIs exposed on `listeners`.
 
-In order to utilize pull queries and their high availability functionality,
-the hosts within the cluster must be configured to speak to each other via their
-internal endpoints. The following describes how to configure listeners depending on
-the nature of your environment.
+In order to utilize pull queries and their high availability functionality, the nodes within the
+cluster must be able to communication with each other. KsqlDB supports setups with either a single
+shared listener for both client and internal communication, or dual single-purpose listeners. The
+following describes how to configure listeners depending on the nature of your environment and
+requirements.
 
-### Listener Uses a Routable IP Address
+### Single listener
 
-If you want to configure your listener with an expicit IP address that is reachable
-within the cluster, you might do the following:
+#### Single routable listener
+
+If you want to configure your listener with an IP address or hostname that is resolvable and
+routable from within the cluster, you might do the following:
 
 ```properties
-listeners=http://192.168.1.101:8088
+# Hostname that other nodes can resolve to an routable IP:
+listeners=https://ksqlHost56:8088
+
+# Or, routable IP address:
+listeners=https://192.168.1.101:8088
 ```
 
-This listener will bind the client and internal endpoints to the given address, which
-will also be utilized by inter-node communication.
+In this setup, the node will share the first url in the `listeners` config as its internal
+endpoint, which other nodes will use for inter-node communication. Inter-node communication will
+use the same listener as client communication.
 
-### Listener Uses a Special or Unroutable Address
+#### Single non-routable listener
 
-It's common to setup a service using special hostnames such as `localhost` or special
-addresses such as `0.0.0.0`.  Both have special meanings and are not appropriate for
-inter-node commmunication.  Similarly, if your network is setup such that the IP you
-bind isn't routeable, it's also not appropriate.  If you choose to use such a listener,
-you must set `ksql.advertised.listener` specifying which address to use:
+It's common to setup a service using special hostnames such as `localhost` or wildcard addresses
+such as `0.0.0.0` or `[::]`. These have special meanings and are not appropriate for
+inter-node communication, as they are not routable from other machines. Similarly, if your
+network is setup such that the IP or hostname you bind isn't resolvable or routable.
+
+If you choose to use a non-routable listener, you must set `ksql.advertised.listener`, specifying a
+url that is externally accessible and which will resolve to an endpoint defined in `listeners`.
 
 ```properties
+# Non-routable wildcard ip:
 listeners=http://0.0.0.0:8088
+
+# External accessible name that will resolve to the IP of the machine:
 ksql.advertised.listener=http://host1.internal.example.com:8088
 ```
 
-This listener will bind the client and internal endpoints to the given address.  Now
-inter-node communication will explicity use the other address 
-`http://host1.internal.example.com:8088`.
+In this setup, the node will share the url in the `ksql.advertised.listener` config as its
+internal endpoint, which other nodes will use for inter-node communication. Inter-node
+communication will use the same listener as client communication.
 
-### Listener Binds Client and Internal Listeners Separately
+### Dual listeners
 
-If ksqlDB is being run in an environment where you require more security, you first
-want to enable [authentication and other security measures](security.md).  Secondly,
-you may choose to configure internal endpoints to be bound using a separate listener
-from the client endpoints. This allows for port filtering, to make internal endpoints
-unreachable beyond the internal network of the cluster, based on the port bound.
-Similarly, it allows for the use of dual network interfaces where one is public facing,
-and the other is cluster facing.  Both measures can used to add additional security to
-your configuration.  To do this, you can set a separate listener for inter-node
-communication `ksql.internal.listener`:
+You may choose to configure internal communication to use a different listener to client
+ommunication, which allows for port filtering rules to deny clients access the internal listener, or
+the use of a different network interface for internal communication, for security or QoS reasons.
+
+This can be achieved by setting the `ksql.internal.listener` configuration to start a second
+listener that will exclusively used for inter-node communication.
+
+If running dual listeners to improve security, you may also wish to enable
+[authentication and other security measures](security.md).
+
+#### Dual routable listeners
+
+Where the internal IP or hostname used in the `ksql.internal.listener` configuration is externally
+resolvable and routable, only `ksql.internal.listener` needs to configured to set the internal
+listener, for example:
 
 ```properties
+# Client listener:
 listeners=https://192.168.1.101:8088
-# Port 8099 is available only to the trusted internal network
-ksql.internal.listener=https://192.168.1.101:8099
+
+# Inter-node listener on different NIC:
+ksql.internal.listener=https://192.168.1.102:8088
 ```
 
-Now, `listener` will bind the client endpoints, while `ksql.internal.listener` binds
-the internal ones.  Also, inter-node communication will now utilize the addess from 
-`ksql.internal.listener`.
+!!! note
+    Only the `ksql.internal.listener` needs to be resolvable and routable from servers running other
+    nodes in the cluster. The `listener` configuration can be non-resolvable and non-routable, as
+    clients' can connect using whatever url you choose.
 
+In this setup, the node will share the url in the `ksql.internal.listener` config as its
+internal endpoint, which other nodes will use for inter-node communication. Inter-node
+communication will use a different listener to client communication.
 
-### Listener Binds Client and Internal Listeners Separately With Special Addresses
+#### Dual non-routable listeners
 
-This combines two of the previous configurations:
+Where the internal IP or hostname used in the `ksql.internal.listener` configuration is not
+externally resolvable and routable, for example where it uses `localhost` or wildcard IPs such as
+`0.0.0.0` or `[::]`, both `ksql.internal.listener` and `ksql.advertised.listener` need to configured
+to set the internal listener:
 
 ```properties
+# Client listener:
 listeners=https://0.0.0.0:8088
-# Port 8099 is available only to the trusted internal network
+
+# Inter-node listener on wildcard address and different port:
+# Note: port 8099 could be locked down using port forward or other network tools.
 ksql.internal.listener=https://0.0.0.0:8099
+
+# Url that other nodes can resolve and use to route requests to this node:
 ksql.advertised.listener=http://host1.internal.example.com:8099
 ```
+
+!!! note
+    Only the `ksql.advertised.listener` needs to be resolvable and routable from servers running
+    other nodes in the cluster. The `listener` configuration can be non-resolvable and non-routable,
+    as clients' can connect using whatever url you choose, and `ksql.internal.listener` is only used
+    to start the listener.
+
+In this setup, the node will share the url in the `ksql.advertised.listener` config as its
+internal endpoint, which other nodes will use for inter-node communication. Inter-node
+communication will use a different listener to client communication.

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -384,7 +384,7 @@ If you're running dual listeners to improve security, you may also wish to enabl
 
 #### Dual routable listeners
 
-Where the internal IP or hostname used in the `ksql.internal.listener` configuration is externally
+If the internal IP address or hostname used in the `ksql.internal.listener` configuration is externally
 resolvable and routable, only `ksql.internal.listener` needs to configured to set the internal
 listener, for example:
 

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -401,7 +401,7 @@ ksql.internal.listener=https://192.168.1.102:8088
     nodes in the cluster. The `listener` configuration can be non-resolvable and non-routable, because
     clients' can connect using whatever url you choose.
 
-In this setup, the node will share the url in the `ksql.internal.listener` config as its
+In this setup, the node shares the URL in the `ksql.internal.listener` config as its
 internal endpoint, which other nodes will use for inter-node communication. Inter-node
 communication uses a different listener to client communication.
 

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -346,7 +346,7 @@ listeners=https://192.168.1.101:8088
 
 In this setup, the node shares the first URL in the `listeners` config as its internal
 endpoint, which other nodes use for inter-node communication. Inter-node communication
-use the same listener as client communication.
+uses the same listener as client communication.
 
 #### Single non-routable listener
 

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -350,7 +350,7 @@ use the same listener as client communication.
 
 #### Single non-routable listener
 
-It's common to setup a service using special hostnames such as `localhost` or wildcard addresses
+It's common to set up a service using special hostnames, like `localhost`, or wildcard addresses,
 such as `0.0.0.0` or `[::]`. These have special meanings and are not appropriate for
 inter-node communication, as they are not routable from other machines. Similarly, if your
 network is setup such that the IP or hostname you bind isn't resolvable or routable.

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -367,7 +367,7 @@ ksql.advertised.listener=http://host1.internal.example.com:8088
 ```
 
 In this setup, the node shares the URL in the `ksql.advertised.listener` config as its
-internal endpoint, which other nodes will use for inter-node communication. Inter-node
+internal endpoint, which other nodes use for inter-node communication. Inter-node
 communication will use the same listener as client communication.
 
 ### Dual listeners

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -326,7 +326,7 @@ Once formed, many operations can be run using the client APIs exposed on `listen
 In order to utilize pull queries and their high availability functionality, the nodes within the
 cluster must be able to communicate with each other. ksqlDB supports setups with either a single
 shared listener for both client and internal communication, or dual single-purpose listeners. The
-following describes how to configure listeners depending on the nature of your environment and
+following section describes how to configure listeners depending on the nature of your environment and
 requirements.
 
 ### Single listener


### PR DESCRIPTION
### Description 

Hopefully add more improvements to the docs improvements @AlanConfluent already made around the listener config. 
 
* fixed some spelling mistakes.
* hopefully added more clarification of _when_ the advertised listener config should be set.
* added a link from the config help page to the new, more detailed, docs Alan added
* hopefully made it clear that resolvable hostnames can be used as an alternative to IP addresses.
* Added a "In this setup..." paragraph to each of the four configurations to more easily allow comparison.


