### PR TITLE
fix: fail on WINDOW clause without matching GROUP BY

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -43,6 +43,7 @@ import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.function.udf.AsValue;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.parser.NodeLocation;
 import io.confluent.ksql.parser.tree.AllColumns;
 import io.confluent.ksql.parser.tree.GroupBy;
 import io.confluent.ksql.parser.tree.PartitionBy;
@@ -131,6 +132,13 @@ public class LogicalPlanner {
     if (analysis.getGroupBy().isPresent()) {
       currentNode = buildAggregateNode(currentNode);
     } else {
+      if (analysis.getWindowExpression().isPresent()) {
+        final String loc = analysis.getWindowExpression().get()
+            .getLocation()
+            .map(NodeLocation::asPrefix)
+            .orElse("");
+        throw new KsqlException(loc + "WINDOW clause requires a GROUP BY clause.");
+      }
       currentNode = buildUserProjectNode(currentNode);
     }
 

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/windowed-source.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/windowed-source.json
@@ -13,6 +13,17 @@
         "type": "io.confluent.ksql.util.KsqlException",
         "message": "KSQL does not support persistent queries on windowed tables."
       }
+    },
+    {
+      "name": "window without group by",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "CREATE STREAM OUTPUT as SELECT * FROM INPUT WINDOW TUMBLING (SIZE 30 SECONDS);"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "WINDOW clause requires a GROUP BY clause."
+      }
     }
   ]
 }


### PR DESCRIPTION
### Description 

A WINDOW clause is only valid if there is no matching GROUP BY. Before this change, if user submitted a query without a GROUP BY it would silently be ignored, which is poor UX. With this change an helpful error message is displayed.

See the QTT test for an example.

### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

