### PR TITLE
fix: KSQL does not accept queries when running QueryLimit - 1 queries

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/RequestValidator.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/RequestValidator.java
@@ -109,10 +109,10 @@ public class RequestValidator {
 
       numPersistentQueries +=
           validate(serviceContext, configured, sessionProperties, ctx, injector);
-    }
 
-    if (QueryCapacityUtil.exceedsPersistentQueryCapacity(ctx, ksqlConfig, numPersistentQueries)) {
-      QueryCapacityUtil.throwTooManyActivePersistentQueriesException(ctx, ksqlConfig, sql);
+      if (QueryCapacityUtil.exceedsPersistentQueryCapacity(ctx, ksqlConfig)) {
+        QueryCapacityUtil.throwTooManyActivePersistentQueriesException(ctx, ksqlConfig, sql);
+      }
     }
 
     return numPersistentQueries;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/QueryCapacityUtil.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/QueryCapacityUtil.java
@@ -25,11 +25,9 @@ public final class QueryCapacityUtil {
 
   public static boolean exceedsPersistentQueryCapacity(
       final KsqlExecutionContext executionContext,
-      final KsqlConfig ksqlConfig,
-      final long additionalQueries
+      final KsqlConfig ksqlConfig
   ) {
-    final long newTotal = executionContext.getPersistentQueries().size() + additionalQueries;
-    return newTotal > getQueryLimit(ksqlConfig);
+    return executionContext.getPersistentQueries().size() > getQueryLimit(ksqlConfig);
   }
 
   public static void throwTooManyActivePersistentQueriesException(

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -587,6 +587,27 @@ public class KsqlResourceTest {
   }
 
   @Test
+  public void shouldExecuteMaxNumberPersistentQueries() {
+    // Given:
+    final String sql = "CREATE STREAM S AS SELECT * FROM test_stream;";
+    givenKsqlConfigWith(ImmutableMap.of(
+        KsqlConfig.KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_CONFIG, "1"
+    ));
+    setUpKsqlResource();
+
+
+    // When:
+    makeSingleRequest(sql, CommandStatusEntity.class);
+
+    // Then:
+    verify(commandStore).enqueueCommand(
+        any(),
+        argThat(is(commandWithStatement(sql))),
+        any(Producer.class)
+    );
+  }
+
+  @Test
   public void shouldFailForIncorrectCSASStatementResultType() {
     // When:
     final KsqlRestException e = assertThrows(
@@ -1491,7 +1512,8 @@ public class KsqlResourceTest {
 
     givenMockEngine();
 
-    givenPersistentQueryCount(3);
+    // mock 3 queries already running + 1 new query to execute
+    givenPersistentQueryCount(4);
 
     // When:
     final KsqlErrorMessage result = makeFailingRequest(
@@ -1508,12 +1530,13 @@ public class KsqlResourceTest {
   public void shouldFailAllCommandsIfWouldReachActivePersistentQueriesLimit() {
     // Given:
     givenKsqlConfigWith(
-        ImmutableMap.of(KsqlConfig.KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_CONFIG, 3));
+        ImmutableMap.of(KsqlConfig.KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_CONFIG, 1));
 
     final String ksqlString = "CREATE STREAM new_stream AS SELECT * FROM test_stream;"
         + "CREATE STREAM another_stream AS SELECT * FROM test_stream;";
     givenMockEngine();
 
+    // mock 2 new query to execute
     givenPersistentQueryCount(2);
 
     // When:

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/RequestValidatorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/RequestValidatorTest.java
@@ -55,7 +55,10 @@ import io.confluent.ksql.statement.InjectorChain;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlStatementException;
+import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.Sandbox;
+
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.junit.Before;
@@ -197,6 +200,7 @@ public class RequestValidatorTest {
   public void shouldThrowIfTooManyPersistentQueries() {
     // Given:
     when(ksqlConfig.getInt(KsqlConfig.KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_CONFIG)).thenReturn(1);
+    givenPersistentQueryCount(2);
 
     final List<ParsedStatement> statements =
         givenParsed(
@@ -302,6 +306,13 @@ public class RequestValidatorTest {
         ksqlConfig,
         distributedStatementValidator
     );
+  }
+
+  @SuppressWarnings("unchecked")
+  private void givenPersistentQueryCount(final int value) {
+    final List<PersistentQueryMetadata> queries = mock(List.class);
+    when(queries.size()).thenReturn(value);
+    when(ksqlEngine.getPersistentQueries()).thenReturn(queries);
   }
 
   @Sandbox

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/QueryCapacityUtilTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/QueryCapacityUtilTest.java
@@ -47,18 +47,7 @@ public class QueryCapacityUtilTest {
     givenQueryLimit(2);
 
     // Then:
-    assertThat(QueryCapacityUtil.exceedsPersistentQueryCapacity(ksqlEngine, ksqlConfig, 0),
-        equalTo(true));
-  }
-
-  @Test
-  public void shouldReportCapacityExceededIfTooManyQueriesAdded() {
-    // Given:
-    givenActivePersistentQueries(2);
-    givenQueryLimit(4);
-
-    // Then:
-    assertThat(QueryCapacityUtil.exceedsPersistentQueryCapacity(ksqlEngine, ksqlConfig, 3),
+    assertThat(QueryCapacityUtil.exceedsPersistentQueryCapacity(ksqlEngine, ksqlConfig),
         equalTo(true));
   }
 
@@ -66,21 +55,10 @@ public class QueryCapacityUtilTest {
   public void shouldNotReportCapacityExceededIfReached() {
     // Given:
     givenActivePersistentQueries(2);
-    givenQueryLimit(4);
+    givenQueryLimit(2);
 
     // Then:
-    assertThat(QueryCapacityUtil.exceedsPersistentQueryCapacity(ksqlEngine, ksqlConfig, 2),
-        equalTo(false));
-  }
-
-  @Test
-  public void shouldNotReportCapacityExceededIfNotReached() {
-    // Given:
-    givenActivePersistentQueries(2);
-    givenQueryLimit(4);
-
-    // Then:
-    assertThat(QueryCapacityUtil.exceedsPersistentQueryCapacity(ksqlEngine, ksqlConfig, 1),
+    assertThat(QueryCapacityUtil.exceedsPersistentQueryCapacity(ksqlEngine, ksqlConfig),
         equalTo(false));
   }
 


### PR DESCRIPTION
### Description 
Fixes https://github.com/confluentinc/ksql/issues/5454

**Problem**
Users were not able to execute the maximum number of queries allowed. It was always limit -1 queries permitted.

**Reason**
The `RequestValidator` class is checking if the user exceeded the maximum number of queries after the queries are validated and registered in the sandboxed query registry. This check was comparing the current values in the query registry + the new queries to execute. 

For instance, if the limit = 1 and there are no queries running, then the check was comparing 1 (new query added to the registry after validation) + 1 (new query already validated) > 1.

**Fix**
Check if the current values in the query registry exceeded the limit without adding again the new queries to execute. 


### Testing done 
- Unit tests
- Manual tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

