### PR TITLE
chore: Remove some more unneeded deps from client

### DIFF
--- a/ksqldb-api-client/pom.xml
+++ b/ksqldb-api-client/pom.xml
@@ -19,7 +19,6 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksqldb-parent</artifactId>
@@ -52,19 +51,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-guava</artifactId>
             <version>${jackson.version}</version>
         </dependency>
 
@@ -78,6 +66,12 @@
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
             <version>${vertx.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -87,6 +81,12 @@
         </dependency>
 
         <!-- Required for running tests -->
+
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>common-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>io.confluent.ksql</groupId>

--- a/ksqldb-api-client/pom.xml
+++ b/ksqldb-api-client/pom.xml
@@ -29,8 +29,8 @@
 
     <!--
     A note on dependencies.
-    The Java client module has a different approach top dependencies than the server module.
-    The client is used in a user's application so it's really important that:
+    The Java client module has a different approach to dependencies than server modules.
+    The client is embedded in a user's application so it's really important that:
     * It's small. We don't want to drag in a load of dependencies and make our user's apps big and
     bloated. Also, the user's app might be a lightweight microservice running on a cloud or similar
     where binary size can really matter.

--- a/ksqldb-api-client/pom.xml
+++ b/ksqldb-api-client/pom.xml
@@ -27,6 +27,19 @@
 
     <artifactId>ksqldb-api-client</artifactId>
 
+    <!--
+    A note on dependencies.
+    The Java client module has a different approach top dependencies than the server module.
+    The client is used in a user's application so it's really important that:
+    * It's small. We don't want to drag in a load of dependencies and make our user's apps big and
+    bloated. Also, the user's app might be a lightweight microservice running on a cloud or similar
+    where binary size can really matter.
+    * We minimise the probability of version conflicts. The more libraries that we depend on the
+    greater the risk of a version conflict with a different version of the same library already
+    used in the user's app. Version conflicts are a real pain for user's to resolve. It gets worse
+    if we're pulling in commonly used libraries such as Apache commons, Guava, Google stuff, etc.
+    as the probability of a conflict gets even higher. These ones in particular should really be avoided.
+    -->
     <dependencies>
         <dependency>
             <groupId>io.confluent.ksql</groupId>

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/StreamedQueryResultImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/StreamedQueryResultImpl.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.api.client.impl;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.api.client.ColumnType;
 import io.confluent.ksql.api.client.Row;
 import io.confluent.ksql.api.client.StreamedQueryResult;
@@ -129,7 +128,6 @@ public class StreamedQueryResultImpl extends BufferedPublisher<Row> implements S
     log.error("Unexpected error while polling: " + t);
   }
 
-  @VisibleForTesting
   public static Row pollWithCallback(
       final StreamedQueryResult queryResult,
       final Runnable callback

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/util/JsonMapper.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/util/JsonMapper.java
@@ -15,18 +15,22 @@
 
 package io.confluent.ksql.api.client.util;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.google.common.collect.ImmutableList;
-import io.vertx.core.json.jackson.DatabindCodec;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 
 public final class JsonMapper {
 
-  private static final ObjectMapper MAPPER = DatabindCodec.mapper();
+  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   static {
-    MAPPER.registerModule(new GuavaModule());
-    MAPPER.registerSubtypes(ImmutableList.class);
+    MAPPER.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET)
+        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+        .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+        .enable(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN)
+        .setNodeFactory(JsonNodeFactory.withExactBigDecimals(true));
   }
 
   private JsonMapper() {
@@ -35,4 +39,5 @@ public final class JsonMapper {
   public static ObjectMapper get() {
     return MAPPER;
   }
+
 }

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryResponseMetadata.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryResponseMetadata.java
@@ -17,29 +17,27 @@ package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableList;
-import com.google.errorprone.annotations.Immutable;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
 /**
  * Represents the metadata of a query stream response
  */
-@Immutable
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class QueryResponseMetadata {
 
   public final String queryId;
-  public final ImmutableList<String> columnNames;
-  public final ImmutableList<String> columnTypes;
+  public final List<String> columnNames;
+  public final List<String> columnTypes;
 
   public QueryResponseMetadata(
       final @JsonProperty(value = "queryId") String queryId,
       final @JsonProperty(value = "columnNames") List<String> columnNames,
       final @JsonProperty(value = "columnTypes") List<String> columnTypes) {
     this.queryId = queryId;
-    this.columnNames = ImmutableList.copyOf(Objects.requireNonNull(columnNames));
-    this.columnTypes = ImmutableList.copyOf(Objects.requireNonNull(columnTypes));
+    this.columnNames = Collections.unmodifiableList(Objects.requireNonNull(columnNames));
+    this.columnTypes = Collections.unmodifiableList(Objects.requireNonNull(columnTypes));
   }
 
   public QueryResponseMetadata(final List<String> columnNames, final List<String> columnTypes) {


### PR DESCRIPTION
### Description 

It's super important that the Java client doesn't depend on too many 3rd party deps, in particular commonly used ones such as Google/Apache/Guava stuff as the chance of version classes when the Java client is used in a user's app becomes higher. This can give the user a real headache and results in a poor user experience and potential bad sentiment towards the project.

Most of the work in removing deps has already been done by @vcrfxia , this just removes a bit more.

### Testing done 

Non functional change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

