### PR TITLE
fix(client): expose query ID from executeQuery() return type

### DIFF
--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/BatchedQueryResult.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/BatchedQueryResult.java
@@ -16,18 +16,14 @@
 package io.confluent.ksql.api.client;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * The result of a query (push or pull), returned as a single batch once the query has finished
  * executing. For non-terminating push queries, {@code StreamedQueryResult} should be used instead.
  */
-public interface BatchedQueryResult {
+public abstract class BatchedQueryResult extends CompletableFuture<List<Row>> {
 
-  List<String> columnNames();
+  public abstract CompletableFuture<String> queryID();
 
-  List<ColumnType> columnTypes();
-
-  String queryID();
-
-  List<Row> rows();
 }

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/Client.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/Client.java
@@ -48,7 +48,7 @@ public interface Client {
    * @param sql statement of query to execute.
    * @return query result.
    */
-  CompletableFuture<BatchedQueryResult> executeQuery(String sql);
+  BatchedQueryResult executeQuery(String sql);
 
   /**
    * Execute a query (push or pull) and receive all result rows together, once the query has
@@ -58,7 +58,7 @@ public interface Client {
    * @param properties query properties.
    * @return query result.
    */
-  CompletableFuture<BatchedQueryResult> executeQuery(String sql, Map<String, Object> properties);
+  BatchedQueryResult executeQuery(String sql, Map<String, Object> properties);
 
   CompletableFuture<Void> insertInto(String streamName, Map<String, Object> row);
 

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/BatchedQueryResultImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/BatchedQueryResultImpl.java
@@ -16,48 +16,19 @@
 package io.confluent.ksql.api.client.impl;
 
 import io.confluent.ksql.api.client.BatchedQueryResult;
-import io.confluent.ksql.api.client.ColumnType;
-import io.confluent.ksql.api.client.Row;
-import java.util.List;
-import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 
-public class BatchedQueryResultImpl implements BatchedQueryResult {
+public class BatchedQueryResultImpl extends BatchedQueryResult {
 
-  private final String queryId;
-  private final List<String> columnNames;
-  private final List<ColumnType> columnTypes;
-  private final List<Row> rows;
+  private final CompletableFuture<String> queryId;
 
-  BatchedQueryResultImpl(
-      final String queryId,
-      final List<String> columnNames,
-      final List<ColumnType> columnTypes,
-      final List<Row> rows
-  ) {
-    this.queryId = queryId;
-    this.columnNames = Objects.requireNonNull(columnNames);
-    this.columnTypes = Objects.requireNonNull(columnTypes);
-    this.rows = Objects.requireNonNull(rows);
+  BatchedQueryResultImpl() {
+    this.queryId = new CompletableFuture<>();
   }
 
   @Override
-  public List<String> columnNames() {
-    return columnNames;
-  }
-
-  @Override
-  public List<ColumnType> columnTypes() {
-    return columnTypes;
-  }
-
-  @Override
-  public String queryID() {
+  public CompletableFuture<String> queryID() {
     return queryId;
-  }
-
-  @Override
-  public List<Row> rows() {
-    return rows;
   }
 
 }

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ExecuteQueryResponseHandler.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ExecuteQueryResponseHandler.java
@@ -28,7 +28,6 @@ import io.vertx.core.parsetools.RecordParser;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +37,6 @@ public class ExecuteQueryResponseHandler extends QueryResponseHandler<BatchedQue
 
   private final List<Row> rows;
   private final int maxRows;
-  private String queryId;
   private List<String> columnNames;
   private List<ColumnType> columnTypes;
   private Map<String, Integer> columnNameToIndex;
@@ -46,7 +44,7 @@ public class ExecuteQueryResponseHandler extends QueryResponseHandler<BatchedQue
   ExecuteQueryResponseHandler(
       final Context context,
       final RecordParser recordParser,
-      final CompletableFuture<BatchedQueryResult> cf,
+      final BatchedQueryResult cf,
       final int maxRows) {
     super(context, recordParser, cf);
     this.maxRows = maxRows;
@@ -55,7 +53,7 @@ public class ExecuteQueryResponseHandler extends QueryResponseHandler<BatchedQue
 
   @Override
   protected void handleMetadata(final QueryResponseMetadata queryResponseMetadata) {
-    queryId = queryResponseMetadata.queryId;
+    cf.queryID().complete(queryResponseMetadata.queryId);
     columnNames = queryResponseMetadata.columnNames;
     columnTypes = RowUtil.columnTypesFromStrings(queryResponseMetadata.columnTypes);
     columnNameToIndex = RowUtil.valueToIndexMap(columnNames);
@@ -80,7 +78,7 @@ public class ExecuteQueryResponseHandler extends QueryResponseHandler<BatchedQue
       throw new IllegalStateException("Body ended before metadata received");
     }
 
-    cf.complete(new BatchedQueryResultImpl(queryId, columnNames, columnTypes, rows));
+    cf.complete(rows);
   }
 
   @Override

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/QueryResponseHandler.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/QueryResponseHandler.java
@@ -23,15 +23,14 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.parsetools.RecordParser;
 import java.util.concurrent.CompletableFuture;
 
-abstract class QueryResponseHandler<T> {
+abstract class QueryResponseHandler<T extends CompletableFuture<?>> {
 
   protected final Context context;
   protected final RecordParser recordParser;
-  protected final CompletableFuture<T> cf;
+  protected final T cf;
   protected boolean hasReadArguments;
 
-  QueryResponseHandler(final Context context, final RecordParser recordParser,
-      final CompletableFuture<T> cf) {
+  QueryResponseHandler(final Context context, final RecordParser recordParser, final T cf) {
     this.context = context;
     this.recordParser = recordParser;
     this.cf = cf;

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/StreamQueryResponseHandler.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/StreamQueryResponseHandler.java
@@ -31,7 +31,8 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-public class StreamQueryResponseHandler extends QueryResponseHandler<StreamedQueryResult> {
+public class StreamQueryResponseHandler
+    extends QueryResponseHandler<CompletableFuture<StreamedQueryResult>> {
 
   private static final Logger log = LoggerFactory.getLogger(StreamQueryResponseHandler.class);
 


### PR DESCRIPTION
### Description 

This PR addresses the issue raised in https://github.com/confluentinc/ksql/pull/5236#issuecomment-628997138: the current method signature
```
public interface Client {

  /**
   * Execute a query (push or pull) and receive all result rows together, once the query has
   * completed.
   *
   * @param sql statement of query to execute.
   * @return query result.
   */
  CompletableFuture<BatchedQueryResult> executeQuery(String sql);

  ...
}
```
with
```
public interface BatchedQueryResult {

  List<String> columnNames();

  List<ColumnType> columnTypes();

  String queryID();

  List<Row> rows();
}
```
doesn't work in terms of exposing the query ID so users can terminate queries issued via `executeQuery()` since by the time the user has the BatchedQueryResult (in order to get the query ID) the query must already have completed. This PR updates the interface to become
```
public abstract class BatchedQueryResult extends CompletableFuture<List<Row>> {

  CompletableFuture<String> getQueryId();

}
```
to fix this issue.

### Testing done 

Added tests for terminating queries issued via `executeQuery()`.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

