### PR TITLE
fix: Prevent memory leaks caused by pull query logging

### DIFF
--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/context/QueryLoggerUtil.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/context/QueryLoggerUtil.java
@@ -23,6 +23,21 @@ public final class QueryLoggerUtil {
   private QueryLoggerUtil() {
   }
 
+  /**
+   * Variant of the version below that doesn't track every query individually,
+   * but instead by type. This should be used for frequent query types
+   * (e.g. pull queries) since each new name stores a unique logger object.
+   */
+  public static String queryLoggerName(final QueryType queryType, final QueryContext queryContext) {
+    return String.join(
+        ".",
+        new ImmutableList.Builder<String>()
+            .add(queryType.name().toLowerCase())
+            .addAll(queryContext.getContext())
+            .build()
+    );
+  }
+
   public static String queryLoggerName(final QueryId queryId, final QueryContext queryContext) {
     return String.join(
         ".",
@@ -31,5 +46,9 @@ public final class QueryLoggerUtil {
             .addAll(queryContext.getContext())
             .build()
     );
+  }
+
+  public enum QueryType {
+    PULL_QUERY
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PullQueryExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PullQueryExecutor.java
@@ -35,6 +35,7 @@ import io.confluent.ksql.engine.rewrite.ExpressionTreeRewriter.Context;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.context.QueryContext.Stacker;
 import io.confluent.ksql.execution.context.QueryLoggerUtil;
+import io.confluent.ksql.execution.context.QueryLoggerUtil.QueryType;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression.Type;
 import io.confluent.ksql.execution.expression.tree.Expression;
@@ -896,8 +897,8 @@ public final class PullQueryExecutor {
         .getProcessingLogContext()
         .getLoggerFactory()
         .getLogger(
-            QueryLoggerUtil
-                .queryLoggerName(queryId, contextStacker.push("PROJECT").getQueryContext())
+            QueryLoggerUtil.queryLoggerName(
+                QueryType.PULL_QUERY, contextStacker.push("PROJECT").getQueryContext())
         );
 
     final KsqlTransformer<Object, GenericRow> transformer = select

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/KsqlMaterializationFactory.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/KsqlMaterializationFactory.java
@@ -21,6 +21,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.context.QueryLoggerUtil;
+import io.confluent.ksql.execution.context.QueryLoggerUtil.QueryType;
 import io.confluent.ksql.execution.materialization.MaterializationInfo;
 import io.confluent.ksql.execution.materialization.MaterializationInfo.MapperInfo;
 import io.confluent.ksql.execution.materialization.MaterializationInfo.PredicateInfo;
@@ -126,7 +127,7 @@ public final class KsqlMaterializationFactory {
         stacker = stacker.push(ctx);
       }
       return processingLogContext.getLoggerFactory().getLogger(
-          QueryLoggerUtil.queryLoggerName(queryId, stacker.getQueryContext())
+          QueryLoggerUtil.queryLoggerName(QueryType.PULL_QUERY, stacker.getQueryContext())
       );
     }
   }

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/KsqlMaterializationFactoryTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/KsqlMaterializationFactoryTest.java
@@ -112,8 +112,8 @@ public class KsqlMaterializationFactoryTest {
     );
 
     when(processingLogContext.getLoggerFactory()).thenReturn(processingLoggerFactory);
-    when(processingLoggerFactory.getLogger("start.filter")).thenReturn(filterProcessingLogger);
-    when(processingLoggerFactory.getLogger("start.project")).thenReturn(mapProcessingLogger);
+    when(processingLoggerFactory.getLogger("pull_query.filter")).thenReturn(filterProcessingLogger);
+    when(processingLoggerFactory.getLogger("pull_query.project")).thenReturn(mapProcessingLogger);
 
     when(mapperInfo.visit(any())).thenCallRealMethod();
     when(predicateInfo.visit(any())).thenCallRealMethod();


### PR DESCRIPTION
### Description 
This changes Pull Queries to use a fixed logger name rather than use the query id.  KSQL otherwise gets OOM Errors after doing high QPS for half an hour, due to creating so many unique loggers.

This is because both in the class `io.confluent.common.logging.StructuredLoggerFactory` and in the `slf4j` Logger factory itself, they keep a ConcurrentMap of name -> Logger to reuse loggers.  After many, many queries, you eventually get OOMs if you create a new one every pull query.

Fixes #5527 

### Testing done 
Profiled memory before and after change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

