### PR TITLE
chore: make ksql.streams.num.stream.threads immutable

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/config/ImmutableProperties.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/config/ImmutableProperties.java
@@ -32,6 +32,7 @@ public final class ImmutableProperties {
       .add(KsqlConfig.KSQL_PULL_QUERIES_ENABLE_CONFIG)
       .add(KsqlConfig.KSQL_HIDDEN_TOPICS_CONFIG)
       .add(KsqlConfig.KSQL_READONLY_TOPICS_CONFIG)
+      .add(StreamsConfig.NUM_STREAM_THREADS_CONFIG)
       .addAll(KsqlConfig.SSL_CONFIG_NAMES)
       .build();
 


### PR DESCRIPTION
### Description 
Any CLI/Rest user can change the number of stream threads a query will use. The configuration they use is set `'ksql.streams.num.stream.threads'='x'`

This config might cause KSQL to crash or being too slow if users set it to a high number. We should  avoid users to set such config from the client. It must be a Server side config.

### Testing done 
- Verified manually

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

