### PR TITLE
feat: new string UDFs LPad, RPad

### DIFF
--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -376,7 +376,7 @@ The length of a string.
 LPAD(input, length, padding)
 ```
 
-Pads the input string, beginning from the left, with the specified padding string until the target length is reached. 
+Pads the input string, beginning from the left, with the specified padding string, until the target length is reached. 
 If the input string is longer than the specified target length it will be truncated.
 
 If the padding string is empty or NULL, or the target length is negative, then NULL is returned.

--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -377,7 +377,7 @@ LPAD(input, length, padding)
 ```
 
 Pads the input string, beginning from the left, with the specified padding string, until the target length is reached. 
-If the input string is longer than the specified target length it will be truncated.
+If the input string is longer than the specified target length, it is truncated.
 
 If the padding string is empty or NULL, or the target length is negative, then NULL is returned.
 

--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -379,7 +379,7 @@ LPAD(input, length, padding)
 Pads the input string, beginning from the left, with the specified padding string, until the target length is reached. 
 If the input string is longer than the specified target length, it is truncated.
 
-If the padding string is empty or NULL, or the target length is negative, then NULL is returned.
+If the padding string is empty or NULL, or the target length is negative, NULL is returned.
 
 Examples:
 ```sql

--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -370,6 +370,25 @@ LEN(col1)
 
 The length of a string.
 
+### `LPAD`
+
+```sql
+LPAD(input, length, padding)
+```
+
+Pads the input string, beginning from the left, with the specified padding string until the target length is reached. 
+If the input string is longer than the specified target length it will be truncated.
+
+If the padding string is empty or NULL, or the target length is negative, then NULL is returned.
+
+Examples:
+```sql
+LPAD('Foo', 7, 'Bar')  =>  'BarBFoo'
+LPAD('Foo', 2, 'Bar')  =>  'Fo'
+LPAD('', 2, 'Bar')  =>  'Ba'
+LPAD('123', 5, '0')  => '00123'
+```
+
 ### `MASK`
 
 ```sql
@@ -508,6 +527,23 @@ NULL value is returned.
 If the regular expression is found at the beginning or end
 of the string, or there are contiguous matches,
 then an empty element is added to the array.
