### PR TITLE
fix: Block writer thread if response output buffer is full

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ResponseOutputStream.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ResponseOutputStream.java
@@ -74,8 +74,9 @@ public class ResponseOutputStream extends OutputStream {
       final CompletableFuture<Void> cf = new CompletableFuture<>();
       response.drainHandler(v -> cf.complete(null));
       try {
-        cf.get(10, TimeUnit.SECONDS);
+        cf.get(60, TimeUnit.SECONDS);
       } catch (Exception e) {
+        // Very slow consumers will result in a timeout, this will cause the push query to be closed
         throw new KsqlException(e);
       }
     }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -226,6 +226,8 @@ public class ServerVerticle extends AbstractVerticle {
     final CompletableFuture<Void> connectionClosedFuture = new CompletableFuture<>();
     routingContext.request().connection().closeHandler(v -> connectionClosedFuture.complete(null));
 
+    routingContext.response().setWriteQueueMaxSize(200 * 1024);
+
     handleOldApiRequest(server, routingContext, KsqlRequest.class,
         (request, apiSecurityContext) ->
             endpoints


### PR DESCRIPTION
### Description 

Previously there was no back pressure on writes from the legacy streaming API to the response. This could mean that writes buffered in memory if the client was slow which could lead to unbounded memory usage.

This PR blocks the writer thread if the response is full and unblocks it when it is drained to provide some synchronous back pressure to the caller.

### Testing done 

Manually tested.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

