### PR TITLE
feat: Pull Queries: QPS check utilizes internal API flag to determine if forwarded

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
@@ -95,7 +95,7 @@ public class QueryEndpoint {
       final ServiceContext serviceContext,
       final ConfiguredStatement<Query> statement) {
     final TableRowsEntity tableRows = pullQueryExecutor.execute(
-        statement, serviceContext, Optional.empty(), Optional.empty());
+        statement, serviceContext, Optional.empty(), Optional.of(false));
     return new PullQueryPublisher(context, tableRows, colNamesFromSchema(tableRows.getSchema()),
         colTypesFromSchema(tableRows.getSchema()));
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
@@ -95,7 +95,7 @@ public class QueryEndpoint {
       final ServiceContext serviceContext,
       final ConfiguredStatement<Query> statement) {
     final TableRowsEntity tableRows = pullQueryExecutor.execute(
-        statement, serviceContext, Optional.empty());
+        statement, serviceContext, Optional.empty(), Optional.empty());
     return new PullQueryPublisher(context, tableRows, colNamesFromSchema(tableRows.getSchema()),
         colTypesFromSchema(tableRows.getSchema()));
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/InternalEndpointHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/InternalEndpointHandler.java
@@ -24,6 +24,8 @@ import io.vertx.ext.web.RoutingContext;
 import java.util.Set;
 
 public class InternalEndpointHandler implements Handler<RoutingContext> {
+  public static final String CONTEXT_DATA_IS_INTERNAL = "isInternal";
+
   private static final Set<String> INTERNAL_PATHS = ImmutableSet.of(
       "/heartbeat", "/lag");
 
@@ -42,6 +44,7 @@ public class InternalEndpointHandler implements Handler<RoutingContext> {
           new KsqlApiException("Can't call internal endpoint on public listener",
               ERROR_CODE_SERVER_ERROR));
     } else {
+      routingContext.put(CONTEXT_DATA_IS_INTERNAL, isFromInternalListener);
       routingContext.next();
     }
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.api.server;
 
+import static io.confluent.ksql.api.server.InternalEndpointHandler.CONTEXT_DATA_IS_INTERNAL;
 import static io.confluent.ksql.api.server.OldApiUtils.handleOldApiRequest;
 import static io.netty.handler.codec.http.HttpResponseStatus.TEMPORARY_REDIRECT;
 
@@ -230,7 +231,8 @@ public class ServerVerticle extends AbstractVerticle {
         (request, apiSecurityContext) ->
             endpoints
                 .executeQueryRequest(request, server.getWorkerExecutor(), connectionClosedFuture,
-                    DefaultApiSecurityContext.create(routingContext))
+                    DefaultApiSecurityContext.create(routingContext),
+                    isInternalRequest(routingContext))
     );
   }
 
