### PR TITLE
fix: /inserts-stream endpoint now accepts complex types

### DIFF
--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/KsqlArray.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/KsqlArray.java
@@ -282,7 +282,9 @@ public class KsqlArray {
    * @return a reference to this
    */
   public KsqlArray add(final BigDecimal value) {
-    delegate.add(value.doubleValue());
+    // Vert.x JsonArray does not accept BigDecimal values. Instead we store the value as a string
+    // so as to not lose precision.
+    delegate.add(value.toString());
     return this;
   }
 

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/KsqlObject.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/KsqlObject.java
@@ -300,7 +300,9 @@ public class KsqlObject {
    * @return a reference to this
    */
   public KsqlObject put(final String key, final BigDecimal value) {
-    delegate.put(key, value.doubleValue());
+    // Vert.x JsonObject does not accept BigDecimal values. Instead we store the value as a string
+    // so as to not lose precision.
+    delegate.put(key, value.toString());
     return this;
   }
 

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
@@ -57,11 +57,12 @@ import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.SerdeOption;
-import io.confluent.ksql.util.PageViewDataProvider;
+import io.confluent.ksql.util.StructuredTypesDataProvider;
 import io.confluent.ksql.util.TestDataProvider;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import java.math.BigDecimal;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -85,41 +86,42 @@ import org.reactivestreams.Publisher;
 @Category({IntegrationTest.class})
 public class ClientIntegrationTest {
 
-  private static final PageViewDataProvider PAGE_VIEWS_PROVIDER = new PageViewDataProvider();
-  private static final String PAGE_VIEW_TOPIC = PAGE_VIEWS_PROVIDER.topicName();
-  private static final String PAGE_VIEW_STREAM = PAGE_VIEWS_PROVIDER.kstreamName();
-  private static final int PAGE_VIEW_NUM_ROWS = PAGE_VIEWS_PROVIDER.data().size();
-  private static final List<String> PAGE_VIEW_COLUMN_NAMES =
-      ImmutableList.of("PAGEID", "USERID", "VIEWTIME");
-  private static final List<ColumnType> PAGE_VIEW_COLUMN_TYPES =
-      RowUtil.columnTypesFromStrings(ImmutableList.of("STRING", "STRING", "BIGINT"));
-  private static final List<KsqlArray> PAGE_VIEW_EXPECTED_ROWS = convertToClientRows(PAGE_VIEWS_PROVIDER.data());
+  private static final StructuredTypesDataProvider TEST_DATA_PROVIDER = new StructuredTypesDataProvider();
+  private static final String TEST_TOPIC = TEST_DATA_PROVIDER.topicName();
+  private static final String TEST_STREAM = TEST_DATA_PROVIDER.kstreamName();
+  private static final int TEST_NUM_ROWS = TEST_DATA_PROVIDER.data().size();
+  private static final List<String> TEST_COLUMN_NAMES =
+      ImmutableList.of("STR", "LONG", "DEC", "ARRAY", "MAP");
+  private static final List<ColumnType> TEST_COLUMN_TYPES =
+      RowUtil.columnTypesFromStrings(ImmutableList.of("STRING", "BIGINT", "DECIMAL", "ARRAY", "MAP"));
+  private static final List<KsqlArray> TEST_EXPECTED_ROWS = convertToClientRows(
+      TEST_DATA_PROVIDER.data());
 
   private static final String AGG_TABLE = "AGG_TABLE";
-  private static final String AN_AGG_KEY = "USER_1";
+  private static final String AN_AGG_KEY = "FOO";
   private static final PhysicalSchema AGG_SCHEMA = PhysicalSchema.from(
       LogicalSchema.builder()
-          .keyColumn(ColumnName.of("USERID"), SqlTypes.STRING)
+          .keyColumn(ColumnName.of("STR"), SqlTypes.STRING)
           .valueColumn(ColumnName.of("COUNT"), SqlTypes.BIGINT)
           .build(),
       SerdeOption.none()
   );
 
-  private static final TestDataProvider<String> EMPTY_PAGE_VIEWS_PROVIDER = new TestDataProvider<>(
-      "EMPTY_PAGEVIEW", PAGE_VIEWS_PROVIDER.schema(), ImmutableListMultimap.of());
-  private static final String EMPTY_PAGE_VIEWS_TOPIC = EMPTY_PAGE_VIEWS_PROVIDER.topicName();
-  private static final String EMPTY_PAGE_VIEWS_STREAM = EMPTY_PAGE_VIEWS_PROVIDER.kstreamName();
+  private static final TestDataProvider<String> EMPTY_TEST_DATA_PROVIDER = new TestDataProvider<>(
+      "EMPTY_STRUCTURED_TYPES", TEST_DATA_PROVIDER.schema(), ImmutableListMultimap.of());
+  private static final String EMPTY_TEST_TOPIC = EMPTY_TEST_DATA_PROVIDER.topicName();
+  private static final String EMPTY_TEST_STREAM = EMPTY_TEST_DATA_PROVIDER.kstreamName();
 
-  private static final String PUSH_QUERY = "SELECT * FROM " + PAGE_VIEW_STREAM + " EMIT CHANGES;";
-  private static final String PULL_QUERY = "SELECT * from " + AGG_TABLE + " WHERE USERID='" + AN_AGG_KEY + "';";
+  private static final String PUSH_QUERY = "SELECT * FROM " + TEST_STREAM + " EMIT CHANGES;";
+  private static final String PULL_QUERY = "SELECT * from " + AGG_TABLE + " WHERE STR='" + AN_AGG_KEY + "';";
   private static final int PUSH_QUERY_LIMIT_NUM_ROWS = 2;
   private static final String PUSH_QUERY_WITH_LIMIT =
-      "SELECT * FROM " + PAGE_VIEW_STREAM + " EMIT CHANGES LIMIT " + PUSH_QUERY_LIMIT_NUM_ROWS + ";";
+      "SELECT * FROM " + TEST_STREAM + " EMIT CHANGES LIMIT " + PUSH_QUERY_LIMIT_NUM_ROWS + ";";
 
-  private static final List<String> PULL_QUERY_COLUMN_NAMES = ImmutableList.of("USERID", "COUNT");
+  private static final List<String> PULL_QUERY_COLUMN_NAMES = ImmutableList.of("STR", "COUNT");
   private static final List<ColumnType> PULL_QUERY_COLUMN_TYPES =
       RowUtil.columnTypesFromStrings(ImmutableList.of("STRING", "BIGINT"));
-  private static final KsqlArray PULL_QUERY_EXPECTED_ROW = new KsqlArray(ImmutableList.of("USER_1", 1));
+  private static final KsqlArray PULL_QUERY_EXPECTED_ROW = new KsqlArray(ImmutableList.of("FOO", 1));
 
   private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
 
@@ -136,20 +138,20 @@ public class ClientIntegrationTest {
 
   @BeforeClass
   public static void setUpClass() {
-    TEST_HARNESS.ensureTopics(PAGE_VIEW_TOPIC);
-    TEST_HARNESS.produceRows(PAGE_VIEW_TOPIC, PAGE_VIEWS_PROVIDER, FormatFactory.JSON);
-    RestIntegrationTestUtil.createStream(REST_APP, PAGE_VIEWS_PROVIDER);
+    TEST_HARNESS.ensureTopics(TEST_TOPIC);
+    TEST_HARNESS.produceRows(TEST_TOPIC, TEST_DATA_PROVIDER, FormatFactory.JSON);
+    RestIntegrationTestUtil.createStream(REST_APP, TEST_DATA_PROVIDER);
 
     makeKsqlRequest("CREATE TABLE " + AGG_TABLE + " AS "
-        + "SELECT USERID, COUNT(1) AS COUNT FROM " + PAGE_VIEW_STREAM + " GROUP BY USERID;"
+        + "SELECT STR, COUNT(1) AS COUNT FROM " + TEST_STREAM + " GROUP BY STR;"
     );
 
-    TEST_HARNESS.ensureTopics(EMPTY_PAGE_VIEWS_TOPIC);
-    RestIntegrationTestUtil.createStream(REST_APP, EMPTY_PAGE_VIEWS_PROVIDER);
+    TEST_HARNESS.ensureTopics(EMPTY_TEST_TOPIC);
+    RestIntegrationTestUtil.createStream(REST_APP, EMPTY_TEST_DATA_PROVIDER);
 
     TEST_HARNESS.verifyAvailableUniqueRows(
         AGG_TABLE,
-        5, // Only unique keys are counted
+        4, // Only unique keys are counted
         FormatFactory.JSON,
         AGG_SCHEMA
     );
@@ -186,11 +188,11 @@ public class ClientIntegrationTest {
     final StreamedQueryResult streamedQueryResult = client.streamQuery(PUSH_QUERY).get();
 
     // Then
-    assertThat(streamedQueryResult.columnNames(), is(PAGE_VIEW_COLUMN_NAMES));
-    assertThat(streamedQueryResult.columnTypes(), is(PAGE_VIEW_COLUMN_TYPES));
+    assertThat(streamedQueryResult.columnNames(), is(TEST_COLUMN_NAMES));
+    assertThat(streamedQueryResult.columnTypes(), is(TEST_COLUMN_TYPES));
     assertThat(streamedQueryResult.queryID(), is(notNullValue()));
 
-    shouldReceivePageViewRows(streamedQueryResult, false);
+    shouldReceiveStreamRows(streamedQueryResult, false);
 
     assertThat(streamedQueryResult.isComplete(), is(false));
   }
@@ -201,13 +203,13 @@ public class ClientIntegrationTest {
     final StreamedQueryResult streamedQueryResult = client.streamQuery(PUSH_QUERY).get();
 
     // Then
-    assertThat(streamedQueryResult.columnNames(), is(PAGE_VIEW_COLUMN_NAMES));
-    assertThat(streamedQueryResult.columnTypes(), is(PAGE_VIEW_COLUMN_TYPES));
+    assertThat(streamedQueryResult.columnNames(), is(TEST_COLUMN_NAMES));
+    assertThat(streamedQueryResult.columnTypes(), is(TEST_COLUMN_TYPES));
     assertThat(streamedQueryResult.queryID(), is(notNullValue()));
 
-    for (int i = 0; i < PAGE_VIEW_NUM_ROWS; i++) {
+    for (int i = 0; i < TEST_NUM_ROWS; i++) {
       final Row row = streamedQueryResult.poll();
-      verifyPageViewRowWithIndex(row, i);
+      verifyStreamRowWithIndex(row, i);
     }
 
     assertThat(streamedQueryResult.isComplete(), is(false));
@@ -251,11 +253,11 @@ public class ClientIntegrationTest {
     final StreamedQueryResult streamedQueryResult = client.streamQuery(PUSH_QUERY_WITH_LIMIT).get();
 
     // Then
-    assertThat(streamedQueryResult.columnNames(), is(PAGE_VIEW_COLUMN_NAMES));
-    assertThat(streamedQueryResult.columnTypes(), is(PAGE_VIEW_COLUMN_TYPES));
+    assertThat(streamedQueryResult.columnNames(), is(TEST_COLUMN_NAMES));
+    assertThat(streamedQueryResult.columnTypes(), is(TEST_COLUMN_TYPES));
     assertThat(streamedQueryResult.queryID(), is(notNullValue()));
 
-    shouldReceivePageViewRows(streamedQueryResult, true, PUSH_QUERY_LIMIT_NUM_ROWS);
+    shouldReceiveStreamRows(streamedQueryResult, true, PUSH_QUERY_LIMIT_NUM_ROWS);
 
     assertThat(streamedQueryResult.isComplete(), is(true));
   }
@@ -266,13 +268,13 @@ public class ClientIntegrationTest {
     final StreamedQueryResult streamedQueryResult = client.streamQuery(PUSH_QUERY_WITH_LIMIT).get();
 
     // Then
-    assertThat(streamedQueryResult.columnNames(), is(PAGE_VIEW_COLUMN_NAMES));
-    assertThat(streamedQueryResult.columnTypes(), is(PAGE_VIEW_COLUMN_TYPES));
+    assertThat(streamedQueryResult.columnNames(), is(TEST_COLUMN_NAMES));
+    assertThat(streamedQueryResult.columnTypes(), is(TEST_COLUMN_TYPES));
     assertThat(streamedQueryResult.queryID(), is(notNullValue()));
 
     for (int i = 0; i < PUSH_QUERY_LIMIT_NUM_ROWS; i++) {
       final Row row = streamedQueryResult.poll();
-      verifyPageViewRowWithIndex(row, i);
+      verifyStreamRowWithIndex(row, i);
     }
     assertThat(streamedQueryResult.poll(), is(nullValue()));
 
@@ -302,7 +304,7 @@ public class ClientIntegrationTest {
     // When / Then
     for (int i = 0; i < PUSH_QUERY_LIMIT_NUM_ROWS; i++) {
       final Row row = streamedQueryResult.poll();
-      verifyPageViewRowWithIndex(row, i);
+      verifyStreamRowWithIndex(row, i);
     }
     assertThat(streamedQueryResult.poll(), is(nullValue()));
   }
@@ -320,7 +322,7 @@ public class ClientIntegrationTest {
 
     // Then
     assertThatEventually(subscriber::getValues, hasSize(PUSH_QUERY_LIMIT_NUM_ROWS));
-    verifyPageViewRows(subscriber.getValues(), PUSH_QUERY_LIMIT_NUM_ROWS);
+    verifyStreamRows(subscriber.getValues(), PUSH_QUERY_LIMIT_NUM_ROWS);
     assertThat(subscriber.getError(), is(nullValue()));
   }
 
@@ -343,7 +345,7 @@ public class ClientIntegrationTest {
     // Then
     assertThat(batchedQueryResult.queryID().get(), is(notNullValue()));
 
-    verifyPageViewRows(batchedQueryResult.get(), PUSH_QUERY_LIMIT_NUM_ROWS);
+    verifyStreamRows(batchedQueryResult.get(), PUSH_QUERY_LIMIT_NUM_ROWS);
   }
 
   @Test
@@ -422,29 +424,33 @@ public class ClientIntegrationTest {
   public void shouldInsertInto() throws Exception {
     // Given
     final KsqlObject insertRow = new KsqlObject()
-        .put("VIEWTIME", 1000L)
-        .put("USERID", "User_1")
-        .put("PAGEID", "Page_28");
+        .put("STR", "HELLO")
+        .put("LONG", 100L)
+        .put("DEC", new BigDecimal("13.31"))
+        .put("ARRAY", new KsqlArray().add("v1").add("v2"))
+        .put("MAP", new KsqlObject().put("some_key", "a_value").put("another_key", ""));
 
     // When
-    client.insertInto(EMPTY_PAGE_VIEWS_STREAM, insertRow).get();
+    client.insertInto(EMPTY_TEST_STREAM, insertRow).get();
 
     // Then: should receive new row
-    final String query = "SELECT * FROM " + EMPTY_PAGE_VIEWS_STREAM + " EMIT CHANGES LIMIT 1;";
+    final String query = "SELECT * FROM " + EMPTY_TEST_STREAM + " EMIT CHANGES LIMIT 1;";
     final List<Row> rows = client.executeQuery(query).get();
 
     // Verify inserted row is as expected
     assertThat(rows, hasSize(1));
-    assertThat(rows.get(0).getLong("VIEWTIME"), is(1000L));
-    assertThat(rows.get(0).getString("USERID"), is("User_1"));
-    assertThat(rows.get(0).getString("PAGEID"), is("Page_28"));
+    assertThat(rows.get(0).getString("STR"), is("HELLO"));
+    assertThat(rows.get(0).getLong("LONG"), is(100L));
+    assertThat(rows.get(0).getDecimal("DEC"), is(new BigDecimal("13.31")));
+    assertThat(rows.get(0).getKsqlArray("ARRAY"), is(new KsqlArray().add("v1").add("v2")));
+    assertThat(rows.get(0).getKsqlObject("MAP"), is(new KsqlObject().put("some_key", "a_value").put("another_key", "")));
   }
 
   @Test
   public void shouldHandleErrorResponseFromInsertInto() {
     // Given
     final KsqlObject insertRow = new KsqlObject()
-        .put("USERID", "User_11")
+        .put("STR", "BLAH")
         .put("COUNT", 11L);
 
     // When
@@ -464,12 +470,14 @@ public class ClientIntegrationTest {
     // Given
     final Map<String, Object> properties = new HashMap<>();
     properties.put("auto.offset.reset", "latest");
-    final String sql = "SELECT * FROM " + PAGE_VIEW_STREAM + " EMIT CHANGES LIMIT 1;";
+    final String sql = "SELECT * FROM " + TEST_STREAM + " EMIT CHANGES LIMIT 1;";
 
     final KsqlObject insertRow = new KsqlObject()
-        .put("VIEWTIME", 2000L)
-        .put("USERID", "User_shouldStreamQueryWithProperties")
-        .put("PAGEID", "Page_shouldStreamQueryWithProperties");
+        .put("STR", "Value_shouldStreamQueryWithProperties")
+        .put("LONG", 2000L)
+        .put("DEC", new BigDecimal("12.34"))
+        .put("ARRAY", new KsqlArray().add("v1_shouldStreamQueryWithProperties").add("v2_shouldStreamQueryWithProperties"))
+        .put("MAP", new KsqlObject().put("test_name", "shouldStreamQueryWithProperties"));
 
     // When
     final StreamedQueryResult queryResult = client.streamQuery(sql, properties).get();
@@ -478,16 +486,18 @@ public class ClientIntegrationTest {
     final Row row = assertThatEventually(() -> {
       // Potentially try inserting multiple times, in case the query wasn't started by the first time
       try {
-        client.insertInto(PAGE_VIEW_STREAM, insertRow).get();
+        client.insertInto(TEST_STREAM, insertRow).get();
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
       return queryResult.poll(Duration.ofMillis(10));
     }, is(notNullValue()));
 
-    assertThat(row.getLong("VIEWTIME"), is(2000L));
-    assertThat(row.getString("USERID"), is("User_shouldStreamQueryWithProperties"));
-    assertThat(row.getString("PAGEID"), is("Page_shouldStreamQueryWithProperties"));
+    assertThat(row.getString("STR"), is("Value_shouldStreamQueryWithProperties"));
+    assertThat(row.getLong("LONG"), is(2000L));
+    assertThat(row.getDecimal("DEC"), is(new BigDecimal("12.34")));
+    assertThat(row.getKsqlArray("ARRAY"), is(new KsqlArray().add("v1_shouldStreamQueryWithProperties").add("v2_shouldStreamQueryWithProperties")));
+    assertThat(row.getKsqlObject("MAP"), is(new KsqlObject().put("test_name", "shouldStreamQueryWithProperties")));
   }
 
   @Test
@@ -495,12 +505,14 @@ public class ClientIntegrationTest {
     // Given
     final Map<String, Object> properties = new HashMap<>();
     properties.put("auto.offset.reset", "latest");
-    final String sql = "SELECT * FROM " + PAGE_VIEW_STREAM + " EMIT CHANGES LIMIT 1;";
+    final String sql = "SELECT * FROM " + TEST_STREAM + " EMIT CHANGES LIMIT 1;";
 
     final KsqlObject insertRow = new KsqlObject()
-        .put("VIEWTIME", 2000L)
-        .put("USERID", "User_shouldExecuteQueryWithProperties")
-        .put("PAGEID", "Page_shouldExecuteQueryWithProperties");
+        .put("STR", "Value_shouldExecuteQueryWithProperties")
+        .put("LONG", 2000L)
+        .put("DEC", new BigDecimal("12.34"))
+        .put("ARRAY", new KsqlArray().add("v1_shouldExecuteQueryWithProperties").add("v2_shouldExecuteQueryWithProperties"))
+        .put("MAP", new KsqlObject().put("test_name", "shouldExecuteQueryWithProperties"));
 
     // When
     final BatchedQueryResult queryResult = client.executeQuery(sql, properties);
@@ -523,7 +535,7 @@ public class ClientIntegrationTest {
     final Row row = assertThatEventually(() -> {
       // Potentially try inserting multiple times, in case the query wasn't started by the first time
       try {
-        client.insertInto(PAGE_VIEW_STREAM, insertRow).get();
+        client.insertInto(TEST_STREAM, insertRow).get();
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
@@ -531,9 +543,11 @@ public class ClientIntegrationTest {
     }, is(notNullValue()));
 
     // Verify received row
-    assertThat(row.getLong("VIEWTIME"), is(2000L));
-    assertThat(row.getString("USERID"), is("User_shouldExecuteQueryWithProperties"));
-    assertThat(row.getString("PAGEID"), is("Page_shouldExecuteQueryWithProperties"));
+    assertThat(row.getString("STR"), is("Value_shouldExecuteQueryWithProperties"));
+    assertThat(row.getLong("LONG"), is(2000L));
+    assertThat(row.getDecimal("DEC"), is(new BigDecimal("12.34")));
+    assertThat(row.getKsqlArray("ARRAY"), is(new KsqlArray().add("v1_shouldExecuteQueryWithProperties").add("v2_shouldExecuteQueryWithProperties")));
+    assertThat(row.getKsqlObject("MAP"), is(new KsqlObject().put("test_name", "shouldExecuteQueryWithProperties")));
   }
 
   private Client createClient() {
@@ -552,14 +566,14 @@ public class ClientIntegrationTest {
     assertThatEventually(engine::numberOfLiveQueries, is(numQueries));
   }
 
-  private static void shouldReceivePageViewRows(
+  private static void shouldReceiveStreamRows(
       final Publisher<Row> publisher,
       final boolean subscriberCompleted
   ) {
-    shouldReceivePageViewRows(publisher, subscriberCompleted, PAGE_VIEW_NUM_ROWS);
+    shouldReceiveStreamRows(publisher, subscriberCompleted, TEST_NUM_ROWS);
   }
 
-  private static void shouldReceivePageViewRows(
+  private static void shouldReceiveStreamRows(
       final Publisher<Row> publisher,
       final boolean subscriberCompleted,
       final int numRows
@@ -567,62 +581,69 @@ public class ClientIntegrationTest {
     shouldReceiveRows(
         publisher,
         numRows,
-        rows -> verifyPageViewRows(rows, numRows),
+        rows -> verifyStreamRows(rows, numRows),
         subscriberCompleted
     );
   }
 
-  private static void verifyPageViewRows(final List<Row> rows, final int numRows) {
+  private static void verifyStreamRows(final List<Row> rows, final int numRows) {
     assertThat(rows, hasSize(numRows));
     for (int i = 0; i < numRows; i++) {
-      verifyPageViewRowWithIndex(rows.get(i), i);
+      verifyStreamRowWithIndex(rows.get(i), i);
     }
   }
 
-  private static void verifyPageViewRowWithIndex(final Row row, final int index) {
-    final KsqlArray expectedRow = PAGE_VIEW_EXPECTED_ROWS.get(index);
+  private static void verifyStreamRowWithIndex(final Row row, final int index) {
+    final KsqlArray expectedRow = TEST_EXPECTED_ROWS.get(index);
 
     // verify metadata
     assertThat(row.values(), equalTo(expectedRow));
-    assertThat(row.columnNames(), equalTo(PAGE_VIEW_COLUMN_NAMES));
-    assertThat(row.columnTypes(), equalTo(PAGE_VIEW_COLUMN_TYPES));
+    assertThat(row.columnNames(), equalTo(TEST_COLUMN_NAMES));
+    assertThat(row.columnTypes(), equalTo(TEST_COLUMN_TYPES));
 
     // verify type-based getters
-    assertThat(row.getString("PAGEID"), is(expectedRow.getString(0)));
-    assertThat(row.getString("USERID"), is(expectedRow.getString(1)));
-    assertThat(row.getLong("VIEWTIME"), is(expectedRow.getLong(2)));
+    assertThat(row.getString("STR"), is(expectedRow.getString(0)));
+    assertThat(row.getLong("LONG"), is(expectedRow.getLong(1)));
+    assertThat(row.getDecimal("DEC"), is(expectedRow.getDecimal(2)));
+    assertThat(row.getKsqlArray("ARRAY"), is(expectedRow.getKsqlArray(3)));
+    assertThat(row.getKsqlObject("MAP"), is(expectedRow.getKsqlObject(4)));
 
     // verify index-based getters are 1-indexed
-    assertThat(row.getString(1), is(row.getString("PAGEID")));
-    assertThat(row.getString(2), is(row.getString("USERID")));
-    assertThat(row.getLong(3), is(row.getLong("VIEWTIME")));
+    assertThat(row.getString(1), is(row.getString("STR")));
+    assertThat(row.getLong(2), is(row.getLong("LONG")));
+    assertThat(row.getDecimal(3), is(row.getDecimal("DEC")));
+    assertThat(row.getKsqlArray(4), is(row.getKsqlArray("ARRAY")));
+    assertThat(row.getKsqlObject(5), is(row.getKsqlObject("MAP")));
 
     // verify isNull() evaluation
-    assertThat(row.isNull("PAGEID"), is(false));
-    assertThat(row.isNull("VIEWTIME"), is(false));
+    assertThat(row.isNull("STR"), is(false));
 
     // verify exception on invalid cast
-    assertThrows(ClassCastException.class, () -> row.getInteger("PAGEID"));
+    assertThrows(ClassCastException.class, () -> row.getInteger("STR"));
 
     // verify KsqlArray methods
     final KsqlArray values = row.values();
-    assertThat(values.size(), is(PAGE_VIEW_COLUMN_NAMES.size()));
+    assertThat(values.size(), is(TEST_COLUMN_NAMES.size()));
     assertThat(values.isEmpty(), is(false));
-    assertThat(values.getString(0), is(row.getString("PAGEID")));
-    assertThat(values.getString(1), is(row.getString("USERID")));
-    assertThat(values.getLong(2), is(row.getLong("VIEWTIME")));
+    assertThat(values.getString(0), is(row.getString("STR")));
+    assertThat(values.getLong(1), is(row.getLong("LONG")));
+    assertThat(values.getDecimal(2), is(row.getDecimal("DEC")));
+    assertThat(values.getKsqlArray(3), is(row.getKsqlArray("ARRAY")));
+    assertThat(values.getKsqlObject(4), is(row.getKsqlObject("MAP")));
     assertThat(values.toJsonString(), is((new JsonArray(values.getList())).toString()));
     assertThat(values.toString(), is(values.toJsonString()));
 
     // verify KsqlObject methods
     final KsqlObject obj = row.asObject();
-    assertThat(obj.size(), is(PAGE_VIEW_COLUMN_NAMES.size()));
+    assertThat(obj.size(), is(TEST_COLUMN_NAMES.size()));
     assertThat(obj.isEmpty(), is(false));
-    assertThat(obj.fieldNames(), contains(PAGE_VIEW_COLUMN_NAMES.toArray()));
-    assertThat(obj.getString("PAGEID"), is(row.getString("PAGEID")));
-    assertThat(obj.getString("USERID"), is(row.getString("USERID")));
-    assertThat(obj.getLong("VIEWTIME"), is(row.getLong("VIEWTIME")));
-    assertThat(obj.containsKey("VIEWTIME"), is(true));
+    assertThat(obj.fieldNames(), contains(TEST_COLUMN_NAMES.toArray()));
+    assertThat(obj.getString("STR"), is(row.getString("STR")));
+    assertThat(obj.getLong("LONG"), is(row.getLong("LONG")));
+    assertThat(obj.getDecimal("DEC"), is(row.getDecimal("DEC")));
+    assertThat(obj.getKsqlArray("ARRAY"), is(row.getKsqlArray("ARRAY")));
+    assertThat(obj.getKsqlObject("MAP"), is(row.getKsqlObject("MAP")));
+    assertThat(obj.containsKey("DEC"), is(true));
     assertThat(obj.containsKey("notafield"), is(false));
     assertThat(obj.toJsonString(), is((new JsonObject(obj.getMap())).toString()));
     assertThat(obj.toString(), is(obj.toJsonString()));
@@ -649,25 +670,25 @@ public class ClientIntegrationTest {
     assertThat(row.columnTypes(), equalTo(PULL_QUERY_COLUMN_TYPES));
 
     // verify type-based getters
-    assertThat(row.getString("USERID"), is(PULL_QUERY_EXPECTED_ROW.getString(0)));
+    assertThat(row.getString("STR"), is(PULL_QUERY_EXPECTED_ROW.getString(0)));
     assertThat(row.getLong("COUNT"), is(PULL_QUERY_EXPECTED_ROW.getLong(1)));
 
     // verify index-based getters are 1-indexed
-    assertThat(row.getString(1), is(row.getString("USERID")));
+    assertThat(row.getString(1), is(row.getString("STR")));
     assertThat(row.getLong(2), is(row.getLong("COUNT")));
 
     // verify isNull() evaluation
-    assertThat(row.isNull("USERID"), is(false));
+    assertThat(row.isNull("STR"), is(false));
     assertThat(row.isNull("COUNT"), is(false));
 
     // verify exception on invalid cast
-    assertThrows(ClassCastException.class, () -> row.getInteger("USERID"));
+    assertThrows(ClassCastException.class, () -> row.getInteger("STR"));
 
     // verify KsqlArray methods
     final KsqlArray values = row.values();
     assertThat(values.size(), is(PULL_QUERY_COLUMN_NAMES.size()));
     assertThat(values.isEmpty(), is(false));
-    assertThat(values.getString(0), is(row.getString("USERID")));
+    assertThat(values.getString(0), is(row.getString("STR")));
     assertThat(values.getLong(1), is(row.getLong("COUNT")));
     assertThat(values.toJsonString(), is((new JsonArray(values.getList())).toString()));
     assertThat(values.toString(), is(values.toJsonString()));
@@ -677,7 +698,7 @@ public class ClientIntegrationTest {
     assertThat(obj.size(), is(PULL_QUERY_COLUMN_NAMES.size()));
     assertThat(obj.isEmpty(), is(false));
     assertThat(obj.fieldNames(), contains(PULL_QUERY_COLUMN_NAMES.toArray()));
-    assertThat(obj.getString("USERID"), is(row.getString("USERID")));
+    assertThat(obj.getString("STR"), is(row.getString("STR")));
     assertThat(obj.getLong("COUNT"), is(row.getLong("COUNT")));
     assertThat(obj.containsKey("COUNT"), is(true));
     assertThat(obj.containsKey("notafield"), is(false));

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/StructuredTypesDataProvider.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/StructuredTypesDataProvider.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.confluent.ksql.util;
+
+import static io.confluent.ksql.GenericRow.genericRow;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Multimap;
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.serde.SerdeOption;
+import java.math.BigDecimal;
+import java.util.Collections;
+
+public class StructuredTypesDataProvider extends TestDataProvider<String> {
+
+  private static final LogicalSchema LOGICAL_SCHEMA = LogicalSchema.builder()
+      .keyColumn(ColumnName.of("STR"), SqlTypes.STRING)
+      .valueColumn(ColumnName.of("LONG"), SqlTypes.BIGINT)
+      .valueColumn(ColumnName.of("DEC"), SqlTypes.decimal(4, 2))
+      .valueColumn(ColumnName.of("ARRAY"), SqlTypes.array(SqlTypes.STRING))
+      .valueColumn(ColumnName.of("MAP"), SqlTypes.map(SqlTypes.STRING))
+      .build();
+
+  private static final PhysicalSchema PHYSICAL_SCHEMA = PhysicalSchema
+      .from(LOGICAL_SCHEMA, SerdeOption.none());
+
+  private static final Multimap<String, GenericRow> ROWS = ImmutableListMultimap
+      .<String, GenericRow>builder()
+      .put("FOO", genericRow(1L, new BigDecimal("1.11"), Collections.singletonList("a"), Collections.singletonMap("k1", "v1")))
+      .put("BAR", genericRow(2L, new BigDecimal("2.22"), Collections.emptyList(), Collections.emptyMap()))
+      .put("BAZ", genericRow(3L, new BigDecimal("30.33"), Collections.singletonList("b"), Collections.emptyMap()))
+      .put("BUZZ", genericRow(4L, new BigDecimal("40.44"), ImmutableList.of("c", "d"), Collections.emptyMap()))
+      // Additional entries for repeated keys
+      .put("BAZ", genericRow(5L, new BigDecimal("12"), ImmutableList.of("e"), ImmutableMap.of("k1", "v1", "k2", "v2")))
+      .put("BUZZ", genericRow(6L, new BigDecimal("10.1"), ImmutableList.of("f", "g"), Collections.emptyMap()))
+      .build();
+
+  public StructuredTypesDataProvider() {
+    super("STRUCTURED_TYPES", PHYSICAL_SCHEMA, ROWS);
+  }
+}

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/KeyValueExtractor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/KeyValueExtractor.java
@@ -22,7 +22,6 @@ import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.schema.ksql.SqlValueCoercer;
-import io.confluent.ksql.schema.ksql.types.SqlArray;
 import io.confluent.ksql.schema.ksql.types.SqlDecimal;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.vertx.core.json.JsonArray;

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
@@ -109,7 +109,7 @@ public class ApiIntegrationTest {
     RestIntegrationTestUtil.createStream(REST_APP, TEST_DATA_PROVIDER);
 
     makeKsqlRequest("CREATE TABLE " + AGG_TABLE + " AS "
-        + "SELECT STR, COUNT(1) AS COUNT FROM " + TEST_STREAM + " GROUP BY STR;"
+        + "SELECT STR, LATEST_BY_OFFSET(LONG) AS LONG FROM " + TEST_STREAM + " GROUP BY STR;"
     );
   }
 
@@ -262,14 +262,14 @@ public class ApiIntegrationTest {
     QueryResponse response = atomicReference.get();
 
     // Then:
-    JsonArray expectedColumnNames = new JsonArray().add("STR").add("COUNT");
+    JsonArray expectedColumnNames = new JsonArray().add("STR").add("LONG");
     JsonArray expectedColumnTypes = new JsonArray().add("STRING").add("BIGINT");
     assertThat(response.rows, hasSize(1));
     assertThat(response.responseObject.getJsonArray("columnNames"), is(expectedColumnNames));
     assertThat(response.responseObject.getJsonArray("columnTypes"), is(expectedColumnTypes));
     assertThat(response.responseObject.getString("queryId"), is(nullValue()));
     assertThat(response.rows.get(0).getString(0), is("FOO")); // rowkey
-    assertThat(response.rows.get(0).getLong(1), is(1L)); // count
+    assertThat(response.rows.get(0).getLong(1), is(1L)); // latest_by_offset(long)
   }
 
   @Test
@@ -307,10 +307,10 @@ public class ApiIntegrationTest {
   public void shouldFailPullQueryWithNonKeyLookup() {
 
     // Given:
-    String sql = "SELECT * from " + AGG_TABLE + " WHERE COUNT=12345;";
+    String sql = "SELECT * from " + AGG_TABLE + " WHERE LONG=12345;";
 
     // Then:
-    shouldFailToExecuteQuery(sql, "WHERE clause on unsupported column: COUNT.");
+    shouldFailToExecuteQuery(sql, "WHERE clause on unsupported column: LONG.");
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
@@ -41,7 +41,7 @@ import io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster;
 import io.confluent.ksql.test.util.secure.ClientTrustStore;
 import io.confluent.ksql.test.util.secure.Credentials;
 import io.confluent.ksql.test.util.secure.SecureKafkaHelper;
-import io.confluent.ksql.util.PageViewDataProvider;
+import io.confluent.ksql.util.StructuredTypesDataProvider;
 import io.confluent.ksql.util.VertxCompletableFuture;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -70,13 +70,13 @@ import org.junit.rules.RuleChain;
 @Category({IntegrationTest.class})
 public class ApiIntegrationTest {
 
-  private static final PageViewDataProvider PAGE_VIEWS_PROVIDER = new PageViewDataProvider();
-  private static final String PAGE_VIEW_TOPIC = PAGE_VIEWS_PROVIDER.topicName();
-  private static final String PAGE_VIEW_STREAM = PAGE_VIEWS_PROVIDER.kstreamName();
+  private static final StructuredTypesDataProvider TEST_DATA_PROVIDER = new StructuredTypesDataProvider();
+  private static final String TEST_TOPIC = TEST_DATA_PROVIDER.topicName();
+  private static final String TEST_STREAM = TEST_DATA_PROVIDER.kstreamName();
 
   private static final String AGG_TABLE = "AGG_TABLE";
   private static final Credentials NORMAL_USER = VALID_USER2;
-  private static final String AN_AGG_KEY = "USER_1";
+  private static final String AN_AGG_KEY = "FOO";
 
   private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.builder()
       .withKafkaCluster(
@@ -102,14 +102,14 @@ public class ApiIntegrationTest {
 
   @BeforeClass
   public static void setUpClass() {
-    TEST_HARNESS.ensureTopics(PAGE_VIEW_TOPIC);
+    TEST_HARNESS.ensureTopics(TEST_TOPIC);
 
-    TEST_HARNESS.produceRows(PAGE_VIEW_TOPIC, PAGE_VIEWS_PROVIDER, FormatFactory.JSON);
+    TEST_HARNESS.produceRows(TEST_TOPIC, TEST_DATA_PROVIDER, FormatFactory.JSON);
 
-    RestIntegrationTestUtil.createStream(REST_APP, PAGE_VIEWS_PROVIDER);
+    RestIntegrationTestUtil.createStream(REST_APP, TEST_DATA_PROVIDER);
 
     makeKsqlRequest("CREATE TABLE " + AGG_TABLE + " AS "
-        + "SELECT USERID, COUNT(1) AS COUNT FROM " + PAGE_VIEW_STREAM + " GROUP BY USERID;"
+        + "SELECT STR, COUNT(1) AS COUNT FROM " + TEST_STREAM + " GROUP BY STR;"
     );
   }
 
@@ -142,7 +142,7 @@ public class ApiIntegrationTest {
   public void shouldExecutePushQueryWithLimit() {
 
     // Given:
-    String sql = "SELECT * from " + PAGE_VIEW_STREAM + " EMIT CHANGES LIMIT " + 2 + ";";
+    String sql = "SELECT * from " + TEST_STREAM + " EMIT CHANGES LIMIT " + 2 + ";";
 
     // When:
     QueryResponse response = executeQuery(sql);
@@ -150,9 +150,9 @@ public class ApiIntegrationTest {
     // Then:
     assertThat(response.rows, hasSize(2));
     assertThat(response.responseObject.getJsonArray("columnNames"), is(
-        new JsonArray().add("PAGEID").add("USERID").add("VIEWTIME")));
+        new JsonArray().add("STR").add("LONG").add("DEC").add("ARRAY").add("MAP")));
     assertThat(response.responseObject.getJsonArray("columnTypes"), is(
-        new JsonArray().add("STRING").add("STRING").add("BIGINT")));
+        new JsonArray().add("STRING").add("BIGINT").add("DECIMAL(4, 2)").add("ARRAY<STRING>").add("MAP<STRING, STRING>")));
     assertThat(response.responseObject.getString("queryId"), is(notNullValue()));
   }
 
@@ -160,7 +160,7 @@ public class ApiIntegrationTest {
   public void shouldFailPushQueryWithInvalidSql() {
 
     // Given:
-    String sql = "SLECTT * from " + PAGE_VIEW_STREAM + " EMIT CHANGES;";
+    String sql = "SLECTT * from " + TEST_STREAM + " EMIT CHANGES;";
 
     // Then:
     shouldFailToExecuteQuery(sql, "line 1:1: mismatched input 'SLECTT' expecting");
@@ -170,8 +170,8 @@ public class ApiIntegrationTest {
   public void shouldFailPushQueryWithMoreThanOneStatement() {
 
     // Given:
-    String sql = "SELECT * from " + PAGE_VIEW_STREAM + " EMIT CHANGES;" +
-        "SELECT * from " + PAGE_VIEW_STREAM + " EMIT CHANGES;";
+    String sql = "SELECT * from " + TEST_STREAM + " EMIT CHANGES;" +
+        "SELECT * from " + TEST_STREAM + " EMIT CHANGES;";
 
     // Then:
     shouldFailToExecuteQuery(sql, "Expected exactly one KSQL statement; found 2 instead");
@@ -182,7 +182,7 @@ public class ApiIntegrationTest {
 
     // Given:
     String sql =
-        "CREATE STREAM SOME_STREAM AS SELECT * from " + PAGE_VIEW_STREAM + " EMIT CHANGES;";
+        "CREATE STREAM SOME_STREAM AS SELECT * from " + TEST_STREAM + " EMIT CHANGES;";
 
     // Then:
     shouldFailToExecuteQuery(sql, "Not a query");
@@ -196,7 +196,7 @@ public class ApiIntegrationTest {
     assertThatEventually(engine::numberOfLiveQueries, is(1));
 
     // Given:
-    String sql = "SELECT * from " + PAGE_VIEW_STREAM + " EMIT CHANGES;";
+    String sql = "SELECT * from " + TEST_STREAM + " EMIT CHANGES;";
 
     // Create a write stream to capture the incomplete response
     ReceiveStream writeStream = new ReceiveStream(vertx);
@@ -221,7 +221,7 @@ public class ApiIntegrationTest {
       } catch (Throwable t) {
         return Integer.MAX_VALUE;
       }
-    }, is(7));
+    }, is(6));
 
     // The response shouldn't have ended yet
     assertThat(writeStream.isEnded(), is(false));
@@ -248,7 +248,7 @@ public class ApiIntegrationTest {
   public void shouldExecutePullQuery() {
 
     // Given:
-    String sql = "SELECT * from " + AGG_TABLE + " WHERE USERID='" + AN_AGG_KEY + "';";
+    String sql = "SELECT * from " + AGG_TABLE + " WHERE STR='" + AN_AGG_KEY + "';";
 
     // When:
     // Maybe need to retry as populating agg table is async
@@ -262,13 +262,13 @@ public class ApiIntegrationTest {
     QueryResponse response = atomicReference.get();
 
     // Then:
-    JsonArray expectedColumnNames = new JsonArray().add("USERID").add("COUNT");
+    JsonArray expectedColumnNames = new JsonArray().add("STR").add("COUNT");
     JsonArray expectedColumnTypes = new JsonArray().add("STRING").add("BIGINT");
     assertThat(response.rows, hasSize(1));
     assertThat(response.responseObject.getJsonArray("columnNames"), is(expectedColumnNames));
     assertThat(response.responseObject.getJsonArray("columnTypes"), is(expectedColumnTypes));
     assertThat(response.responseObject.getString("queryId"), is(nullValue()));
-    assertThat(response.rows.get(0).getString(0), is("USER_1"));  // rowkey
+    assertThat(response.rows.get(0).getString(0), is("FOO")); // rowkey
     assertThat(response.rows.get(0).getLong(1), is(1L)); // count
   }
 
@@ -276,7 +276,7 @@ public class ApiIntegrationTest {
   public void shouldFailPullQueryWithInvalidSql() {
 
     // Given:
-    String sql = "SLLLECET * from " + AGG_TABLE + " WHERE USERID='" + AN_AGG_KEY + "';";
+    String sql = "SLLLECET * from " + AGG_TABLE + " WHERE STR='" + AN_AGG_KEY + "';";
 
     // Then:
     shouldFailToExecuteQuery(sql, "line 1:1: mismatched input 'SLLLECET' expecting");
@@ -286,8 +286,8 @@ public class ApiIntegrationTest {
   public void shouldFailPullQueryWithMoreThanOneStatement() {
 
     // Given:
-    String sql = "SELECT * from " + AGG_TABLE + " WHERE USERID='" + AN_AGG_KEY + "';" +
-        "SELECT * from " + AGG_TABLE + " WHERE USERID='" + AN_AGG_KEY + "';";
+    String sql = "SELECT * from " + AGG_TABLE + " WHERE STR='" + AN_AGG_KEY + "';" +
+        "SELECT * from " + AGG_TABLE + " WHERE STR='" + AN_AGG_KEY + "';";
 
     // Then:
     shouldFailToExecuteQuery(sql, "Expected exactly one KSQL statement; found 2 instead");
@@ -307,10 +307,10 @@ public class ApiIntegrationTest {
   public void shouldFailPullQueryWithNonKeyLookup() {
 
     // Given:
-    String sql = "SELECT * from " + AGG_TABLE + " WHERE ROWTIME=12345;";
+    String sql = "SELECT * from " + AGG_TABLE + " WHERE COUNT=12345;";
 
     // Then:
-    shouldFailToExecuteQuery(sql, "WHERE clause on unsupported column: ROWTIME.");
+    shouldFailToExecuteQuery(sql, "WHERE clause on unsupported column: COUNT.");
   }
 
   @Test
@@ -319,7 +319,7 @@ public class ApiIntegrationTest {
     // Given:
     JsonObject properties = new JsonObject();
     JsonObject requestBody = new JsonObject()
-        .put("target", PAGE_VIEW_STREAM).put("properties", properties);
+        .put("target", TEST_STREAM).put("properties", properties);
     Buffer bodyBuffer = requestBody.toBuffer();
     bodyBuffer.appendString("\n");
 
@@ -327,9 +327,11 @@ public class ApiIntegrationTest {
 
     for (int i = 0; i < numRows; i++) {
       JsonObject row = new JsonObject()
-          .put("VIEWTIME", 1000 + i)
-          .put("USERID", "User" + i % 3)
-          .put("PAGEID", "PAGE" + (numRows - i));
+          .put("STR", "Value_" + i)
+          .put("LONG", 1000 + i)
+          .put("DEC", i + 0.11) // JsonObject does not accept BigDecimal
+          .put("ARRAY", new JsonArray().add("a_" + i).add("b_" + i))
+          .put("MAP", new JsonObject().put("k1", "v1_" + i).put("k2", "v2_" + i));
       bodyBuffer.appendBuffer(row.toBuffer()).appendString("\n");
     }
 
@@ -358,12 +360,14 @@ public class ApiIntegrationTest {
 
     // Given:
     JsonObject row = new JsonObject()
-        .put("VIEWTIME", 1000)
-        .put("USERID", "User123");
+        .put("LONG", 1000)
+        .put("DEC", 12.21) // JsonObject does not accept BigDecimal
+        .put("ARRAY", new JsonArray().add("a").add("b"))
+        .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"));
 
     // Then:
     shouldFailToInsert(row, ERROR_CODE_BAD_REQUEST,
-        "Key field must be specified: PAGEID");
+        "Key field must be specified: STR");
   }
 
   @Test
@@ -371,9 +375,11 @@ public class ApiIntegrationTest {
 
     // Given:
     JsonObject row = new JsonObject()
-        .put("PAGEID", true)
-        .put("VIEWTIME", 1000)
-        .put("USERID", "User123");
+        .put("STR", true)
+        .put("LONG", 1000)
+        .put("DEC", 12.21) // JsonObject does not accept BigDecimal
+        .put("ARRAY", new JsonArray().add("a").add("b"))
+        .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"));
 
     // Then:
     shouldFailToInsert(row, ERROR_CODE_BAD_REQUEST,
@@ -385,23 +391,26 @@ public class ApiIntegrationTest {
 
     // Given:
     JsonObject row = new JsonObject()
-        .put("VIEWTIME", 1000)
-        .put("USERID", 123)
-        .put("PAGEID", "PAGE23");
+        .put("STR", "HELLO")
+        .put("LONG", "not a number")
+        .put("DEC", 12.21) // JsonObject does not accept BigDecimal
+        .put("ARRAY", new JsonArray().add("a").add("b"))
+        .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"));
 
     // Then:
     shouldFailToInsert(row, ERROR_CODE_BAD_REQUEST,
-        "Can't coerce a field of type class java.lang.Integer (123) into type STRING");
+        "Can't coerce a field of type class java.lang.String (not a number) into type BIGINT");
   }
 
   @Test
   public void shouldInsertWithMissingValueField() {
 
     // Given:
-    JsonObject row = new JsonObject();
-    row.put("PAGEID", "10");
-    row.put("VIEWTIME", 1000);
-    row.put("USERID", "User123");
+    JsonObject row = new JsonObject()
+        .put("STR", "HELLO")
+        .put("DEC", 12.21) // JsonObject does not accept BigDecimal
+        .put("ARRAY", new JsonArray().add("a").add("b"))
+        .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"));
 
     // Then:
     shouldInsert(row);
@@ -415,7 +424,7 @@ public class ApiIntegrationTest {
     assertThatEventually(engine::numberOfLiveQueries, is(1));
 
     // Given:
-    String sql = "SELECT VIEWTIME, USERID, PAGEID from " + PAGE_VIEW_STREAM + " EMIT CHANGES LIMIT 1;";
+    String sql = "SELECT * from " + TEST_STREAM + " EMIT CHANGES LIMIT 1;";
 
     // Create a write stream to capture the incomplete response
     ReceiveStream writeStream = new ReceiveStream(vertx);
@@ -433,9 +442,11 @@ public class ApiIntegrationTest {
 
     // New row to insert
     JsonObject row = new JsonObject()
-        .put("VIEWTIME", 2000L)
-        .put("USERID", "User_shouldExecutePushQueryFromLatestOffset")
-        .put("PAGEID", "PAGE_shouldExecutePushQueryFromLatestOffset");
+        .put("STR", "Value_shouldExecutePushQueryFromLatestOffset")
+        .put("LONG", 2000L)
+        .put("DEC", 12.34) // JsonObject does not accept BigDecimal
+        .put("ARRAY", new JsonArray().add("a_shouldExecutePushQueryFromLatestOffset"))
+        .put("MAP", new JsonObject().put("k1", "v1_shouldExecutePushQueryFromLatestOffset"));
 
     // Insert a new row and wait for it to arrive
     assertThatEventually(() -> {
@@ -452,9 +463,11 @@ public class ApiIntegrationTest {
     // Verify that the received row is the expected one
     Buffer buff = writeStream.getBody();
     QueryResponse queryResponse = new QueryResponse(buff.toString());
-    assertThat(queryResponse.rows.get(0).getLong(0), is(2000L));
-    assertThat(queryResponse.rows.get(0).getString(1), is("User_shouldExecutePushQueryFromLatestOffset"));
-    assertThat(queryResponse.rows.get(0).getString(2), is("PAGE_shouldExecutePushQueryFromLatestOffset"));
+    assertThat(queryResponse.rows.get(0).getString(0), is("Value_shouldExecutePushQueryFromLatestOffset"));
+    assertThat(queryResponse.rows.get(0).getLong(1), is(2000L));
+    assertThat(queryResponse.rows.get(0).getDouble(2), is(12.34));
+    assertThat(queryResponse.rows.get(0).getJsonArray(3), is(new JsonArray().add("a_shouldExecutePushQueryFromLatestOffset")));
+    assertThat(queryResponse.rows.get(0).getJsonObject(4), is(new JsonObject().put("k1", "v1_shouldExecutePushQueryFromLatestOffset")));
 
     // Check that query is cleaned up on the server
     assertThatEventually(engine::numberOfLiveQueries, is(1));
@@ -483,7 +496,7 @@ public class ApiIntegrationTest {
   private void shouldFailToInsert(final JsonObject row, final int errorCode, final String message) {
     JsonObject properties = new JsonObject();
     JsonObject requestBody = new JsonObject()
-        .put("target", PAGE_VIEW_STREAM).put("properties", properties);
+        .put("target", TEST_STREAM).put("properties", properties);
     Buffer bodyBuffer = requestBody.toBuffer();
     bodyBuffer.appendString("\n");
 
@@ -504,7 +517,7 @@ public class ApiIntegrationTest {
   private void shouldInsert(final JsonObject row) {
     JsonObject properties = new JsonObject();
     JsonObject requestBody = new JsonObject()
-        .put("target", PAGE_VIEW_STREAM).put("properties", properties);
+        .put("target", TEST_STREAM).put("properties", properties);
     Buffer bodyBuffer = requestBody.toBuffer();
     bodyBuffer.appendString("\n");
 


### PR DESCRIPTION
### Description 

Three changes in this PR:

(1) Prior to this PR, inserting a row with a complex column type (array, map, or struct) via /inserts-stream would fail since the SqlValueCoercer can't handle JsonArray or JsonObject. This PR fixes the bug.

(2)  This PR adds server-side and client-side test coverage for complex types including decimal, array, and map. A follow-up PR will add coverage for struct as well.

(3) Besides (1), the only other non-test change in this PR is in response to https://github.com/confluentinc/ksql/pull/5448#discussion_r429314072: rather than serializing BigDecimal as double on the client, we instead serialize BigDecimal as string in order to avoid loss of precision. The drawback is we now have an inconsistency where the decimal type is treated differently in terms of allowable casts, compared to the other numeric types. For example:
```
final KsqlObject obj = new KsqlObject().put("f1", new BigDecimal("1.13")).put("f2", 12.23);
System.out.println(obj.getString("f1")); // This succeeds
System.out.println(obj.getString("f2")); // This fails with "java.lang.ClassCastException: java.lang.Double cannot be cast to java.lang.CharSequence"
```

### Testing done 

Tests pass.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

