### PR TITLE
fix(client): fail queryID future if executeQuery() request fails (MINOR)

### DIFF
--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/BatchedQueryResult.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/BatchedQueryResult.java
@@ -31,6 +31,8 @@ public abstract class BatchedQueryResult extends CompletableFuture<List<Row>> {
    * Returns a {@code CompletableFuture} containing the ID of the underlying query if the query is
    * a push query, else null. The future is completed once a response is received from the server.
    *
+   * <p>If a non-200 response is received from the server, this future will complete exceptionally.
+   *
    * @return a future containing the query ID (or null in the case of pull queries)
    */
   public abstract CompletableFuture<String> queryID();

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/BatchedQueryResultImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/BatchedQueryResultImpl.java
@@ -24,6 +24,11 @@ public class BatchedQueryResultImpl extends BatchedQueryResult {
 
   BatchedQueryResultImpl() {
     this.queryId = new CompletableFuture<>();
+
+    this.exceptionally(t -> {
+      queryId.completeExceptionally(t);
+      return null;
+    });
   }
 
   @Override

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
@@ -433,15 +433,25 @@ public class ClientTest extends BaseApiTest {
     testEndpoints.setCreateQueryPublisherException(pfe);
 
     // When
+    final BatchedQueryResult batchedQueryResult = javaClient.executeQuery("bad query");
     final Exception e = assertThrows(
         ExecutionException.class, // thrown from .get() when the future completes exceptionally
-        () -> javaClient.executeQuery("bad query").get()
+        batchedQueryResult::get
     );
 
     // Then
     assertThat(e.getCause(), instanceOf(KsqlClientException.class));
     assertThat(e.getCause().getMessage(), containsString("Received 400 response from server"));
     assertThat(e.getCause().getMessage(), containsString("invalid query blah"));
+
+    // queryID future should also be completed exceptionally
+    final Exception queryIdException = assertThrows(
+        ExecutionException.class, // thrown from .get() when the future completes exceptionally
+        () -> batchedQueryResult.queryID().get()
+    );
+    assertThat(queryIdException.getCause(), instanceOf(KsqlClientException.class));
+    assertThat(queryIdException.getCause().getMessage(), containsString("Received 400 response from server"));
+    assertThat(queryIdException.getCause().getMessage(), containsString("invalid query blah"));
   }
 
   @Test


### PR DESCRIPTION
### Description 

The query ID future was not being completed if the executeQuery() request failed. This PR fixes the issue. The new behavior is for the query ID future to be failed with the same exception as the BatchedQueryResult.

### Testing done 

Added verification in unit and integration tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

