### PR TITLE
docs: widen plugin path for tutorial

### DIFF
--- a/docs/tutorials/materialized.md
+++ b/docs/tutorials/materialized.md
@@ -134,7 +134,7 @@ services:
     ports:
       - "8088:8088"
     volumes:
-      - "./confluent-hub-components/debezium-debezium-connector-mysql:/usr/share/kafka/plugins/debezium-mysql"
+      - "./confluent-hub-components/:/usr/share/kafka/plugins/"
     environment:
       KSQL_LISTENERS: "http://0.0.0.0:8088"
       KSQL_BOOTSTRAP_SERVERS: "broker:9092"


### PR DESCRIPTION
### Description 

Changes the Docker Compose file for the materialized view tutorial to allow more connectors to be added without changing the env var. Doesn't need to be backported to previous versions.

