### PR TITLE
docs: update requirements in ksqlDB docs build (DOCS-4396)

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,4 @@ mkdocs-git-revision-date-plugin==0.3
 pymdown-extensions
 Pygments==2.4.2
 mkdocs-material==5.1.3
+python-dateutil


### PR DESCRIPTION
Something changed in the last couple of days, because the build is choking on a requirement for python-dateutil.