### PR TITLE
feat: introduce RegexClassifier for classifying errors via cfg

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -27,7 +27,9 @@ import io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler;
 import io.confluent.ksql.errors.ProductionExceptionHandlerUtil;
 import io.confluent.ksql.logging.processing.ProcessingLogConfig;
 import io.confluent.ksql.model.SemanticVersion;
+import io.confluent.ksql.query.QueryError;
 import io.confluent.ksql.testing.EffectivelyImmutable;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -261,6 +263,16 @@ public class KsqlConfig extends AbstractConfig {
       + "contains an invalid timestamp, ksqlDB will log a warning and continue. To disable this "
       + "behavior, and instead throw an exception to ensure that no data is missed, set "
       + "ksql.timestamp.skip.invalid to true.";
+
+  public static final String KSQL_ERROR_CLASSIFIER_REGEX_PREFIX = "ksql.error.classifier.regex";
+  public static final String KSQL_ERROR_CLASSIFIER_REGEX_PREFIX_DOC = "Any configuration with the "
+      + "regex prefix will create a new classifier that will be configured to classify anything "
+      + "that matches the content as the specified type. The value must match "
+      + "<TYPE><whitespace><REGEX> (for example " + KSQL_ERROR_CLASSIFIER_REGEX_PREFIX + ".invalid"
+      + "=\"USER .*InvalidTopicException.*\"). The type can be one of "
+      + GrammaticalJoiner.or().join(Arrays.stream(QueryError.Type.values()))
+      + " and the regex pattern will be matched against the error class name and message of any "
+      + "uncaught error and subsequent error causes in the Kafka Streams applications.";
 
   private enum ConfigGeneration {
     LEGACY,
@@ -623,6 +635,13 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_QUERY_PULL_MAX_QPS_DEFAULT,
             Importance.LOW,
             KSQL_QUERY_PULL_MAX_QPS_DOC
+        )
+        .define(
+            KSQL_ERROR_CLASSIFIER_REGEX_PREFIX,
+            Type.STRING,
+            "",
+            Importance.LOW,
+            KSQL_ERROR_CLASSIFIER_REGEX_PREFIX_DOC
         )
         .withClientSslSupport();
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/MissingTopicClassifier.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/MissingTopicClassifier.java
@@ -48,7 +48,7 @@ public class MissingTopicClassifier implements QueryErrorClassifier {
 
   @Override
   public Type classify(final Throwable e) {
-    LOG.warn("Attempting to classify error for {}", queryId, e);
+    LOG.info("Attempting to classify error for {}", queryId);
     for (String requiredTopic : requiredTopics) {
       if (!topicClient.isTopicExists(requiredTopic)) {
         LOG.warn("Query {} requires topic {} which cannot be found.", queryId, requiredTopic);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/RegexClassifier.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/RegexClassifier.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.query;
+
+import io.confluent.ksql.query.QueryError.Type;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@code RegexClassifier} classifies errors based on regex patterns of
+ * the stack trace. This class is intended as "last resort" so that noisy
+ * errors can be classified without deploying a new version of code.
+ */
+public final class RegexClassifier implements QueryErrorClassifier {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RegexClassifier.class);
+
+  private final Pattern pattern;
+  private final Type type;
+  private final String queryId;
+
+  /**
+   * Specifying a RegexClassifier in a config requires specifying
+   * {@code <TYPE> <PATTERN>}, for example {@code USER .*InvalidTopicException.*}
+   *
+   * @param config the configuration specifying the type and pattern
+   * @return the classifier
+   */
+  public static QueryErrorClassifier fromConfig(final String config, final String queryId) {
+    final String[] split = config.split("\\s", 2);
+    if (split.length < 2) {
+      LOG.warn("Ignoring invalid configuration for RegexClassifier: " + config);
+      return err -> Type.UNKNOWN;
+    }
+
+    return new RegexClassifier(
+        Type.valueOf(split[0].toUpperCase()),
+        Pattern.compile(split[1], Pattern.DOTALL),
+        queryId
+    );
+  }
+
+  private RegexClassifier(final Type type, final Pattern pattern, final String queryId) {
+    this.type = Objects.requireNonNull(type, "type");
+    this.pattern = Objects.requireNonNull(pattern, "pattern");
+    this.queryId = Objects.requireNonNull(queryId, "queryId");
+  }
+
+  @Override
+  public Type classify(final Throwable e) {
+    LOG.info("Attempting to classify for {} under regex pattern {}.", queryId, pattern);
+
+    Throwable error = e;
+    do {
+      if (matches(error)) {
+        LOG.warn(
+            "Classified error for queryId {} under regex pattern {} as type {}.",
+            queryId,
+            pattern,
+            type);
+        return type;
+      }
+      error = error.getCause();
+    } while (error != null);
+
+    return Type.UNKNOWN;
+  }
+
+  private boolean matches(final Throwable e) {
+    return pattern.matcher(e.getClass().getName()).matches()
+        || pattern.matcher(e.getMessage()).matches();
+  }
+
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/RegexClassifierTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/RegexClassifierTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.query;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+
+import io.confluent.ksql.query.QueryError.Type;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RegexClassifierTest {
+
+  @Mock
+  private Throwable error;
+  @Mock
+  private Throwable cause;
+
+  @Test
+  public void shouldClassifyWithRegex() {
+    // Given:
+    final QueryErrorClassifier classifier = RegexClassifier.fromConfig("USER .*foo.*", "id");
+    givenMessage(error, "foo");
+
+    // When:
+    final Type type = classifier.classify(error);
+
+    // Then:
+    assertThat(type, is(Type.USER));
+  }
+
+  @Test
+  public void shouldClassifyWithRegexInCause() {
+    // Given:
+    final QueryErrorClassifier classifier = RegexClassifier.fromConfig("USER .*foo.*", "id");
+    when(error.getCause()).thenReturn(cause);
+    givenMessage(error, "bar");
+    givenMessage(cause, "foo");
+
+    // When:
+    final Type type = classifier.classify(error);
+
+    // Then:
+    assertThat(type, is(Type.USER));
+  }
+
+
+  @Test
+  public void shouldClassifyAsUnknownIfBadRegex() {
+    // Given:
+    final QueryErrorClassifier classifier = RegexClassifier.fromConfig("USER", "id");
+    givenMessage(error, "foo");
+
+    // When:
+    final Type type = classifier.classify(error);
+
+    // Then:
+    assertThat(type, is(Type.UNKNOWN));
+  }
+
+  @Test
+  public void shouldClassifyAsUnknown() {
+    // Given:
+    final QueryErrorClassifier classifier = RegexClassifier.fromConfig("USER .*foo.*", "id");
+    when(error.getCause()).thenReturn(cause);
+    givenMessage(error, "bar");
+    givenMessage(cause, "baz");
+
+    // When:
+    final Type type = classifier.classify(error);
+
+    // Then:
+    assertThat(type, is(Type.UNKNOWN));
+  }
+
+  private void givenMessage(final Throwable error, final String message) {
+    when(error.getMessage()).thenReturn(message);
+  }
+}


### PR DESCRIPTION
### Description 

This change introduces the ability to use config to classify errors as one of `UNKNOWN`, `USER` or `SYSTEM` (see #5374 for more information) via regex patterns. 

### Testing done 

Tested with:
```properties
ksql.error.classifier.regex.1=USER .*task directory .* doesn't exist and couldn't be created.* 
```

And saw the following in the logs:
```
[2020-05-19 10:48:46,336] ERROR Unhandled exception caught in streams thread _confluent-ksql-default_query_CTAS_COUNTS_0-49406875-bc65-4fe2-9932-640c88dac8ae-StreamThread-3. (io.confluent.ksql.engine.KsqlEngine:43)
org.apache.kafka.streams.errors.ProcessorStateException: task directory [/tmp/kafka-streams/_confluent-ksql-default_query_CTAS_COUNTS_0/1_0] doesn't exist and couldn't be created
...
[2020-05-19 10:48:46,968] WARN Classified error for queryId _confluent-ksql-default_query_CTAS_COUNTS_0 under regex pattern .*task directory .* doesn't exist and couldn't be created.* as type USER. (io.confluent.ksql.query.RegexClassifier:71)
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