+
+### `RPAD`
+
+```sql
+RPAD(input, length, padding)
+```
+
+Pads the input string, starting from the end, with the specified padding string until the target length is reached. If the input string is longer than the specified target length it will be truncated. 
+
+If the padding string is empty or NULL, or the target length is negative, then NULL is returned.
+
+Examples:
+```sql
+RPAD('Foo', 7, 'Bar')  =>  'FooBarB'
+RPAD('Foo', 2, 'Bar')  =>  'Fo'
+RPAD('', 2, 'Bar')  =>  'Ba'
+```
 
 ### `SPLIT`
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/LPad.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/LPad.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package io.confluent.ksql.function.udf.string;
+
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
+
+@UdfDescription(
+    name = "LPad",
+    description = "Pads the input string, beginning from the left, with the specified padding"
+        + " string until the target length is reached. If the input string is longer than the"
+        + " specified target length it will be truncated. If the padding string is empty or"
+        + " NULL, or the target length is negative, then NULL is returned.")
+public class LPad {
+
+  @Udf
+  public String lpad(
+      @UdfParameter(description = "String to be padded") final String input,
+      @UdfParameter(description = "Target length") final Integer targetLen,
+      @UdfParameter(description = "Padding string") final String padding) {
+
+    if (input == null) {
+      return null;
+    }
+    if (padding == null || padding.isEmpty() || targetLen == null || targetLen < 0) {
+      return null;
+    }
+    final StringBuilder sb = new StringBuilder(targetLen + padding.length());
+    final int padUpTo = Math.max(targetLen - input.length(), 0);
+    for (int i = 0; i < padUpTo; i += padding.length()) {
+      sb.append(padding);
+    }
+    sb.setLength(padUpTo);
+    sb.append(input);
+    sb.setLength(targetLen);
+    return sb.toString();
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/RPad.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/RPad.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package io.confluent.ksql.function.udf.string;
+
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
+
+@UdfDescription(
+    name = "RPad",
+    description = "Pads the input string, starting from the end, with the specified padding"
+        + " string until the target length is reached. If the input string is longer than the"
+        + " specified target length it will be truncated. If the padding string is empty or"
+        + " NULL, or the target length is negative, then NULL is returned.")
+public class RPad {
+
+  @Udf
+  public String rpad(
+      @UdfParameter(description = "String to be padded") final String input,
+      @UdfParameter(description = "Target length") final Integer targetLen,
+      @UdfParameter(description = "Padding string") final String padding) {
+
+    if (input == null) {
+      return null;
+    }
+    if (padding == null || padding.isEmpty() || targetLen == null || targetLen < 0) {
+      return null;
+    }
+    final StringBuilder sb = new StringBuilder(targetLen + padding.length());
+    sb.append(input);
+    final int padChars = Math.max(targetLen - input.length(), 0);
+    for (int i = 0; i < padChars; i += padding.length()) {
+      sb.append(padding);
+    }
+    sb.setLength(targetLen);
+    return sb.toString();
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/LPadTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/LPadTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package io.confluent.ksql.function.udf.string;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.Test;
+
+public class LPadTest {
+  private final LPad udf = new LPad();
+
+  @Test
+  public void shouldPadInput() {
+    final String result = udf.lpad("foo", 7, "Bar");
+    assertThat(result, is("BarBfoo"));
+  }
+
+  @Test
+  public void shouldReturnNullForNullInput() {
+    final String result = udf.lpad(null, 4, "foo");
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  public void shouldReturnNullForNullPadding() {
+    final String result = udf.lpad("foo", 4, null);
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  public void shouldReturnNullForEmptyPadding() {
+    final String result = udf.lpad("foo", 4, "");
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  public void shouldPadEmptyInput() {
+    final String result = udf.lpad("", 4, "foo");
+    assertThat(result, is("foof"));
+  }
+
+  @Test
+  public void shouldTruncateInputIfTargetLengthTooSmall() {
+    final String result = udf.lpad("foo", 2, "bar");
+    assertThat(result, is("fo"));
+  }
+
+  @Test
+  public void shouldReturnNullForNegativeLength() {
+    final String result = udf.lpad("foo", -1, "bar");
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  public void shouldReturnNullForNullLength() {
+    final String result = udf.lpad("foo", null, "bar");
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  public void shouldReturnEmptyStringForZeroLength() {
+    final String result = udf.lpad("foo", 0, "bar");
+    assertThat(result, is(""));
+  }
+
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/RPadTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/RPadTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package io.confluent.ksql.function.udf.string;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.Test;
+
+public class RPadTest {
+  private final RPad udf = new RPad();
+
+  @Test
+  public void shouldPadInput() {
+    final String result = udf.rpad("foo", 7, "Bar");
+    assertThat(result, is("fooBarB"));
+  }
+
+  @Test
+  public void shouldAppendPartialPadding() {
+    final String result = udf.rpad("foo", 4, "Bar");
+    assertThat(result, is("fooB"));
+  }
+
+  @Test
+  public void shouldReturnNullForNullInput() {
+    final String result = udf.rpad(null, 4, "foo");
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  public void shouldReturnNullForNullPadding() {
+    final String result = udf.rpad("foo", 4, null);
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  public void shouldReturnNullForEmptyPadding() {
+    final String result = udf.rpad("foo", 4, "");
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  public void shouldPadEmptyInput() {
+    final String result = udf.rpad("", 4, "foo");
+    assertThat(result, is("foof"));
+  }
+
+  @Test
+  public void shouldTruncateInputIfTargetLengthTooSmall() {
+    final String result = udf.rpad("foo", 2, "bar");
+    assertThat(result, is("fo"));
+  }
+
+  @Test
+  public void shouldReturnNullForNegativeLength() {
+    final String result = udf.rpad("foo", -1, "bar");
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  public void shouldReturnEmptyStringForZeroLength() {
+    final String result = udf.rpad("foo", 0, "bar");
+    assertThat(result, is(""));
+  }
+
+  @Test
+  public void shouldReturnNullForNullLength() {
+    final String result = udf.rpad("foo", null, "bar");
+    assertThat(result, is(nullValue()));
+  }
+
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/string-lpad-rpad_-_LPad_with_all_args_from_record_-_JSON/6.0.0_1591214175122/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/string-lpad-rpad_-_LPad_with_all_args_from_record_-_JSON/6.0.0_1591214175122/plan.json
@@ -1,0 +1,126 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID STRING KEY, SUBJECT STRING, LEN INTEGER, PADDING STRING) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` STRING KEY, `SUBJECT` STRING, `LEN` INTEGER, `PADDING` STRING",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.ID ID,\n  LPAD(INPUT.SUBJECT, INPUT.LEN, INPUT.PADDING) RESULT\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `RESULT` STRING",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY, `SUBJECT` STRING, `LEN` INTEGER, `PADDING` STRING"
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "LPAD(SUBJECT, LEN, PADDING) AS RESULT" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.error.classifier.regex" : ""
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/string-lpad-rpad_-_LPad_with_all_args_from_record_-_JSON/6.0.0_1591214175122/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/string-lpad-rpad_-_LPad_with_all_args_from_record_-_JSON/6.0.0_1591214175122/spec.json
@@ -1,0 +1,177 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1591214175122,
+  "path" : "query-validation-tests\\string-lpad-rpad.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<SUBJECT VARCHAR, LEN INT, PADDING VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<RESULT VARCHAR> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "LPad with all args from record - JSON",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "r1",
+      "value" : {
+        "subject" : "foo",
+        "len" : 7,
+        "padding" : "Bar"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r2",
+      "value" : {
+        "subject" : "foo",
+        "len" : 5,
+        "padding" : "Bar"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r3",
+      "value" : {
+        "subject" : "foo",
+        "len" : 2,
+        "padding" : "Bar"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r4",
+      "value" : {
+        "subject" : "foo",
+        "len" : -1,
+        "padding" : "Bar"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r5",
+      "value" : {
+        "subject" : "foo",
+        "len" : 5,
+        "padding" : null
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r6",
+      "value" : {
+        "subject" : "foo",
+        "len" : null,
+        "padding" : "Bar"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r7",
+      "value" : {
+        "subject" : null,
+        "len" : -5,
+        "padding" : "Bar"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r8",
+      "value" : {
+        "subject" : "foo",
+        "len" : 7,
+        "padding" : ""
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r9",
+      "value" : {
+        "subject" : "",
+        "len" : 7,
+        "padding" : "Bar"
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "r1",
+      "value" : {
+        "RESULT" : "BarBfoo"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r2",
+      "value" : {
+        "RESULT" : "Bafoo"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r3",
+      "value" : {
+        "RESULT" : "fo"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r4",
+      "value" : {
+        "RESULT" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r5",
+      "value" : {
+        "RESULT" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r6",
+      "value" : {
+        "RESULT" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r7",
+      "value" : {
+        "RESULT" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r8",
+      "value" : {
+        "RESULT" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r9",
+      "value" : {
+        "RESULT" : "BarBarB"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (id STRING KEY, subject STRING, len INT, padding STRING) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT id, lpad(subject, len, padding) as result FROM INPUT;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/string-lpad-rpad_-_LPad_with_all_args_from_record_-_JSON/6.0.0_1591214175122/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/string-lpad-rpad_-_LPad_with_all_args_from_record_-_JSON/6.0.0_1591214175122/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/string-lpad-rpad_-_LPad_with_literal_args_-_JSON/6.0.0_1591214175189/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/string-lpad-rpad_-_LPad_with_literal_args_-_JSON/6.0.0_1591214175189/plan.json
@@ -1,0 +1,126 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID STRING KEY) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` STRING KEY",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.ID ID,\n  LPAD('foo', 7, 'Bar') RESULT\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `RESULT` STRING",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY"
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "LPAD('foo', 7, 'Bar') AS RESULT" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.error.classifier.regex" : ""
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/string-lpad-rpad_-_LPad_with_literal_args_-_JSON/6.0.0_1591214175189/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/string-lpad-rpad_-_LPad_with_literal_args_-_JSON/6.0.0_1591214175189/spec.json
@@ -1,0 +1,71 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1591214175189,
+  "path" : "query-validation-tests\\string-lpad-rpad.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<RESULT VARCHAR> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "LPad with literal args - JSON",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "r1",
+      "value" : { }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r2",
+      "value" : { }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "r1",
+      "value" : {
+        "RESULT" : "BarBfoo"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r2",
+      "value" : {
+        "RESULT" : "BarBfoo"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (id STRING KEY) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT id, lpad('foo', 7, 'Bar') as result FROM INPUT;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/string-lpad-rpad_-_LPad_with_literal_args_-_JSON/6.0.0_1591214175189/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/string-lpad-rpad_-_LPad_with_literal_args_-_JSON/6.0.0_1591214175189/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/string-lpad-rpad_-_RPad_with_all_args_from_record_-_JSON/6.0.0_1591214175269/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/string-lpad-rpad_-_RPad_with_all_args_from_record_-_JSON/6.0.0_1591214175269/plan.json
@@ -1,0 +1,126 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID STRING KEY, SUBJECT STRING, LEN INTEGER, PADDING STRING) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` STRING KEY, `SUBJECT` STRING, `LEN` INTEGER, `PADDING` STRING",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.ID ID,\n  RPAD(INPUT.SUBJECT, INPUT.LEN, INPUT.PADDING) RESULT\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `RESULT` STRING",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY, `SUBJECT` STRING, `LEN` INTEGER, `PADDING` STRING"
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "RPAD(SUBJECT, LEN, PADDING) AS RESULT" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.error.classifier.regex" : ""
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/string-lpad-rpad_-_RPad_with_all_args_from_record_-_JSON/6.0.0_1591214175269/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/string-lpad-rpad_-_RPad_with_all_args_from_record_-_JSON/6.0.0_1591214175269/spec.json
@@ -1,0 +1,177 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1591214175269,
+  "path" : "query-validation-tests\\string-lpad-rpad.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<SUBJECT VARCHAR, LEN INT, PADDING VARCHAR> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<RESULT VARCHAR> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "RPad with all args from record - JSON",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "r1",
+      "value" : {
+        "subject" : "foo",
+        "len" : 7,
+        "padding" : "Bar"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r2",
+      "value" : {
+        "subject" : "foo",
+        "len" : 5,
+        "padding" : "Bar"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r3",
+      "value" : {
+        "subject" : "foo",
+        "len" : 2,
+        "padding" : "Bar"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r4",
+      "value" : {
+        "subject" : "foo",
+        "len" : -1,
+        "padding" : "Bar"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r5",
+      "value" : {
+        "subject" : "foo",
+        "len" : 5,
+        "padding" : null
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r6",
+      "value" : {
+        "subject" : "foo",
+        "len" : null,
+        "padding" : "Bar"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r7",
+      "value" : {
+        "subject" : null,
+        "len" : -5,
+        "padding" : "Bar"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r8",
+      "value" : {
+        "subject" : "foo",
+        "len" : 7,
+        "padding" : ""
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r9",
+      "value" : {
+        "subject" : "",
+        "len" : 7,
+        "padding" : "Bar"
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "r1",
+      "value" : {
+        "RESULT" : "fooBarB"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r2",
+      "value" : {
+        "RESULT" : "fooBa"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r3",
+      "value" : {
+        "RESULT" : "fo"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r4",
+      "value" : {
+        "RESULT" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r5",
+      "value" : {
+        "RESULT" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r6",
+      "value" : {
+        "RESULT" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r7",
+      "value" : {
+        "RESULT" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r8",
+      "value" : {
+        "RESULT" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r9",
+      "value" : {
+        "RESULT" : "BarBarB"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (id STRING KEY, subject STRING, len INT, padding STRING) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT id, rpad(subject, len, padding) as result FROM INPUT;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/string-lpad-rpad_-_RPad_with_all_args_from_record_-_JSON/6.0.0_1591214175269/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/string-lpad-rpad_-_RPad_with_all_args_from_record_-_JSON/6.0.0_1591214175269/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/string-lpad-rpad_-_RPad_with_literal_args_-_JSON/6.0.0_1591214175330/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/string-lpad-rpad_-_RPad_with_literal_args_-_JSON/6.0.0_1591214175330/plan.json
@@ -1,0 +1,126 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID STRING KEY) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` STRING KEY",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.ID ID,\n  RPAD('foo', 7, 'Bar') RESULT\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `RESULT` STRING",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY"
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "RPAD('foo', 7, 'Bar') AS RESULT" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.error.classifier.regex" : ""
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/string-lpad-rpad_-_RPad_with_literal_args_-_JSON/6.0.0_1591214175330/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/string-lpad-rpad_-_RPad_with_literal_args_-_JSON/6.0.0_1591214175330/spec.json
@@ -1,0 +1,71 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1591214175330,
+  "path" : "query-validation-tests\\string-lpad-rpad.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<RESULT VARCHAR> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "RPad with literal args - JSON",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "r1",
+      "value" : { }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r2",
+      "value" : { }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "r1",
+      "value" : {
+        "RESULT" : "fooBarB"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r2",
+      "value" : {
+        "RESULT" : "fooBarB"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (id STRING KEY) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT id, rpad('foo', 7, 'Bar') as result FROM INPUT;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/string-lpad-rpad_-_RPad_with_literal_args_-_JSON/6.0.0_1591214175330/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/string-lpad-rpad_-_RPad_with_literal_args_-_JSON/6.0.0_1591214175330/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/string-lpad-rpad.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/string-lpad-rpad.json
@@ -1,0 +1,67 @@
+{
+  "comments": [
+    "Tests covering usage of the Lpad and RPad string functions."
+  ],
+  "tests": [
+    {
+      "name": "LPad with all args from record",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM INPUT (id STRING KEY, subject STRING, len INT, padding STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT id, lpad(subject, len, padding) as result FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "r1", "value": {"subject": "foo", "len": 7, "padding": "Bar"}},
+        {"topic": "test_topic", "key": "r2", "value": {"subject": "foo", "len": 5, "padding": "Bar"}},
+        {"topic": "test_topic", "key": "r3", "value": {"subject": "foo", "len": 2, "padding": "Bar"}},
+        {"topic": "test_topic", "key": "r4", "value": {"subject": "foo", "len": -1, "padding": "Bar"}},
+        {"topic": "test_topic", "key": "r5", "value": {"subject": "foo", "len": 5, "padding": null}},
+        {"topic": "test_topic", "key": "r6", "value": {"subject": "foo", "len": null, "padding": "Bar"}},
+        {"topic": "test_topic", "key": "r7", "value": {"subject": null, "len": -5, "padding": "Bar"}},
+        {"topic": "test_topic", "key": "r8", "value": {"subject": "foo", "len": 7, "padding": ""}},
+        {"topic": "test_topic", "key": "r9", "value": {"subject": "", "len": 7, "padding": "Bar"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "r1", "value": {"RESULT": "BarBfoo"}},
+        {"topic": "OUTPUT", "key": "r2", "value": {"RESULT": "Bafoo"}},
+        {"topic": "OUTPUT", "key": "r3", "value": {"RESULT": "fo"}},
+        {"topic": "OUTPUT", "key": "r4", "value": {"RESULT": null}},
+        {"topic": "OUTPUT", "key": "r5", "value": {"RESULT": null}},
+        {"topic": "OUTPUT", "key": "r6", "value": {"RESULT": null}},
+        {"topic": "OUTPUT", "key": "r7", "value": {"RESULT": null}},
+        {"topic": "OUTPUT", "key": "r8", "value": {"RESULT": null}},
+        {"topic": "OUTPUT", "key": "r9", "value": {"RESULT": "BarBarB"}}
+      ]
+    },
+    {
+      "name": "RPad with all args from record",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM INPUT (id STRING KEY, subject STRING, len INT, padding STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT id, rpad(subject, len, padding) as result FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "r1", "value": {"subject": "foo", "len": 7, "padding": "Bar"}},
+        {"topic": "test_topic", "key": "r2", "value": {"subject": "foo", "len": 5, "padding": "Bar"}},
+        {"topic": "test_topic", "key": "r3", "value": {"subject": "foo", "len": 2, "padding": "Bar"}},
+        {"topic": "test_topic", "key": "r4", "value": {"subject": "foo", "len": -1, "padding": "Bar"}},
+        {"topic": "test_topic", "key": "r5", "value": {"subject": "foo", "len": 5, "padding": null}},
+        {"topic": "test_topic", "key": "r6", "value": {"subject": "foo", "len": null, "padding": "Bar"}},
+        {"topic": "test_topic", "key": "r7", "value": {"subject": null, "len": -5, "padding": "Bar"}},
+        {"topic": "test_topic", "key": "r8", "value": {"subject": "foo", "len": 7, "padding": ""}},
+        {"topic": "test_topic", "key": "r9", "value": {"subject": "", "len": 7, "padding": "Bar"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "r1", "value": {"RESULT": "fooBarB"}},
+        {"topic": "OUTPUT", "key": "r2", "value": {"RESULT": "fooBa"}},
+        {"topic": "OUTPUT", "key": "r3", "value": {"RESULT": "fo"}},
+        {"topic": "OUTPUT", "key": "r4", "value": {"RESULT": null}},
+        {"topic": "OUTPUT", "key": "r5", "value": {"RESULT": null}},
+        {"topic": "OUTPUT", "key": "r6", "value": {"RESULT": null}},
+        {"topic": "OUTPUT", "key": "r7", "value": {"RESULT": null}},
+        {"topic": "OUTPUT", "key": "r8", "value": {"RESULT": null}},
+        {"topic": "OUTPUT", "key": "r9", "value": {"RESULT": "BarBarB"}}
+      ]
+    }
+ ]
+}

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/string-lpad-rpad.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/string-lpad-rpad.json
@@ -34,6 +34,22 @@
       ]
     },
     {
+      "name": "LPad with literal args",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM INPUT (id STRING KEY) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT id, lpad('foo', 7, 'Bar') as result FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "r1", "value": {} },
+        {"topic": "test_topic", "key": "r2", "value": {} }
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "r1", "value": {"RESULT": "BarBfoo"}},
+        {"topic": "OUTPUT", "key": "r2", "value": {"RESULT": "BarBfoo"}}
+      ]
+    },
+    {
       "name": "RPad with all args from record",
       "format": ["JSON"],
       "statements": [
@@ -61,6 +77,22 @@
         {"topic": "OUTPUT", "key": "r7", "value": {"RESULT": null}},
         {"topic": "OUTPUT", "key": "r8", "value": {"RESULT": null}},
         {"topic": "OUTPUT", "key": "r9", "value": {"RESULT": "BarBarB"}}
+      ]
+    },
+    {
+      "name": "RPad with literal args",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM INPUT (id STRING KEY) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT id, rpad('foo', 7, 'Bar') as result FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "r1", "value": {} },
+        {"topic": "test_topic", "key": "r2", "value": {} }
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "r1", "value": {"RESULT": "fooBarB"}},
+        {"topic": "OUTPUT", "key": "r2", "value": {"RESULT": "fooBarB"}}
       ]
     }
  ]


### PR DESCRIPTION
Simple string-padding functions based on the RDBMS stalwarts of the same names.

- `LPad(input_str, target_len, padding_str)`
- `RPad(input_str, target_len, padding_str)`

Docs, unit tests, QTT, historical plans for the above.