### PR TITLE
refactor: remove duplicate code & unneeded validation from logical plan

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
@@ -40,13 +40,11 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.tree.GroupBy;
 import io.confluent.ksql.parser.tree.WindowExpression;
-import io.confluent.ksql.planner.Projection;
 import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.ColumnNames;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SystemColumns;
 import io.confluent.ksql.serde.ValueFormat;
-import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.structured.SchemaKGroupedStream;
 import io.confluent.ksql.structured.SchemaKStream;
 import io.confluent.ksql.structured.SchemaKTable;
@@ -62,7 +60,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 
-public class AggregateNode extends PlanNode implements VerifiableNode {
+public class AggregateNode extends SingleSourcePlanNode implements VerifiableNode {
 
   private static final String INTERNAL_COLUMN_NAME_PREFIX = "KSQL_INTERNAL_COL_";
 
@@ -72,7 +70,6 @@ public class AggregateNode extends PlanNode implements VerifiableNode {
   private static final String HAVING_FILTER_OP_NAME = "HavingFilter";
   private static final String PROJECT_OP_NAME = "Project";
 
-  private final PlanNode source;
   private final GroupBy groupBy;
   private final Optional<WindowExpression> windowExpression;
   private final ImmutableList<Expression> aggregateFunctionArguments;
@@ -82,7 +79,6 @@ public class AggregateNode extends PlanNode implements VerifiableNode {
   private final ImmutableList<SelectExpression> selectExpressions;
   private final ImmutableList<SelectExpression> finalSelectExpressions;
   private final ValueFormat valueFormat;
-  private final Projection projection;
   private final LogicalSchema schema;
 
   public AggregateNode(
@@ -95,13 +91,11 @@ public class AggregateNode extends PlanNode implements VerifiableNode {
       final AggregateAnalysisResult rewrittenAggregateAnalysis,
       final List<SelectExpression> projectionExpressions
   ) {
-    super(id, DataSourceType.KTABLE, Optional.empty());
+    super(id, DataSourceType.KTABLE, Optional.empty(), source);
 
     this.schema = requireNonNull(schema, "schema");
-    this.source = requireNonNull(source, "source");
     this.groupBy = requireNonNull(groupBy, "groupBy");
     this.windowExpression = requireNonNull(analysis, "analysis").getWindowExpression();
-    this.projection = Projection.of(analysis.getSelectItems());
 
     final AggregateExpressionRewriter aggregateExpressionRewriter =
         new AggregateExpressionRewriter(functionRegistry);
@@ -138,15 +132,6 @@ public class AggregateNode extends PlanNode implements VerifiableNode {
   @Override
   public LogicalSchema getSchema() {
     return schema;
-  }
-
-  @Override
-  public List<PlanNode> getSources() {
-    return ImmutableList.of(source);
-  }
-
-  public PlanNode getSource() {
-    return source;
   }
 
   public List<Expression> getGroupByExpressions() {
@@ -196,10 +181,6 @@ public class AggregateNode extends PlanNode implements VerifiableNode {
     if (!missing.isEmpty()) {
       throwKeysNotIncludedError(sinkName, "grouping expression", missing);
     }
-  }
-
-  protected int getPartitions(final KafkaTopicClient kafkaTopicClient) {
-    return source.getPartitions(kafkaTopicClient);
   }
 
   private SchemaKStream<?> selectRequiredInputColumns(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/FilterNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/FilterNode.java
@@ -15,19 +15,15 @@
 
 package io.confluent.ksql.planner.plan;
 
-import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext.Stacker;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
-import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.structured.SchemaKStream;
-import java.util.List;
 import java.util.Objects;
 
-public class FilterNode extends PlanNode {
+public class FilterNode extends SingleSourcePlanNode {
 
-  private final PlanNode source;
   private final Expression predicate;
 
   public FilterNode(
@@ -35,9 +31,8 @@ public class FilterNode extends PlanNode {
       final PlanNode source,
       final Expression predicate
   ) {
-    super(id, source.getNodeOutputType(), source.getSourceName());
+    super(id, source.getNodeOutputType(), source.getSourceName(), source);
 
-    this.source = Objects.requireNonNull(source, "source");
     this.predicate = Objects.requireNonNull(predicate, "predicate");
   }
 
@@ -47,28 +42,14 @@ public class FilterNode extends PlanNode {
 
   @Override
   public LogicalSchema getSchema() {
-    return source.getSchema();
-  }
-
-  @Override
-  public List<PlanNode> getSources() {
-    return ImmutableList.of(source);
-  }
-
-  public PlanNode getSource() {
-    return source;
-  }
-
-  @Override
-  protected int getPartitions(final KafkaTopicClient kafkaTopicClient) {
-    return source.getPartitions(kafkaTopicClient);
+    return getSource().getSchema();
   }
 
   @Override
   public SchemaKStream<?> buildStream(final KsqlQueryBuilder builder) {
     final Stacker contextStacker = builder.buildNodeContext(getId().toString());
 
-    return source.buildStream(builder)
+    return getSource().buildStream(builder)
         .filter(
             getPredicate(),
             contextStacker

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/FlatMapNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/FlatMapNode.java
@@ -34,7 +34,6 @@ import io.confluent.ksql.parser.tree.SelectItem;
 import io.confluent.ksql.parser.tree.SingleColumn;
 import io.confluent.ksql.schema.ksql.ColumnNames;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
-import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.structured.SchemaKStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -45,9 +44,8 @@ import java.util.Optional;
  * A node in the logical plan which represents a flat map operation - transforming a single row into
  * zero or more rows.
  */
-public class FlatMapNode extends PlanNode {
+public class FlatMapNode extends SingleSourcePlanNode {
 
-  private final PlanNode source;
   private final ImmutableList<FunctionCall> tableFunctions;
   private final ImmutableMap<Integer, UnqualifiedColumnReferenceExp> columnMappings;
   private final LogicalSchema schema;
@@ -61,10 +59,10 @@ public class FlatMapNode extends PlanNode {
     super(
         id,
         source.getNodeOutputType(),
-        Optional.empty()
+        Optional.empty(),
+        source
     );
     this.schema = buildSchema(source, functionRegistry, analysis);
-    this.source = Objects.requireNonNull(source, "source");
     this.tableFunctions = ImmutableList.copyOf(analysis.getTableFunctions());
     this.columnMappings = buildColumnMappings(functionRegistry, analysis);
   }
@@ -72,20 +70,6 @@ public class FlatMapNode extends PlanNode {
   @Override
   public LogicalSchema getSchema() {
     return schema;
-  }
-
-  @Override
-  public List<PlanNode> getSources() {
-    return ImmutableList.of(source);
-  }
-
-  public PlanNode getSource() {
-    return source;
-  }
-
-  @Override
-  protected int getPartitions(final KafkaTopicClient kafkaTopicClient) {
-    return source.getPartitions(kafkaTopicClient);
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/OutputNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/OutputNode.java
@@ -17,21 +17,16 @@ package io.confluent.ksql.planner.plan;
 
 import static java.util.Objects.requireNonNull;
 
-import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.execution.timestamp.TimestampColumn;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.query.id.QueryIdGenerator;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
-import io.confluent.ksql.services.KafkaTopicClient;
-import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-public abstract class OutputNode
-    extends PlanNode {
+public abstract class OutputNode extends SingleSourcePlanNode {
 
-  private final PlanNode source;
   private final OptionalInt limit;
   private final Optional<TimestampColumn> timestampColumn;
   private final LogicalSchema schema;
@@ -43,10 +38,9 @@ public abstract class OutputNode
       final OptionalInt limit,
       final Optional<TimestampColumn> timestampColumn
   ) {
-    super(id, source.getNodeOutputType(), source.getSourceName());
+    super(id, source.getNodeOutputType(), source.getSourceName(), source);
 
     this.schema = requireNonNull(schema, "schema");
-    this.source = requireNonNull(source, "source");
     this.limit = requireNonNull(limit, "limit");
     this.timestampColumn =
         requireNonNull(timestampColumn, "timestampColumn");
@@ -57,22 +51,8 @@ public abstract class OutputNode
     return schema;
   }
 
-  @Override
-  public List<PlanNode> getSources() {
-    return ImmutableList.of(source);
-  }
-
   public OptionalInt getLimit() {
     return limit;
-  }
-
-  public PlanNode getSource() {
-    return source;
-  }
-
-  @Override
-  protected int getPartitions(final KafkaTopicClient kafkaTopicClient) {
-    return source.getPartitions(kafkaTopicClient);
   }
 
   public Optional<TimestampColumn> getTimestampColumn() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/ProjectNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/ProjectNode.java
@@ -15,47 +15,21 @@
 
 package io.confluent.ksql.planner.plan;
 
-import static java.util.Objects.requireNonNull;
-
-import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.plan.SelectExpression;
-import io.confluent.ksql.function.udf.AsValue;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.Column;
-import io.confluent.ksql.schema.ksql.LogicalSchema;
-import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.structured.SchemaKStream;
-import io.confluent.ksql.util.GrammaticalJoiner;
-import io.confluent.ksql.util.KsqlException;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public abstract class ProjectNode extends PlanNode {
-
-  private final PlanNode source;
+public abstract class ProjectNode extends SingleSourcePlanNode {
 
   public ProjectNode(
       final PlanNodeId id,
       final PlanNode source
   ) {
-    super(id, source.getNodeOutputType(), source.getSourceName());
-
-    this.source = requireNonNull(source, "source");
-  }
-
-  @Override
-  public List<PlanNode> getSources() {
-    return ImmutableList.of(source);
-  }
-
-  public PlanNode getSource() {
-    return source;
-  }
-
-  @Override
-  protected int getPartitions(final KafkaTopicClient kafkaTopicClient) {
-    return source.getPartitions(kafkaTopicClient);
+    super(id, source.getNodeOutputType(), source.getSourceName(), source);
   }
 
   public abstract List<SelectExpression> getSelectExpressions();
@@ -74,39 +48,5 @@ public abstract class ProjectNode extends PlanNode {
         builder.buildNodeContext(getId().toString()),
         builder
     );
-  }
-
-  protected void validate() {
-    final LogicalSchema schema = getSchema();
-
-    if (schema.key().size() > 1) {
-      final String keys = GrammaticalJoiner.and().join(schema.key().stream().map(Column::name));
-      throw new KsqlException("The projection contains the key column more than once: " + keys + "."
-          + System.lineSeparator()
-          + "Each key column must only be in the projection once. "
-          + "If you intended to copy the key into the value, then consider using the "
-          + AsValue.NAME + " function to indicate which key reference should be copied."
-      );
-    }
-
-    if (schema.value().isEmpty()) {
-      throw new KsqlException("The projection contains no value columns.");
-    }
-
-    final List<SelectExpression> selectExpressions = getSelectExpressions();
-
-    if (schema.value().size() != selectExpressions.size()) {
-      throw new IllegalArgumentException("Error in projection. "
-          + "Schema fields and expression list size mismatch.");
-    }
-
-    for (int i = 0; i < selectExpressions.size(); i++) {
-      final Column column = schema.value().get(i);
-      final SelectExpression selectExpression = selectExpressions.get(i);
-
-      if (!column.name().equals(selectExpression.getAlias())) {
-        throw new IllegalArgumentException("Mismatch between schema and selects");
-      }
-    }
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/SingleSourcePlanNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/SingleSourcePlanNode.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.planner.plan;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.services.KafkaTopicClient;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Abstract base class for logical plan nodes with only a single source
+ */
+public abstract class SingleSourcePlanNode extends PlanNode {
+
+  private final PlanNode source;
+
+  public SingleSourcePlanNode(
+      final PlanNodeId id,
+      final DataSourceType nodeOutputType,
+      final Optional<SourceName> sourceName,
+      final PlanNode source
+  ) {
+    super(id, nodeOutputType, sourceName);
+
+    this.source = requireNonNull(source, "source");
+  }
+
+  @Override
+  public List<PlanNode> getSources() {
+    return ImmutableList.of(source);
+  }
+
+  public PlanNode getSource() {
+    return source;
+  }
+
+  @Override
+  protected int getPartitions(final KafkaTopicClient kafkaTopicClient) {
+    return source.getPartitions(kafkaTopicClient);
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/PreJoinProjectNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/PreJoinProjectNodeTest.java
@@ -75,6 +75,8 @@ public class PreJoinProjectNodeTest {
       SELECT_2
   );
 
+  private static final SourceName ALIAS = SourceName.of("a");
+
   @Mock
   private PlanNode source;
   @Mock
@@ -92,8 +94,8 @@ public class PreJoinProjectNodeTest {
 
     projectNode = new PreJoinProjectNode(NODE_ID,
         source,
-        SELECTS,
-        SCHEMA);
+        ALIAS
+    );
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/PreJoinProjectNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/PreJoinProjectNodeTest.java
@@ -22,17 +22,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
-import io.confluent.ksql.execution.context.QueryContext.Stacker;
-import io.confluent.ksql.execution.expression.tree.BooleanLiteral;
-import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
-import io.confluent.ksql.execution.plan.SelectExpression;
 import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.schema.ksql.ColumnNames;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.structured.SchemaKStream;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -53,44 +48,25 @@ public class PreJoinProjectNodeTest {
   private static final ColumnName COL_0 = ColumnName.of("col0");
   private static final ColumnName COL_1 = ColumnName.of("col1");
   private static final ColumnName COL_2 = ColumnName.of("col2");
-  private static final ColumnName ALIASED_COL_2 = ColumnName.of("a_col2");
-
-  private static final SelectExpression SELECT_0 = SelectExpression
-      .of(COL_0, new BooleanLiteral("true"));
-  private static final SelectExpression SELECT_1 = SelectExpression
-      .of(COL_1, new BooleanLiteral("false"));
-  private static final SelectExpression SELECT_2 = SelectExpression
-      .of(ALIASED_COL_2, new UnqualifiedColumnReferenceExp(COL_2));
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
       .keyColumn(K, SqlTypes.STRING)
       .valueColumn(COL_0, SqlTypes.STRING)
       .valueColumn(COL_1, SqlTypes.STRING)
-      .valueColumn(ALIASED_COL_2, SqlTypes.STRING)
+      .valueColumn(COL_2, SqlTypes.STRING)
       .build();
-
-  private static final List<SelectExpression> SELECTS = ImmutableList.of(
-      SELECT_0,
-      SELECT_1,
-      SELECT_2
-  );
 
   private static final SourceName ALIAS = SourceName.of("a");
 
   @Mock
   private PlanNode source;
-  @Mock
-  private SchemaKStream<?> stream;
-  @Mock
-  private KsqlQueryBuilder ksqlStreamBuilder;
-  @Mock
-  private Stacker stacker;
 
   private PreJoinProjectNode projectNode;
 
   @Before
   public void setUp()  {
     when(source.getNodeOutputType()).thenReturn(DataSourceType.KSTREAM);
+    when(source.getSchema()).thenReturn(SCHEMA);
 
     projectNode = new PreJoinProjectNode(NODE_ID,
         source,
@@ -111,7 +87,7 @@ public class PreJoinProjectNodeTest {
   }
 
   @Test
-  public void shouldResolveStarSelectWhenAliased() {
+  public void shouldAddAliasOnResolveSelectStarWhenAliased() {
     // Given:
     when(source.resolveSelectStar(any()))
         .thenReturn(ImmutableList.of(COL_1, COL_0, COL_2).stream());
@@ -121,6 +97,26 @@ public class PreJoinProjectNodeTest {
 
     // Then:
     final List<ColumnName> columns = result.collect(Collectors.toList());
-    assertThat(columns, contains(COL_1, COL_0, ALIASED_COL_2));
+    assertThat(columns, contains(
+        ColumnNames.generatedJoinColumnAlias(ALIAS, COL_1),
+        ColumnNames.generatedJoinColumnAlias(ALIAS, COL_0),
+        ColumnNames.generatedJoinColumnAlias(ALIAS, COL_2)
+    ));
+  }
+
+  @Test
+  public void shouldNotAddAliasOnResolveSelectStarWhenNotAliased() {
+    // Given:
+    final ColumnName unknown = ColumnName.of("unknown");
+
+    when(source.resolveSelectStar(any()))
+        .thenReturn(ImmutableList.of(K, unknown).stream());
+
+    // When:
+    final Stream<ColumnName> result = projectNode.resolveSelectStar(Optional.empty());
+
+    // Then:
+    final List<ColumnName> columns = result.collect(Collectors.toList());
+    assertThat(columns, contains(K, unknown));
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/ProjectNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/ProjectNodeTest.java
@@ -15,10 +15,6 @@
 
 package io.confluent.ksql.planner.plan;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -35,7 +31,6 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.structured.SchemaKStream;
-import io.confluent.ksql.util.KsqlException;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -99,83 +94,6 @@ public class ProjectNodeTest {
         SELECTS,
         SCHEMA
     );
-  }
-
-  @Test
-  public void shouldThrowOnValidateIfSchemaHasNoValueColumns() {
-    // Given:
-    final LogicalSchema schema = LogicalSchema.builder()
-        .keyColumn(ColumnName.of("bob"), SqlTypes.STRING)
-        .build();
-
-    projectNode = new TestProjectNode(
-        NODE_ID,
-        source,
-        ImmutableList.of(),
-        schema
-    );
-
-    // When:
-    final Exception e = assertThrows(
-        KsqlException.class,
-        projectNode::validate
-    );
-
-    // Then:
-    assertThat(e.getMessage(), is("The projection contains no value columns."));
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldThrowIfSchemaSizeDoesntMatchProjection() {
-    new TestProjectNode(
-        NODE_ID,
-        source,
-        ImmutableList.of(SELECT_0), // <-- not enough expressions
-        SCHEMA
-    ).validate();
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldThrowOnValidateIfSchemaSelectNameMismatch() {
-    new TestProjectNode(
-        NODE_ID,
-        source,
-        ImmutableList.of(
-            SelectExpression.of(ColumnName.of("wrongName"), new BooleanLiteral("true")),
-            SELECT_1,
-            SELECT_2
-        ),
-        SCHEMA
-    ).validate();
-  }
-
-  @Test
-  public void shouldThrowOnValidateIfMultipleKeyColumns() {
-    // Given:
-    final LogicalSchema badSchema = LogicalSchema.builder()
-        .keyColumn(ColumnName.of("K"), SqlTypes.STRING)
-        .keyColumn(ColumnName.of("SecondKey"), SqlTypes.STRING)
-        .valueColumn(COL_0, SqlTypes.STRING)
-        .valueColumn(COL_1, SqlTypes.STRING)
-        .valueColumn(ALIASED_COL_2, SqlTypes.STRING)
-        .build();
-
-    projectNode = new TestProjectNode(
-        NODE_ID,
-        source,
-        SELECTS,
-        badSchema
-    );
-
-    // When:
-    final KsqlException e = assertThrows(
-        KsqlException.class,
-        projectNode::validate
-    );
-
-    // Then:
-    assertThat(e.getMessage(), containsString("The projection contains the key column "
-        + "more than once: `K` and `SecondKey`."));
   }
 
   @Test


### PR DESCRIPTION
### Description 

This change removes some duplication by adding an abstract `SingleSourcePlanNode` class to handle the common case of nodes that only have a single source node.

It also simplifies `PreJoinProjectNode` by moving the creation of the schema and select expressions into the class itself, removing the need to validate they match,
and simplifies the `FinalProjectNode`  by also removing unnecessary validation that the schema matches the selects, which is not needed as the class builds these.

The `PreJoinProjectNode` could also be simplified more as its not actually mutating the data, only the schema of the data, but this is left to another PR.

### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

