### PR TITLE
feat: implements ARRAY_JOIN as requested in (#5028)

### DIFF
--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -386,11 +386,10 @@ include both endpoints.
 ARRAY_JOIN(col1, delimiter)
 ```
 
-Creates a flat String representation of all the elements contained in the given array.
-The elements in the resulting String are separated by the chosen `delimiter`, 
-which is an optional parameter that falls back to a comma `,`. The array may contain
-all valid ksql types and supports nested and complex data structures as well, 
-for instance, lists of lists or structs containing maps. 
+Creates a flat string representation of all the elements contained in the given array.
+The elements in the resulting string are separated by the chosen `delimiter`, 
+which is an optional parameter that falls back to a comma `,`. The current implementation only
+allows for array elements of primitive ksqlDB types.
 
 ## Strings
 

--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -380,6 +380,18 @@ SLICE(col1, from, to)
 Slices a list based on the supplied indices. The indices start at 1 and
 include both endpoints.
 
+### `ARRAY_JOIN`
+
+```sql
+ARRAY_JOIN(col1, delimiter)
+```
+
+Creates a flat String representation of all the elements contained in the given array.
+The elements in the resulting String are separated by the chosen `delimiter`, 
+which is an optional parameter that falls back to a comma `,`. The array may contain
+all valid ksql types and supports nested and complex data structures as well, 
+for instance, lists of lists or structs containing maps. 
+
 ## Strings
 
 ### `CHR`

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/ArrayJoin.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/ArrayJoin.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.array;
+
+import io.confluent.ksql.function.KsqlFunctionException;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
+import io.confluent.ksql.util.KsqlConstants;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringJoiner;
+import org.apache.kafka.connect.data.Struct;
+
+@SuppressWarnings("MethodMayBeStatic") // UDF methods can not be static.
+@UdfDescription(
+    name = "ARRAY_JOIN",
+    description = "joins the array elements into a flat string representation",
+    author = KsqlConstants.CONFLUENT_AUTHOR
+)
+public class ArrayJoin {
+
+  private static final String DEFAULT_DELIMITER = ",";
+  private static final Set<Class> KSQL_PRIMITIVES = new HashSet<>(
+      Arrays.asList(Boolean.class,Integer.class,BigInteger.class,Double.class,String.class)
+  );
+
+  @Udf
+  public <T> String join(
+      @UdfParameter(description = "the array to join using the default delimiter '"
+          + DEFAULT_DELIMITER + "'") final List<T> array
+  ) {
+    return join(array, DEFAULT_DELIMITER);
+  }
+
+  @Udf
+  public <T> String join(
+      @UdfParameter(description = "the array to join using the specified delimiter")
+      final List<T> array,
+      @UdfParameter(description = "the string to be used as element delimiter")
+      final String delimiter
+  ) {
+
+    if (array == null) {
+      return null;
+    }
+
+    final StringJoiner sj = new StringJoiner(delimiter);
+    array.forEach(e -> processElement(e, sj));
+    return sj.toString();
+
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> void processElement(final T element, final StringJoiner joiner) {
+
+    if (element == null || KSQL_PRIMITIVES.contains(element.getClass())) {
+      handlePrimitiveType(element, joiner);
+    } else if (element instanceof List) {
+      handleListType((List)element,joiner);
+    } else if (element instanceof Map) {
+      handleMapType((Map) element, joiner);
+    } else if (element instanceof Struct) {
+      handleStructType((Struct)element, joiner);
+    } else {
+      throw new KsqlFunctionException("error: hit element of type "
+          + element.getClass().getTypeName() + " which is currently not supported");
+    }
+
+  }
+
+  private static void handlePrimitiveType(final Object element, final StringJoiner joiner) {
+    joiner.add(element != null ? element.toString() : null);
+  }
+
+  private static void handleListType(final List<?> element, final StringJoiner joiner) {
+    element.forEach(e -> processElement(e, joiner));
+  }
+
+  private static void handleMapType(final Map<String,?> element, final StringJoiner joiner) {
+    element.entrySet().forEach(e -> {
+      joiner.add(((Map.Entry) e).getKey().toString());
+      processElement(((Map.Entry) e).getValue(), joiner);
+    });
+  }
+
+  private static void handleStructType(final Struct element, final StringJoiner joiner) {
+    element.schema().fields().forEach(f -> {
+      joiner.add(f.name());
+      processElement(element.get(f), joiner);
+    });
+  }
+
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/array/ArrayJoinTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/array/ArrayJoinTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.array;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import io.confluent.ksql.function.KsqlFunctionException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ArrayJoinTest {
+
+  private static final String CUSTOM_DELIMITER = "|";
+  private static Struct STRUCT_DATA;
+
+  private final ArrayJoin arrayJoinUDF = new ArrayJoin();
+
+  @BeforeClass
+  public static void initializeComplexStructTypeSampleData() {
+
+    Schema structSchema = SchemaBuilder.struct()
+        .field("f1", Schema.STRING_SCHEMA)
+        .field("f2", Schema.INT32_SCHEMA)
+        .field("f3", Schema.BOOLEAN_SCHEMA)
+        .field("f4", SchemaBuilder.struct()
+            .field("f4-1", Schema.STRING_SCHEMA)
+            .build()
+        )
+        .field("f5", SchemaBuilder.array(Schema.STRING_SCHEMA).build())
+        .field("f6", SchemaBuilder.array(SchemaBuilder.struct()
+            .field("k", Schema.STRING_SCHEMA)
+            .field("v", Schema.INT32_SCHEMA)
+            .build())
+        )
+        .field("f7",
+            SchemaBuilder.array(SchemaBuilder.array(SchemaBuilder.array(Schema.INT32_SCHEMA))))
+        .field("f8", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT32_SCHEMA).build())
+        .field("f9", SchemaBuilder
+            .map(Schema.STRING_SCHEMA, SchemaBuilder.array(Schema.STRING_SCHEMA).build()).build())
+        .field("f10", SchemaBuilder
+            .map(Schema.STRING_SCHEMA, SchemaBuilder.array(Schema.INT32_SCHEMA).build()).build())
+        .build();
+
+    STRUCT_DATA = new Struct(structSchema)
+        .put("f1", "ksqldb UDF sample data")
+        .put("f2", 42)
+        .put("f3", true)
+        .put("f4", new Struct(structSchema.field("f4").schema())
+            .put("f4-1", "hello ksqldb")
+        )
+        .put("f5", Arrays.asList("str_1", "str_2", "...", "str_N"))
+        .put("f6", Arrays.asList(
+            new Struct(structSchema.field("f6").schema().valueSchema())
+                .put("k", "a").put("v", 1),
+            new Struct(structSchema.field("f6").schema().valueSchema())
+                .put("k", "b").put("v", 2),
+            new Struct(structSchema.field("f6").schema().valueSchema())
+                .put("k", "c").put("v", 3)
+            )
+        )
+        .put("f7", Arrays.asList(
+            Arrays.asList(Arrays.asList(0,1), Arrays.asList(2,3,4), Arrays.asList(5, 6),
+                Arrays.asList(7,8,9)),
+            Arrays.asList(Arrays.asList(9,8,7),Arrays.asList(6,5), Arrays.asList(4,3,2),
+                Arrays.asList(1,0)
+            )
+        ))
+        .put("f8", new LinkedHashMap<String, Integer>() {{
+          put("k1", 6);
+          put("k2", 5);
+          put("k3", 4);
+        }})
+        .put("f9", new LinkedHashMap<String, List<String>>() {{
+          put("k1", Arrays.asList("v1-a", "v1-b"));
+          put("k2", Arrays.asList("v2-a","v2-b", "v2-c", "v2-d"));
+          put("k3", Arrays.asList("v3-a","v3-b","v3-c"));
+        }})
+        .put("f10", new LinkedHashMap<String, List<Integer>>() {{
+          put("k1", Arrays.asList(12, 21));
+          put("k2", Arrays.asList(23, 32));
+          put("k3", Arrays.asList(24, 42));
+        }});
+  }
+
+  @Test
+  public void shouldReturnNullForNullInput() {
+    assertNull(arrayJoinUDF.join(null));
+    assertNull(arrayJoinUDF.join(null,CUSTOM_DELIMITER));
+  }
+
+  @Test
+  public void shouldReturnEmptyStringForEmptyArrays() {
+    assertTrue(arrayJoinUDF.join(Collections.emptyList()).isEmpty());
+    assertTrue(arrayJoinUDF.join(Collections.emptyList(),CUSTOM_DELIMITER).isEmpty());
+  }
+
+  @Test
+  public void shouldReturnCorrectStringForFlatArraysWithPrimitiveTypes() {
+
+    assertEquals("true,null,false",
+        arrayJoinUDF.join(Arrays.asList(true, null, false)));
+    assertEquals("true"+CUSTOM_DELIMITER+"null"+CUSTOM_DELIMITER+"false",
+        arrayJoinUDF.join(Arrays.asList(true,null,false),CUSTOM_DELIMITER));
+
+    assertEquals("1,23,-42,0",
+        arrayJoinUDF.join(Arrays.asList(1,23,-42,0)));
+    assertEquals("1"+CUSTOM_DELIMITER+"23"+CUSTOM_DELIMITER+"-42"+CUSTOM_DELIMITER+"0",
+        arrayJoinUDF.join(Arrays.asList(1,23,-42,0),CUSTOM_DELIMITER));
+
+    assertEquals("-4294967297,8589934592",
+        arrayJoinUDF.join(Arrays.asList(new BigInteger("-4294967297"),
+                                        new BigInteger("8589934592")))
+    );
+    assertEquals("-4294967297"+CUSTOM_DELIMITER+"8589934592",
+        arrayJoinUDF.join(Arrays.asList(
+            new BigInteger("-4294967297"), new BigInteger("8589934592")
+            ), CUSTOM_DELIMITER)
+    );
+
+    assertEquals("1.23,-23.42,0.0",
+        arrayJoinUDF.join(Arrays.asList(1.23,-23.42,0.0)));
+    assertEquals("1.23"+CUSTOM_DELIMITER+"-23.42"+CUSTOM_DELIMITER+"0.0",
+        arrayJoinUDF.join(Arrays.asList(1.23,-23.42,0.0),CUSTOM_DELIMITER));
+
+    assertEquals("hello,from,,ksqldb,udf,null",
+        arrayJoinUDF.join(Arrays.asList("hello","from","","ksqldb","udf",null)));
+    assertEquals("hello"+CUSTOM_DELIMITER+"from"+CUSTOM_DELIMITER+CUSTOM_DELIMITER
+            +"ksqldb"+CUSTOM_DELIMITER+"udf"+CUSTOM_DELIMITER+"null",
+        arrayJoinUDF.join(Arrays.asList("hello","from","","ksqldb","udf",null),CUSTOM_DELIMITER));
+
+  }
+
+  @Test
+  public void shouldReturnCorrectStringForNestedArraysWithPrimitiveTypes() {
+
+    assertEquals("true,false,null,null,true",
+        arrayJoinUDF.join(Arrays.asList(Arrays.asList(true,false),null,Arrays.asList(null,true))));
+    assertEquals("true"+CUSTOM_DELIMITER+"false"+CUSTOM_DELIMITER+"null"
+                  +CUSTOM_DELIMITER+"null"+CUSTOM_DELIMITER+"true",
+        arrayJoinUDF.join(Arrays.asList(Arrays.asList(true,false), null, Arrays.asList(null,true)),
+            CUSTOM_DELIMITER));
+
+    assertEquals("0,0,7,null,100,-10",
+        arrayJoinUDF.join(Arrays.asList(Arrays.asList(0,0,7),null,Arrays.asList(100,-10))));
+    assertEquals("0"+CUSTOM_DELIMITER+"0"+CUSTOM_DELIMITER+"7"
+            +CUSTOM_DELIMITER+"null"+CUSTOM_DELIMITER+"100"+CUSTOM_DELIMITER+"-10",
+        arrayJoinUDF.join(Arrays.asList(Arrays.asList(0,0,7),null,Arrays.asList(100,-10)),
+            CUSTOM_DELIMITER));
+
+    assertEquals("-4294967297,0,8589934592,null,1",
+        arrayJoinUDF.join(Arrays.asList(Arrays.asList(new BigInteger("-4294967297"),
+            BigInteger.ZERO,new BigInteger("8589934592")),Arrays.asList(null,BigInteger.ONE))));
+    assertEquals("-4294967297"+CUSTOM_DELIMITER+"0"+CUSTOM_DELIMITER+"8589934592"
+            +CUSTOM_DELIMITER+"null"+CUSTOM_DELIMITER+"1",
+        arrayJoinUDF.join(Arrays.asList(Arrays.asList(new BigInteger("-4294967297"),
+            BigInteger.ZERO,new BigInteger("8589934592")),Arrays.asList(null,BigInteger.ONE)),
+            CUSTOM_DELIMITER));
+
+    assertEquals("1.23,-23.42,0.0,1.0",
+        arrayJoinUDF.join(Arrays.asList(Arrays.asList(1.23,-23.42),Arrays.asList(0.0,1.0))));
+    assertEquals("1.23"+CUSTOM_DELIMITER+"-23.42"+CUSTOM_DELIMITER+"0.0"+CUSTOM_DELIMITER+"1.0",
+        arrayJoinUDF.join(Arrays.asList(Arrays.asList(1.23,-23.42),Arrays.asList(0.0,1.0)),
+            CUSTOM_DELIMITER));
+
+    assertEquals("hello,from,,ksqldb,udf,null",
+        arrayJoinUDF.join(Arrays.asList(Arrays.asList("hello","from"),
+            Arrays.asList("","ksqldb", "udf",null))));
+    assertEquals("hello"+CUSTOM_DELIMITER+"from"+CUSTOM_DELIMITER+CUSTOM_DELIMITER
+            +"ksqldb"+CUSTOM_DELIMITER+"udf"+CUSTOM_DELIMITER+"null",
+        arrayJoinUDF.join(Arrays.asList(Arrays.asList("hello","from"),
+            Arrays.asList("","ksqldb", "udf",null)),CUSTOM_DELIMITER));
+
+  }
+
+  @Test
+  public void shouldReturnCorrectStringForNestedComplexTypes() {
+
+    Map<String,Integer> mapData1 = new LinkedHashMap<>();
+    mapData1.put("k1",12);
+    mapData1.put("k2",34);
+    mapData1.put("k3",0);
+
+    Map<String,Integer> mapData2 = new LinkedHashMap<>();
+    mapData2.put("k4",null);
+    mapData2.put("k5",-100);
+
+    assertEquals("k1,12,k2,34,k3,0,k4,null,k5,-100",
+        arrayJoinUDF.join(Arrays.asList(mapData1,mapData2)));
+
+    Map<String,List<String>> mapData3 = new LinkedHashMap<>();
+    mapData3.put("k1",Arrays.asList("hello","from"));
+    mapData3.put("k2",Arrays.asList("ksqldb",""));
+
+    Map<String,List<String>> mapData4 = new LinkedHashMap<>();
+    mapData4.put("k3",Arrays.asList(null,"",""));
+
+    assertEquals("k1,hello,from,k2,ksqldb,,k3,null,,",
+        arrayJoinUDF.join(Arrays.asList(mapData3,mapData4)));
+
+    Map<String,Map<String,Integer>> mapData5 = new LinkedHashMap<>();
+    mapData5.put("k1",mapData1);
+    mapData5.put("k2",mapData2);
+
+    assertEquals("k1,k1,12,k2,34,k3,0,k2,k4,null,k5,-100",
+        arrayJoinUDF.join(Collections.singletonList(mapData5)));
+
+    assertEquals("f1,ksqldb UDF sample data,f2,42,f3,true,f4,f4-1,hello ksqldb," +
+            "f5,str_1,str_2,...,str_N,f6,k,a,v,1,k,b,v,2,k,c,v,3,f7,0,1,2,3,4,5,6,7,8,9," +
+            "9,8,7,6,5,4,3,2,1,0,f8,k1,6,k2,5,k3,4,f9,k1,v1-a,v1-b,k2,v2-a,v2-b,v2-c,v2-d," +
+            "k3,v3-a,v3-b,v3-c,f10,k1,12,21,k2,23,32,k3,24,42",
+        arrayJoinUDF.join(Collections.singletonList(STRUCT_DATA)));
+
+  }
+
+  @Test
+  public void shouldThrowExceptionForExamplesOfUnsupportedElementTypes() {
+    assertThrows(KsqlFunctionException.class,
+        () -> arrayJoinUDF.join(Arrays.asList('a','b')));
+    assertThrows(KsqlFunctionException.class,
+        () -> arrayJoinUDF.join(Arrays.asList(BigDecimal.ZERO,BigDecimal.ONE)));
+    assertThrows(KsqlFunctionException.class,
+        () -> arrayJoinUDF.join(Arrays.asList(-23.0f,42.42f,0.0f)));
+    assertThrows(KsqlFunctionException.class,
+        () -> arrayJoinUDF.join(Arrays.asList(
+            new HashSet<>(Arrays.asList("foo", "blah")),
+            new HashSet<>(Arrays.asList("ksqlDB", "UDF"))
+        ))
+    );
+  }
+
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/array/ArrayJoinTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/array/ArrayJoinTest.java
@@ -15,10 +15,10 @@
 
 package io.confluent.ksql.function.udf.array;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
 import io.confluent.ksql.function.KsqlFunctionException;
 import java.math.BigDecimal;
@@ -26,216 +26,89 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
-import org.apache.kafka.connect.data.Struct;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class ArrayJoinTest {
 
   private static final String CUSTOM_DELIMITER = "|";
-  private static Struct STRUCT_DATA;
 
   private final ArrayJoin arrayJoinUDF = new ArrayJoin();
 
-  @BeforeClass
-  public static void initializeComplexStructTypeSampleData() {
-
-    Schema structSchema = SchemaBuilder.struct()
-        .field("f1", Schema.STRING_SCHEMA)
-        .field("f2", Schema.INT32_SCHEMA)
-        .field("f3", Schema.BOOLEAN_SCHEMA)
-        .field("f4", SchemaBuilder.struct()
-            .field("f4-1", Schema.STRING_SCHEMA)
-            .build()
-        )
-        .field("f5", SchemaBuilder.array(Schema.STRING_SCHEMA).build())
-        .field("f6", SchemaBuilder.array(SchemaBuilder.struct()
-            .field("k", Schema.STRING_SCHEMA)
-            .field("v", Schema.INT32_SCHEMA)
-            .build())
-        )
-        .field("f7",
-            SchemaBuilder.array(SchemaBuilder.array(SchemaBuilder.array(Schema.INT32_SCHEMA))))
-        .field("f8", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT32_SCHEMA).build())
-        .field("f9", SchemaBuilder
-            .map(Schema.STRING_SCHEMA, SchemaBuilder.array(Schema.STRING_SCHEMA).build()).build())
-        .field("f10", SchemaBuilder
-            .map(Schema.STRING_SCHEMA, SchemaBuilder.array(Schema.INT32_SCHEMA).build()).build())
-        .build();
-
-    STRUCT_DATA = new Struct(structSchema)
-        .put("f1", "ksqldb UDF sample data")
-        .put("f2", 42)
-        .put("f3", true)
-        .put("f4", new Struct(structSchema.field("f4").schema())
-            .put("f4-1", "hello ksqldb")
-        )
-        .put("f5", Arrays.asList("str_1", "str_2", "...", "str_N"))
-        .put("f6", Arrays.asList(
-            new Struct(structSchema.field("f6").schema().valueSchema())
-                .put("k", "a").put("v", 1),
-            new Struct(structSchema.field("f6").schema().valueSchema())
-                .put("k", "b").put("v", 2),
-            new Struct(structSchema.field("f6").schema().valueSchema())
-                .put("k", "c").put("v", 3)
-            )
-        )
-        .put("f7", Arrays.asList(
-            Arrays.asList(Arrays.asList(0,1), Arrays.asList(2,3,4), Arrays.asList(5, 6),
-                Arrays.asList(7,8,9)),
-            Arrays.asList(Arrays.asList(9,8,7),Arrays.asList(6,5), Arrays.asList(4,3,2),
-                Arrays.asList(1,0)
-            )
-        ))
-        .put("f8", new LinkedHashMap<String, Integer>() {{
-          put("k1", 6);
-          put("k2", 5);
-          put("k3", 4);
-        }})
-        .put("f9", new LinkedHashMap<String, List<String>>() {{
-          put("k1", Arrays.asList("v1-a", "v1-b"));
-          put("k2", Arrays.asList("v2-a","v2-b", "v2-c", "v2-d"));
-          put("k3", Arrays.asList("v3-a","v3-b","v3-c"));
-        }})
-        .put("f10", new LinkedHashMap<String, List<Integer>>() {{
-          put("k1", Arrays.asList(12, 21));
-          put("k2", Arrays.asList(23, 32));
-          put("k3", Arrays.asList(24, 42));
-        }});
-  }
-
   @Test
   public void shouldReturnNullForNullInput() {
-    assertNull(arrayJoinUDF.join(null));
-    assertNull(arrayJoinUDF.join(null,CUSTOM_DELIMITER));
+    assertThat(arrayJoinUDF.join(null), nullValue());
+    assertThat(arrayJoinUDF.join(null,CUSTOM_DELIMITER), nullValue());
   }
 
   @Test
   public void shouldReturnEmptyStringForEmptyArrays() {
-    assertTrue(arrayJoinUDF.join(Collections.emptyList()).isEmpty());
-    assertTrue(arrayJoinUDF.join(Collections.emptyList(),CUSTOM_DELIMITER).isEmpty());
+    assertThat(arrayJoinUDF.join(Collections.emptyList()).isEmpty(),is(true));
+    assertThat(arrayJoinUDF.join(Collections.emptyList(),CUSTOM_DELIMITER).isEmpty(),is(true));
   }
 
   @Test
   public void shouldReturnCorrectStringForFlatArraysWithPrimitiveTypes() {
 
-    assertEquals("true,null,false",
-        arrayJoinUDF.join(Arrays.asList(true, null, false)));
-    assertEquals("true"+CUSTOM_DELIMITER+"null"+CUSTOM_DELIMITER+"false",
-        arrayJoinUDF.join(Arrays.asList(true,null,false),CUSTOM_DELIMITER));
-
-    assertEquals("1,23,-42,0",
-        arrayJoinUDF.join(Arrays.asList(1,23,-42,0)));
-    assertEquals("1"+CUSTOM_DELIMITER+"23"+CUSTOM_DELIMITER+"-42"+CUSTOM_DELIMITER+"0",
-        arrayJoinUDF.join(Arrays.asList(1,23,-42,0),CUSTOM_DELIMITER));
-
-    assertEquals("-4294967297,8589934592",
-        arrayJoinUDF.join(Arrays.asList(new BigInteger("-4294967297"),
-                                        new BigInteger("8589934592")))
+    assertThat(arrayJoinUDF.join(Arrays.asList(true, null, false),""),
+        is("truenullfalse")
     );
-    assertEquals("-4294967297"+CUSTOM_DELIMITER+"8589934592",
-        arrayJoinUDF.join(Arrays.asList(
-            new BigInteger("-4294967297"), new BigInteger("8589934592")
-            ), CUSTOM_DELIMITER)
+    assertThat(arrayJoinUDF.join(Arrays.asList(true, null, false)),
+        is("true,null,false")
+    );
+    assertThat(arrayJoinUDF.join(Arrays.asList(true,null,false),CUSTOM_DELIMITER),
+        is("true"+CUSTOM_DELIMITER+"null"+CUSTOM_DELIMITER+"false")
     );
 
-    assertEquals("1.23,-23.42,0.0",
-        arrayJoinUDF.join(Arrays.asList(1.23,-23.42,0.0)));
-    assertEquals("1.23"+CUSTOM_DELIMITER+"-23.42"+CUSTOM_DELIMITER+"0.0",
-        arrayJoinUDF.join(Arrays.asList(1.23,-23.42,0.0),CUSTOM_DELIMITER));
+    assertThat(arrayJoinUDF.join(Arrays.asList(1,23,-42,0),null), is("123-420"));
+    assertThat(arrayJoinUDF.join(Arrays.asList(1,23,-42,0)), is("1,23,-42,0"));
+    assertThat(arrayJoinUDF.join(Arrays.asList(1,23,-42,0),CUSTOM_DELIMITER),
+        is("1"+CUSTOM_DELIMITER+"23"+CUSTOM_DELIMITER+"-42"+CUSTOM_DELIMITER+"0")
+    );
 
-    assertEquals("hello,from,,ksqldb,udf,null",
-        arrayJoinUDF.join(Arrays.asList("hello","from","","ksqldb","udf",null)));
-    assertEquals("hello"+CUSTOM_DELIMITER+"from"+CUSTOM_DELIMITER+CUSTOM_DELIMITER
-            +"ksqldb"+CUSTOM_DELIMITER+"udf"+CUSTOM_DELIMITER+"null",
-        arrayJoinUDF.join(Arrays.asList("hello","from","","ksqldb","udf",null),CUSTOM_DELIMITER));
+    assertThat(arrayJoinUDF.join(Arrays.asList(-4294967297L, 8589934592L),""),
+        is("-42949672978589934592")
+    );
+    assertThat(arrayJoinUDF.join(Arrays.asList(-4294967297L, 8589934592L)),
+        is("-4294967297,8589934592")
+    );
+    assertThat(arrayJoinUDF.join(Arrays.asList(-4294967297L, 8589934592L), CUSTOM_DELIMITER),
+        is("-4294967297"+CUSTOM_DELIMITER+"8589934592")
+    );
 
-  }
+    assertThat(arrayJoinUDF.join(Arrays.asList(1.23,-23.42,0.0),null),
+        is("1.23-23.420.0")
+    );
+    assertThat(arrayJoinUDF.join(Arrays.asList(1.23,-23.42,0.0)),
+        is("1.23,-23.42,0.0")
+    );
+    assertThat(arrayJoinUDF.join(Arrays.asList(1.23,-23.42,0.0),CUSTOM_DELIMITER),
+        is("1.23"+CUSTOM_DELIMITER+"-23.42"+CUSTOM_DELIMITER+"0.0")
+    );
 
-  @Test
-  public void shouldReturnCorrectStringForNestedArraysWithPrimitiveTypes() {
+    assertThat(arrayJoinUDF.join(
+        Arrays.asList(new BigDecimal("123.45"), new BigDecimal("987.65")),null
+        ),
+        is("123.45987.65")
+    );
+    assertThat(arrayJoinUDF.join(Arrays.asList(new BigDecimal("123.45"), new BigDecimal("987.65"))),
+        is("123.45,987.65")
+    );
+    assertThat(arrayJoinUDF.join(
+        Arrays.asList(new BigDecimal("123.45"), new BigDecimal("987.65")),CUSTOM_DELIMITER),
+        is("123.45"+CUSTOM_DELIMITER+"987.65")
+    );
 
-    assertEquals("true,false,null,null,true",
-        arrayJoinUDF.join(Arrays.asList(Arrays.asList(true,false),null,Arrays.asList(null,true))));
-    assertEquals("true"+CUSTOM_DELIMITER+"false"+CUSTOM_DELIMITER+"null"
-                  +CUSTOM_DELIMITER+"null"+CUSTOM_DELIMITER+"true",
-        arrayJoinUDF.join(Arrays.asList(Arrays.asList(true,false), null, Arrays.asList(null,true)),
-            CUSTOM_DELIMITER));
-
-    assertEquals("0,0,7,null,100,-10",
-        arrayJoinUDF.join(Arrays.asList(Arrays.asList(0,0,7),null,Arrays.asList(100,-10))));
-    assertEquals("0"+CUSTOM_DELIMITER+"0"+CUSTOM_DELIMITER+"7"
-            +CUSTOM_DELIMITER+"null"+CUSTOM_DELIMITER+"100"+CUSTOM_DELIMITER+"-10",
-        arrayJoinUDF.join(Arrays.asList(Arrays.asList(0,0,7),null,Arrays.asList(100,-10)),
-            CUSTOM_DELIMITER));
-
-    assertEquals("-4294967297,0,8589934592,null,1",
-        arrayJoinUDF.join(Arrays.asList(Arrays.asList(new BigInteger("-4294967297"),
-            BigInteger.ZERO,new BigInteger("8589934592")),Arrays.asList(null,BigInteger.ONE))));
-    assertEquals("-4294967297"+CUSTOM_DELIMITER+"0"+CUSTOM_DELIMITER+"8589934592"
-            +CUSTOM_DELIMITER+"null"+CUSTOM_DELIMITER+"1",
-        arrayJoinUDF.join(Arrays.asList(Arrays.asList(new BigInteger("-4294967297"),
-            BigInteger.ZERO,new BigInteger("8589934592")),Arrays.asList(null,BigInteger.ONE)),
-            CUSTOM_DELIMITER));
-
-    assertEquals("1.23,-23.42,0.0,1.0",
-        arrayJoinUDF.join(Arrays.asList(Arrays.asList(1.23,-23.42),Arrays.asList(0.0,1.0))));
-    assertEquals("1.23"+CUSTOM_DELIMITER+"-23.42"+CUSTOM_DELIMITER+"0.0"+CUSTOM_DELIMITER+"1.0",
-        arrayJoinUDF.join(Arrays.asList(Arrays.asList(1.23,-23.42),Arrays.asList(0.0,1.0)),
-            CUSTOM_DELIMITER));
-
-    assertEquals("hello,from,,ksqldb,udf,null",
-        arrayJoinUDF.join(Arrays.asList(Arrays.asList("hello","from"),
-            Arrays.asList("","ksqldb", "udf",null))));
-    assertEquals("hello"+CUSTOM_DELIMITER+"from"+CUSTOM_DELIMITER+CUSTOM_DELIMITER
-            +"ksqldb"+CUSTOM_DELIMITER+"udf"+CUSTOM_DELIMITER+"null",
-        arrayJoinUDF.join(Arrays.asList(Arrays.asList("hello","from"),
-            Arrays.asList("","ksqldb", "udf",null)),CUSTOM_DELIMITER));
-
-  }
-
-  @Test
-  public void shouldReturnCorrectStringForNestedComplexTypes() {
-
-    Map<String,Integer> mapData1 = new LinkedHashMap<>();
-    mapData1.put("k1",12);
-    mapData1.put("k2",34);
-    mapData1.put("k3",0);
-
-    Map<String,Integer> mapData2 = new LinkedHashMap<>();
-    mapData2.put("k4",null);
-    mapData2.put("k5",-100);
-
-    assertEquals("k1,12,k2,34,k3,0,k4,null,k5,-100",
-        arrayJoinUDF.join(Arrays.asList(mapData1,mapData2)));
-
-    Map<String,List<String>> mapData3 = new LinkedHashMap<>();
-    mapData3.put("k1",Arrays.asList("hello","from"));
-    mapData3.put("k2",Arrays.asList("ksqldb",""));
-
-    Map<String,List<String>> mapData4 = new LinkedHashMap<>();
-    mapData4.put("k3",Arrays.asList(null,"",""));
-
-    assertEquals("k1,hello,from,k2,ksqldb,,k3,null,,",
-        arrayJoinUDF.join(Arrays.asList(mapData3,mapData4)));
-
-    Map<String,Map<String,Integer>> mapData5 = new LinkedHashMap<>();
-    mapData5.put("k1",mapData1);
-    mapData5.put("k2",mapData2);
-
-    assertEquals("k1,k1,12,k2,34,k3,0,k2,k4,null,k5,-100",
-        arrayJoinUDF.join(Collections.singletonList(mapData5)));
-
-    assertEquals("f1,ksqldb UDF sample data,f2,42,f3,true,f4,f4-1,hello ksqldb," +
-            "f5,str_1,str_2,...,str_N,f6,k,a,v,1,k,b,v,2,k,c,v,3,f7,0,1,2,3,4,5,6,7,8,9," +
-            "9,8,7,6,5,4,3,2,1,0,f8,k1,6,k2,5,k3,4,f9,k1,v1-a,v1-b,k2,v2-a,v2-b,v2-c,v2-d," +
-            "k3,v3-a,v3-b,v3-c,f10,k1,12,21,k2,23,32,k3,24,42",
-        arrayJoinUDF.join(Collections.singletonList(STRUCT_DATA)));
+    assertThat(arrayJoinUDF.join(Arrays.asList("Hello","From","","Ksqldb","Udf"),""),
+        is("HelloFromKsqldbUdf")
+    );
+    assertThat(arrayJoinUDF.join(Arrays.asList("Hello","From","","Ksqldb","Udf")),
+        is("Hello,From,,Ksqldb,Udf")
+    );
+    assertThat(
+        arrayJoinUDF.join(Arrays.asList("hello","from","","ksqldb","udf",null),CUSTOM_DELIMITER),
+        is("hello"+CUSTOM_DELIMITER+"from"+CUSTOM_DELIMITER+CUSTOM_DELIMITER
+            +"ksqldb"+CUSTOM_DELIMITER+"udf"+CUSTOM_DELIMITER+"null")
+    );
 
   }
 
@@ -244,7 +117,7 @@ public class ArrayJoinTest {
     assertThrows(KsqlFunctionException.class,
         () -> arrayJoinUDF.join(Arrays.asList('a','b')));
     assertThrows(KsqlFunctionException.class,
-        () -> arrayJoinUDF.join(Arrays.asList(BigDecimal.ZERO,BigDecimal.ONE)));
+        () -> arrayJoinUDF.join(Arrays.asList(BigInteger.ONE,BigInteger.ZERO)));
     assertThrows(KsqlFunctionException.class,
         () -> arrayJoinUDF.join(Arrays.asList(-23.0f,42.42f,0.0f)));
     assertThrows(KsqlFunctionException.class,

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/arrayjoin_-_join_flat_arrays_with_primitive_ksqldb_types_and_custom_delimiters/6.0.0_1591955240274/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/arrayjoin_-_join_flat_arrays_with_primitive_ksqldb_types_and_custom_delimiters/6.0.0_1591955240274/plan.json
@@ -1,0 +1,126 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID STRING KEY, BOOLEANARRAY ARRAY<BOOLEAN>, INTARRAY ARRAY<INTEGER>, BIGINTARRAY ARRAY<BIGINT>, DOUBLEARRAY ARRAY<DOUBLE>, DECIMALARRAY ARRAY<DECIMAL(5, 2)>, STRINGARRAY ARRAY<STRING>) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` STRING KEY, `BOOLEANARRAY` ARRAY<BOOLEAN>, `INTARRAY` ARRAY<INTEGER>, `BIGINTARRAY` ARRAY<BIGINT>, `DOUBLEARRAY` ARRAY<DOUBLE>, `DECIMALARRAY` ARRAY<DECIMAL(5, 2)>, `STRINGARRAY` ARRAY<STRING>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  TEST.ID ID,\n  ARRAY_JOIN(TEST.BOOLEANARRAY, '|') KSQL_COL_0,\n  ARRAY_JOIN(TEST.INTARRAY, '?') KSQL_COL_1,\n  ARRAY_JOIN(TEST.BIGINTARRAY, ';') KSQL_COL_2,\n  ARRAY_JOIN(TEST.DOUBLEARRAY, ' ') KSQL_COL_3,\n  ARRAY_JOIN(TEST.DECIMALARRAY, '#') KSQL_COL_4,\n  ARRAY_JOIN(TEST.STRINGARRAY, '_') KSQL_COL_5\nFROM TEST TEST\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `KSQL_COL_0` STRING, `KSQL_COL_1` STRING, `KSQL_COL_2` STRING, `KSQL_COL_3` STRING, `KSQL_COL_4` STRING, `KSQL_COL_5` STRING",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY, `BOOLEANARRAY` ARRAY<BOOLEAN>, `INTARRAY` ARRAY<INTEGER>, `BIGINTARRAY` ARRAY<BIGINT>, `DOUBLEARRAY` ARRAY<DOUBLE>, `DECIMALARRAY` ARRAY<DECIMAL(5, 2)>, `STRINGARRAY` ARRAY<STRING>"
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "ARRAY_JOIN(BOOLEANARRAY, '|') AS KSQL_COL_0", "ARRAY_JOIN(INTARRAY, '?') AS KSQL_COL_1", "ARRAY_JOIN(BIGINTARRAY, ';') AS KSQL_COL_2", "ARRAY_JOIN(DOUBLEARRAY, ' ') AS KSQL_COL_3", "ARRAY_JOIN(DECIMALARRAY, '#') AS KSQL_COL_4", "ARRAY_JOIN(STRINGARRAY, '_') AS KSQL_COL_5" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.error.classifier.regex" : ""
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/arrayjoin_-_join_flat_arrays_with_primitive_ksqldb_types_and_custom_delimiters/6.0.0_1591955240274/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/arrayjoin_-_join_flat_arrays_with_primitive_ksqldb_types_and_custom_delimiters/6.0.0_1591955240274/spec.json
@@ -1,0 +1,73 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1591955240274,
+  "path" : "query-validation-tests/arrayjoin.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<BOOLEANARRAY ARRAY<BOOLEAN>, INTARRAY ARRAY<INT>, BIGINTARRAY ARRAY<BIGINT>, DOUBLEARRAY ARRAY<DOUBLE>, DECIMALARRAY ARRAY<DECIMAL(5, 2)>, STRINGARRAY ARRAY<VARCHAR>> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<KSQL_COL_0 VARCHAR, KSQL_COL_1 VARCHAR, KSQL_COL_2 VARCHAR, KSQL_COL_3 VARCHAR, KSQL_COL_4 VARCHAR, KSQL_COL_5 VARCHAR> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "join flat arrays with primitive ksqldb types and custom delimiters",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "1",
+      "value" : {
+        "BOOLEANARRAY" : [ true, null, false ],
+        "INTARRAY" : [ 1, 23, -42, 0 ],
+        "BIGINTARRAY" : [ -4294967297, 8589934592 ],
+        "DOUBLEARRAY" : [ 1.23, -23.42, 0.0 ],
+        "DECIMALARRAY" : [ 123.45, 987.65 ],
+        "STRINGARRAY" : [ "Hello", "From", "", "Ksqldb", "Udf" ]
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "1",
+      "value" : {
+        "KSQL_COL_0" : "true|null|false",
+        "KSQL_COL_1" : "1?23?-42?0",
+        "KSQL_COL_2" : "-4294967297;8589934592",
+        "KSQL_COL_3" : "1.23 -23.42 0.0",
+        "KSQL_COL_4" : "123.45#987.65",
+        "KSQL_COL_5" : "Hello_From__Ksqldb_Udf"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID STRING KEY, BOOLEANARRAY ARRAY<BOOLEAN>, INTARRAY ARRAY<INT>, BIGINTARRAY ARRAY<BIGINT>, DOUBLEARRAY ARRAY<DOUBLE>, DECIMALARRAY ARRAY<DECIMAL(5,2)>, STRINGARRAY ARRAY<STRING>) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT ID, ARRAY_JOIN(BOOLEANARRAY,'|'), ARRAY_JOIN(INTARRAY,'?'), ARRAY_JOIN(BIGINTARRAY,';'), ARRAY_JOIN(DOUBLEARRAY,' '), ARRAY_JOIN(DECIMALARRAY,'#'), ARRAY_JOIN(STRINGARRAY,'_') FROM TEST;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/arrayjoin_-_join_flat_arrays_with_primitive_ksqldb_types_and_custom_delimiters/6.0.0_1591955240274/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/arrayjoin_-_join_flat_arrays_with_primitive_ksqldb_types_and_custom_delimiters/6.0.0_1591955240274/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/arrayjoin_-_join_flat_arrays_with_primitive_ksqldb_types_and_default_delimiter/6.0.0_1591953360045/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/arrayjoin_-_join_flat_arrays_with_primitive_ksqldb_types_and_default_delimiter/6.0.0_1591953360045/plan.json
@@ -1,0 +1,126 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID STRING KEY, BOOLEANARRAY ARRAY<BOOLEAN>, INTARRAY ARRAY<INTEGER>, BIGINTARRAY ARRAY<BIGINT>, DOUBLEARRAY ARRAY<DOUBLE>, DECIMALARRAY ARRAY<DECIMAL(5, 2)>, STRINGARRAY ARRAY<STRING>) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` STRING KEY, `BOOLEANARRAY` ARRAY<BOOLEAN>, `INTARRAY` ARRAY<INTEGER>, `BIGINTARRAY` ARRAY<BIGINT>, `DOUBLEARRAY` ARRAY<DOUBLE>, `DECIMALARRAY` ARRAY<DECIMAL(5, 2)>, `STRINGARRAY` ARRAY<STRING>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  TEST.ID ID,\n  ARRAY_JOIN(TEST.BOOLEANARRAY) KSQL_COL_0,\n  ARRAY_JOIN(TEST.INTARRAY) KSQL_COL_1,\n  ARRAY_JOIN(TEST.BIGINTARRAY) KSQL_COL_2,\n  ARRAY_JOIN(TEST.DOUBLEARRAY) KSQL_COL_3,\n  ARRAY_JOIN(TEST.DECIMALARRAY) KSQL_COL_4,\n  ARRAY_JOIN(TEST.STRINGARRAY) KSQL_COL_5\nFROM TEST TEST\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `KSQL_COL_0` STRING, `KSQL_COL_1` STRING, `KSQL_COL_2` STRING, `KSQL_COL_3` STRING, `KSQL_COL_4` STRING, `KSQL_COL_5` STRING",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY, `BOOLEANARRAY` ARRAY<BOOLEAN>, `INTARRAY` ARRAY<INTEGER>, `BIGINTARRAY` ARRAY<BIGINT>, `DOUBLEARRAY` ARRAY<DOUBLE>, `DECIMALARRAY` ARRAY<DECIMAL(5, 2)>, `STRINGARRAY` ARRAY<STRING>"
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "ARRAY_JOIN(BOOLEANARRAY) AS KSQL_COL_0", "ARRAY_JOIN(INTARRAY) AS KSQL_COL_1", "ARRAY_JOIN(BIGINTARRAY) AS KSQL_COL_2", "ARRAY_JOIN(DOUBLEARRAY) AS KSQL_COL_3", "ARRAY_JOIN(DECIMALARRAY) AS KSQL_COL_4", "ARRAY_JOIN(STRINGARRAY) AS KSQL_COL_5" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.error.classifier.regex" : ""
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/arrayjoin_-_join_flat_arrays_with_primitive_ksqldb_types_and_default_delimiter/6.0.0_1591953360045/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/arrayjoin_-_join_flat_arrays_with_primitive_ksqldb_types_and_default_delimiter/6.0.0_1591953360045/spec.json
@@ -1,0 +1,73 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1591953360045,
+  "path" : "query-validation-tests/arrayjoin.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<BOOLEANARRAY ARRAY<BOOLEAN>, INTARRAY ARRAY<INT>, BIGINTARRAY ARRAY<BIGINT>, DOUBLEARRAY ARRAY<DOUBLE>, DECIMALARRAY ARRAY<DECIMAL(5, 2)>, STRINGARRAY ARRAY<VARCHAR>> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<KSQL_COL_0 VARCHAR, KSQL_COL_1 VARCHAR, KSQL_COL_2 VARCHAR, KSQL_COL_3 VARCHAR, KSQL_COL_4 VARCHAR, KSQL_COL_5 VARCHAR> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "join flat arrays with primitive ksqldb types and default delimiter",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "1",
+      "value" : {
+        "BOOLEANARRAY" : [ true, null, false ],
+        "INTARRAY" : [ 1, 23, -42, 0 ],
+        "BIGINTARRAY" : [ -4294967297, 8589934592 ],
+        "DOUBLEARRAY" : [ 1.23, -23.42, 0.0 ],
+        "DECIMALARRAY" : [ 123.45, 987.65 ],
+        "STRINGARRAY" : [ "Hello", "From", "", "Ksqldb", "Udf" ]
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "1",
+      "value" : {
+        "KSQL_COL_0" : "true,null,false",
+        "KSQL_COL_1" : "1,23,-42,0",
+        "KSQL_COL_2" : "-4294967297,8589934592",
+        "KSQL_COL_3" : "1.23,-23.42,0.0",
+        "KSQL_COL_4" : "123.45,987.65",
+        "KSQL_COL_5" : "Hello,From,,Ksqldb,Udf"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID STRING KEY, BOOLEANARRAY ARRAY<BOOLEAN>, INTARRAY ARRAY<INT>, BIGINTARRAY ARRAY<BIGINT>, DOUBLEARRAY ARRAY<DOUBLE>, DECIMALARRAY ARRAY<DECIMAL(5,2)>, STRINGARRAY ARRAY<STRING>) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT ID, ARRAY_JOIN(BOOLEANARRAY), ARRAY_JOIN(INTARRAY), ARRAY_JOIN(BIGINTARRAY), ARRAY_JOIN(DOUBLEARRAY), ARRAY_JOIN(DECIMALARRAY), ARRAY_JOIN(STRINGARRAY) FROM TEST;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/arrayjoin_-_join_flat_arrays_with_primitive_ksqldb_types_and_default_delimiter/6.0.0_1591953360045/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/arrayjoin_-_join_flat_arrays_with_primitive_ksqldb_types_and_default_delimiter/6.0.0_1591953360045/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/arrayjoin_-_join_flat_arrays_with_primitive_ksqldb_types_and_empty_or_null_delimiter/6.0.0_1591955240399/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/arrayjoin_-_join_flat_arrays_with_primitive_ksqldb_types_and_empty_or_null_delimiter/6.0.0_1591955240399/plan.json
@@ -1,0 +1,126 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID STRING KEY, BOOLEANARRAY ARRAY<BOOLEAN>, INTARRAY ARRAY<INTEGER>, BIGINTARRAY ARRAY<BIGINT>, DOUBLEARRAY ARRAY<DOUBLE>, DECIMALARRAY ARRAY<DECIMAL(5, 2)>, STRINGARRAY ARRAY<STRING>) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` STRING KEY, `BOOLEANARRAY` ARRAY<BOOLEAN>, `INTARRAY` ARRAY<INTEGER>, `BIGINTARRAY` ARRAY<BIGINT>, `DOUBLEARRAY` ARRAY<DOUBLE>, `DECIMALARRAY` ARRAY<DECIMAL(5, 2)>, `STRINGARRAY` ARRAY<STRING>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  TEST.ID ID,\n  ARRAY_JOIN(TEST.BOOLEANARRAY, '') KSQL_COL_0,\n  ARRAY_JOIN(TEST.INTARRAY, null) KSQL_COL_1,\n  ARRAY_JOIN(TEST.BIGINTARRAY, '') KSQL_COL_2,\n  ARRAY_JOIN(TEST.DOUBLEARRAY, null) KSQL_COL_3,\n  ARRAY_JOIN(TEST.DECIMALARRAY, '') KSQL_COL_4,\n  ARRAY_JOIN(TEST.STRINGARRAY, null) KSQL_COL_5\nFROM TEST TEST\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `KSQL_COL_0` STRING, `KSQL_COL_1` STRING, `KSQL_COL_2` STRING, `KSQL_COL_3` STRING, `KSQL_COL_4` STRING, `KSQL_COL_5` STRING",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY, `BOOLEANARRAY` ARRAY<BOOLEAN>, `INTARRAY` ARRAY<INTEGER>, `BIGINTARRAY` ARRAY<BIGINT>, `DOUBLEARRAY` ARRAY<DOUBLE>, `DECIMALARRAY` ARRAY<DECIMAL(5, 2)>, `STRINGARRAY` ARRAY<STRING>"
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "ARRAY_JOIN(BOOLEANARRAY, '') AS KSQL_COL_0", "ARRAY_JOIN(INTARRAY, null) AS KSQL_COL_1", "ARRAY_JOIN(BIGINTARRAY, '') AS KSQL_COL_2", "ARRAY_JOIN(DOUBLEARRAY, null) AS KSQL_COL_3", "ARRAY_JOIN(DECIMALARRAY, '') AS KSQL_COL_4", "ARRAY_JOIN(STRINGARRAY, null) AS KSQL_COL_5" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.error.classifier.regex" : ""
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/arrayjoin_-_join_flat_arrays_with_primitive_ksqldb_types_and_empty_or_null_delimiter/6.0.0_1591955240399/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/arrayjoin_-_join_flat_arrays_with_primitive_ksqldb_types_and_empty_or_null_delimiter/6.0.0_1591955240399/spec.json
@@ -1,0 +1,73 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1591955240399,
+  "path" : "query-validation-tests/arrayjoin.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<BOOLEANARRAY ARRAY<BOOLEAN>, INTARRAY ARRAY<INT>, BIGINTARRAY ARRAY<BIGINT>, DOUBLEARRAY ARRAY<DOUBLE>, DECIMALARRAY ARRAY<DECIMAL(5, 2)>, STRINGARRAY ARRAY<VARCHAR>> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<KSQL_COL_0 VARCHAR, KSQL_COL_1 VARCHAR, KSQL_COL_2 VARCHAR, KSQL_COL_3 VARCHAR, KSQL_COL_4 VARCHAR, KSQL_COL_5 VARCHAR> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "join flat arrays with primitive ksqldb types and empty or null delimiter",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "1",
+      "value" : {
+        "BOOLEANARRAY" : [ true, null, false ],
+        "INTARRAY" : [ 1, 23, -42, 0 ],
+        "BIGINTARRAY" : [ -4294967297, 8589934592 ],
+        "DOUBLEARRAY" : [ 1.23, -23.42, 0.0 ],
+        "DECIMALARRAY" : [ 123.45, 987.65 ],
+        "STRINGARRAY" : [ "Hello", "From", "", "Ksqldb", "Udf" ]
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "1",
+      "value" : {
+        "KSQL_COL_0" : "truenullfalse",
+        "KSQL_COL_1" : "123-420",
+        "KSQL_COL_2" : "-42949672978589934592",
+        "KSQL_COL_3" : "1.23-23.420.0",
+        "KSQL_COL_4" : "123.45987.65",
+        "KSQL_COL_5" : "HelloFromKsqldbUdf"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID STRING KEY, BOOLEANARRAY ARRAY<BOOLEAN>, INTARRAY ARRAY<INT>, BIGINTARRAY ARRAY<BIGINT>, DOUBLEARRAY ARRAY<DOUBLE>, DECIMALARRAY ARRAY<DECIMAL(5,2)>, STRINGARRAY ARRAY<STRING>) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT ID, ARRAY_JOIN(BOOLEANARRAY,''), ARRAY_JOIN(INTARRAY,null), ARRAY_JOIN(BIGINTARRAY,''), ARRAY_JOIN(DOUBLEARRAY,null), ARRAY_JOIN(DECIMALARRAY,''), ARRAY_JOIN(STRINGARRAY,null) FROM TEST;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/arrayjoin_-_join_flat_arrays_with_primitive_ksqldb_types_and_empty_or_null_delimiter/6.0.0_1591955240399/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/arrayjoin_-_join_flat_arrays_with_primitive_ksqldb_types_and_empty_or_null_delimiter/6.0.0_1591955240399/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/arrayjoin.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/arrayjoin.json
@@ -1,0 +1,109 @@
+{
+  "comments": [
+    "Tests covering the use of the ARRAY_JOIN function."
+  ],
+  "tests": [
+    {
+      "name": "join flat arrays with primitive ksqldb types and default delimiter",
+      "statements": [
+        "CREATE STREAM TEST (ID STRING KEY, BOOLEANARRAY ARRAY<BOOLEAN>, INTARRAY ARRAY<INT>, BIGINTARRAY ARRAY<BIGINT>, DOUBLEARRAY ARRAY<DOUBLE>, DECIMALARRAY ARRAY<DECIMAL(5,2)>, STRINGARRAY ARRAY<STRING>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT ID, ARRAY_JOIN(BOOLEANARRAY), ARRAY_JOIN(INTARRAY), ARRAY_JOIN(BIGINTARRAY), ARRAY_JOIN(DOUBLEARRAY), ARRAY_JOIN(DECIMALARRAY), ARRAY_JOIN(STRINGARRAY) FROM TEST;"
+      ],
+      "inputs": [
+        {
+          "topic": "test_topic", "key": "1",
+          "value": {
+            "BOOLEANARRAY": [true, null, false],
+            "INTARRAY": [1, 23, -42, 0],
+            "BIGINTARRAY": [-4294967297, 8589934592],
+            "DOUBLEARRAY": [1.23, -23.42, 0.0],
+            "DECIMALARRAY": [123.45, 987.65],
+            "STRINGARRAY": ["Hello", "From", "", "Ksqldb", "Udf"]
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "topic": "OUTPUT",
+          "key": "1",
+          "value": {
+            "KSQL_COL_0": "true,null,false",
+            "KSQL_COL_1": "1,23,-42,0",
+            "KSQL_COL_2": "-4294967297,8589934592",
+            "KSQL_COL_3": "1.23,-23.42,0.0",
+            "KSQL_COL_4": "123.45,987.65",
+            "KSQL_COL_5": "Hello,From,,Ksqldb,Udf"
+          }
+        }
+      ]
+    },
+    {
+      "name": "join flat arrays with primitive ksqldb types and custom delimiters",
+      "statements": [
+        "CREATE STREAM TEST (ID STRING KEY, BOOLEANARRAY ARRAY<BOOLEAN>, INTARRAY ARRAY<INT>, BIGINTARRAY ARRAY<BIGINT>, DOUBLEARRAY ARRAY<DOUBLE>, DECIMALARRAY ARRAY<DECIMAL(5,2)>, STRINGARRAY ARRAY<STRING>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT ID, ARRAY_JOIN(BOOLEANARRAY,'|'), ARRAY_JOIN(INTARRAY,'?'), ARRAY_JOIN(BIGINTARRAY,';'), ARRAY_JOIN(DOUBLEARRAY,' '), ARRAY_JOIN(DECIMALARRAY,'#'), ARRAY_JOIN(STRINGARRAY,'_') FROM TEST;"
+      ],
+      "inputs": [
+        {
+          "topic": "test_topic", "key": "1",
+          "value": {
+            "BOOLEANARRAY": [true, null, false],
+            "INTARRAY": [1, 23, -42, 0],
+            "BIGINTARRAY": [-4294967297, 8589934592],
+            "DOUBLEARRAY": [1.23, -23.42, 0.0],
+            "DECIMALARRAY": [123.45, 987.65],
+            "STRINGARRAY": ["Hello", "From", "", "Ksqldb", "Udf"]
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "topic": "OUTPUT",
+          "key": "1",
+          "value": {
+            "KSQL_COL_0": "true|null|false",
+            "KSQL_COL_1": "1?23?-42?0",
+            "KSQL_COL_2": "-4294967297;8589934592",
+            "KSQL_COL_3": "1.23 -23.42 0.0",
+            "KSQL_COL_4": "123.45#987.65",
+            "KSQL_COL_5": "Hello_From__Ksqldb_Udf"
+          }
+        }
+      ]
+    },
+    {
+      "name": "join flat arrays with primitive ksqldb types and empty or null delimiter",
+      "statements": [
+        "CREATE STREAM TEST (ID STRING KEY, BOOLEANARRAY ARRAY<BOOLEAN>, INTARRAY ARRAY<INT>, BIGINTARRAY ARRAY<BIGINT>, DOUBLEARRAY ARRAY<DOUBLE>, DECIMALARRAY ARRAY<DECIMAL(5,2)>, STRINGARRAY ARRAY<STRING>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT ID, ARRAY_JOIN(BOOLEANARRAY,''), ARRAY_JOIN(INTARRAY,null), ARRAY_JOIN(BIGINTARRAY,''), ARRAY_JOIN(DOUBLEARRAY,null), ARRAY_JOIN(DECIMALARRAY,''), ARRAY_JOIN(STRINGARRAY,null) FROM TEST;"
+      ],
+      "inputs": [
+        {
+          "topic": "test_topic", "key": "1",
+          "value": {
+            "BOOLEANARRAY": [true, null, false],
+            "INTARRAY": [1, 23, -42, 0],
+            "BIGINTARRAY": [-4294967297, 8589934592],
+            "DOUBLEARRAY": [1.23, -23.42, 0.0],
+            "DECIMALARRAY": [123.45, 987.65],
+            "STRINGARRAY": ["Hello", "From", "", "Ksqldb", "Udf"]
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "topic": "OUTPUT",
+          "key": "1",
+          "value": {
+            "KSQL_COL_0": "truenullfalse",
+            "KSQL_COL_1": "123-420",
+            "KSQL_COL_2": "-42949672978589934592",
+            "KSQL_COL_3": "1.23-23.420.0",
+            "KSQL_COL_4": "123.45987.65",
+            "KSQL_COL_5": "HelloFromKsqldbUdf"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Description 
This PR implements the UDF / scalar function ARRAY_JOIN as requested in (#5028). It creates a flat string representation of all the elements contained in the given array.

### Testing done 
There are unit tests with several applications of the UDF to verify that it follows the expected behaviour as discussed in the linked issue.