### PR TITLE
chore: push query websocket response should not include key columns

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -204,6 +204,11 @@ public class RestApiTest {
     // Then:
     assertThat(messages, hasSize(HEADER + LIMIT));
     assertValidJsonMessages(messages);
+    assertThat(messages.get(0), is("["
+        + "{\"name\":\"PAGEID\",\"schema\":{\"type\":\"STRING\",\"fields\":null,\"memberSchema\":null}},"
+        + "{\"name\":\"USERID\",\"schema\":{\"type\":\"STRING\",\"fields\":null,\"memberSchema\":null}},"
+        + "{\"name\":\"VIEWTIME\",\"schema\":{\"type\":\"BIGINT\",\"fields\":null,\"memberSchema\":null}}"
+        + "]"));
   }
 
   @Test
@@ -218,6 +223,11 @@ public class RestApiTest {
     // Then:
     assertThat(messages, hasSize(HEADER + LIMIT));
     assertValidJsonMessages(messages);
+    assertThat(messages.get(0), is("["
+        + "{\"name\":\"PAGEID\",\"schema\":{\"type\":\"STRING\",\"fields\":null,\"memberSchema\":null}},"
+        + "{\"name\":\"USERID\",\"schema\":{\"type\":\"STRING\",\"fields\":null,\"memberSchema\":null}},"
+        + "{\"name\":\"VIEWTIME\",\"schema\":{\"type\":\"BIGINT\",\"fields\":null,\"memberSchema\":null}}"
+        + "]"));
   }
 
   @Test


### PR DESCRIPTION
### Description 

fixes: https://github.com/confluentinc/ksql/issues/5541

While push queries over http, and push queries over the new WS API, were both doing the right thing, missing test coverage on the old WS API allowed a change to go in that caused the old WS API to return a schema containing the key columns, even through the data does not.

### Testing done 

usual 


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

