### PR TITLE
chore: update git commit id plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
         <compile.warnings-flag>-Werror</compile.warnings-flag>
         <!-- Only used to provide login module implementation for tests -->
         <jetty.version>9.4.28.v20200408</jetty.version>
-        <git-commit-id-plugin.version>2.2.1</git-commit-id-plugin.version>
+        <git-commit-id-plugin.version>2.2.6</git-commit-id-plugin.version>
         <scala.version>2.13.2</scala.version>
     </properties>
 
@@ -591,7 +591,7 @@
             <plugin>
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
-                <version>2.2.0</version>
+                <version>${git-commit-id-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
### Description 
Update the version so it includes this fix for using the plugin with shallow git repos 
https://github.com/git-commit-id/git-commit-id-maven-plugin/pull/290

### Testing done 
`git clone https://github.com/confluentinc/ksql --depth 1 `
run `mvn install`

this would previously fail without updating the version
### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

