### PR TITLE
feat: expose JMX metric that classifies an error state

### DIFF
--- a/config/ksql-server.properties
+++ b/config/ksql-server.properties
@@ -56,7 +56,7 @@ ksql.logging.processing.stream.auto.create=true
 #------ External service config -------
 
 # The set of Kafka brokers to bootstrap Kafka cluster information from:
-bootstrap.servers=localhost:9092
+bootstrap.servers=localhost:29092
 
 # uncomment the below to start an embedded Connect worker
 # ksql.connect.worker.config=config/connect.properties

--- a/config/ksql-server.properties
+++ b/config/ksql-server.properties
@@ -56,7 +56,7 @@ ksql.logging.processing.stream.auto.create=true
 #------ External service config -------
 
 # The set of Kafka brokers to bootstrap Kafka cluster information from:
-bootstrap.servers=localhost:29092
+bootstrap.servers=localhost:9092
 
 # uncomment the below to start an embedded Connect worker
 # ksql.connect.worker.config=config/connect.properties

--- a/ksqldb-common/src/main/java/io/confluent/ksql/query/ErrorStateListener.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/query/ErrorStateListener.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.query;
+
+import org.apache.kafka.streams.KafkaStreams.StateListener;
+
+/**
+ * An extension of {@link StateListener} which can also react
+ * to classified uncaught errors, represented by {@link QueryError}.
+ */
+public interface ErrorStateListener extends StateListener {
+
+  /**
+   * This method will be called whenever the underlying application
+   * throws an uncaught exception.
+   *
+   * @param error the error that occurred
+   */
+  void onError(QueryError error);
+
+}

--- a/ksqldb-common/src/main/java/io/confluent/ksql/query/QueryError.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/query/QueryError.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.query;
+
+import java.util.Objects;
+
+/**
+ * {@code QueryError} indicates additional information
+ * about a query error that originated from Kafka Streams.
+ */
+public final class QueryError {
+
+  private final Throwable error;
+  private final Type type;
+
+  public QueryError(final Throwable error, final Type type) {
+    this.error = Objects.requireNonNull(error, "e");
+    this.type = Objects.requireNonNull(type, "type");
+  }
+
+  public Throwable getError() {
+    return error;
+  }
+
+  public Type getType() {
+    return type;
+  }
+
+  /**
+   * Specifies the type of error.
+   */
+  public enum Type {
+    /**
+     * An error that can not be classified as any of the below.
+     */
+    UNKNOWN,
+
+    /**
+     * A {@code USER} error is something that is not recoverable
+     * by simple retries. Common errors in this category include
+     * out-of-band topic deletion or bad ACL configuration.
+     */
+    USER,
+
+    /**
+     * A {@code SYSTEM} error occurs when something in the
+     * environment causes the query to fail. This could be caused
+     * by timeouts when attempting to access the Kafka broker while
+     * it is temporarily unavailable. Retrying these queries are
+     * likely to remediate the issue.
+     */
+    SYSTEM
+  }
+
+}

--- a/ksqldb-common/src/main/java/io/confluent/ksql/query/QueryErrorClassifier.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/query/QueryErrorClassifier.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.query;
+
+import io.confluent.ksql.query.QueryError.Type;
+
+public interface QueryErrorClassifier {
+
+  QueryErrorClassifier DEFAULT_CLASSIFIER = e -> Type.UNKNOWN;
+
+  /**
+   * Classifies this error with a specific type
+   *
+   * @param e the error
+   * @return the classification
+   */
+  Type classify(Throwable e);
+
+  /**
+   * Chains two classifiers so that:
+   * <ol>
+   *   <li>If they classify the error in the same way, return that classification</li>
+   *   <li>If they classify the error differently and exactly one is classified as
+   *       {@link Type#UNKNOWN}, return the other classification.</li>
+   *   <li>If they classify the error differently and neither is classified as
+   *       {@link Type#UNKNOWN}, return {@link Type#UNKNOWN}</li>
+   * </ol>
+   *
+   * @param other the other classifier to chain
+   * @return a {@code QueryErrorClassifier} that chains both
+   */
+  default QueryErrorClassifier and(QueryErrorClassifier other) {
+    return e -> {
+      final Type first = this.classify(e);
+      final Type second = other.classify(e);
+
+      if (first == second) {
+        return first;
+      } else if (first == Type.UNKNOWN) {
+        return second;
+      } else if (second == Type.UNKNOWN) {
+        return first;
+      } else {
+        return Type.UNKNOWN;
+      }
+    };
+  }
+
+}

