### PR TITLE
fix: Remove stacktrace from error message

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
@@ -794,7 +794,7 @@ public class ApiTest extends BaseApiTest {
 
   private static void validateInsertStreamError(final int errorCode, final String message,
       final JsonObject error, final long sequence) {
-    assertThat(error.size(), is(6));
+    assertThat(error.size(), is(5));
     validateErrorCommon(errorCode, message, error);
     assertThat(error.getLong("seq"), is(sequence));
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/BaseApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/BaseApiTest.java
@@ -218,7 +218,7 @@ public class BaseApiTest {
 
   protected static void validateError(final int errorCode, final String message,
       final JsonObject error) {
-    assertThat(error.size(), is(4));
+    assertThat(error.size(), is(3));
     validateErrorCommon(errorCode, message, error);
   }
 

--- a/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlClientTest.java
+++ b/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlClientTest.java
@@ -584,8 +584,7 @@ public class KsqlClientTest {
   @Test
   public void shouldHandleErrorMessageOnPostRequests() {
     // Given:
-    KsqlErrorMessage ksqlErrorMessage = new KsqlErrorMessage(40000, "ouch",
-        ImmutableList.of("s1", "s2"));
+    KsqlErrorMessage ksqlErrorMessage = new KsqlErrorMessage(40000, "ouch");
     server.setResponseObject(ksqlErrorMessage);
     server.setErrorCode(400);
 
@@ -597,13 +596,12 @@ public class KsqlClientTest {
     assertThat(response.getStatusCode(), is(400));
     assertThat(response.getErrorMessage().getErrorCode(), is(40000));
     assertThat(response.getErrorMessage().getMessage(), is("ouch"));
-    assertThat(response.getErrorMessage().getStackTrace(), is(ImmutableList.of("s1", "s2")));
   }
 
   @Test
   public void shouldHandleErrorMessageOnGetRequests() {
     // Given:
-    server.setResponseObject(new KsqlErrorMessage(40000, "ouch", ImmutableList.of("s1", "s2")));
+    server.setResponseObject(new KsqlErrorMessage(40000, "ouch"));
     server.setErrorCode(400);
 
     // When:
@@ -614,7 +612,6 @@ public class KsqlClientTest {
     assertThat(response.getStatusCode(), is(400));
     assertThat(response.getErrorMessage().getErrorCode(), is(40000));
     assertThat(response.getErrorMessage().getMessage(), is("ouch"));
-    assertThat(response.getErrorMessage().getStackTrace(), is(ImmutableList.of("s1", "s2")));
   }
 
   @Test

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/InsertError.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/InsertError.java
@@ -45,8 +45,7 @@ public class InsertError extends KsqlErrorMessage {
     }
     final KsqlErrorMessage that = (KsqlErrorMessage) o;
     return getErrorCode() == that.getErrorCode()
-        && Objects.equals(that.getMessage(), that.getMessage())
-        && Objects.equals(getStackTrace(), that.getStackTrace());
+        && Objects.equals(that.getMessage(), that.getMessage());
   }
 
   @Override

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlErrorMessage.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlErrorMessage.java
@@ -20,11 +20,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.util.ErrorMessageUtil;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -39,25 +36,18 @@ public class KsqlErrorMessage {
 
   private final int errorCode;
   private final String errorMessage;
-  private final ImmutableList<String> stackTrace;
 
   @JsonCreator
   public KsqlErrorMessage(
       @JsonProperty("error_code") final int errorCode,
-      @JsonProperty("message") final String message,
-      @JsonProperty("stackTrace") final List<String> stackTrace
+      @JsonProperty("message") final String message
   ) {
     this.errorCode = errorCode;
     this.errorMessage = message == null ? "" : message;
-    this.stackTrace = stackTrace == null ? ImmutableList.of() : ImmutableList.copyOf(stackTrace);
   }
 
   public KsqlErrorMessage(final int errorCode, final Throwable exception) {
-    this(errorCode, ErrorMessageUtil.buildErrorMessage(exception), getStackTraceStrings(exception));
-  }
-
-  public KsqlErrorMessage(final int errorCode, final String message) {
-    this(errorCode, message, Collections.emptyList());
+    this(errorCode, ErrorMessageUtil.buildErrorMessage(exception));
   }
 
   static List<String> getStackTraceStrings(final Throwable exception) {
@@ -75,20 +65,9 @@ public class KsqlErrorMessage {
     return errorMessage;
   }
 
-  public List<String> getStackTrace() {
-    return new ArrayList<>(stackTrace);
-  }
-
   @Override
   public String toString() {
-    final StringBuilder sb = new StringBuilder();
-    sb.append(getMessage());
-    sb.append("\n");
-    for (final String line : stackTrace) {
-      sb.append(line);
-      sb.append("\n");
-    }
-    return sb.toString();
+    return errorMessage;
   }
 
   @Override
@@ -101,12 +80,11 @@ public class KsqlErrorMessage {
     }
     final KsqlErrorMessage that = (KsqlErrorMessage) o;
     return errorCode == that.errorCode
-        && Objects.equals(errorMessage, that.errorMessage)
-        && Objects.equals(stackTrace, that.stackTrace);
+        && errorMessage.equals(that.errorMessage);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, errorMessage, stackTrace);
+    return Objects.hash(errorCode, errorMessage);
   }
 }

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlStatementErrorMessage.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlStatementErrorMessage.java
@@ -18,8 +18,6 @@ package io.confluent.ksql.rest.entity;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.confluent.ksql.util.ErrorMessageUtil;
-import java.util.Collections;
-import java.util.List;
 import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -31,20 +29,11 @@ public class KsqlStatementErrorMessage extends KsqlErrorMessage {
   public KsqlStatementErrorMessage(
       @JsonProperty("error_code") final int errorCode,
       @JsonProperty("message") final String message,
-      @JsonProperty("stackTrace") final List<String> stackTrace,
       @JsonProperty("statementText") final String statementText,
       @JsonProperty("entities") final KsqlEntityList entities) {
-    super(errorCode, message, stackTrace);
+    super(errorCode, message);
     this.entities = entities;
     this.statementText = statementText;
-  }
-
-  public KsqlStatementErrorMessage(
-      final int errorCode,
-      final String message,
-      final String statementText,
-      final KsqlEntityList entityList) {
-    this(errorCode, message, Collections.emptyList(), statementText, entityList);
   }
 
   public KsqlStatementErrorMessage(
@@ -52,9 +41,7 @@ public class KsqlStatementErrorMessage extends KsqlErrorMessage {
       final Throwable t,
       final String statementText,
       final KsqlEntityList entityList) {
-    this(
-        errorCode, ErrorMessageUtil.buildErrorMessage(t), getStackTraceStrings(t),
-        statementText, entityList);
+    this(errorCode, ErrorMessageUtil.buildErrorMessage(t), statementText, entityList);
   }
 
   public String getStatementText() {
@@ -78,7 +65,9 @@ public class KsqlStatementErrorMessage extends KsqlErrorMessage {
     }
     final KsqlStatementErrorMessage that = (KsqlStatementErrorMessage) o;
     return Objects.equals(statementText, that.statementText)
-           && Objects.equals(entities, that.entities);
+        && Objects.equals(entities, that.entities)
+        && Objects.equals(this.getMessage(), that.getMessage())
+        && Objects.equals(this.getErrorCode(), that.getErrorCode());
   }
 
   @Override

--- a/ksqldb-rest-model/src/test/java/io/confluent/ksql/rest/entity/KsqlErrorMessageTest.java
+++ b/ksqldb-rest-model/src/test/java/io/confluent/ksql/rest/entity/KsqlErrorMessageTest.java
@@ -30,7 +30,7 @@ public class KsqlErrorMessageTest {
   private static final KsqlErrorMessage MESSAGE =
       new KsqlErrorMessage(40301, "foo");
   private static final String SERIALIZED_MESSAGE =
-      "{\"@type\":\"generic_error\",\"error_code\":40301,\"message\":\"foo\",\"stackTrace\":[]}";
+      "{\"@type\":\"generic_error\",\"error_code\":40301,\"message\":\"foo\"}";
 
   @Test
   public void shouldSerializeToJson() {

--- a/ksqldb-rest-model/src/test/java/io/confluent/ksql/rest/entity/KsqlErrorMessageTest.java
+++ b/ksqldb-rest-model/src/test/java/io/confluent/ksql/rest/entity/KsqlErrorMessageTest.java
@@ -21,7 +21,6 @@ import static org.hamcrest.Matchers.is;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.ksql.rest.ApiJsonMapper;
 import java.io.IOException;
-import java.util.Collections;
 import org.junit.Test;
 
 public class KsqlErrorMessageTest {
@@ -29,7 +28,7 @@ public class KsqlErrorMessageTest {
   private static final ObjectMapper OBJECT_MAPPER = ApiJsonMapper.INSTANCE.get();
 
   private static final KsqlErrorMessage MESSAGE =
-      new KsqlErrorMessage(40301, "foo", Collections.emptyList());
+      new KsqlErrorMessage(40301, "foo");
   private static final String SERIALIZED_MESSAGE =
       "{\"@type\":\"generic_error\",\"error_code\":40301,\"message\":\"foo\",\"stackTrace\":[]}";
 


### PR DESCRIPTION
### Description 

Fixes: https://github.com/confluentinc/ksql/issues/5398

As a general rule servers should log internal errors but not expose internal stack traces to clients. Sending stack traces to clients can create a security risk - stack traces expose implementation details of servers - libraries used, class names, private IP, paths, etc, that can potentially be used to compromise the server or leak information that the server administrator does not want to be public.

### Testing done 

Updated tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

