### PR TITLE
test: enhance ImmutableTester to support wildcards (MINOR)

### DIFF
--- a/ksqldb-test-util/src/test/java/io/confluent/ksql/test/util/ImmutableTesterTest.java
+++ b/ksqldb-test-util/src/test/java/io/confluent/ksql/test/util/ImmutableTesterTest.java
@@ -159,8 +159,44 @@ public class ImmutableTesterTest {
     tester.test(TestSubject.class);
   }
 
-  private static final class MutableType {
-      private int i;
+  @Test(expected = AssertionError.class)
+  public void shouldFailOnWildcardType() {
+    // Given:
+    @Immutable
+    class TestSubject {
+      final ImmutableList<?> f0 = null;
+    }
+
+    // When:
+    tester.test(TestSubject.class);
+  }
+
+  @Test(expected = AssertionError.class)
+  public void shouldFailOnWildcardTypeWithMutableUpperBound() {
+    // Given:
+    @Immutable
+    class TestSubject {
+      final ImmutableList<? extends MutableType> f0 = null;
+    }
+
+    // When:
+    tester.test(TestSubject.class);
+  }
+
+  @Test
+  public void shouldNotFailOnWildcardTypeWithImmutableUpperBound() {
+    // Given:
+    @Immutable
+    class TestSubject {
+      final ImmutableList<? extends ImplementsNonImmutableInterface> f0 = null;
+    }
+
+    // When:
+    tester.test(TestSubject.class);
+  }
+
+  private static class MutableType {
+    private int i;
   }
 
   @Immutable


### PR DESCRIPTION
### Description 

Tester now correctly handles wildcards with immutable upper bounds, e.g. `ImmutableList<? extends SomeImmutableType>`.

### Testing done 

test only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