--- a/ksqldb-common/src/test/java/io/confluent/ksql/query/QueryErrorClassifierTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/query/QueryErrorClassifierTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.query;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.confluent.ksql.query.QueryError.Type;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class QueryErrorClassifierTest {
+
+  @Mock
+  private Throwable error;
+  @Mock
+  private QueryErrorClassifier classifierA;
+  @Mock
+  private QueryErrorClassifier classifierB;
+
+  @Before
+  public void setUp() {
+    when(classifierA.and(any())).thenCallRealMethod();
+  }
+
+  @Test
+  public void shouldChainUnknownUnknown() {
+    // Given:
+    when(classifierA.classify(any())).thenReturn(Type.UNKNOWN);
+    when(classifierB.classify(any())).thenReturn(Type.UNKNOWN);
+
+    // When:
+    final Type type = classifierA.and(classifierB).classify(error);
+
+    // Then:
+    assertThat(type, is(Type.UNKNOWN));
+  }
+
+  @Test
+  public void shouldChainUnknownSomething() {
+    // Given:
+    when(classifierA.classify(any())).thenReturn(Type.UNKNOWN);
+    when(classifierB.classify(any())).thenReturn(Type.USER);
+
+    // When:
+    final Type type = classifierA.and(classifierB).classify(error);
+
+    // Then:
+    assertThat(type, is(Type.USER));
+  }
+
+  @Test
+  public void shouldChainSomethingUnknown() {
+    // Given:
+    when(classifierA.classify(any())).thenReturn(Type.USER);
+    when(classifierB.classify(any())).thenReturn(Type.UNKNOWN);
+
+    // When:
+    final Type type = classifierA.and(classifierB).classify(error);
+
+    // Then:
+    assertThat(type, is(Type.USER));
+  }
+
+  @Test
+  public void shouldChainIdentical() {
+    // Given:
+    when(classifierA.classify(any())).thenReturn(Type.USER);
+    when(classifierB.classify(any())).thenReturn(Type.USER);
+
+    // When:
+    final Type type = classifierA.and(classifierB).classify(error);
+
+    // Then:
+    assertThat(type, is(Type.USER));
+  }
+
+  @Test
+  public void shouldChainDiffering() {
+    // Given:
+    when(classifierA.classify(any())).thenReturn(Type.USER);
+    when(classifierB.classify(any())).thenReturn(Type.SYSTEM);
+
+    // When:
+    final Type type = classifierA.and(classifierB).classify(error);
+
+    // Then:
+    assertThat(type, is(Type.UNKNOWN));
+  }
+
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsBuilderImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsBuilderImpl.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.query;
 
-import io.confluent.ksql.util.KafkaStreamsUncaughtExceptionHandler;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
@@ -41,7 +40,6 @@ public class KafkaStreamsBuilderImpl implements KafkaStreamsBuilder {
     props.putAll(conf);
     final Topology topology = builder.build(props);
     final KafkaStreams kafkaStreams = new KafkaStreams(topology, props, clientSupplier);
-    kafkaStreams.setUncaughtExceptionHandler(new KafkaStreamsUncaughtExceptionHandler());
     return new BuildResult(topology, kafkaStreams);
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/MissingTopicClassifier.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/MissingTopicClassifier.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.query;
+
+import io.confluent.ksql.query.QueryError.Type;
+import io.confluent.ksql.services.KafkaTopicClient;
+import java.util.Objects;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@code MissingTopicClassifier} classifies errors by querying the broker
+ * to check that all topics that the query relies on being accessible exist
+ * and are accessible
+ */
+public class MissingTopicClassifier implements QueryErrorClassifier {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MissingTopicClassifier.class);
+
+  private final Set<String> requiredTopics;
+  private final KafkaTopicClient topicClient;
+  private final String queryId;
+
+  public MissingTopicClassifier(
+      final String queryId,
+      final Set<String> requiredTopics,
+      final KafkaTopicClient topicClient
+  ) {
+    this.queryId = Objects.requireNonNull(queryId, "queryId");
+    this.requiredTopics = Objects.requireNonNull(requiredTopics, "requiredTopics");
+    this.topicClient = Objects.requireNonNull(topicClient, "topicClient");
+    LOG.info("Query {} requires topics {}", queryId, requiredTopics);
+  }
+
+  @Override
+  public Type classify(final Throwable e) {
+    LOG.warn("Attempting to classify error for {}", queryId, e);
+    for (String requiredTopic : requiredTopics) {
+      if (!topicClient.isTopicExists(requiredTopic)) {
+        LOG.warn("Query {} requires topic {} which cannot be found.", queryId, requiredTopic);
+        return Type.USER;
+      }
+    }
+
+    return Type.UNKNOWN;
+  }
+
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -23,6 +23,7 @@ import io.confluent.ksql.execution.streams.materialization.Materialization;
 import io.confluent.ksql.execution.streams.materialization.MaterializationProvider;
 import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.query.QueryErrorClassifier;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import java.util.Map;
@@ -63,7 +64,9 @@ public class PersistentQueryMetadata extends QueryMetadata {
       final Map<String, Object> streamsProperties,
       final Map<String, Object> overriddenProperties,
       final Consumer<QueryMetadata> closeCallback,
-      final long closeTimeout) {
+      final long closeTimeout,
+      final QueryErrorClassifier errorClassifier
+  ) {
     // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     super(
         statementString,
@@ -77,7 +80,9 @@ public class PersistentQueryMetadata extends QueryMetadata {
         overriddenProperties,
         closeCallback,
         closeTimeout,
-        id);
+        id,
+        errorClassifier
+    );
 
     this.resultTopic = requireNonNull(resultTopic, "resultTopic");
     this.sinkName = Objects.requireNonNull(sinkName, "sinkName");

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.util;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.BlockingRowQueue;
 import io.confluent.ksql.query.LimitHandler;
+import io.confluent.ksql.query.QueryErrorClassifier;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.util.KsqlConstants.KsqlQueryType;
@@ -64,8 +65,8 @@ public class TransientQueryMetadata extends QueryMetadata {
         overriddenProperties,
         closeCallback,
         closeTimeout,
-        new QueryId(queryApplicationId)
-    );
+        new QueryId(queryApplicationId),
+        QueryErrorClassifier.DEFAULT_CLASSIFIER);
     this.rowQueue = Objects.requireNonNull(rowQueue, "rowQueue");
 
     if (!logicalSchema.key().isEmpty()) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/KsqlEngineMetricsTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/KsqlEngineMetricsTest.java
