### PR TITLE
Fix markdown for function references

### DIFF
--- a/docs/developer-guide/ksqldb-reference/aggregate-functions.md
+++ b/docs/developer-guide/ksqldb-reference/aggregate-functions.md
@@ -6,39 +6,21 @@ description: Aggregate functions to use in  ksqlDB statements and queries
 keywords: ksqlDB, function, aggregate
 ---
 
-Aggregate Functions
-===================
+## `AVG`
 
-For more information, see
-[Aggregate Streaming Data With ksqlDB](../aggregate-streaming-data.md).
-
-  - [AVG](#average)
-  - [COLLECT_LIST](#collect_list)
-  - [COLLECT_SET](#collect_set)
-  - [COUNT](#count)
-  - [COUNT_DISTINCT](#count_distinct)
-  - [EARLIEST_BY_OFFSET](#earliest_by_offset)
-  - [HISTOGRAM](#histogram)
-  - [LATEST_BY_OFFSET](#latest_by_offset)
-  - [MAX](#max)
-  - [MIN](#min)
-  - [SUM](#sum)
-  - [TOPK](#topk)
-  - [TOPKDISTINCT](#topkdistinct)
-
-AVG
----
-
-`AVG(col1)`
+```sql
+AVG(col1)
+```
 
 Stream, Table
 
 Return the average value for a given column.
 
-COLLECT_LIST
-------------
+## `COLLECT_LIST`
 
-`COLLECT_LIST(col1)`
+```sql
+COLLECT_LIST(col1)
+```
 
 Stream, Table
 
@@ -56,10 +38,11 @@ late-arriving record, then the records from the second window in
 the order they were originally processed.
 
 
-COLLECT_SET
------------
+## `COLLECT_SET`
 
-`COLLECT_SET(col1)`
+```sql
+COLLECT_SET(col1)
+```
 
 Stream
 
@@ -77,11 +60,15 @@ late-arriving record, then the records from the second window in
 the order they were originally processed.
 
 
-COUNT
------
+## `COUNT`
 
-`COUNT(col1)`, 
-`COUNT(*)`     
+```sql
+COUNT(col1)
+```
+
+```sql
+COUNT(*)
+```
 
 Stream, Table
 
@@ -90,10 +77,11 @@ returned will be the number of rows where `col1` is non-null.
 When `*` is specified, the count returned will be the total
 number of rows.
 
-COUNT_DISTINCT
---------------
+## `COUNT_DISTINCT`
 
-`COUNT_DISTINCT(col1)`
+```sql
+COUNT_DISTINCT(col1)
+```
 
 Stream, Table
 
@@ -101,10 +89,11 @@ Returns the _approximate_ number of unique values of `col1` in a group.
 The function implementation uses [HyperLogLog](https://en.wikipedia.org/wiki/HyperLogLog)
 to estimate cardinalities of 10^9 with a typical standard error of 2%.
 
-EARLIEST_BY_OFFSET
-------------------
+## `EARLIEST_BY_OFFSET`
 
-`EARLIEST_BY_OFFSET(col1)`
+```sql
+EARLIEST_BY_OFFSET(col1)
+```
 
 Stream
 
@@ -112,10 +101,11 @@ Return the earliest value for a given column. Earliest here is defined as the va
 with the lowest offset. Rows that have `col1` set to null are ignored.
 
 
-HISTOGRAM
----------
+## `HISTOGRAM`
 
-`HISTOGRAM(col1)`
+```sql
+HISTOGRAM(col1)
+```
 
 Stream, Table
 
@@ -131,60 +121,66 @@ first considering all the records from the first window, then the
 late-arriving record, then the records from the second window in
 the order they were originally processed.
 
-LATEST_BY_OFFSET
-----------------
+## `LATEST_BY_OFFSET`
 
-`LATEST_BY_OFFSET(col1)`
+```sql
+LATEST_BY_OFFSET(col1)
+```
 
 Stream
 
 Return the latest value for a given column. Latest here is defined as the value in the partition
 with the greatest offset. Rows that have `col1` set to null are ignored.
 
-MAX
----
+## `MAX`
 
-`MAX(col1)`
+```sql
+MAX(col1)
+```
 
 Stream
 
 Return the maximum value for a given column and window.
 Rows that have `col1` set to null are ignored.
 
-MIN
----
+## `MIN`
 
-`MIN(col1)`
+```sql
+MIN(col1)
+```
 
 Stream
 
 Return the minimum value for a given column and window.
 Rows that have `col1` set to null are ignored.
 
-SUM
----
+## `SUM`
 
-`SUM(col1)`
+```sql
+SUM(col1)
+```
 
 Stream, Table
 
 Sums the column values.
 Rows that have `col1` set to null are ignored.
 
-TOPK
-----
+## `TOPK`
 
-`TOPK(col1, k)`
+```sql
+TOPK(col1, k)
+```
 
 Stream
 
 Return the Top *K* values for the given column and window
 Rows that have `col1` set to null are ignored.
 
-TOPKDISTINCT
-------------
+## `TOPKDISTINCT`
 
-`TOPKDISTINCT(col1, k)`
+```sql
+TOPKDISTINCT(col1, k)
+```
 
 Stream
 

--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -510,7 +510,7 @@ complex type are not inspected.
 Date and Time
 =============
 
-UNIX_DAT
+UNIX_DATE
 --------
 
 `UNIX_DATE()`

--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -6,89 +6,29 @@ description: Scalar functions to use in  ksqlDB statements and queries
 keywords: ksqlDB, function, scalar
 ---
 
-- [Numeric Functions](#numeric-functions)
-  - [ABS](#abs)
-  - [CEIL](#ceil)
-  - [ENTRIES](#entries)
-  - [EXP](#exp)
-  - [FLOOR](#floor)
-  - [GENERATE_SERIES](#generate_series)
-  - [GEO_DISTANCE](#geo_distance)
-  - [LN](#ln)
-  - [RANDOM](#random)
-  - [ROUND](#round)
-  - [SIGN](#sign)
-  - [SQRT](#sqrt)
-- [Collections](#collections)
-  - [ARRAY_LENGTH](#array_length)
-  - [ARRAY_CONTAINS](#array_contains)
-  - [JSON_ARRAY_CONTAINS](#json_array_contains)
-  - [ARRAY](#array)
-  - [MAP](#map)
-  - [AS_MAP](#asmap)
-  - [ELT](#elt)
-  - [FIELD](#field)
-  - [SLICE](#slice)
-- [Strings](#strings)
-  - [CONCAT](#concat)
-  - [EXTRACTJSONFIELD](#extractjsonfield)
-  - [INITCAP](#initcap)
-  - [INSTR](#instr)
-  - [LCASE](#lcase)
-  - [LEN](#len)
-  - [MASK](#mask)
-  - [MASK_KEEP_LEFT](#mask_keep_left)
-  - [MASK_KEEP_RIGHT](#mask_keep_right)
-  - [MASK_LEFT](#mask_left)
-  - [MASK_RIGHT](#mask_right)
-  - [REPLACE](#replace)
-  - [REGEXP_EXTRACT](#regexp_extract)
-  - [SPLIT](#split)
-  - [SUBSTRING](#substring)
-  - [TRIM](#trim)
-  - [UCASE](#ucase)
-- [Nulls](#nulls)
-  - [COALESCE](#coalesce)
-  - [IFNULL](#ifnull)
-- [Date and Time](#date-and-time)
-  - [UNIX_DATE](#unix_date)
-  - [UNIX_TIMESTAMP](#unix_timestamp)
-  - [DATETOSTRING](#datetostring)
-  - [STRINGTODATE](#stringtodate)
-  - [STRINGTOTIMESTAMP](#stringtotimestamp)
-  - [TIMESTAMPTOSTRING](#timestamptostring)
-- [URL](#url)
-  - [URL_DECODE_PARAM](#url_decode_param)
-  - [URL_ENCODE_PARAM](#url_encode_param)
-  - [URL_EXTRACT_FRAGMENT](#url_extract_fragment)
-  - [URL_EXTRACT_HOST](#url_extract_host)
-  - [URL_EXTRACT_PARAMETER](#url_extract_parameter)
-  - [URL_EXTRACT_PATH](#url_extract_path)
-  - [URL_EXTRACT_PORT](#url_extract_port)
-  - [URL_EXTRACT_PROTOCOL](#url_extract_protocol)
-  - [URL_EXTRACT_QUERY](#url_extract_query)
+## Numeric functions
 
-Numeric Functions
-=================
+### `ABS`
 
-ABS
----
-
-`ABS(col1)`
+```sql
+ABS(col1)
+```
 
 The absolute value of a value.
 
-CEIL
-----
+### `CEIL`
 
-`CEIL(col1)`
+```sql
+CEIL(col1)
+```
 
 The ceiling of a value.
 
-ENTRIES
--------
+### `ENTRIES`
 
-`ENTRIES(map MAP, sorted BOOLEAN)`
+```sql
+ENTRIES(map MAP, sorted BOOLEAN)
+```
 
 Constructs an array of structs from the entries in a map. Each struct has
 a field named `K` containing the key, which is a string, and a field named
@@ -96,25 +36,31 @@ a field named `K` containing the key, which is a string, and a field named
 
 If `sorted` is true, the entries are sorted by key.
 
-EXP
----
+### `EXP`
 
-`EXP(col1)`
+```sql
+EXP(col1)
+```
 
 The exponential of a value.
 
-FLOOR
------
+### `FLOOR`
 
-`FLOOR(col1)`
+```sql
+FLOOR(col1)
+```
 
 The floor of a value.
 
-GENERATE_SERIES
----------------
+### `GENERATE_SERIES`
 
-`GENERATE_SERIES(start, end)`
-`GENERATE_SERIES(start, end, step)`
+```sql
+GENERATE_SERIES(start, end)
+```
+
+```sql
+GENERATE_SERIES(start, end, step)
+```
 
 Constructs an array of values between `start` and `end` (inclusive).
 
@@ -123,33 +69,41 @@ Parameters `start` and `end` can be an `INT` or `BIGINT`.
 `step`, if supplied, specifies the step size. The step can be positive or negative.
 If not supplied, `step` defaults to `1`. Parameter `step` must be an `INT`.
 
-GEO_DISTANCE
-------------
+### `GEO_DISTANCE`
 
-`GEO_DISTANCE(lat1, lon1, lat2, lon2, unit)`
+```sql
+GEO_DISTANCE(lat1, lon1, lat2, lon2, unit)
+```
 
 The great-circle distance between two lat-long points, both specified
 in decimal degrees. An optional final parameter specifies `KM`
 (the default) or `miles`.
 
-LN
---
+### `LN`
 
-`LN(col1)`
+```sql
+LN(col1)
+```
 
 The natural logarithm of a value.
 
-RANDOM
-------
+### `RANDOM`
 
-`RANDOM()`
+```sql
+RANDOM()
+```
 
 Return a random DOUBLE value between 0.0 and 1.0.
 
-ROUND
------
+### `ROUND`
 
-`ROUND(col1)` or `ROUND(col1, scale)`
+```sql
+ROUND(col1)
+```
+
+```sql
+ROUND(col1, scale)
+```
 
 Round a value to the number of decimal places
 as specified by scale to the right of the decimal
@@ -161,10 +115,11 @@ rounded up (in the positive direction).
 If the number of decimal places is not provided
 it defaults to zero.
 
-SIGN
-----
+### `SIGN`
 
-`SIGN(col1)`
+```sql
+SIGN(col1)
+```
 
 The sign of a numeric value as an INTEGER:
 
@@ -173,106 +128,114 @@ The sign of a numeric value as an INTEGER:
 * 1 if the argument is positive
 * `null` argument is null
 
-SQRT
-----
+### `SQRT`
 
-`SQRT(col1)`
+```sql
+SQRT(col1)
+```
 
 The square root of a value.
 
+## Collections
 
-Collections
-===========
+### `ARRAY_LENGTH`
 
-ARRAY_LENGTH
-------------
-
-`ARRAY_LENGTH(ARRAY[1, 2, 3])`
+```sql
+ARRAY_LENGTH(ARRAY[1, 2, 3])
+```
 
 Given an array, return the number of elements in the array.
 
 If the supplied parameter is NULL the method returns NULL.
 
-ARRAY_CONTAINS
---------------
+### ``ARRAY_CONTAINS``
 
-`ARRAY_CONTAINS([1, 2, 3], 3)`
+```sql
+ARRAY_CONTAINS([1, 2, 3], 3)
+```
 
 Given an array, checks if a search value is contained in the array.
 
 Accepts any `ARRAY` type. The type of the second param must match the element type of the `ARRAY`.
 
-JSON_ARRAY_CONTAINS
--------------------
+### `JSON_ARRAY_CONTAINS`
 
-`JSON_ARRAY_CONTAINS('[1, 2, 3]', 3)`
+```sql
+JSON_ARRAY_CONTAINS('[1, 2, 3]', 3)
+```
 
 Given a `STRING` containing a JSON array, checks if a search value is contained in the array.
 
 Returns `false` if the first parameter does not contain a JSON array.
 
-ARRAY
------
+### `ARRAY`
 
-`ARRAY[col1, col2, ...]`
+```sql
+ARRAY[col1, col2, ...]
+```
 
 Construct an array from a variable number of inputs.
 
-MAP
----
+### `MAP`
 
-`MAP(key VARCHAR := value, ...)`
+```sql
+MAP(key VARCHAR := value, ...)
+```
 
 Construct a map from specific key-value tuples.
 
-AS_MAP
-------
+### `AS_MAP`
 
-`AS_MAP(keys, vals)`
+```sql
+AS_MAP(keys, vals)
+```
 
 Construct a map from a list of keys and a list of values.
 
-ELT
----
+### `ELT`
 
-`ELT(n INTEGER, args VARCHAR[])`
+```sql
+ELT(n INTEGER, args VARCHAR[])
+```
 
 Returns element `n` in the `args` list of strings, or NULL if `n` is less than
 1 or greater than the number of arguments. This function is 1-indexed. ELT is
 the complement to FIELD.
 
-FIELD
------
+### `FIELD`
 
-`FIELD(str VARCHAR, args VARCHAR[])`
+```sql
+FIELD(str VARCHAR, args VARCHAR[])
+```
 
 Returns the 1-indexed position of `str` in `args`, or 0 if not found.
 If `str` is NULL, the return value is 0, because NULL is not considered
 to be equal to any value. FIELD is the complement to ELT.
 
-SLICE
------
+### `SLICE`
 
-`SLICE(col1, from, to)`
+```sql
+SLICE(col1, from, to)
+```
 
 Slices a list based on the supplied indices. The indices start at 1 and
 include both endpoints.
 
+## Strings
 
-Strings
-=======
+### `CONCAT`
 
-CONCAT
-------
-
-`CONCAT(col1, '_hello')`
+```sql
+CONCAT(col1, '_hello')
+```
 
 Concatenate two or more strings.
 
-EXTRACTJSONFIELD
-----------------
+### `EXTRACTJSONFIELD`
 
-`EXTRACTJSONFIELD(message, '$.log.cloud')`
+```sql
+EXTRACTJSONFIELD(message, '$.log.cloud')
+```
 
 Given a STRING that contains JSON data, extract the value at the specified [JSONPath](https://jsonpath.com/).
 
@@ -289,7 +252,6 @@ For example, given a STRING containing the following JSON:
 ```
 
 `EXTRACTJSONFIELD(message, '$.log.cloud')` returns the STRING `gcp836Csd`.
-
 
 If the requested JSONPath does not exist, the function returns NULL.
 
@@ -309,18 +271,20 @@ instance number from the above JSON object as a INT.
 
     `CREATE STREAM LOGS (LOG STRUCT<CLOUD STRING, APP STRING, INSTANCE INT, ...) WITH (VALUE_FORMAT=JSON, ...)`
 
-INITCAP
--------
+### `INITCAP`
 
-`INITCAP(col1)`
+```sql
+INITCAP(col1)
+```
 
 Capitalize the first letter in each word and convert all other letters
 to lowercase. Words are delimited by whitespace.
 
-INSTR
------
+### `INSTR`
 
-`INSTR(string, substring, [position], [occurrence])`
+```sql
+INSTR(string, substring, [position], [occurrence])
+```
 
 Returns the position of `substring` in `string`. The first character is at position 1.
 
@@ -332,7 +296,8 @@ If `occurrence` is provided, the position of *n*-th occurrence is returned.
 If `substring` is not found, the return value is 0.
 
 Examples:
-```
+
+```sql
 INSTR('CORPORATE FLOOR', 'OR') -> 2
 INSTR('CORPORATE FLOOR', 'OR', 3) -> 5
 INSTR('CORPORATE FLOOR', 'OR', 3, 2) -> 14
@@ -341,25 +306,27 @@ INSTR('CORPORATE FLOOR', 'OR', -3, 2) -> 2b
 INSTR('CORPORATE FLOOR', 'MISSING') -> 0
 ```
 
+### `LCASE`
 
-LCASE
------
-
-`LCASE(col1)`
+```sql
+LCASE(col1)
+```
 
 Convert a string to lowercase.
 
-LEN
----
+### `LEN`
 
-`LEN(col1)`
+```sql
+LEN(col1)
+```
 
 The length of a string.
 
-MASK
-----
+### `MASK`
 
-`MASK(col1, 'X', 'x', 'n', '-')`
+```sql
+MASK(col1, 'X', 'x', 'n', '-')
+```
 
 Convert a string to a masked or obfuscated version of itself. The optional
 arguments following the input string to be masked are the characters to be
@@ -374,10 +341,11 @@ type. For example: `MASK("My Test $123")` will return `Xx-Xxxx--nnn`, applying
 all default masks. `MASK("My Test $123", '*', NULL, '1', NULL)` will yield
 `*y *est $111`.
 
-MASK_KEEP_LEFT
---------------
+### `MASK_KEEP_LEFT`
 
-`MASK_KEEP_LEFT(col1, numChars, 'X', 'x', 'n', '-')`
+```sql
+MASK_KEEP_LEFT(col1, numChars, 'X', 'x', 'n', '-')
+```
 
 Similar to the `MASK` function above, except
 that the first or left-most `numChars`
@@ -385,10 +353,11 @@ characters will not be masked in any way.
 For example: `MASK_KEEP_LEFT("My Test $123", 4)`
 will return `My Txxx--nnn`.
 
-MASK_KEEP_RIGHT
----------------
+### `MASK_KEEP_RIGHT`
 
-`MASK_KEEP_RIGHT(col1, numChars, 'X', 'x', 'n', '-')`
+```sql
+MASK_KEEP_RIGHT(col1, numChars, 'X', 'x', 'n', '-')
+```
 
 Similar to the `MASK` function above, except
 that the last or right-most `numChars`
@@ -396,10 +365,11 @@ characters will not be masked in any way.
 For example:`MASK_KEEP_RIGHT("My Test $123", 4)`
 will return `Xx-Xxxx-$123`.
 
-MASK_LEFT
----------
+### `MASK_LEFT`
 
-`MASK_LEFT(col1, numChars, 'X', 'x', 'n', '-')`
+```sql
+MASK_LEFT(col1, numChars, 'X', 'x', 'n', '-')
+```
 
 Similar to the `MASK` function above, except
 that only the first or left-most `numChars`
@@ -407,10 +377,11 @@ characters will have any masking applied to them.
 For example, `MASK_LEFT("My Test $123", 4)`
 will return `Xx-Xest $123`.
 
-MASK_RIGHT
-----------
+### `MASK_RIGHT`
 
-`MASK_RIGHT(col1, numChars, 'X', 'x', 'n', '-')`
+```sql
+MASK_RIGHT(col1, numChars, 'X', 'x', 'n', '-')
+```
 
 Similar to the `MASK` function above, except
 that only the last or right-most `numChars`
@@ -418,18 +389,23 @@ characters will have any masking applied to them.
 For example: `MASK_RIGHT("My Test $123", 4)`
 will return `My Test -nnn`.
 
-REPLACE
--------
+### `REPLACE`
 
-`REPLACE(col1, 'foo', 'bar')`
+```sql
+REPLACE(col1, 'foo', 'bar')
+```
 
 Replace all instances of a substring in a string with a new string.
 
-REGEXP_EXTRACT
--------
+### `REGEXP_EXTRACT`
 
-`REGEXP_EXTRACT('.*', col1)`
-`REGEXP_EXTRACT('(([AEIOU]).)', col1, 2)`
+```sql
+REGEXP_EXTRACT('.*', col1)
+```
+
+```sql
+REGEXP_EXTRACT('(([AEIOU]).)', col1, 2)
+```
 
 Extract the first subtring matched by the regex pattern from the input.
 
@@ -439,10 +415,11 @@ the entire substring is returned by default.
 For example, `REGEXP_EXTRACT("(.*) (.*)", 'hello there', 2)`
 returns "there".
 
-SPLIT
------
+### `SPLIT`
 
-`SPLIT(col1, delimiter)`
+```sql
+SPLIT(col1, delimiter)
+```
 
 Splits a string into an array of substrings based
 on a delimiter. If the delimiter is not found,
@@ -456,11 +433,15 @@ If the delimiter is found at the beginning or end
 of the string, or there are contiguous delimiters,
 then an empty space is added to the array.
 
-SUBSTRING
----------
+### `SUBSTRING`
 
-`SUBSTRING(col1, 2, 5)`
-`SUBSTRING(str, pos, [len])`
+```sql
+SUBSTRING(col1, 2, 5)
+```
+
+```sql
+SUBSTRING(str, pos, [len])
+```
 
 Returns a substring of `str` that starts at
 `pos` (first character is at position 1) and
@@ -470,66 +451,71 @@ the string.
 For example, `SUBSTRING("stream", 1, 4)`
 returns "stre".
 
-TRIM
-----
+### `TRIM`
 
-`TRIM(col1)`
+```sql
+TRIM(col1)
+```
 
 Trim the spaces from the beginning and end of a string.
 
-UCASE
------
+### `UCASE`
 
-`UCASE(col1)`
+```sql
+UCASE(col1)
+```
 
 Convert a string to uppercase.
 
-Nulls
-=====
+## Nulls
 
-COALESCE
---------
+### `COALESCE`
 
-`COALESCE(a, b, c, d)`
+```sql
+COALESCE(a, b, c, d)
+```
 
 Returns the first parameter that is not NULL. All parameters must be of the same type.
 
 Where the parameter type is a complex type, for example `ARRAY` or `STRUCT`, the contents of the
 complex type are not inspected. The behaviour is the same: the first NOT NULL element is returned.
 
-IFNULL
-------
+### `IFNULL`
 
-`IFNULL(expression, altValue)`
+```sql
+IFNULL(expression, altValue)
+```
 
 If the provided `expression` is NULL, returns `altValue`, otherwise, returns `expression`.
 
 Where the parameter type is a complex type, for example `ARRAY` or `STRUCT`, the contents of the
 complex type are not inspected.
 
-Date and Time
-=============
+## Date and time
 
-UNIX_DATE
---------
+### `UNIX_DATE`
 
-`UNIX_DATE()`
+```sql
+UNIX_DATE()
+```
  
 Gets an integer representing days since epoch. The returned timestamp
 may differ depending on the local time of different ksqlDB Server instances.
 
-UNIX_TIMESTAMP
---------------
+### `UNIX_TIMESTAMP`
 
-`UNIX_TIMESTAMP()`
+```sql
+UNIX_TIMESTAMP()
+```
 
 Gets the Unix timestamp in milliseconds, represented as a BIGINT. The returned
 timestamp may differ depending on the local time of different ksqlDB Server instances.
 
-DATETOSTRING
-------------
+### `DATETOSTRING`
 
-`DATETOSTRING(START_DATE, 'yyyy-MM-dd')`
+```sql
+DATETOSTRING(START_DATE, 'yyyy-MM-dd')
+```
 
 Converts an integer representation of a date into a string representing the
 date in the given format. Single quotes in the timestamp format can be escaped
@@ -537,10 +523,11 @@ with two successive single quotes, `''`, for example: `'yyyy-MM-dd''T'''`.
 The integer represents days since epoch matching the encoding used by
 {{ site.kconnect }} dates.
 
-STRINGTODATE
-------------
+### `STRINGTODATE`
 
-`STRINGTODATE(col1, 'yyyy-MM-dd')`
+```sql
+STRINGTODATE(col1, 'yyyy-MM-dd')
+```
 
 Converts a string representation of a date in the
 given format into an integer representing days
@@ -548,10 +535,11 @@ since epoch. Single quotes in the timestamp
 format can be escaped with two successive single
 quotes, `''`, for example: `'yyyy-MM-dd''T'''`.
 
-STRINGTOTIMESTAMP
------------------
+### `STRINGTOTIMESTAMP`
 
-`STRINGTOTIMESTAMP(col1, 'yyyy-MM-dd HH:mm:ss.SSS' [, TIMEZONE])`
+```sql
+STRINGTOTIMESTAMP(col1, 'yyyy-MM-dd HH:mm:ss.SSS' [, TIMEZONE])
+```
 
 Converts a string value in the given
 format into the BIGINT value                      
@@ -566,10 +554,11 @@ TIMEZONE is an optional parameter and it is a
 more information on timestamp formats, see
 [DateTimeFormatter](https://cnfl.io/java-dtf).    
 
-TIMESTAMPTOSTRING
------------------
+### `TIMESTAMPTOSTRING`
 
-`TIMESTAMPTOSTRING(ROWTIME, 'yyyy-MM-dd HH:mm:ss.SSS' [, TIMEZONE])`
+```sql
+TIMESTAMPTOSTRING(ROWTIME, 'yyyy-MM-dd HH:mm:ss.SSS' [, TIMEZONE])
+```
 
 Converts a BIGINT millisecond timestamp value into
 the string representation of the timestamp in
@@ -583,13 +572,20 @@ java.util.TimeZone ID format, for example: "UTC",
 more information on timestamp formats, see
 [DateTimeFormatter](https://cnfl.io/java-dtf).
 
-URL
-===
+## URLs
 
-URL_DECODE_PARAM
-----------------
+!!! note
+    All ksqlDB URL functions assume URI syntax defined in
+    [RFC 39386](https://tools.ietf.org/html/rfc3986). For more information on the
+    structure of a URI, including definitions of the various components, see
+    Section 3 of the RFC. For encoding/decoding, the
+    `application/x-www-form-urlencoded` convention is followed.
 
-`URL_DECODE_PARAM(col1)`
+### `URL_DECODE_PARAM`
+
+```sql
+URL_DECODE_PARAM(col1)
+```
 
 Unescapes the `URL-param-encoded`_ value in `col1`. This is the inverse of
 `URL_ENCODE_PARAM`.
@@ -597,10 +593,11 @@ Unescapes the `URL-param-encoded`_ value in `col1`. This is the inverse of
 - Input: `'url%20encoded`
 - Output: `url encoded`
 
-URL_ENCODE_PARAM
-----------------
+### `URL_ENCODE_PARAM`
 
-`URL_ENCODE_PARAM(col1)`
+```sql
+URL_ENCODE_PARAM(col1)
+```
 
 Escapes the value of `col1` such that it can
 safely be used in URL query parameters. Note that
@@ -610,10 +607,11 @@ in the path portion of a URL.
 - Input: `url encoded`                             
 - Output: `'url%20encoded`                         
 
-URL_EXTRACT_FRAGMENT
---------------------
+### `URL_EXTRACT_FRAGMENT`
 
-`URL_EXTRACT_FRAGMENT(url)`
+```sql
+URL_EXTRACT_FRAGMENT(url)
+```
 
 Extract the fragment portion of the specified
 value. Returns NULL if `url` is not a valid URL
@@ -626,10 +624,11 @@ value will be decoded.
 - Input: `http://test.com#frag%20space`,         
 - Output: `frag space`                           
 
-URL_EXTRACT_HOST
-----------------
+### `URL_EXTRACT_HOST`
 
-`URL_EXTRACT_HOST(url)`
+```sql
+URL_EXTRACT_HOST(url)
+```
 
 Extract the host-name portion of the specified
 value. Returns NULL if the `url` is not a valid  
@@ -638,10 +637,11 @@ URI according to RFC-2396.
 - Input: `http://test.com:8080/path`,              
 - Output: `test.com`                               
 
-URL_EXTRACT_PARAMETER
----------------------
+### `URL_EXTRACT_PARAMETER`
 
-`URL_EXTRACT_PARAMETER(url, parameter_name)`
+```sql
+URL_EXTRACT_PARAMETER(url, parameter_name)
+```
 
 Extract the value of the requested parameter from
 the query-string of `url`. Returns NULL
@@ -659,10 +659,11 @@ URL as a single string, see `URL_EXTRACT_QUERY.`
 - Input: `http://test.com?a=foo&b=bar`, `b`
 - Output: `bar`
 
-URL_EXTRACT_PATH
-----------------
+### `URL_EXTRACT_PATH`
 
-`URL_EXTRACT_PATH(url)`
+```sql
+URL_EXTRACT_PATH(url)
+```
 
 Extracts the path from `url`.
 Returns NULL if `url` is not a valid URI but  
@@ -671,10 +672,11 @@ returns an empty string if the path is empty.
 - Input: `http://test.com/path/to#a`            
 - Output: `path/to`                             
 
-URL_EXTRACT_PORT
-----------------
+### `URL_EXTRACT_PORT`
 
-`URL_EXTRACT_PORT(url)`
+```sql
+URL_EXTRACT_PORT(url)
+```
 
 Extract the port number from `url`.
 Returns NULL if `url` is not a valid URI or does
@@ -683,10 +685,11 @@ not contain an explicit port number.
 - Input: `http://localhost:8080/path`             
 - Output: `8080`                                  
 
-URL_EXTRACT_PROTOCOL
---------------------
+### `URL_EXTRACT_PROTOCOL`
 
-`URL_EXTRACT_PROTOCOL(url)`
+```sql
+URL_EXTRACT_PROTOCOL(url)
+```
 
 Extract the protocol from `url`. Returns NULL if
 `url` is an invalid URI or has no protocol.
@@ -694,10 +697,11 @@ Extract the protocol from `url`. Returns NULL if
 - Input: `http://test.com?a=foo&b=bar`       
 - Output: `http`                             
 
-URL_EXTRACT_QUERY
------------------
+### `URL_EXTRACT_QUERY`
 
-`URL_EXTRACT_QUERY(url)`
+```sql
+URL_EXTRACT_QUERY(url)
+```
 
 Extract the decoded query-string portion of
 `url`. Returns NULL if no query-string is  
@@ -705,11 +709,3 @@ present or `url` is not a valid URI.
                                            
 - Input: `http://test.com?a=foo%20bar&b=baz` 
 - Output: `a=foo bar&b=baz`                  
-
-
-!!! note
-    All ksqlDB URL functions assume URI syntax defined in
-    [RFC 39386](https://tools.ietf.org/html/rfc3986). For more information on the
-    structure of a URI, including definitions of the various components, see
-    Section 3 of the RFC. For encoding/decoding, the
-    `application/x-www-form-urlencoded` convention is followed.

--- a/docs/developer-guide/ksqldb-reference/table-functions.md
+++ b/docs/developer-guide/ksqldb-reference/table-functions.md
@@ -6,15 +6,7 @@ description: Learn how to use table function in a SELECT clause
 keywords: ksqldb, table, function, select
 ---
 
-Table Functions
-===============
-
-- [CUBE](#cube) 
-- [EXPLODE](#explode)
-- More to come
-
-ksqlDB Table Functions
-======================
+## Synopsis
 
 A table function is a function that returns a set of zero or more rows.
 Contrast this to a scalar function, which returns a single value.
@@ -98,10 +90,13 @@ Would give:
   {country: 'USA', name: null, age: 56}
 ```
 
-CUBE
-----
+## Functions
 
-`cube_explode(array[col1, ..., colN])`
+### `CUBE`
+
+```sql
+cube_explode(array[col1, ..., colN])
+```
 
 Array
 
@@ -109,10 +104,11 @@ Takes as argument an array of columns and outputs all possible combinations of t
 It produces `2^d` new rows where `d` is the number of columns given as parameter.
 Duplicate entries for columns with null value are skipped.
 
-EXPLODE
--------
+### `EXPLODE`
 
-`EXPLODE(col1)`
+```sql
+EXPLODE(col1)
+```
 
 Array
 


### PR DESCRIPTION
### Description 

A lot of the right sidebars that pre-populate the table of contents were messed up for function references. I fixed that and made the code snippets more readable.