### PR TITLE
feat: turn on snappy compression for produced data

### DIFF
--- a/config/ksql-production-server.properties
+++ b/config/ksql-production-server.properties
@@ -58,6 +58,9 @@ ksql.logging.processing.stream.auto.create=true
 # The set of Kafka brokers to bootstrap Kafka cluster information from:
 bootstrap.servers=localhost:9092
 
+# Enable snappy compression for the Kafka producers
+compression.type=snappy
+
 # uncomment the below to start an embedded Connect worker
 # ksql.connect.worker.config=config/connect.properties
 # ksql.connect.configs.topic=ksql-connect-configs

--- a/config/ksql-server.properties
+++ b/config/ksql-server.properties
@@ -55,11 +55,20 @@ ksql.logging.processing.stream.auto.create=true
 
 #------ External service config -------
 
+#------ Kafka -------
+
 # The set of Kafka brokers to bootstrap Kafka cluster information from:
 bootstrap.servers=localhost:9092
 
+# Enable snappy compression for the Kafka producers
+compression.type=snappy
+
+#------ Connect -------
+
 # uncomment the below to start an embedded Connect worker
 # ksql.connect.worker.config=config/connect.properties
+
+#------ Schema Registry -------
 
 # Uncomment and complete the following to enable KSQL's integration to the Confluent Schema Registry:
 # ksql.schema.registry.url=http://localhost:8081


### PR DESCRIPTION
### Description 

Sets all Kafka producers used by ksqlDB to use snappy compression to reduce the size across the wire and on-disk in the Kafka brokers. There is a slight hit to CPU load. However, its rare that turning compression on reduces throughput: almost universally it increases it.

### Testing done 

Ensures this was flowing through to the producers

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