@@ -281,7 +281,7 @@ public class KsqlEngineMetricsTest {
 
   private double getMetricValue(final String metricName) {
     final Metrics metrics = engineMetrics.getMetrics();
-    return Double.valueOf(
+    return Double.parseDouble(
         metrics.metric(
             metrics.metricName(
                 metricName, metricNamePrefix + METRIC_GROUP + "-query-stats", CUSTOM_TAGS)
@@ -301,7 +301,7 @@ public class KsqlEngineMetricsTest {
 
   private double getMetricValueLegacy(final String metricName) {
     final Metrics metrics = engineMetrics.getMetrics();
-    return Double.valueOf(
+    return Double.parseDouble(
         metrics.metric(
             metrics.metricName(
                 metricNamePrefix + metricName, METRIC_GROUP + "-query-stats")

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/QueryStateListenerTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/QueryStateListenerTest.java
@@ -28,6 +28,8 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.NullPointerTester;
+import io.confluent.ksql.query.QueryError;
+import io.confluent.ksql.query.QueryError.Type;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.Gauge;
 import org.apache.kafka.common.metrics.Metrics;
@@ -43,8 +45,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class QueryStateListenerTest {
 
-  private static final MetricName METRIC_NAME =
+  private static final MetricName METRIC_NAME_1 =
       new MetricName("bob", "g1", "d1", ImmutableMap.of());
+  private static final MetricName METRIC_NAME_2 =
+      new MetricName("dylan", "g1", "d1", ImmutableMap.of());
 
   @Mock
   private Metrics metrics;
@@ -54,7 +58,9 @@ public class QueryStateListenerTest {
 
   @Before
   public void setUp() {
-    when(metrics.metricName(any(), any(), any(), anyMap())).thenReturn(METRIC_NAME);
+    when(metrics.metricName(any(), any(), any(), anyMap()))
+        .thenReturn(METRIC_NAME_1)
+        .thenReturn(METRIC_NAME_2);
 
     listener = new QueryStateListener(metrics, "", "app-id");
   }
@@ -73,8 +79,12 @@ public class QueryStateListenerTest {
     verify(metrics).metricName("query-status", "ksql-queries",
         "The current status of the given query.",
         ImmutableMap.of("status", "app-id"));
+    verify(metrics).metricName("error-status", "ksql-queries",
+        "The current error status of the given query, if the state is in ERROR state",
+        ImmutableMap.of("status", "app-id"));
 
-    verify(metrics).addMetric(eq(METRIC_NAME), isA(Gauge.class));
+    verify(metrics).addMetric(eq(METRIC_NAME_1), isA(Gauge.class));
+    verify(metrics).addMetric(eq(METRIC_NAME_2), isA(Gauge.class));
   }
 
   @Test
@@ -91,6 +101,9 @@ public class QueryStateListenerTest {
     verify(metrics).metricName("query-status", groupPrefix + "ksql-queries",
         "The current status of the given query.",
         ImmutableMap.of("status", "app-id"));
+    verify(metrics).metricName("error-status", groupPrefix + "ksql-queries",
+        "The current error status of the given query, if the state is in ERROR state",
+        ImmutableMap.of("status", "app-id"));
   }
 
   @Test
@@ -99,7 +112,8 @@ public class QueryStateListenerTest {
     // Listener created in setup
 
     // Then:
-    assertThat(currentGaugeValue(), is("-"));
+    assertThat(currentGaugeValue(METRIC_NAME_1), is("-"));
+    assertThat(currentGaugeValue(METRIC_NAME_2), is("NO_ERROR"));
   }
 
   @Test
@@ -108,7 +122,16 @@ public class QueryStateListenerTest {
     listener.onChange(State.REBALANCING, State.RUNNING);
 
     // Then:
-    assertThat(currentGaugeValue(), is("REBALANCING"));
+    assertThat(currentGaugeValue(METRIC_NAME_1), is("REBALANCING"));
+  }
+
+  @Test
+  public void shouldUpdateOnError() {
+    // When:
+    listener.onError(new QueryError(new Throwable("foo"), Type.USER));
+
+    // Then:
+    assertThat(currentGaugeValue(METRIC_NAME_2), is("OPERATOR"));
   }
 
   @Test
@@ -117,11 +140,12 @@ public class QueryStateListenerTest {
     listener.close();
 
     // Then:
-    verify(metrics).removeMetric(METRIC_NAME);
+    verify(metrics).removeMetric(METRIC_NAME_1);
+    verify(metrics).removeMetric(METRIC_NAME_2);
   }
 
-  private String currentGaugeValue() {
-    verify(metrics).addMetric(any(), gaugeCaptor.capture());
+  private String currentGaugeValue(final MetricName name) {
+    verify(metrics).addMetric(eq(name), gaugeCaptor.capture());
     return gaugeCaptor.getValue().value(null, 0L);
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/QueryStateListenerTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/QueryStateListenerTest.java
@@ -131,7 +131,7 @@ public class QueryStateListenerTest {
     listener.onError(new QueryError(new Throwable("foo"), Type.USER));
 
     // Then:
-    assertThat(currentGaugeValue(METRIC_NAME_2), is("OPERATOR"));
+    assertThat(currentGaugeValue(METRIC_NAME_2), is("USER"));
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/MissingTopicClassifierTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/MissingTopicClassifierTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.query;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableSet;
+import io.confluent.ksql.query.QueryError.Type;
+import io.confluent.ksql.services.KafkaTopicClient;
+import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MissingTopicClassifierTest {
+
+  @Mock
+  private KafkaTopicClient topicClient;
+  @Mock
+  private Throwable error;
+
+  @Test
+  public void shouldClassifyMissingTopicAsUserError() {
+    // Given:
+    final Set<String> requiredTopics = ImmutableSet.of("A", "B");
+    when(topicClient.isTopicExists("A")).thenReturn(true);
+    when(topicClient.isTopicExists("B")).thenReturn(false);
+
+    // When:
+    final Type type = new MissingTopicClassifier("", requiredTopics, topicClient).classify(error);
+
+    // Then:
+    assertThat(type, is(Type.USER));
+  }
+
+  @Test
+  public void shouldClassifyNoMissingTopicAsUnknownError() {
+    // Given:
+    final Set<String> requiredTopics = ImmutableSet.of("A", "B");
+    when(topicClient.isTopicExists("A")).thenReturn(true);
+    when(topicClient.isTopicExists("B")).thenReturn(false);
+
+    // When:
+    final Type type = new MissingTopicClassifier("", requiredTopics, topicClient).classify(error);
+
+    // Then:
+    assertThat(type, is(Type.USER));
+  }
+
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
@@ -45,6 +45,7 @@ import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
+import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.PersistentQueryMetadata;
@@ -69,6 +70,7 @@ import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyDescription;
 import org.apache.kafka.streams.kstream.KStream;
 import org.junit.Before;
 import org.junit.Test;
@@ -134,6 +136,8 @@ public class QueryExecutorTest {
   @Mock
   private ServiceContext serviceContext;
   @Mock
+  private KafkaTopicClient topicClient;
+  @Mock
   private Consumer<QueryMetadata> closeCallback;
   @Mock
   private KafkaStreamsBuilder kafkaStreamsBuilder;
@@ -145,6 +149,8 @@ public class QueryExecutorTest {
   private KafkaStreams kafkaStreams;
   @Mock
   private Topology topology;
+  @Mock
+  private TopologyDescription topoDesc;
   @Mock
   private KsMaterializationFactory ksMaterializationFactory;
   @Mock
@@ -189,6 +195,9 @@ public class QueryExecutorTest {
         .thenReturn(PERSISTENT_PREFIX);
     when(ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG)).thenReturn(SERVICE_ID);
     when(physicalPlan.build(any())).thenReturn(tableHolder);
+    when(topology.describe()).thenReturn(topoDesc);
+    when(topoDesc.subtopologies()).thenReturn(ImmutableSet.of());
+    when(serviceContext.getTopicClient()).thenReturn(topicClient);
     queryBuilder = new QueryExecutor(
         ksqlConfig,
         OVERRIDES,

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.internal.QueryStateListener;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.query.QueryErrorClassifier;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SystemColumns;
@@ -85,7 +86,7 @@ public class QueryMetadataTest {
         Collections.emptyMap(),
         closeCallback,
         closeTimeout,
-        QUERY_ID) {
+        QUERY_ID, QueryErrorClassifier.DEFAULT_CLASSIFIER) {
       @Override
       public void stop() {
         doClose(cleanUp);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
@@ -26,6 +26,7 @@ import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.BlockingRowQueue;
+import io.confluent.ksql.query.QueryErrorClassifier;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.entity.FieldInfo.FieldType;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
@@ -140,7 +141,8 @@ public class QueryDescriptionFactoryTest {
         STREAMS_PROPS,
         PROP_OVERRIDES,
         queryCloseCallback,
-        closeTimeout);
+        closeTimeout,
+        QueryErrorClassifier.DEFAULT_CLASSIFIER);
 
     persistentQueryDescription = QueryDescriptionFactory.forQueryMetadata(persistentQuery, STATUS_MAP);
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -35,6 +35,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -469,7 +470,8 @@ public class StreamedQueryResourceTest {
 
     // Definitely want to make sure that the Kafka Streams instance has been closed and cleaned up
     verify(mockKafkaStreams).start();
-    verify(mockKafkaStreams).setUncaughtExceptionHandler(any());
+    // called on init and when setting uncaught exception handler manually
+    verify(mockKafkaStreams, times(2)).setUncaughtExceptionHandler(any());
     verify(mockKafkaStreams).cleanUp();
     verify(mockKafkaStreams).close(Duration.ofMillis(closeTimeout));
 


### PR DESCRIPTION
### Description 

This PR introduces JMX metrics that drill query errors down into more specific categories: `UNKNOWN`, `USER` and `SYSTEM` (open to better names) when an uncaught error is raised from KafkaStreams.

### Review Guide

There's a lot in this PR, I can split it up if it helps the review but it's not that many lines of code so I figured it's digestible with a little guide:

- `QueryError` a throwable paired with a classification of that error (see above)
- `ErrorStateListener` extends `StateListener` to add an additional method that reacts to `QueryError` when its raised
- `QueryErrorClassifier` classifies exceptions; it also supports chaining so we can easily introduce other ones
- `MissingTopicClassifier` will check if any required topics are missing, and if so classifies the error as `USER`
- I moved registering the uncaught exceptions into the `QueryMetadata` where I have more information than in the `KafkaStreamsBuilder`
- The rest is wiring

### Testing done 

Caused a failure by deleting a necessary topic (`foo`) and then deleting the kafka streams local dir to trigger a faster error. In the logs:

```
[2020-05-15 10:47:35,201] ERROR Unhandled exception caught in streams thread _confluent-ksql-def
ault_query_CTAS_COUNTS_0-8d6e554e-a19b-4c68-abe7-eca385fc9630-StreamThread-3. (io.confluent.ksql
.engine.KsqlEngine:43)
org.apache.kafka.streams.errors.ProcessorStateException: task directory [/tmp/kafka-streams/_con
fluent-ksql-default_query_CTAS_COUNTS_0/0_0] doesn't exist and couldn't be created
...
[2020-05-15 10:47:35,880] WARN Query _confluent-ksql-default_query_CTAS_COUNTS_0 requires topic Aggregate-GroupBy-repartition which cannot be found. (io.confluent.ksql.query.MissingTopicClassifier:54)
```

I used `jconsole` to make sure that the JMX MBean metrics were properly set. Here's a picture of it below:

![image](https://user-images.githubusercontent.com/3172405/82080782-0c142c00-969a-11ea-8c9e-0c8efb18952d.png)


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

