### PR TITLE
chore: add a link to docs when synth join key missing from projection

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/links/DocumentationLinks.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/links/DocumentationLinks.java
@@ -33,6 +33,8 @@ public final class DocumentationLinks {
   public static final String SECURITY_REQUIRED_ACLS_DOC_URL = SECURITY_DOCS_URL
       + "#required-acls";
 
+  public static final String SYNTHETIC_JOIN_KEY_DOC_URL = "https://cnfl.io/2LV7ouS";
+
   /*
   Schema Registry
    */

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.planner.plan;
 
 import static io.confluent.ksql.metastore.model.DataSource.DataSourceType;
-import static io.confluent.ksql.util.GrammaticalJoiner.and;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.ImmutableList;
@@ -195,7 +194,7 @@ public class AggregateNode extends PlanNode implements VerifiableNode {
         .forEach(missing::remove);
 
     if (!missing.isEmpty()) {
-      throwKeysNotIncludedError(sinkName, "grouping expression", missing, and());
+      throwKeysNotIncludedError(sinkName, "grouping expression", missing);
     }
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/DataSourceNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/DataSourceNode.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.planner.plan;
 
-import static io.confluent.ksql.util.GrammaticalJoiner.and;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.ImmutableList;
@@ -135,7 +134,7 @@ public class DataSourceNode extends PlanNode {
         && !projection.containsExpression(new UnqualifiedColumnReferenceExp(keyName))
     ) {
       throwKeysNotIncludedError(sinkName, "key column", ImmutableList.of(
-          (ColumnReferenceExp) new UnqualifiedColumnReferenceExp(keyName)), and());
+          (ColumnReferenceExp) new UnqualifiedColumnReferenceExp(keyName)));
     }
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.planner.plan;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static io.confluent.ksql.util.GrammaticalJoiner.or;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.ImmutableList;
@@ -162,20 +161,10 @@ public class JoinNode extends PlanNode {
         .anyMatch(projection::containsExpression);
 
     if (!atLeastOneKey) {
-      final List<? extends Expression> originalKeys = joinKey.getOriginalViableKeys(schema);
+      final boolean synthetic = joinKey.isSynthetic();
+      final List<? extends Expression> viable = joinKey.getOriginalViableKeys(schema);
 
-      final Optional<Expression> syntheticKey = joinKey.isSynthetic()
-          ? Optional.of(originalKeys.get(0))
-          : Optional.empty();
-
-      final String additional = syntheticKey
-          .map(e -> System.lineSeparator()
-              + e + " was added as a synthetic key column because the join criteria did "
-              + "not match any source column. "
-              + "This expression must be included in the projection and may be aliased. ")
-          .orElse("");
-
-      throwKeysNotIncludedError(sinkName, "join expression", originalKeys, or(), additional);
+      throwKeysNotIncludedError(sinkName, "join expression", viable, false, synthetic);
     }
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/UserRepartitionNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/UserRepartitionNode.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.planner.plan;
 
-import static io.confluent.ksql.util.GrammaticalJoiner.and;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.ImmutableList;
@@ -67,7 +66,7 @@ public class UserRepartitionNode extends RepartitionNode {
   void validateKeyPresent(final SourceName sinkName, final Projection projection) {
     if (!projection.containsExpression(getPartitionBy())) {
       final ImmutableList<Expression> keys = ImmutableList.of(originalPartitionBy);
-      throwKeysNotIncludedError(sinkName, "partitioning expression", keys, and());
+      throwKeysNotIncludedError(sinkName, "partitioning expression", keys);
     }
   }
 }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/joins.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/joins.json
@@ -328,7 +328,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "The query used to build `OUTPUT` must include the join expression ROWKEY in its projection.\nROWKEY was added as a synthetic key column because the join criteria did not match any source column."
+        "message": "Key missing from projection. See https://cnfl.io/2LV7ouS.\nThe query used to build `OUTPUT` must include the join expression ROWKEY in its projection.\nROWKEY was added as a synthetic key column because the join criteria did not match any source column."
       }
     },
     {


### PR DESCRIPTION
### Description 

partial fix for: https://github.com/confluentinc/ksql/issues/5466

This change adds the doc link to the error message reported when a projection fails to include the synthetic join key column.


### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