@@ -325,5 +327,15 @@ public class ServerVerticle extends AbstractVerticle {
 
   private static void unhandledExceptionHandler(final Throwable t) {
     log.error("Unhandled exception", t);
+  }
+
+  /**
+   * If the request was received on the internal listener.
+   *
+   * @return If an internal listener is in use and this is an internal request, or
+   * {@code Optional.empty} if an internal listener is not enabled.
+   */
+  private static Optional<Boolean> isInternalRequest(final RoutingContext routingContext) {
+    return Optional.ofNullable(routingContext.get(CONTEXT_DATA_IS_INTERNAL));
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/spi/Endpoints.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/spi/Endpoints.java
@@ -28,6 +28,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.WorkerExecutor;
 import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.json.JsonObject;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.reactivestreams.Subscriber;
 
@@ -79,7 +80,7 @@ public interface Endpoints {
 
   CompletableFuture<EndpointResponse> executeQueryRequest(KsqlRequest request,
       WorkerExecutor workerExecutor, CompletableFuture<Void> connectionClosedFuture,
-      ApiSecurityContext apiSecurityContext);
+      ApiSecurityContext apiSecurityContext, Optional<Boolean> isInternalRequest);
 
   CompletableFuture<EndpointResponse> executeInfo(ApiSecurityContext apiSecurityContext);
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
@@ -154,12 +154,14 @@ public class KsqlServerEndpoints implements Endpoints {
   public CompletableFuture<EndpointResponse> executeQueryRequest(final KsqlRequest request,
       final WorkerExecutor workerExecutor,
       final CompletableFuture<Void> connectionClosedFuture,
-      final ApiSecurityContext apiSecurityContext) {
+      final ApiSecurityContext apiSecurityContext,
+      final Optional<Boolean> isInternalRequest) {
     return executeOldApiEndpointOnWorker(apiSecurityContext,
         ksqlSecurityContext -> streamedQueryResource.streamQuery(
             ksqlSecurityContext,
             request,
-            connectionClosedFuture), workerExecutor);
+            connectionClosedFuture,
+            isInternalRequest), workerExecutor);
   }
 
   @Override

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PullQueryExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PullQueryExecutor.java
@@ -181,9 +181,9 @@ public final class PullQueryExecutor {
           statement.getConfig(), statement.getConfigOverrides(), statement.getRequestProperties());
       // If internal listeners are in use, we require the request to come from that listener to
       // treat it as having been forwarded.
-      final boolean isAlreadyForwarded = routingOptions.skipForwardRequest() &&
+      final boolean isAlreadyForwarded = routingOptions.skipForwardRequest()
           // Trust the forward request option if isInternalRequest isn't available.
-          isInternalRequest.orElse(true);
+          && isInternalRequest.orElse(true);
 
       // Only check the rate limit at the forwarding host
       if (!isAlreadyForwarded) {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisher.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisher.java
@@ -54,7 +54,7 @@ class PullQueryPublisher implements Flow.Publisher<Collection<StreamedRow>> {
   public synchronized void subscribe(final Subscriber<Collection<StreamedRow>> subscriber) {
     final PullQuerySubscription subscription = new PullQuerySubscription(
         subscriber,
-        () -> pullQueryExecutor.execute(query, serviceContext, Optional.empty())
+        () -> pullQueryExecutor.execute(query, serviceContext, Optional.empty(), Optional.empty())
     );
 
     subscriber.onSubscribe(subscription);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisher.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisher.java
@@ -54,7 +54,7 @@ class PullQueryPublisher implements Flow.Publisher<Collection<StreamedRow>> {
   public synchronized void subscribe(final Subscriber<Collection<StreamedRow>> subscriber) {
     final PullQuerySubscription subscription = new PullQuerySubscription(
         subscriber,
-        () -> pullQueryExecutor.execute(query, serviceContext, Optional.empty(), Optional.empty())
+        () -> pullQueryExecutor.execute(query, serviceContext, Optional.empty(), Optional.of(false))
     );
 
     subscriber.onSubscribe(subscription);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TestEndpoints.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TestEndpoints.java
@@ -36,6 +36,7 @@ import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.json.JsonObject;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
@@ -122,7 +123,7 @@ public class TestEndpoints implements Endpoints {
   @Override
   public CompletableFuture<EndpointResponse> executeQueryRequest(KsqlRequest request,
       WorkerExecutor workerExecutor, CompletableFuture<Void> connectionClosedFuture,
-      ApiSecurityContext apiSecurityContext) {
+      ApiSecurityContext apiSecurityContext, Optional<Boolean> isInternalRequest) {
     return null;
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/InsertsStreamRunner.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/InsertsStreamRunner.java
@@ -39,6 +39,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.parsetools.RecordParser;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.ext.web.codec.BodyCodec;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -189,7 +190,7 @@ public class InsertsStreamRunner extends BasePerfRunner {
     @Override
     public CompletableFuture<EndpointResponse> executeQueryRequest(KsqlRequest request,
         WorkerExecutor workerExecutor, CompletableFuture<Void> connectionClosedFuture,
-        ApiSecurityContext apiSecurityContext) {
+        ApiSecurityContext apiSecurityContext, Optional<Boolean> isInternalRequest) {
       return null;
     }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/PullQueryRunner.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/PullQueryRunner.java
@@ -42,6 +42,7 @@ import io.vertx.ext.web.client.HttpResponse;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Semaphore;
@@ -146,7 +147,7 @@ public class PullQueryRunner extends BasePerfRunner {
     @Override
     public CompletableFuture<EndpointResponse> executeQueryRequest(KsqlRequest request,
         WorkerExecutor workerExecutor, CompletableFuture<Void> connectionClosedFuture,
-        ApiSecurityContext apiSecurityContext) {
+        ApiSecurityContext apiSecurityContext, Optional<Boolean> isInternalRequest) {
       return null;
     }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/QueryStreamRunner.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/QueryStreamRunner.java
@@ -42,6 +42,7 @@ import io.vertx.core.parsetools.RecordParser;
 import io.vertx.ext.web.codec.BodyCodec;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -131,7 +132,8 @@ public class QueryStreamRunner extends BasePerfRunner {
     public CompletableFuture<EndpointResponse> executeQueryRequest(KsqlRequest request,
         WorkerExecutor workerExecutor,
         CompletableFuture<Void> connectionClosedFuture,
-        ApiSecurityContext apiSecurityContext) {
+        ApiSecurityContext apiSecurityContext,
+        Optional<Boolean> isInternalRequest) {
       return null;
     }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PullQueryExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PullQueryExecutorTest.java
@@ -31,8 +31,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.execution.streams.RoutingFilter.RoutingFilterFactory;
 import io.confluent.ksql.execution.streams.RoutingFilters;
+import io.confluent.ksql.parser.DefaultKsqlParser;
+import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.Query;
+import io.confluent.ksql.parser.tree.ResultMaterialization;
 import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.server.TemporaryEngine;
 import io.confluent.ksql.rest.server.resources.KsqlRestException;
@@ -40,6 +43,7 @@ import io.confluent.ksql.rest.server.validation.CustomValidators;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
+import java.util.List;
 import java.util.Optional;
 import org.junit.Rule;
 import org.junit.Test;
@@ -74,7 +78,8 @@ public class PullQueryExecutorTest {
       // When:
       final Exception e = assertThrows(
           KsqlException.class,
-          () -> pullQueryExecutor.execute(query, engine.getServiceContext(), Optional.empty())
+          () -> pullQueryExecutor.execute(query, engine.getServiceContext(), Optional.empty(),
+              Optional.empty())
       );
 
       // Then:

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisherTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisherTest.java
@@ -80,7 +80,7 @@ public class PullQueryPublisherTest {
         statement,
         pullQueryExecutor);
 
-    when(pullQueryExecutor.execute(any(), any(), any())).thenReturn(entity);
+    when(pullQueryExecutor.execute(any(), any(), any(), any())).thenReturn(entity);
     when(entity.getSchema()).thenReturn(SCHEMA);
 
     doAnswer(callRequestAgain()).when(subscriber).onNext(any());
@@ -104,7 +104,8 @@ public class PullQueryPublisherTest {
     subscription.request(1);
 
     // Then:
-    verify(pullQueryExecutor).execute(statement, serviceContext, Optional.empty());
+    verify(pullQueryExecutor).execute(statement, serviceContext, Optional.empty(),
+        Optional.empty());
   }
 
   @Test
@@ -117,7 +118,8 @@ public class PullQueryPublisherTest {
 
     // Then:
     verify(subscriber).onNext(any());
-    verify(pullQueryExecutor).execute(statement, serviceContext, Optional.empty());
+    verify(pullQueryExecutor).execute(statement, serviceContext, Optional.empty(),
+        Optional.empty());
   }
 
   @Test
@@ -152,7 +154,7 @@ public class PullQueryPublisherTest {
     // Given:
     givenSubscribed();
     final Throwable e = new RuntimeException("Boom!");
-    when(pullQueryExecutor.execute(any(), any(), any())).thenThrow(e);
+    when(pullQueryExecutor.execute(any(), any(), any(), any())).thenThrow(e);
 
     // When:
     subscription.request(1);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisherTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisherTest.java
@@ -105,7 +105,7 @@ public class PullQueryPublisherTest {
 
     // Then:
     verify(pullQueryExecutor).execute(statement, serviceContext, Optional.empty(),
-        Optional.empty());
+        Optional.of(false));
   }
 
   @Test
@@ -119,7 +119,7 @@ public class PullQueryPublisherTest {
     // Then:
     verify(subscriber).onNext(any());
     verify(pullQueryExecutor).execute(statement, serviceContext, Optional.empty(),
-        Optional.empty());
+        Optional.of(false));
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -224,7 +224,8 @@ public class StreamedQueryResourceTest {
         () -> testResource.streamQuery(
             securityContext,
             new KsqlRequest("query", Collections.emptyMap(), Collections.emptyMap(), null),
-            new CompletableFuture<>()
+            new CompletableFuture<>(),
+            Optional.empty()
         )
     );
 
@@ -245,7 +246,8 @@ public class StreamedQueryResourceTest {
         () -> testResource.streamQuery(
             securityContext,
             new KsqlRequest("query", Collections.emptyMap(), Collections.emptyMap(), null),
-            new CompletableFuture<>()
+            new CompletableFuture<>(),
+            Optional.empty()
         )
     );
 
@@ -261,7 +263,8 @@ public class StreamedQueryResourceTest {
     testResource.streamQuery(
         securityContext,
         new KsqlRequest(PUSH_QUERY_STRING, Collections.emptyMap(), Collections.emptyMap(), null),
-        new CompletableFuture<>()
+        new CompletableFuture<>(),
+        Optional.empty()
     );
 
     // Then:
@@ -274,7 +277,8 @@ public class StreamedQueryResourceTest {
     testResource.streamQuery(
         securityContext,
         new KsqlRequest(PUSH_QUERY_STRING, Collections.emptyMap(), Collections.emptyMap(), 3L),
-        new CompletableFuture<>()
+        new CompletableFuture<>(),
+        Optional.empty()
     );
 
     // Then:
@@ -294,7 +298,8 @@ public class StreamedQueryResourceTest {
         () -> testResource.streamQuery(
             securityContext,
             new KsqlRequest(PUSH_QUERY_STRING, Collections.emptyMap(), Collections.emptyMap(), 3L),
-            new CompletableFuture<>()
+            new CompletableFuture<>(),
+            Optional.empty()
         )
     );
 
@@ -316,7 +321,8 @@ public class StreamedQueryResourceTest {
     testResource.streamQuery(
         securityContext,
         new KsqlRequest(PULL_QUERY_STRING, Collections.emptyMap(), Collections.emptyMap(), null),
-        new CompletableFuture<>()
+        new CompletableFuture<>(),
+        Optional.empty()
     );
 
     // Then:
@@ -339,7 +345,8 @@ public class StreamedQueryResourceTest {
     final EndpointResponse response = testResource.streamQuery(
         securityContext,
         new KsqlRequest(PULL_QUERY_STRING, Collections.emptyMap(), Collections.emptyMap(), null),
-        new CompletableFuture<>()
+        new CompletableFuture<>(),
+        Optional.empty()
     );
 
     final KsqlErrorMessage responseEntity = (KsqlErrorMessage) response.getEntity();
@@ -407,7 +414,8 @@ public class StreamedQueryResourceTest {
         testResource.streamQuery(
             securityContext,
             new KsqlRequest(queryString, requestStreamsProperties, Collections.emptyMap(), null),
-            new CompletableFuture<>()
+            new CompletableFuture<>(),
+            Optional.empty()
         );
     final PipedOutputStream responseOutputStream = new EOFPipedOutputStream();
     final PipedInputStream responseInputStream = new PipedInputStream(responseOutputStream, 1);
@@ -547,7 +555,8 @@ public class StreamedQueryResourceTest {
     testResource.streamQuery(
         securityContext,
         new KsqlRequest(PUSH_QUERY_STRING, Collections.emptyMap(), Collections.emptyMap(), null),
-        new CompletableFuture<>()
+        new CompletableFuture<>(),
+        Optional.empty()
     );
 
     // Then:
@@ -567,7 +576,8 @@ public class StreamedQueryResourceTest {
     final EndpointResponse response = testResource.streamQuery(
         securityContext,
         new KsqlRequest(PUSH_QUERY_STRING, Collections.emptyMap(), Collections.emptyMap(), null),
-        new CompletableFuture<>()
+        new CompletableFuture<>(),
+        Optional.empty()
     );
 
     final KsqlErrorMessage responseEntity = (KsqlErrorMessage) response.getEntity();
@@ -591,7 +601,8 @@ public class StreamedQueryResourceTest {
     final EndpointResponse response = testResource.streamQuery(
         securityContext,
         new KsqlRequest(PRINT_TOPIC, Collections.emptyMap(), Collections.emptyMap(), null),
-        new CompletableFuture<>()
+        new CompletableFuture<>(),
+        Optional.empty()
     );
 
     assertEquals(response.getStatus(), AUTHORIZATION_ERROR_RESPONSE.getStatus());
@@ -620,7 +631,8 @@ public class StreamedQueryResourceTest {
         () -> testResource.streamQuery(
             securityContext,
             new KsqlRequest(PRINT_TOPIC, Collections.emptyMap(), Collections.emptyMap(), null),
-            new CompletableFuture<>()
+            new CompletableFuture<>(),
+            Optional.empty()
         )
     );
 


### PR DESCRIPTION
### Description 
When doing pull queries, we do a QPS check.  At the moment, we only check at the initial client request, regardless of whether it gets forwarded.  This makes it easy to reason about the total cluster QPS.

To do this, we utilize a request property, `request.ksql.query.pull.skip.forwarding`.  This PR adds the additional requirement that if `ksql.internal.listener` is in use, the request must be internal to be considered a forwarded request.

This prevents a user from setting `request.ksql.query.pull.skip.forwarding` explicitly.

### Testing done 
`mvn package`.  Also tested manually.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

