### PR TITLE
feat: Add encode udf

### DIFF
--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -279,6 +279,16 @@ CONCAT(col1, '_hello')
 
 Concatenate two or more strings.
 
+### `ENCODE`
+
+```sql
+ENCODE(col1, input_encoding, output_encoding)
+```
+
+Given a STRING that is encoded as input_encoding, encode it using the output_encoding. The accepted input and output encodings are:
+hex, utf8, ascii and base64. Throws exception if provided encodings are not supported.
+
+For example, to encode a string in hex to utf8 use `ENCODE(string, 'hex', 'utf8')` 
 ### `EXTRACTJSONFIELD`
 
 ```sql

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Encode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Encode.java
@@ -66,13 +66,13 @@ public class Encode {
       return null;
     }
 
-    String encoderString = inputEncoding.toLowerCase() + outputEncoding.toLowerCase();
+    final String encodedString = inputEncoding.toLowerCase() + outputEncoding.toLowerCase();
 
-    if (encoderMap.get(encoderString) == null) {
+    if (encoderMap.get(encodedString) == null) {
       throw new KsqlFunctionException("Supported input and output encodings are: "
                                   + "hex, utf8, ascii and base64");
     }
-    return encoderMap.get(encoderString).apply(str);
+    return encoderMap.get(encodedString).apply(str);
   }
 
 
@@ -85,7 +85,7 @@ public class Encode {
     @Override
     public String apply(final String input) {
       try {
-        byte[] decoded = Hex.decodeHex(input);
+        final byte[] decoded = Hex.decodeHex(input);
         return new String(decoded, StandardCharsets.US_ASCII);
       } catch (DecoderException e) {
         throw new KsqlFunctionException(e.getMessage());
@@ -97,13 +97,13 @@ public class Encode {
 
     @Override
     public String apply(final String input) throws KsqlFunctionException {
-      byte[] decodedHex;
+      final byte[] decodedHex;
       try {
         decodedHex = Hex.decodeHex(input);
       } catch (DecoderException e) {
         throw new KsqlFunctionException(e.getMessage());
       }
-      byte[] encodedHexB64 = Base64.encodeBase64(decodedHex);
+      final byte[] encodedHexB64 = Base64.encodeBase64(decodedHex);
       return new String(encodedHexB64);
 
     }
@@ -113,7 +113,7 @@ public class Encode {
 
     @Override
     public String apply(final String input) throws KsqlFunctionException {
-      byte[] decodedHex;
+      final byte[] decodedHex;
       try {
         decodedHex = Hex.decodeHex(input);
       } catch (DecoderException e) {
@@ -127,8 +127,8 @@ public class Encode {
 
     @Override
     public String apply(final String input) {
-      String hex = Hex.encodeHexString(input.getBytes(StandardCharsets.US_ASCII));
-      return hex;
+      final String encodedHex = Hex.encodeHexString(input.getBytes(StandardCharsets.US_ASCII));
+      return encodedHex;
     }
   }
 
@@ -136,7 +136,7 @@ public class Encode {
 
     @Override
     public String apply(final String input) {
-      byte[] encodedB64 = Base64.encodeBase64(input.getBytes(StandardCharsets.US_ASCII));
+      final byte[] encodedB64 = Base64.encodeBase64(input.getBytes(StandardCharsets.US_ASCII));
       return new String(encodedB64);
     }
   }
@@ -145,7 +145,7 @@ public class Encode {
 
     @Override
     public String apply(final String input) {
-      byte[] decoded = input.getBytes(StandardCharsets.US_ASCII);
+      final byte[] decoded = input.getBytes(StandardCharsets.US_ASCII);
       return new String(decoded, StandardCharsets.UTF_8);
     }
   }
@@ -154,7 +154,7 @@ public class Encode {
 
     @Override
     public String apply(final String input) {
-      byte[] decoded = input.getBytes(StandardCharsets.UTF_8);
+      final byte[] decoded = input.getBytes(StandardCharsets.UTF_8);
       return new String(decoded, StandardCharsets.US_ASCII);
     }
   }
@@ -163,7 +163,7 @@ public class Encode {
 
     @Override
     public String apply(final String input) {
-      char[] encodeHex = Hex.encodeHex(input.getBytes(StandardCharsets.UTF_8));
+      final char[] encodeHex = Hex.encodeHex(input.getBytes(StandardCharsets.UTF_8));
       return new String(encodeHex);
     }
   }
@@ -172,7 +172,7 @@ public class Encode {
 
     @Override
     public String apply(final String input) {
-      byte[] encodedB64 = Base64.encodeBase64(input.getBytes(StandardCharsets.UTF_8));
+      final byte[] encodedB64 = Base64.encodeBase64(input.getBytes(StandardCharsets.UTF_8));
       return new String(encodedB64);
     }
   }
@@ -181,8 +181,8 @@ public class Encode {
 
     @Override
     public String apply(final String input) throws KsqlFunctionException {
-      byte[] decodedB64 = Base64.decodeBase64(input);
-      char[] encodedHex = Hex.encodeHex(decodedB64);
+      final byte[] decodedB64 = Base64.decodeBase64(input);
+      final char[] encodedHex = Hex.encodeHex(decodedB64);
       return new String(encodedHex);
     }
   }
@@ -191,7 +191,7 @@ public class Encode {
 
     @Override
     public String apply(final String input) throws KsqlFunctionException {
-      byte[] decodedB64 = Base64.decodeBase64(input);
+      final byte[] decodedB64 = Base64.decodeBase64(input);
       return new String(decodedB64, StandardCharsets.UTF_8);
     }
   }
@@ -200,84 +200,8 @@ public class Encode {
 
     @Override
     public String apply(final String input) throws KsqlFunctionException {
-      byte[] decodedB64 = Base64.decodeBase64(input);
+      final byte[] decodedB64 = Base64.decodeBase64(input);
       return new String(decodedB64, StandardCharsets.US_ASCII);
     }
   }
-
-  /**
-   * Converts a hex string to ASCII.
-   * Parses each hex byte to decimal and then to ASCII character.
-   */
-  /*private String encodeHexToAscii(String hex) {
-    StringBuilder builder = new StringBuilder();
-    for (int i = 0; i < hex.length(); i += 2) {
-      String str = hex.substring(i, i + 2);
-      builder.append((char)Integer.parseInt(str, 16));
-    }
-    return builder.toString();
-  }
-
-  private String encodeHexToBase64(String hex) throws DecoderException {
-    byte[] decodedHex = Hex.decodeHex(hex);
-    byte[] encodedHexB64 = Base64.encodeBase64(decodedHex);
-    return new String(encodedHexB64);
-  }
-
-  private String encodeHexToUtf8(String hex) throws DecoderException {
-    byte[] decodedHex = Hex.decodeHex(hex);
-    return new String(decodedHex, StandardCharsets.UTF_8);
-  }*/
-
-  /*private String encodeAsciiToHex(String ascii) {
-    char[] ch = ascii.toCharArray();
-
-    StringBuilder builder = new StringBuilder();
-    for (char c : ch) {
-      String hexCode = String.format("%H", c);
-      builder.append(hexCode);
-    }
-    return builder.toString();
-  }
-
-  private String encodeAsciiToBase64(String ascii) {
-    byte[] encodedB64 = Base64.encodeBase64(ascii.getBytes());
-    return new String(encodedB64);
-  }
-
-  private String encodeAsciiToUtf8(String ascii) {
-    byte[] decoded = ascii.getBytes(StandardCharsets.UTF_8);
-    return new String(decoded);
-  }*/
-
-  /*private String encodeUtf8ToHex(String utf8) {
-    char[] encodeHex = Hex.encodeHex(utf8.getBytes(StandardCharsets.UTF_8));
-    return new String(encodeHex);
-  }
-
-  private String encodeUtf8ToBase64(String utf8) {
-    byte[] encodedB64 = Base64.encodeBase64(utf8.getBytes(StandardCharsets.UTF_8));
-    return new String(encodedB64);
-  }
-
-  private String encodeUtf8ToAscii(String utf8) {
-    byte[] decoded = utf8.getBytes(StandardCharsets.UTF_8);
-    return new String(decoded, StandardCharsets.US_ASCII);
-  }*/
-
-  /*private String encodeBase64ToHex(String base64) {
-    byte[] decodedB64 = Base64.decodeBase64(base64);
-    char[] encodedHex = Hex.encodeHex(decodedB64);
-    return new String(encodedHex);
-  }
-
-  private String encodeBase64ToUtf8(String base64) {
-    byte[] decodedB64 = Base64.decodeBase64(base64);
-    return new String(decodedB64, StandardCharsets.UTF_8);
-  }
-
-  private String encodeBase64ToAscii(String base64) {
-    byte[] decodedB64 = Base64.decodeBase64(base64);
-    return new String(decodedB64, StandardCharsets.US_ASCII);
-  }*/
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Encode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Encode.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.string;
+
+import io.confluent.ksql.function.KsqlFunctionException;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
+import io.confluent.ksql.util.KsqlConstants;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.codec.binary.Hex;
+
+@SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
+@UdfDescription(name = "encode",
+    author = KsqlConstants.CONFLUENT_AUTHOR,
+    description = "Takes an input string s, which is encoded as input_encoding, "
+        + "and encodes it as output_encoding. The accepted input and output encodings are: "
+        + "hex, utf8, ascii and base64. Throws exception if provided encodings are not supported.")
+public class Encode {
+
+  static Map<String, Encoder> encoderMap = new HashMap<>();
+
+  static {
+    encoderMap.put("hexascii", new HexToAscii());
+    encoderMap.put("hexutf8", new HexToUtf8());
+    encoderMap.put("hexbase64", new HexToBase64());
+    encoderMap.put("utf8ascii", new Utf8ToAscii());
+    encoderMap.put("utf8hex", new Utf8ToHex());
+    encoderMap.put("utf8base64", new Utf8ToBase64());
+    encoderMap.put("asciiutf8", new AsciiToUtf8());
+    encoderMap.put("asciihex", new AsciiToHex());
+    encoderMap.put("asciibase64", new AsciiToBase64());
+    encoderMap.put("base64ascii", new Base64ToAscii());
+    encoderMap.put("base64utf8", new Base64ToUtf8());
+    encoderMap.put("base64hex", new Base64ToHex());
+  }
+
+  @Udf(description = "Returns a new string encoded using the outputEncoding ")
+  public String encode(
+      @UdfParameter(
+          description = "The source string. If null, then function returns null.") final String str,
+      @UdfParameter(
+          description = "The input encoding."
+              + " If null, then function returns null.") final String inputEncoding,
+      @UdfParameter(
+          description = "The output encoding."
+              + " If null, then function returns null.") final String outputEncoding) {
+    if (str == null || inputEncoding == null || outputEncoding == null) {
+      return null;
+    }
+
+    String encoderString = inputEncoding.toLowerCase() + outputEncoding.toLowerCase();
+
+    if (encoderMap.get(encoderString) == null) {
+      throw new KsqlFunctionException("Supported input and output encodings are: "
+                                  + "hex, utf8, ascii and base64");
+    }
+    return encoderMap.get(encoderString).apply(str);
+  }
+
+
+  interface Encoder {
+    String apply(String input) throws KsqlFunctionException;
+  }
+
+  static class HexToAscii implements Encoder {
+
+    @Override
+    public String apply(final String input) {
+      try {
+        byte[] decoded = Hex.decodeHex(input);
+        return new String(decoded, StandardCharsets.US_ASCII);
+      } catch (DecoderException e) {
+        throw new KsqlFunctionException(e.getMessage());
+      }
+    }
+  }
+
+  static class HexToBase64 implements Encoder {
+
+    @Override
+    public String apply(final String input) throws KsqlFunctionException {
+      byte[] decodedHex;
+      try {
+        decodedHex = Hex.decodeHex(input);
+      } catch (DecoderException e) {
+        throw new KsqlFunctionException(e.getMessage());
+      }
+      byte[] encodedHexB64 = Base64.encodeBase64(decodedHex);
+      return new String(encodedHexB64);
+
+    }
+  }
+
+  static class HexToUtf8 implements Encoder {
+
+    @Override
+    public String apply(final String input) throws KsqlFunctionException {
+      byte[] decodedHex;
+      try {
+        decodedHex = Hex.decodeHex(input);
+      } catch (DecoderException e) {
+        throw new KsqlFunctionException(e.getMessage());
+      }
+      return new String(decodedHex, StandardCharsets.UTF_8);
+    }
+  }
+
+  static class AsciiToHex implements Encoder {
+
+    @Override
+    public String apply(final String input) {
+      String hex = Hex.encodeHexString(input.getBytes(StandardCharsets.US_ASCII));
+      return hex;
+    }
+  }
+
+  static class AsciiToBase64 implements Encoder {
+
+    @Override
+    public String apply(final String input) {
+      byte[] encodedB64 = Base64.encodeBase64(input.getBytes(StandardCharsets.US_ASCII));
+      return new String(encodedB64);
+    }
+  }
+
+  static class AsciiToUtf8 implements Encoder {
+
+    @Override
+    public String apply(final String input) {
+      byte[] decoded = input.getBytes(StandardCharsets.US_ASCII);
+      return new String(decoded, StandardCharsets.UTF_8);
+    }
+  }
+
+  static class Utf8ToAscii implements Encoder {
+
+    @Override
+    public String apply(final String input) {
+      byte[] decoded = input.getBytes(StandardCharsets.UTF_8);
+      return new String(decoded, StandardCharsets.US_ASCII);
+    }
+  }
+
+  static class Utf8ToHex implements Encoder {
+
+    @Override
+    public String apply(final String input) {
+      char[] encodeHex = Hex.encodeHex(input.getBytes(StandardCharsets.UTF_8));
+      return new String(encodeHex);
+    }
+  }
+
+  static class Utf8ToBase64 implements Encoder {
+
+    @Override
+    public String apply(final String input) {
+      byte[] encodedB64 = Base64.encodeBase64(input.getBytes(StandardCharsets.UTF_8));
+      return new String(encodedB64);
+    }
+  }
+
+  static class Base64ToHex implements Encoder {
+
+    @Override
+    public String apply(final String input) throws KsqlFunctionException {
+      byte[] decodedB64 = Base64.decodeBase64(input);
+      char[] encodedHex = Hex.encodeHex(decodedB64);
+      return new String(encodedHex);
+    }
+  }
+
+  static class Base64ToUtf8 implements Encoder {
+
+    @Override
+    public String apply(final String input) throws KsqlFunctionException {
+      byte[] decodedB64 = Base64.decodeBase64(input);
+      return new String(decodedB64, StandardCharsets.UTF_8);
+    }
+  }
+
+  static class Base64ToAscii implements Encoder {
+
+    @Override
+    public String apply(final String input) throws KsqlFunctionException {
+      byte[] decodedB64 = Base64.decodeBase64(input);
+      return new String(decodedB64, StandardCharsets.US_ASCII);
+    }
+  }
+
+  /**
+   * Converts a hex string to ASCII.
+   * Parses each hex byte to decimal and then to ASCII character.
+   */
+  /*private String encodeHexToAscii(String hex) {
+    StringBuilder builder = new StringBuilder();
+    for (int i = 0; i < hex.length(); i += 2) {
+      String str = hex.substring(i, i + 2);
+      builder.append((char)Integer.parseInt(str, 16));
+    }
+    return builder.toString();
+  }
+
+  private String encodeHexToBase64(String hex) throws DecoderException {
+    byte[] decodedHex = Hex.decodeHex(hex);
+    byte[] encodedHexB64 = Base64.encodeBase64(decodedHex);
+    return new String(encodedHexB64);
+  }
+
+  private String encodeHexToUtf8(String hex) throws DecoderException {
+    byte[] decodedHex = Hex.decodeHex(hex);
+    return new String(decodedHex, StandardCharsets.UTF_8);
+  }*/
+
+  /*private String encodeAsciiToHex(String ascii) {
+    char[] ch = ascii.toCharArray();
+
+    StringBuilder builder = new StringBuilder();
+    for (char c : ch) {
+      String hexCode = String.format("%H", c);
+      builder.append(hexCode);
+    }
+    return builder.toString();
+  }
+
+  private String encodeAsciiToBase64(String ascii) {
+    byte[] encodedB64 = Base64.encodeBase64(ascii.getBytes());
+    return new String(encodedB64);
+  }
+
+  private String encodeAsciiToUtf8(String ascii) {
+    byte[] decoded = ascii.getBytes(StandardCharsets.UTF_8);
+    return new String(decoded);
+  }*/
+
+  /*private String encodeUtf8ToHex(String utf8) {
+    char[] encodeHex = Hex.encodeHex(utf8.getBytes(StandardCharsets.UTF_8));
+    return new String(encodeHex);
+  }
+
+  private String encodeUtf8ToBase64(String utf8) {
+    byte[] encodedB64 = Base64.encodeBase64(utf8.getBytes(StandardCharsets.UTF_8));
+    return new String(encodedB64);
+  }
+
+  private String encodeUtf8ToAscii(String utf8) {
+    byte[] decoded = utf8.getBytes(StandardCharsets.UTF_8);
+    return new String(decoded, StandardCharsets.US_ASCII);
+  }*/
+
+  /*private String encodeBase64ToHex(String base64) {
+    byte[] decodedB64 = Base64.decodeBase64(base64);
+    char[] encodedHex = Hex.encodeHex(decodedB64);
+    return new String(encodedHex);
+  }
+
+  private String encodeBase64ToUtf8(String base64) {
+    byte[] decodedB64 = Base64.decodeBase64(base64);
+    return new String(decodedB64, StandardCharsets.UTF_8);
+  }
+
+  private String encodeBase64ToAscii(String base64) {
+    byte[] decodedB64 = Base64.decodeBase64(base64);
+    return new String(decodedB64, StandardCharsets.US_ASCII);
+  }*/
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Encode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Encode.java
@@ -103,8 +103,8 @@ public class Encode {
       } catch (DecoderException e) {
         throw new KsqlFunctionException(e.getMessage());
       }
-      final byte[] encodedHexB64 = Base64.encodeBase64(decodedHex);
-      return new String(encodedHexB64);
+      final byte[] encodedB64 = Base64.encodeBase64(decodedHex);
+      return new String(encodedB64, StandardCharsets.UTF_8);
 
     }
   }
@@ -137,7 +137,7 @@ public class Encode {
     @Override
     public String apply(final String input) {
       final byte[] encodedB64 = Base64.encodeBase64(input.getBytes(StandardCharsets.US_ASCII));
-      return new String(encodedB64);
+      return new String(encodedB64, StandardCharsets.UTF_8);
     }
   }
 
@@ -173,7 +173,7 @@ public class Encode {
     @Override
     public String apply(final String input) {
       final byte[] encodedB64 = Base64.encodeBase64(input.getBytes(StandardCharsets.UTF_8));
-      return new String(encodedB64);
+      return new String(encodedB64, StandardCharsets.UTF_8);
     }
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Encode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Encode.java
@@ -34,7 +34,7 @@ import org.apache.commons.codec.binary.Hex;
         + "hex, utf8, ascii and base64. Throws exception if provided encodings are not supported.")
 public class Encode {
 
-  static ImmutableMap<String, Encoder> ENCODER_MAP = new ImmutableMap.Builder<String, Encoder>()
+  private static ImmutableMap<String, Encoder> ENCODER_MAP = new ImmutableMap.Builder<String, Encoder>()
       .put("hexascii", new HexToAscii())
       .put("hexutf8", new HexToUtf8())
       .put("hexbase64", new HexToBase64())
@@ -48,7 +48,7 @@ public class Encode {
       .put("base64utf8", new Base64ToUtf8())
       .put("base64hex", new Base64ToHex())
       .build();
-  
+
   @Udf(description = "Returns a new string encoded using the outputEncoding ")
   public String encode(
       @UdfParameter(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Encode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Encode.java
@@ -15,14 +15,13 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.util.KsqlConstants;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Map;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.Hex;
@@ -35,21 +34,23 @@ import org.apache.commons.codec.binary.Hex;
         + "hex, utf8, ascii and base64. Throws exception if provided encodings are not supported.")
 public class Encode {
 
-  static Map<String, Encoder> encoderMap = new HashMap<>();
+  static ImmutableMap<String, Encoder> ENCODER_MAP = new ImmutableMap.Builder<String, Encoder>()
+      .build();
+
 
   static {
-    encoderMap.put("hexascii", new HexToAscii());
-    encoderMap.put("hexutf8", new HexToUtf8());
-    encoderMap.put("hexbase64", new HexToBase64());
-    encoderMap.put("utf8ascii", new Utf8ToAscii());
-    encoderMap.put("utf8hex", new Utf8ToHex());
-    encoderMap.put("utf8base64", new Utf8ToBase64());
-    encoderMap.put("asciiutf8", new AsciiToUtf8());
-    encoderMap.put("asciihex", new AsciiToHex());
-    encoderMap.put("asciibase64", new AsciiToBase64());
-    encoderMap.put("base64ascii", new Base64ToAscii());
-    encoderMap.put("base64utf8", new Base64ToUtf8());
-    encoderMap.put("base64hex", new Base64ToHex());
+    ENCODER_MAP.put("hexascii", new HexToAscii());
+    ENCODER_MAP.put("hexutf8", new HexToUtf8());
+    ENCODER_MAP.put("hexbase64", new HexToBase64());
+    ENCODER_MAP.put("utf8ascii", new Utf8ToAscii());
+    ENCODER_MAP.put("utf8hex", new Utf8ToHex());
+    ENCODER_MAP.put("utf8base64", new Utf8ToBase64());
+    ENCODER_MAP.put("asciiutf8", new AsciiToUtf8());
+    ENCODER_MAP.put("asciihex", new AsciiToHex());
+    ENCODER_MAP.put("asciibase64", new AsciiToBase64());
+    ENCODER_MAP.put("base64ascii", new Base64ToAscii());
+    ENCODER_MAP.put("base64utf8", new Base64ToUtf8());
+    ENCODER_MAP.put("base64hex", new Base64ToHex());
   }
 
   @Udf(description = "Returns a new string encoded using the outputEncoding ")
@@ -68,11 +69,11 @@ public class Encode {
 
     final String encodedString = inputEncoding.toLowerCase() + outputEncoding.toLowerCase();
 
-    if (encoderMap.get(encodedString) == null) {
+    if (ENCODER_MAP.get(encodedString) == null) {
       throw new KsqlFunctionException("Supported input and output encodings are: "
                                   + "hex, utf8, ascii and base64");
     }
-    return encoderMap.get(encodedString).apply(str);
+    return ENCODER_MAP.get(encodedString).apply(str);
   }
 
 
@@ -127,8 +128,7 @@ public class Encode {
 
     @Override
     public String apply(final String input) {
-      final String encodedHex = Hex.encodeHexString(input.getBytes(StandardCharsets.US_ASCII));
-      return encodedHex;
+      return Hex.encodeHexString(input.getBytes(StandardCharsets.US_ASCII));
     }
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Encode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Encode.java
@@ -34,7 +34,8 @@ import org.apache.commons.codec.binary.Hex;
         + "hex, utf8, ascii and base64. Throws exception if provided encodings are not supported.")
 public class Encode {
 
-  private static ImmutableMap<String, Encoder> ENCODER_MAP = new ImmutableMap.Builder<String, Encoder>()
+  private static ImmutableMap<String, Encoder> ENCODER_MAP =
+      new ImmutableMap.Builder<String, Encoder>()
       .put("hexascii", new HexToAscii())
       .put("hexutf8", new HexToUtf8())
       .put("hexbase64", new HexToBase64())

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Encode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Encode.java
@@ -35,24 +35,20 @@ import org.apache.commons.codec.binary.Hex;
 public class Encode {
 
   static ImmutableMap<String, Encoder> ENCODER_MAP = new ImmutableMap.Builder<String, Encoder>()
+      .put("hexascii", new HexToAscii())
+      .put("hexutf8", new HexToUtf8())
+      .put("hexbase64", new HexToBase64())
+      .put("utf8ascii", new Utf8ToAscii())
+      .put("utf8hex", new Utf8ToHex())
+      .put("utf8base64", new Utf8ToBase64())
+      .put("asciiutf8", new AsciiToUtf8())
+      .put("asciihex", new AsciiToHex())
+      .put("asciibase64", new AsciiToBase64())
+      .put("base64ascii", new Base64ToAscii())
+      .put("base64utf8", new Base64ToUtf8())
+      .put("base64hex", new Base64ToHex())
       .build();
-
-
-  static {
-    ENCODER_MAP.put("hexascii", new HexToAscii());
-    ENCODER_MAP.put("hexutf8", new HexToUtf8());
-    ENCODER_MAP.put("hexbase64", new HexToBase64());
-    ENCODER_MAP.put("utf8ascii", new Utf8ToAscii());
-    ENCODER_MAP.put("utf8hex", new Utf8ToHex());
-    ENCODER_MAP.put("utf8base64", new Utf8ToBase64());
-    ENCODER_MAP.put("asciiutf8", new AsciiToUtf8());
-    ENCODER_MAP.put("asciihex", new AsciiToHex());
-    ENCODER_MAP.put("asciibase64", new AsciiToBase64());
-    ENCODER_MAP.put("base64ascii", new Base64ToAscii());
-    ENCODER_MAP.put("base64utf8", new Base64ToUtf8());
-    ENCODER_MAP.put("base64hex", new Base64ToHex());
-  }
-
+  
   @Udf(description = "Returns a new string encoded using the outputEncoding ")
   public String encode(
       @UdfParameter(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/EncodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/EncodeTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.string;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import io.confluent.ksql.function.KsqlFunctionException;
+import org.junit.Test;
+
+public class EncodeTest {
+
+  private Encode udf = new Encode();
+
+  @Test
+  public void shouldReturnNullOnNullValue() {
+    assertThat(udf.encode(null, "hex", "ascii"), is(nullValue()));
+    assertThat(udf.encode(null, "utf8", "base64"), is(nullValue()));
+    assertThat(udf.encode("some string", null, "utf8"), is(nullValue()));
+    assertThat(udf.encode("some string", "hex", null), is(nullValue()));
+  }
+
+  @Test
+  public void shouldEncodeHexToAscii() {
+    assertThat(udf.encode("4578616d706C6521", "hex", "ascii"), is("Example!"));
+    assertThat(udf.encode("506C616E74207472656573", "hex", "ascii"), is("Plant trees"));
+    assertThat(udf.encode("31202b2031203d2031", "hex", "ascii"), is("1 + 1 = 1"));
+    assertThat(udf.encode("ce95cebbcebbceacceb4ceb1", "hex", "ascii"), is("������������"));
+    assertThat(udf.encode("c39c6265726d656e736368", "hex", "ascii"), is("��bermensch"));
+  }
+
+  @Test
+  public void shouldEncodeHexToUtf8() {
+    assertThat(udf.encode("4578616d706c6521", "hex", "utf8"), is("Example!"));
+    assertThat(udf.encode("506c616e74207472656573", "hex", "utf8"), is("Plant trees"));
+    assertThat(udf.encode("31202b2031203d2031", "hex", "utf8"), is("1 + 1 = 1"));
+    assertThat(udf.encode("ce95cebbcebbceacceb4ceb1", "hex", "utf8"), is("Ελλάδα"));
+    assertThat(udf.encode("c39c6265726d656e736368", "hex", "utf8"), is("Übermensch"));
+
+  }
+
+  @Test
+  public void shouldEncodeHexToBase64() {
+    assertThat(udf.encode("4578616d706c6521", "hex", "base64"), is("RXhhbXBsZSE="));
+    assertThat(udf.encode("506c616e74207472656573", "hex", "base64"), is("UGxhbnQgdHJlZXM="));
+    assertThat(udf.encode("31202b2031203d2031", "hex", "base64"), is("MSArIDEgPSAx"));
+    assertThat(udf.encode("ce95cebbcebbceacceb4ceb1", "hex", "base64"), is("zpXOu867zqzOtM6x"));
+    assertThat(udf.encode("c39c6265726d656e736368", "hex", "base64"), is("w5xiZXJtZW5zY2g="));
+
+  }
+
+  @Test
+  public void shouldEncodeAsciiToHex() {
+    assertThat(udf.encode("Example!", "ascii", "hex"), is("4578616d706c6521"));
+    assertThat(udf.encode("Plant trees", "ascii", "hex"), is("506c616e74207472656573"));
+    assertThat(udf.encode("1 + 1 = 1", "ascii", "hex"), is("31202b2031203d2031"));
+    assertThat(udf.encode("Ελλάδα", "ascii", "hex"), is("3f3f3f3f3f3f"));
+    assertThat(udf.encode("Übermensch", "ascii", "hex"), is("3f6265726d656e736368"));
+  }
+
+  @Test
+  public void shouldEncodeAsciiToUtf8() {
+    assertThat(udf.encode("Example!", "ascii", "utf8"), is("Example!"));
+    assertThat(udf.encode("Plant trees", "ascii", "utf8"), is("Plant trees"));
+    assertThat(udf.encode("1 + 1 = 1", "ascii", "utf8"), is("1 + 1 = 1"));
+    assertThat(udf.encode("Ελλάδα", "ascii", "utf8"), is("??????"));
+    assertThat(udf.encode("Übermensch", "ascii", "utf8"), is("?bermensch"));
+  }
+
+  @Test
+  public void shouldEncodeAsciiToBase64() {
+    assertThat(udf.encode("Example!", "ascii", "base64"), is("RXhhbXBsZSE="));
+    assertThat(udf.encode("Plant trees", "ascii", "base64"), is("UGxhbnQgdHJlZXM="));
+    assertThat(udf.encode("1 + 1 = 1", "ascii", "base64"), is("MSArIDEgPSAx"));
+    assertThat(udf.encode("Ελλάδα", "ascii", "base64"), is("Pz8/Pz8/"));
+    assertThat(udf.encode("Übermensch", "ascii", "base64"), is("P2Jlcm1lbnNjaA=="));
+  }
+
+  @Test
+  public void shouldEncodeUtf8ToHex() {
+    assertThat(udf.encode("Example!", "utf8", "hex"), is("4578616d706c6521"));
+    assertThat(udf.encode("Plant trees", "utf8", "hex"), is("506c616e74207472656573"));
+    assertThat(udf.encode("1 + 1 = 1", "utf8", "hex"), is("31202b2031203d2031"));
+    assertThat(udf.encode("Ελλάδα", "utf8", "hex"), is("ce95cebbcebbceacceb4ceb1"));
+    assertThat(udf.encode("Übermensch", "utf8", "hex"), is("c39c6265726d656e736368"));
+  }
+
+  @Test
+  public void shouldEncodeUtf8ToAscii() {
+    assertThat(udf.encode("Example!", "utf8", "ascii"), is("Example!"));
+    assertThat(udf.encode("Plant trees", "utf8", "ascii"), is("Plant trees"));
+    assertThat(udf.encode("1 + 1 = 1", "utf8", "ascii"), is("1 + 1 = 1"));
+    assertThat(udf.encode("Ελλάδα", "utf8", "ascii"), is("������������"));
+    assertThat(udf.encode("Übermensch", "utf8", "ascii"), is("��bermensch"));
+  }
+
+  @Test
+  public void shouldEncodeUtf8ToBase64() {
+    assertThat(udf.encode("Example!", "utf8", "base64"), is("RXhhbXBsZSE="));
+    assertThat(udf.encode("Plant trees", "utf8", "base64"), is("UGxhbnQgdHJlZXM="));
+    assertThat(udf.encode("1 + 1 = 1", "utf8", "base64"), is("MSArIDEgPSAx"));
+    assertThat(udf.encode("Ελλάδα", "utf8", "base64"), is("zpXOu867zqzOtM6x"));
+    assertThat(udf.encode("Übermensch", "utf8", "base64"), is("w5xiZXJtZW5zY2g="));
+  }
+
+  @Test
+  public void shouldEncodeBase64ToUtf8() {
+    assertThat(udf.encode("RXhhbXBsZSE=", "base64", "utf8"), is("Example!"));
+    assertThat(udf.encode("UGxhbnQgdHJlZXM=", "base64", "utf8"), is("Plant trees"));
+    assertThat(udf.encode("MSArIDEgPSAx", "base64", "utf8"), is("1 + 1 = 1"));
+    assertThat(udf.encode("zpXOu867zqzOtM6x", "base64", "utf8"), is("Ελλάδα"));
+    assertThat(udf.encode("w5xiZXJtZW5zY2g", "base64", "utf8"), is("Übermensch"));
+  }
+
+  @Test
+  public void shouldEncodeBase64ToHex() {
+    assertThat(udf.encode("RXhhbXBsZSE=", "base64", "hex"), is("4578616d706c6521"));
+    assertThat(udf.encode("UGxhbnQgdHJlZXM=", "base64", "hex"), is("506c616e74207472656573"));
+    assertThat(udf.encode("MSArIDEgPSAx", "base64", "hex"), is("31202b2031203d2031"));
+    assertThat(udf.encode("zpXOu867zqzOtM6x", "base64", "hex"), is("ce95cebbcebbceacceb4ceb1"));
+    assertThat(udf.encode("w5xiZXJtZW5zY2g", "base64", "hex"), is("c39c6265726d656e736368"));
+  }
+
+  @Test
+  public void shouldEncodeBase64ToAscii() {
+    assertThat(udf.encode("RXhhbXBsZSE=", "base64", "ascii"), is("Example!"));
+    assertThat(udf.encode("UGxhbnQgdHJlZXM=", "base64", "utf8"), is("Plant trees"));
+    assertThat(udf.encode("MSArIDEgPSAx", "base64", "ascii"), is("1 + 1 = 1"));
+    assertThat(udf.encode("zpXOu867zqzOtM6x", "base64", "ascii"), is("������������"));
+    assertThat(udf.encode("w5xiZXJtZW5zY2g", "base64", "ascii"), is("��bermensch"));
+  }
+
+  @Test(expected = KsqlFunctionException.class)
+  public void shouldThrowIfUnsupportedEncodingTypes() {
+    udf.encode("4578616d706C6521", "hex", "hex");
+    udf.encode("Ελλάδα", "utf8", "utf8");
+    udf.encode("1 + 1 = 1", "ascii", "ascii");
+    udf.encode("w5xiZXJtZW5zY2g=", "base64", "base64");
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/encode_-_encode_ascii/6.0.0_1591057476889/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/encode_-_encode_ascii/6.0.0_1591057476889/plan.json
@@ -1,0 +1,126 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (K STRING KEY, INPUT_STRING STRING) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`K` STRING KEY, `INPUT_STRING` STRING",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  TEST.K K,\n  ENCODE(TEST.INPUT_STRING, 'ascii', 'hex') HEX,\n  ENCODE(TEST.INPUT_STRING, 'ascii', 'utf8') UTF8,\n  ENCODE(TEST.INPUT_STRING, 'ascii', 'base64') BASE64\nFROM TEST TEST\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `HEX` STRING, `UTF8` STRING, `BASE64` STRING",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`K` STRING KEY, `INPUT_STRING` STRING"
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectExpressions" : [ "ENCODE(INPUT_STRING, 'ascii', 'hex') AS HEX", "ENCODE(INPUT_STRING, 'ascii', 'utf8') AS UTF8", "ENCODE(INPUT_STRING, 'ascii', 'base64') AS BASE64" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.error.classifier.regex" : ""
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/encode_-_encode_ascii/6.0.0_1591057476889/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/encode_-_encode_ascii/6.0.0_1591057476889/spec.json
@@ -1,0 +1,93 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1591057476889,
+  "path" : "query-validation-tests/encode.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<INPUT_STRING VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<HEX VARCHAR, UTF8 VARCHAR, BASE64 VARCHAR> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "encode ascii",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "",
+      "value" : {
+        "input_string" : "Example!"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "",
+      "value" : {
+        "input_string" : "Ελλάδα"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "",
+      "value" : {
+        "input_string" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "",
+      "value" : {
+        "HEX" : "4578616d706c6521",
+        "UTF8" : "Example!",
+        "BASE64" : "RXhhbXBsZSE="
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "",
+      "value" : {
+        "HEX" : "3f3f3f3f3f3f",
+        "UTF8" : "??????",
+        "BASE64" : "Pz8/Pz8/"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "",
+      "value" : {
+        "HEX" : null,
+        "UTF8" : null,
+        "BASE64" : null
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (K STRING KEY, input_string VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT K, encode(input_string, 'ascii', 'hex') AS HEX, encode(input_string, 'ascii', 'utf8') as UTF8, encode(input_string, 'ascii', 'base64') as BASE64 FROM TEST;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/encode_-_encode_ascii/6.0.0_1591057476889/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/encode_-_encode_ascii/6.0.0_1591057476889/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/encode_-_encode_base64/6.0.0_1591057476914/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/encode_-_encode_base64/6.0.0_1591057476914/plan.json
@@ -1,0 +1,126 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (K STRING KEY, INPUT_STRING STRING) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`K` STRING KEY, `INPUT_STRING` STRING",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  TEST.K K,\n  ENCODE(TEST.INPUT_STRING, 'base64', 'hex') HEX,\n  ENCODE(TEST.INPUT_STRING, 'base64', 'utf8') UTF8,\n  ENCODE(TEST.INPUT_STRING, 'base64', 'ascii') ASCII\nFROM TEST TEST\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `HEX` STRING, `UTF8` STRING, `ASCII` STRING",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`K` STRING KEY, `INPUT_STRING` STRING"
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectExpressions" : [ "ENCODE(INPUT_STRING, 'base64', 'hex') AS HEX", "ENCODE(INPUT_STRING, 'base64', 'utf8') AS UTF8", "ENCODE(INPUT_STRING, 'base64', 'ascii') AS ASCII" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.error.classifier.regex" : ""
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/encode_-_encode_base64/6.0.0_1591057476914/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/encode_-_encode_base64/6.0.0_1591057476914/spec.json
@@ -1,0 +1,93 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1591057476914,
+  "path" : "query-validation-tests/encode.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<INPUT_STRING VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<HEX VARCHAR, UTF8 VARCHAR, ASCII VARCHAR> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "encode base64",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "",
+      "value" : {
+        "input_string" : "RXhhbXBsZSE="
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "",
+      "value" : {
+        "input_string" : "zpXOu867zqzOtM6x"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "",
+      "value" : {
+        "input_string" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "",
+      "value" : {
+        "HEX" : "4578616d706c6521",
+        "UTF8" : "Example!",
+        "ASCII" : "Example!"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "",
+      "value" : {
+        "HEX" : "ce95cebbcebbceacceb4ceb1",
+        "UTF8" : "Ελλάδα",
+        "ASCII" : "������������"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "",
+      "value" : {
+        "HEX" : null,
+        "UTF8" : null,
+        "BASE64" : null
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (K STRING KEY, input_string VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT K, encode(input_string, 'base64', 'hex') AS HEX, encode(input_string, 'base64', 'utf8') as UTF8, encode(input_string, 'base64', 'ascii') as ASCII FROM TEST;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/encode_-_encode_base64/6.0.0_1591057476914/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/encode_-_encode_base64/6.0.0_1591057476914/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/encode_-_encode_hex/6.0.0_1591057476851/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/encode_-_encode_hex/6.0.0_1591057476851/plan.json
@@ -1,0 +1,126 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (K STRING KEY, INPUT_STRING STRING) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`K` STRING KEY, `INPUT_STRING` STRING",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  TEST.K K,\n  ENCODE(TEST.INPUT_STRING, 'hex', 'ascii') ASCII,\n  ENCODE(TEST.INPUT_STRING, 'hex', 'utf8') UTF8,\n  ENCODE(TEST.INPUT_STRING, 'hex', 'base64') BASE64\nFROM TEST TEST\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `ASCII` STRING, `UTF8` STRING, `BASE64` STRING",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`K` STRING KEY, `INPUT_STRING` STRING"
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectExpressions" : [ "ENCODE(INPUT_STRING, 'hex', 'ascii') AS ASCII", "ENCODE(INPUT_STRING, 'hex', 'utf8') AS UTF8", "ENCODE(INPUT_STRING, 'hex', 'base64') AS BASE64" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.error.classifier.regex" : ""
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/encode_-_encode_hex/6.0.0_1591057476851/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/encode_-_encode_hex/6.0.0_1591057476851/spec.json
@@ -1,0 +1,107 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1591057476851,
+  "path" : "query-validation-tests/encode.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<INPUT_STRING VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<ASCII VARCHAR, UTF8 VARCHAR, BASE64 VARCHAR> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "encode hex",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "",
+      "value" : {
+        "input_string" : "4578616d706C6521"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "",
+      "value" : {
+        "input_string" : "ce95cebbcebbceacceb4ceb1"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "",
+      "value" : {
+        "input_string" : "c39c6265726d656e736368"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "",
+      "value" : {
+        "input_string" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "",
+      "value" : {
+        "ASCII" : "Example!",
+        "UTF8" : "Example!",
+        "BASE64" : "RXhhbXBsZSE="
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "",
+      "value" : {
+        "ASCII" : "������������",
+        "UTF8" : "Ελλάδα",
+        "BASE64" : "zpXOu867zqzOtM6x"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "",
+      "value" : {
+        "ASCII" : "��bermensch",
+        "UTF8" : "Übermensch",
+        "BASE64" : "w5xiZXJtZW5zY2g="
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "",
+      "value" : {
+        "HEX" : null,
+        "UTF8" : null,
+        "BASE64" : null
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (K STRING KEY, input_string VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT K, encode(input_string, 'hex', 'ascii') AS ASCII, encode(input_string, 'hex', 'utf8') as UTF8, encode(input_string, 'hex', 'base64') as BASE64 FROM TEST;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/encode_-_encode_hex/6.0.0_1591057476851/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/encode_-_encode_hex/6.0.0_1591057476851/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/encode_-_encode_null/6.0.0_1591203258645/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/encode_-_encode_null/6.0.0_1591203258645/plan.json
@@ -1,0 +1,126 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (K STRING KEY, INPUT_STRING STRING) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`K` STRING KEY, `INPUT_STRING` STRING",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  TEST.K K,\n  ENCODE(TEST.INPUT_STRING, 'base64', 'null') HEX,\n  ENCODE(TEST.INPUT_STRING, 'null', 'utf8') UTF8,\n  ENCODE(TEST.INPUT_STRING, 'null', 'ascii') ASCII\nFROM TEST TEST\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `HEX` STRING, `UTF8` STRING, `ASCII` STRING",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`K` STRING KEY, `INPUT_STRING` STRING"
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectExpressions" : [ "ENCODE(INPUT_STRING, 'base64', 'null') AS HEX", "ENCODE(INPUT_STRING, 'null', 'utf8') AS UTF8", "ENCODE(INPUT_STRING, 'null', 'ascii') AS ASCII" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.error.classifier.regex" : ""
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/encode_-_encode_null/6.0.0_1591203258645/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/encode_-_encode_null/6.0.0_1591203258645/spec.json
@@ -1,0 +1,79 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1591203258645,
+  "path" : "query-validation-tests/encode.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<INPUT_STRING VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<HEX VARCHAR, UTF8 VARCHAR, ASCII VARCHAR> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "encode null",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "",
+      "value" : {
+        "input_string" : "RXhhbXBsZSE="
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "",
+      "value" : {
+        "input_string" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "",
+      "value" : {
+        "HEX" : null,
+        "UTF8" : null,
+        "ASCII" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "",
+      "value" : {
+        "HEX" : null,
+        "UTF8" : null,
+        "BASE64" : null
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (K STRING KEY, input_string VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT K, encode(input_string, 'base64', 'null') AS HEX, encode(input_string, 'null', 'utf8') as UTF8, encode(input_string, 'null', 'ascii') as ASCII FROM TEST;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/encode_-_encode_null/6.0.0_1591203258645/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/encode_-_encode_null/6.0.0_1591203258645/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/encode.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/encode.json
@@ -1,0 +1,60 @@
+{
+  "comments": [
+    "Tests covering the use of the encode UDF. The currently supported encodings are: hex, ascii, utf8 and base64."
+  ],
+  "tests": [
+    {
+      "name": "encode hex",
+      "statements": [
+        "CREATE STREAM TEST (K STRING KEY, input_string VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT K, encode(input_string, 'hex', 'ascii') AS ASCII, encode(input_string, 'hex', 'utf8') as UTF8, encode(input_string, 'hex', 'base64') as BASE64 FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "value": {"input_string": "4578616d706C6521"}},
+        {"topic": "test_topic", "value": {"input_string": "ce95cebbcebbceacceb4ceb1"}},
+        {"topic": "test_topic", "value": {"input_string": "c39c6265726d656e736368"}},
+        {"topic": "test_topic", "value": {"input_string": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"ASCII":"Example!", "UTF8": "Example!", "BASE64": "RXhhbXBsZSE="}},
+        {"topic": "OUTPUT", "value": {"ASCII":"������������", "UTF8": "Ελλάδα", "BASE64": "zpXOu867zqzOtM6x"}},
+        {"topic": "OUTPUT", "value": {"ASCII":"��bermensch", "UTF8": "Übermensch", "BASE64": "w5xiZXJtZW5zY2g="}},
+        {"topic": "OUTPUT", "value": {"HEX":null, "UTF8": null, "BASE64": null}}
+      ]
+    },
+    {
+      "name": "encode ascii",
+      "statements": [
+        "CREATE STREAM TEST (K STRING KEY, input_string VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT K, encode(input_string, 'ascii', 'hex') AS HEX, encode(input_string, 'ascii', 'utf8') as UTF8, encode(input_string, 'ascii', 'base64') as BASE64 FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "value": {"input_string": "Example!"}},
+        {"topic": "test_topic", "value": {"input_string": "Ελλάδα"}},
+        {"topic": "test_topic", "value": {"input_string": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"HEX":"4578616d706c6521", "UTF8": "Example!", "BASE64": "RXhhbXBsZSE="}},
+        {"topic": "OUTPUT", "value": {"HEX":"3f3f3f3f3f3f", "UTF8": "??????", "BASE64": "Pz8/Pz8/"}},
+        {"topic": "OUTPUT", "value": {"HEX":null, "UTF8": null, "BASE64": null}}
+      ]
+    },
+    {
+      "name": "encode base64",
+      "statements": [
+        "CREATE STREAM TEST (K STRING KEY, input_string VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT K, encode(input_string, 'base64', 'hex') AS HEX, encode(input_string, 'base64', 'utf8') as UTF8, encode(input_string, 'base64', 'ascii') as ASCII FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "value": {"input_string": "RXhhbXBsZSE="}},
+        {"topic": "test_topic", "value": {"input_string": "zpXOu867zqzOtM6x"}},
+        {"topic": "test_topic", "value": {"input_string": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"HEX":"4578616d706c6521", "UTF8": "Example!", "ASCII": "Example!"}},
+        {"topic": "OUTPUT", "value": {"HEX":"ce95cebbcebbceacceb4ceb1", "UTF8": "Ελλάδα", "ASCII": "������������"}},
+        {"topic": "OUTPUT", "value": {"HEX":null, "UTF8": null, "BASE64": null}}
+      ]
+    }
+  ]
+}

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/encode.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/encode.json
@@ -55,6 +55,21 @@
         {"topic": "OUTPUT", "value": {"HEX":"ce95cebbcebbceacceb4ceb1", "UTF8": "Ελλάδα", "ASCII": "������������"}},
         {"topic": "OUTPUT", "value": {"HEX":null, "UTF8": null, "BASE64": null}}
       ]
+    },
+    {
+      "name": "encode null",
+      "statements": [
+        "CREATE STREAM TEST (K STRING KEY, input_string VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT K, encode(input_string, 'base64', 'null') AS HEX, encode(input_string, 'null', 'utf8') as UTF8, encode(input_string, 'null', 'ascii') as ASCII FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "value": {"input_string": "RXhhbXBsZSE="}},
+        {"topic": "test_topic", "value": {"input_string": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"HEX":null, "UTF8": null, "ASCII": null}},
+        {"topic": "OUTPUT", "value": {"HEX":null, "UTF8": null, "BASE64": null}}
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Description 
Fixes #5493
Add `encode` udf that encodes a string from an input encoding to another output encoding

### Testing done 
QTT and Junit

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

