### PR TITLE
feat: new UDFs for set-like operations on Arrays

### DIFF
--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -163,7 +163,7 @@ ARRAY_DISTINCT([1, 2, 3])
 ```
 
 Returns an array of all the distinct values, including NULL if present, from the input array.
-The output array elements will be in order of their first occurrence in the input.
+The output array elements are in order of their first occurrence in the input.
 
 Returns NULL if the input array is NULL.
 
@@ -179,7 +179,7 @@ ARRAY_DISTINCT(ARRAY['apple', 'apple', NULL, 'cherry'])  => ['apple', NULL, 'che
 ARRAY_EXCEPT(array1, array2)
 ```
 
-Returns an array of all the distinct elements from an array except for those also present in a second array. The order of entries in the first array is preserved although any duplicates are removed. 
+Returns an array of all the distinct elements from an array, except for those also present in a second array. The order of entries in the first array is preserved but duplicates are removed. 
 
 Returns NULL if either input is NULL.
 

--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -156,6 +156,55 @@ Given an array, checks if a search value is contained in the array.
 
 Accepts any `ARRAY` type. The type of the second param must match the element type of the `ARRAY`.
 
+### ``ARRAY_DISTINCT``
+
+```sql
+ARRAY_DISTINCT([1, 2, 3])
+```
+
+Returns an array of all the distinct values, including NULL if present, from the input array.
+The output array elements will be in order of their first occurrence in the input.
+
+Returns NULL if the input array is NULL.
+
+Examples:
+```sql 
+ARRAY_DISTINCT(ARRAY[1, 1, 2, 3, 1, 2])  => [1, 2, 3]
+ARRAY_DISTINCT(ARRAY['apple', 'apple', NULL, 'cherry'])  => ['apple', NULL, 'cherry']
+```
+
+### ``ARRAY_EXCEPT``
+
+```sql
+ARRAY_EXCEPT(array1, array2)
+```
+
+Returns an array of all the distinct elements from an array except for those also present in a second array. The order of entries in the first array is preserved although any duplicates are removed. 
+
+Returns NULL if either input is NULL.
+
+Examples:
+```sql 
+ARRAY_EXCEPT(ARRAY[1, 2, 3, 1, 2], [2, 3])  => [1]
+ARRAY_EXCEPT(ARRAY['apple', 'apple', NULL, 'cherry'], ARRAY['cherry'])  => ['apple', NULL]
+```
+
+### ``ARRAY_INTERSECT``
+
+```sql
+ARRAY_INTERSECT(array1, array2)
+```
+
+Returns an array of all the distinct elements from the intersection of both input arrays. The order of entries in the output is the same as in the first input array.
+
+Returns NULL if either input array is NULL.
+
+Examples:
+```sql 
+ARRAY_INTERSECT(ARRAY[1, 2, 3, 1, 2], [2, 1])  => [1, 2]
+ARRAY_INTERSECT(ARRAY['apple', 'apple', NULL, 'cherry'], ARRAY['apple'])  => ['apple']
+```
+
 ### `ARRAY_LENGTH`
 
 ```sql
@@ -212,6 +261,22 @@ For example:
 If the array field is NULL then NULL is returned.
 
 An optional second parameter can be used to specify whether to sort the elements in 'ASC'ending or 'DESC'ending order. If neither is specified then the default is ascending order. 
+
+### ``ARRAY_UNION``
+
+```sql
+ARRAY_UNION(array1, array2)
+```
+
+Returns an array of all the distinct elements from both input arrays, in the order in which they are first encountered.
+
+Returns NULL if either input array is NULL.
+
+Examples:
+```sql 
+ARRAY_UNION(ARRAY[1, 2, 3, 1, 2], [4, 1])  => [1, 2, 3, 4]
+ARRAY_UNION(ARRAY['apple', 'apple', NULL, 'cherry'], ARRAY['cherry'])  => ['apple', NULL, 'cherry']
+```
 
 ### `AS_MAP`
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/ArrayDistinct.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/ArrayDistinct.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package io.confluent.ksql.function.udf.array;
+
+import com.google.common.collect.Sets;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+@UdfDescription(
+    name = "array_distinct",
+    description = "Returns an array of all the distinct values, including NULL if present, from"
+        + " the input array."
+        + " The output array elements will be in order of their first occurrence in the input."
+        + " Returns NULL if the input array is NULL.")
+public class ArrayDistinct {
+
+  @Udf
+  public <T> List<T> distinct(
+      @UdfParameter(description = "Array of values to distinct") final List<T> input) {
+    if (input == null) {
+      return null;
+    }
+    final Set<T> distinctVals = Sets.newLinkedHashSetWithExpectedSize(input.size());
+    input.forEach(entry -> {
+      distinctVals.add(entry);
+    });
+    final List<T> output = new ArrayList<T>(distinctVals);
+    return output;
+  }
+
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/ArrayExcept.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/ArrayExcept.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package io.confluent.ksql.function.udf.array;
+
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@UdfDescription(
+    name = "array_except",
+    description = "Returns an array of all the elements in an array except for those also present"
+        + " in a second array. The order of entries in the first array is preserved although any"
+        + " duplicates are removed. Returns NULL if either input is NULL.")
+public class ArrayExcept {
+
+  @Udf
+  public <T> List<T> except(
+      @UdfParameter(description = "Array of values") final List<T> left,
+      @UdfParameter(description = "Array of exceptions") final List<T> right) {
+    if (left == null || right == null) {
+      return null;
+    }
+    final Set<T> distinctRightValues = new HashSet<>(right);
+    final Set<T> distinctLeftValues = new LinkedHashSet<>(left);
+    final List<T> result = distinctLeftValues
+        .stream()
+        .filter(e -> !distinctRightValues.contains(e))
+        .collect(Collectors.toList());
+    return result;
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/ArrayIntersect.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/ArrayIntersect.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package io.confluent.ksql.function.udf.array;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
+import java.util.List;
+import java.util.Set;
+
+@UdfDescription(
+    name = "array_intersect",
+    description = "Returns an array of all the distinct elements from the intersection of both"
+        + " input arrays, or NULL if either input array is NULL. The order of entries in the"
+        + " output is the same as in the first input array.")
+public class ArrayIntersect {
+
+  @Udf
+  public <T> List<T> intersect(
+      @UdfParameter(description = "First array of values") final List<T> left,
+      @UdfParameter(description = "Second array of values") final List<T> right) {
+    if (left == null || right == null) {
+      return null;
+    }
+    final Set<T> intersection = Sets.newLinkedHashSet(left);
+    intersection.retainAll(Sets.newHashSet(right));
+    return Lists.newArrayList(intersection);
+  }
+
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/ArrayUnion.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/ArrayUnion.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package io.confluent.ksql.function.udf.array;
+
+import com.google.common.collect.Sets;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+@UdfDescription(
+    name = "array_union",
+    description = "Returns an array of all the distinct elements from both input arrays, "
+        + "or NULL if either array is NULL.")
+public class ArrayUnion {
+
+  @SuppressWarnings("unchecked")
+  @Udf
+  public <T> List<T> union(
+      @UdfParameter(description = "First array of values") final List<T> left,
+      @UdfParameter(description = "Second array of values") final List<T> right) {
+    if (left == null || right == null) {
+      return null;
+    }
+    final Set<T> combined = Sets.newLinkedHashSet(left);
+    combined.addAll(right);
+    return (List<T>) Arrays.asList(combined.toArray());
+  }
+
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/array/ArrayDistinctTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/array/ArrayDistinctTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package io.confluent.ksql.function.udf.array;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public class ArrayDistinctTest {
+  private final ArrayDistinct udf = new ArrayDistinct();
+
+  @Test
+  public void shouldDistinctArray() {
+    final List<String> result = udf.distinct(Arrays.asList("foo", " ", "foo", "bar"));
+    assertThat(result, contains("foo", " ", "bar"));
+  }
+
+  @Test
+  public void shouldNotChangeDistinctArray() {
+    final List<String> result = udf.distinct(Arrays.asList("foo", " ", "bar"));
+    assertThat(result, contains("foo", " ", "bar"));
+  }
+
+  @Test
+  public void shouldDistinctIntArray() {
+    final List<Integer> result = udf.distinct(Arrays.asList(1, 2, 3, 2, 1));
+    assertThat(result, contains(1, 2, 3));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void shouldDistinctArrayOfMaps() {
+    final Map<String, Integer> map1 = ImmutableMap.of("foo", 1, "bar", 2, "baz", 3);
+    final Map<String, Integer> map2 = ImmutableMap.of("foo", 10, "baz", 3);
+    final Map<String, Integer> map3 = ImmutableMap.of("foo", 1, "bar", 2, "baz", 3);
+    final List<Map<String, Integer>> result = udf.distinct(Arrays.asList(map1, map2, map3));
+    assertThat(result, contains(map1, map2));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void shouldDistinctArrayOfLists() {
+    final List<String> list1 = Arrays.asList("foo", "bar", "baz");
+    final List<String> list2 = Arrays.asList("foo", "bar");
+    final List<String> list3 = Arrays.asList("foo", "bar", "baz");
+    final List<List<String>> result = udf.distinct(Arrays.asList(list1, list2, list3, null));
+    assertThat(result, contains(list1, list2, null));
+  }
+
+  @Test
+  public void shouldReturnEmptyForEmptyInput() {
+    final List<Double> result = udf.distinct(new ArrayList<Double>());
+    assertThat(result, is(Collections.EMPTY_LIST));
+  }
+
+  @Test
+  public void shouldReturnNullForNullInput() {
+    final List<Double> result = udf.distinct((List<Double>) null);
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  public void shouldConsiderNullAsDistinctValue() {
+    final List<Object> result = udf.distinct(Arrays.asList(1, 2, 1, null, 2, null, 3, 1));
+    assertThat(result, contains(1, 2, null, 3));
+  }
+
+
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/array/ArrayExceptTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/array/ArrayExceptTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package io.confluent.ksql.function.udf.array;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+public class ArrayExceptTest {
+  private final ArrayExcept udf = new ArrayExcept();
+
+  @Test
+  public void shouldRemoveExceptions() {
+    final List<String> input1 = Arrays.asList("foo", "bar", "baz");
+    final List<String> input2 = Arrays.asList("foo", "bar");
+    final List<String> result = udf.except(input1, input2);
+    assertThat(result, is(Arrays.asList("baz")));
+  }
+
+  @Test
+  public void shouldRetainOnlyDistinctValues() {
+    final List<String> input1 = Arrays.asList("foo", " ", "foo", "bar");
+    final List<String> input2 = Arrays.asList("bar");
+    final List<String> result = udf.except(input1, input2);
+    assertThat(result, contains("foo", " "));
+  }
+
+  @Test
+  public void shouldReturnEmptyArrayIfAllExcepted() {
+    final List<String> input1 = Arrays.asList("foo", " ", "foo", "bar");
+    final List<String> input2 = Arrays.asList("bar", " ", "foo", "extra");
+    final List<String> result = udf.except(input1, input2);
+    assertThat(result.isEmpty(), is(true));
+  }
+
+  @Test
+  public void shouldExceptEmptyArray() {
+    final List<String> input1 = Arrays.asList();
+    final List<String> input2 = Arrays.asList("foo");
+    final List<String> result = udf.except(input1, input2);
+    assertThat(result.isEmpty(), is(true));
+  }
+
+  @Test
+  public void shouldDistinctValuesForEmptyExceptionArray() {
+    final List<String> input1 = Arrays.asList("foo", "foo", "bar", "foo");
+    final List<String> input2 = Arrays.asList();
+    final List<String> result = udf.except(input1, input2);
+    assertThat(result, contains("foo", "bar"));
+  }
+
+  @Test
+  public void shouldReturnNullForNullLeftInput() {
+    final List<String> input1 = Arrays.asList("foo");
+    final List<String> result = udf.except(input1, null);
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  public void shouldReturnNullForNullExceptionArray() {
+    final List<String> input2 = Arrays.asList("foo");
+    final List<String> result = udf.except(null, input2);
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  public void shouldReturnNullForNullInputs() {
+    @SuppressWarnings("rawtypes")
+    final List result = udf.except(null, null);
+    assertThat(result, is(nullValue()));
+  }
+
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/array/ArrayExceptTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/array/ArrayExceptTest.java
@@ -67,6 +67,22 @@ public class ArrayExceptTest {
   }
 
   @Test
+  public void shouldExceptFromArrayContainingNulls() {
+    final List<String> input1 = Arrays.asList("foo", null, "foo", "bar");
+    final List<String> input2 = Arrays.asList("foo");
+    final List<String> result = udf.except(input1, input2);
+    assertThat(result, contains(null, "bar"));
+  }
+
+  @Test
+  public void shouldExceptNulls() {
+    final List<String> input1 = Arrays.asList("foo", null, "foo", "bar");
+    final List<String> input2 = Arrays.asList(null, "foo");
+    final List<String> result = udf.except(input1, input2);
+    assertThat(result, contains("bar"));
+  }
+
+  @Test
   public void shouldReturnNullForNullLeftInput() {
     final List<String> input1 = Arrays.asList("foo");
     final List<String> result = udf.except(input1, null);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/array/ArrayIntersectTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/array/ArrayIntersectTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package io.confluent.ksql.function.udf.array;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public class ArrayIntersectTest {
+  private final ArrayIntersect udf = new ArrayIntersect();
+
+  @Test
+  public void shouldIntersectTwoArrays() {
+    final List<String> input1 = Arrays.asList("foo", " ", "foo", "bar");
+    final List<String> input2 = Arrays.asList("foo", "baz");
+    final List<String> result = udf.intersect(input1, input2);
+    assertThat(result, is(Arrays.asList("foo")));
+  }
+
+  @Test
+  public void shouldIntersectIntegerArrays() {
+    final List<Integer> input1 = Arrays.asList(1, 2, 3, 2, 1);
+    final List<Integer> input2 = Arrays.asList(1, 2, 2);
+    final List<Integer> result = udf.intersect(input1, input2);
+    assertThat(result, contains(1, 2));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void shouldIntersectArraysOfMaps() {
+    final Map<String, Integer> map1 = ImmutableMap.of("foo", 1, "bar", 2, "baz", 3);
+    final Map<String, Integer> map2 = ImmutableMap.of("foo", 10, "baz", 3);
+    final Map<String, Integer> map3 = ImmutableMap.of("foo", 1, "bar", 2, "baz", 3);
+    final List<Map<String, Integer>> input1 = Arrays.asList(map1, map2, map3);
+    final List<Map<String, Integer>> input2 = Arrays.asList(map2, map3);
+    final List<Map<String, Integer>> result = udf.intersect(input1, input2);
+    assertThat(result, contains(map1, map2));
+  }
+
+  @Test
+  public void shouldReturnNullForNullLeftInput() {
+    final List<String> input1 = Arrays.asList("foo");
+    final List<String> result = udf.intersect(input1, null);
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  public void shouldReturnNullForNullExceptionArray() {
+    final List<String> input2 = Arrays.asList("foo");
+    final List<String> result = udf.intersect(null, input2);
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  public void shouldReturnNullForNullInputs() {
+    final List<Long> result = udf.intersect((List<Long>) null, (List<Long>) null);
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  public void shouldIntersectArraysContainingNulls() {
+    final List<String> input1 = Arrays.asList(null, "foo");
+    final List<String> input2 = Arrays.asList("foo");
+    final List<String> result = udf.intersect(input1, input2);
+    assertThat(result, contains("foo"));
+  }
+
+  @Test
+  public void shouldIntersectArraysBothContainingNulls() {
+    final List<String> input1 = Arrays.asList(null, "foo", "bar");
+    final List<String> input2 = Arrays.asList("foo", null);
+    final List<String> result = udf.intersect(input1, input2);
+    assertThat(result, contains((String) null, "foo"));
+  }
+
+  @Test
+  public void shouldReturnNullForArraysOfOnlyNulls() {
+    final List<String> input1 = Arrays.asList(null, null);
+    final List<String> input2 = Arrays.asList(null, null, null);
+    final List<String> result = udf.intersect(input1, input2);
+    assertThat(result.get(0), is(nullValue()));
+  }
+
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/array/ArrayUnionTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/array/ArrayUnionTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package io.confluent.ksql.function.udf.array;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public class ArrayUnionTest {
+
+  private final ArrayUnion udf = new ArrayUnion();
+
+  @Test
+  public void shouldUnionArraysOfLikeType() {
+    final List<String> input1 = Arrays.asList("foo", " ", "bar");
+    final List<String> input2 = Arrays.asList("baz");
+    final List<String> result = udf.union(input1, input2);
+    assertThat(result, contains("foo", " ", "bar", "baz"));
+  }
+
+  @Test
+  public void shouldReturnDistinctValues() {
+    final List<String> input1 = Arrays.asList("foo", "foo", "bar");
+    final List<String> input2 = Arrays.asList("baz", "foo");
+    final List<String> result = udf.union(input1, input2);
+    assertThat(result, contains("foo", "bar", "baz"));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void shouldIntersectArraysOfMaps() {
+    final Map<String, Integer> map1 = ImmutableMap.of("foo", 1, "bar", 2, "baz", 3);
+    final Map<String, Integer> map2 = ImmutableMap.of("foo", 10, "baz", 3);
+    final Map<String, Integer> map3 = ImmutableMap.of("foo", 1, "bar", 2, "baz", 3);
+    final List<Map<String, Integer>> input1 = Arrays.asList(map1, map2);
+    final List<Map<String, Integer>> input2 = Arrays.asList(map2, map3);
+    final List<Map<String, Integer>> result = udf.union(input1, input2);
+    assertThat(result, contains(map1, map2));
+  }
+
+  @Test
+  public void shouldUnionArraysContainingNulls() {
+    final List<String> input1 = Arrays.asList(null, "bar");
+    final List<String> input2 = Arrays.asList("foo");
+    final List<String> result = udf.union(input1, input2);
+    assertThat(result, contains(null, "bar", "foo"));
+  }
+
+  @Test
+  public void shouldUnionArraysBothContainingNulls() {
+    final List<String> input1 = Arrays.asList(null, "foo", "bar");
+    final List<String> input2 = Arrays.asList("foo", null);
+    final List<String> result = udf.union(input1, input2);
+    assertThat(result, contains((String) null, "foo", "bar"));
+  }
+
+  @Test
+  public void shouldReturnNullForArraysOfOnlyNulls() {
+    final List<String> input1 = Arrays.asList(null, null);
+    final List<String> input2 = Arrays.asList(null, null, null);
+    final List<String> result = udf.union(input1, input2);
+    assertThat(result, contains(nullValue()));
+  }
+
+  @Test
+  public void shouldReturnNullForNullLeftInput() {
+    final List<String> input1 = Arrays.asList("foo");
+    final List<String> result = udf.union(input1, null);
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  public void shouldReturnNullForNullRightInput() {
+    final List<String> input1 = Arrays.asList("foo");
+    final List<String> result = udf.union(null, input1);
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  public void shouldReturnNullForAllNullInputs() {
+    final List<Long> result = udf.union((List<Long>) null, (List<Long>) null);
+    assertThat(result, is(nullValue()));
+  }
+
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_distinct_with_complex_types/6.0.0_1591248420286/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_distinct_with_complex_types/6.0.0_1591248420286/plan.json
@@ -1,0 +1,126 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID STRING KEY, LISTS ARRAY<ARRAY<STRING>>, MAPS ARRAY<MAP<STRING, INTEGER>>) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` STRING KEY, `LISTS` ARRAY<ARRAY<STRING>>, `MAPS` ARRAY<MAP<STRING, INTEGER>>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.ID ID,\n  ARRAY_DISTINCT(INPUT.LISTS) LISTS_DIST,\n  ARRAY_DISTINCT(INPUT.MAPS) MAPS_DIST\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `LISTS_DIST` ARRAY<ARRAY<STRING>>, `MAPS_DIST` ARRAY<MAP<STRING, INTEGER>>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY, `LISTS` ARRAY<ARRAY<STRING>>, `MAPS` ARRAY<MAP<STRING, INTEGER>>"
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "ARRAY_DISTINCT(LISTS) AS LISTS_DIST", "ARRAY_DISTINCT(MAPS) AS MAPS_DIST" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.error.classifier.regex" : ""
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_distinct_with_complex_types/6.0.0_1591248420286/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_distinct_with_complex_types/6.0.0_1591248420286/spec.json
@@ -1,0 +1,157 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1591248420286,
+  "path" : "query-validation-tests\\array-set-functions.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<LISTS ARRAY<ARRAY<VARCHAR>>, MAPS ARRAY<MAP<VARCHAR, INT>>> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<LISTS_DIST ARRAY<ARRAY<VARCHAR>>, MAPS_DIST ARRAY<MAP<VARCHAR, INT>>> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "array_distinct with complex types",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "r1",
+      "value" : {
+        "lists" : [ [ "foo", "bar", "foo" ], [ "foo", "bar", "foo" ], [ "foo" ] ],
+        "maps" : [ {
+          "apple" : 1,
+          "banana" : 2
+        }, {
+          "apple" : 3,
+          "banana" : 4
+        }, {
+          "apple" : 1,
+          "banana" : 2
+        } ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r2",
+      "value" : {
+        "lists" : [ [ "foo", null ], [ "foo", "bar" ], [ "foo" ] ],
+        "maps" : [ {
+          "apple" : null,
+          "banana" : 2
+        }, {
+          "apple" : 1,
+          "banana" : 2
+        }, {
+          "apple" : 1,
+          "banana" : 2
+        } ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r3",
+      "value" : {
+        "lists" : [ null, [ "foo" ] ],
+        "maps" : [ {
+          "apple" : 1,
+          "banana" : 2
+        }, null ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r4",
+      "value" : {
+        "lists" : [ ],
+        "maps" : [ ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r5",
+      "value" : {
+        "lists" : null,
+        "maps" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "r1",
+      "value" : {
+        "LISTS_DIST" : [ [ "foo", "bar", "foo" ], [ "foo" ] ],
+        "MAPS_DIST" : [ {
+          "apple" : 1,
+          "banana" : 2
+        }, {
+          "apple" : 3,
+          "banana" : 4
+        } ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r2",
+      "value" : {
+        "LISTS_DIST" : [ [ "foo", null ], [ "foo", "bar" ], [ "foo" ] ],
+        "MAPS_DIST" : [ {
+          "apple" : null,
+          "banana" : 2
+        }, {
+          "apple" : 1,
+          "banana" : 2
+        } ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r3",
+      "value" : {
+        "LISTS_DIST" : [ null, [ "foo" ] ],
+        "MAPS_DIST" : [ {
+          "apple" : 1,
+          "banana" : 2
+        }, null ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r4",
+      "value" : {
+        "LISTS_DIST" : [ ],
+        "MAPS_DIST" : [ ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r5",
+      "value" : {
+        "LISTS_DIST" : null,
+        "MAPS_DIST" : null
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (id STRING KEY, lists ARRAY<ARRAY<STRING>>, maps ARRAY<MAP<STRING,INT>>) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT id, array_distinct(lists) as lists_dist, array_distinct(maps) as maps_dist FROM INPUT;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_distinct_with_complex_types/6.0.0_1591248420286/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_distinct_with_complex_types/6.0.0_1591248420286/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_distinct_with_literals/6.0.0_1591248419499/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_distinct_with_literals/6.0.0_1591248419499/plan.json
@@ -1,0 +1,126 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID STRING KEY, DUMMY INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` STRING KEY, `DUMMY` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.ID ID,\n  ARRAY_DISTINCT(ARRAY['foo', 'bar', 'foo']) A1\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `A1` ARRAY<STRING>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY, `DUMMY` INTEGER"
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "ARRAY_DISTINCT(ARRAY['foo', 'bar', 'foo']) AS A1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.error.classifier.regex" : ""
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_distinct_with_literals/6.0.0_1591248419499/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_distinct_with_literals/6.0.0_1591248419499/spec.json
@@ -1,0 +1,75 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1591248419499,
+  "path" : "query-validation-tests\\array-set-functions.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<DUMMY INT> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<A1 ARRAY<VARCHAR>> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "array_distinct with literals",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "r1",
+      "value" : {
+        "dummy" : 0
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r2",
+      "value" : {
+        "dummy" : 0
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "r1",
+      "value" : {
+        "A1" : [ "foo", "bar" ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r2",
+      "value" : {
+        "A1" : [ "foo", "bar" ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (id STRING KEY, dummy INTEGER) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT id, array_distinct(array['foo', 'bar', 'foo']) as a1 FROM INPUT;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_distinct_with_literals/6.0.0_1591248419499/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_distinct_with_literals/6.0.0_1591248419499/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_distinct_with_primitive_types/6.0.0_1591248419616/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_distinct_with_primitive_types/6.0.0_1591248419616/plan.json
@@ -1,0 +1,126 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID STRING KEY, BOOLS ARRAY<BOOLEAN>, INTS ARRAY<INTEGER>, BIGINTS ARRAY<BIGINT>, DOUBLES ARRAY<DOUBLE>, STRINGS ARRAY<STRING>, DECIMALS ARRAY<DECIMAL(2, 1)>) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` STRING KEY, `BOOLS` ARRAY<BOOLEAN>, `INTS` ARRAY<INTEGER>, `BIGINTS` ARRAY<BIGINT>, `DOUBLES` ARRAY<DOUBLE>, `STRINGS` ARRAY<STRING>, `DECIMALS` ARRAY<DECIMAL(2, 1)>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.ID ID,\n  ARRAY_DISTINCT(INPUT.BOOLS) BOOLS_DIST,\n  ARRAY_DISTINCT(INPUT.INTS) INTS_DIST,\n  ARRAY_DISTINCT(INPUT.BIGINTS) BIGINTS_DIST,\n  ARRAY_DISTINCT(INPUT.DOUBLES) DOUBLES_DIST,\n  ARRAY_DISTINCT(INPUT.STRINGS) STRINGS_DIST,\n  ARRAY_DISTINCT(INPUT.DECIMALS) DECIMALS_DIST\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `BOOLS_DIST` ARRAY<BOOLEAN>, `INTS_DIST` ARRAY<INTEGER>, `BIGINTS_DIST` ARRAY<BIGINT>, `DOUBLES_DIST` ARRAY<DOUBLE>, `STRINGS_DIST` ARRAY<STRING>, `DECIMALS_DIST` ARRAY<DECIMAL(2, 1)>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY, `BOOLS` ARRAY<BOOLEAN>, `INTS` ARRAY<INTEGER>, `BIGINTS` ARRAY<BIGINT>, `DOUBLES` ARRAY<DOUBLE>, `STRINGS` ARRAY<STRING>, `DECIMALS` ARRAY<DECIMAL(2, 1)>"
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "ARRAY_DISTINCT(BOOLS) AS BOOLS_DIST", "ARRAY_DISTINCT(INTS) AS INTS_DIST", "ARRAY_DISTINCT(BIGINTS) AS BIGINTS_DIST", "ARRAY_DISTINCT(DOUBLES) AS DOUBLES_DIST", "ARRAY_DISTINCT(STRINGS) AS STRINGS_DIST", "ARRAY_DISTINCT(DECIMALS) AS DECIMALS_DIST" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.error.classifier.regex" : ""
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_distinct_with_primitive_types/6.0.0_1591248419616/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_distinct_with_primitive_types/6.0.0_1591248419616/spec.json
@@ -1,0 +1,139 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1591248419616,
+  "path" : "query-validation-tests\\array-set-functions.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<BOOLS ARRAY<BOOLEAN>, INTS ARRAY<INT>, BIGINTS ARRAY<BIGINT>, DOUBLES ARRAY<DOUBLE>, STRINGS ARRAY<VARCHAR>, DECIMALS ARRAY<DECIMAL(2, 1)>> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<BOOLS_DIST ARRAY<BOOLEAN>, INTS_DIST ARRAY<INT>, BIGINTS_DIST ARRAY<BIGINT>, DOUBLES_DIST ARRAY<DOUBLE>, STRINGS_DIST ARRAY<VARCHAR>, DECIMALS_DIST ARRAY<DECIMAL(2, 1)>> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "array_distinct with primitive types",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "r1",
+      "value" : {
+        "bools" : [ false, true, false ],
+        "ints" : [ 0, 0, 1, 0, -1 ],
+        "bigints" : [ 345, -123, 345 ],
+        "doubles" : [ 0.0, 0.2, -12345.678, 0.2 ],
+        "strings" : [ "foo", "bar", "foo" ],
+        "decimals" : [ 1.0, -0.2, 1.0, -9.9 ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r2",
+      "value" : {
+        "bools" : [ null, false, true ],
+        "ints" : [ 0, null, 1, 0, -1 ],
+        "bigints" : [ null, -123 ],
+        "doubles" : [ 0.3, -12345.678, null, 0.3 ],
+        "strings" : [ "foo", "Food", null, "food" ],
+        "decimals" : [ 1.0, 1.1, 1.1, -0.2, null, 1.0 ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r3",
+      "value" : {
+        "bools" : [ ],
+        "ints" : [ ],
+        "bigints" : [ ],
+        "doubles" : [ ],
+        "strings" : [ ],
+        "decimals" : [ ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r4",
+      "value" : {
+        "bools" : null,
+        "ints" : null,
+        "bigints" : null,
+        "doubles" : null,
+        "strings" : null,
+        "decimals" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "r1",
+      "value" : {
+        "BOOLS_DIST" : [ false, true ],
+        "INTS_DIST" : [ 0, 1, -1 ],
+        "BIGINTS_DIST" : [ 345, -123 ],
+        "DOUBLES_DIST" : [ 0.0, 0.2, -12345.678 ],
+        "STRINGS_DIST" : [ "foo", "bar" ],
+        "DECIMALS_DIST" : [ 1.0, -0.2, -9.9 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r2",
+      "value" : {
+        "BOOLS_DIST" : [ null, false, true ],
+        "INTS_DIST" : [ 0, null, 1, -1 ],
+        "BIGINTS_DIST" : [ null, -123 ],
+        "DOUBLES_DIST" : [ 0.3, -12345.678, null ],
+        "STRINGS_DIST" : [ "foo", "Food", null, "food" ],
+        "DECIMALS_DIST" : [ 1.0, 1.1, -0.2, null ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r3",
+      "value" : {
+        "BOOLS_DIST" : [ ],
+        "INTS_DIST" : [ ],
+        "BIGINTS_DIST" : [ ],
+        "DOUBLES_DIST" : [ ],
+        "STRINGS_DIST" : [ ],
+        "DECIMALS_DIST" : [ ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r4",
+      "value" : {
+        "BOOLS_DIST" : null,
+        "INTS_DIST" : null,
+        "BIGINTS_DIST" : null,
+        "DOUBLES_DIST" : null,
+        "STRINGS_DIST" : null,
+        "DECIMALS_DIST" : null
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (id STRING KEY, bools ARRAY<BOOLEAN>, ints ARRAY<INT>, bigints ARRAY<BIGINT>, doubles ARRAY<DOUBLE>, strings ARRAY<STRING>, decimals ARRAY<DECIMAL(2,1)>) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT id, array_distinct(bools) as bools_dist, array_distinct(ints) as ints_dist, array_distinct(bigints) as bigints_dist, array_distinct(doubles) as doubles_dist, array_distinct(strings) as strings_dist, array_distinct(decimals) as decimals_dist FROM INPUT;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_distinct_with_primitive_types/6.0.0_1591248419616/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_distinct_with_primitive_types/6.0.0_1591248419616/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_except_with_literals/6.0.0_1591248420429/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_except_with_literals/6.0.0_1591248420429/plan.json
@@ -1,0 +1,126 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID STRING KEY, DUMMY INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` STRING KEY, `DUMMY` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.ID ID,\n  ARRAY_EXCEPT(ARRAY['foo', 'bar', 'foo'], ARRAY['bar', 'baz']) A1\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `A1` ARRAY<STRING>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY, `DUMMY` INTEGER"
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "ARRAY_EXCEPT(ARRAY['foo', 'bar', 'foo'], ARRAY['bar', 'baz']) AS A1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.error.classifier.regex" : ""
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_except_with_literals/6.0.0_1591248420429/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_except_with_literals/6.0.0_1591248420429/spec.json
@@ -1,0 +1,75 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1591248420429,
+  "path" : "query-validation-tests\\array-set-functions.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<DUMMY INT> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<A1 ARRAY<VARCHAR>> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "array_except with literals",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "r1",
+      "value" : {
+        "dummy" : 0
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r2",
+      "value" : {
+        "dummy" : 0
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "r1",
+      "value" : {
+        "A1" : [ "foo" ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r2",
+      "value" : {
+        "A1" : [ "foo" ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (id STRING KEY, dummy INTEGER) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT id, array_except(array['foo', 'bar', 'foo'], array['bar', 'baz']) as a1 FROM INPUT;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_except_with_literals/6.0.0_1591248420429/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_except_with_literals/6.0.0_1591248420429/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_except_with_primitive_type/6.0.0_1591248420625/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_except_with_primitive_type/6.0.0_1591248420625/plan.json
@@ -1,0 +1,126 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID STRING KEY, INTS ARRAY<INTEGER>, INT_EXCEPTIONS ARRAY<INTEGER>) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` STRING KEY, `INTS` ARRAY<INTEGER>, `INT_EXCEPTIONS` ARRAY<INTEGER>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.ID ID,\n  ARRAY_EXCEPT(INPUT.INTS, INPUT.INT_EXCEPTIONS) RESULT\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `RESULT` ARRAY<INTEGER>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY, `INTS` ARRAY<INTEGER>, `INT_EXCEPTIONS` ARRAY<INTEGER>"
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "ARRAY_EXCEPT(INTS, INT_EXCEPTIONS) AS RESULT" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.error.classifier.regex" : ""
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_except_with_primitive_type/6.0.0_1591248420625/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_except_with_primitive_type/6.0.0_1591248420625/spec.json
@@ -1,0 +1,129 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1591248420625,
+  "path" : "query-validation-tests\\array-set-functions.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<INTS ARRAY<INT>, INT_EXCEPTIONS ARRAY<INT>> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<RESULT ARRAY<INT>> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "array_except with primitive type",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "r1",
+      "value" : {
+        "ints" : [ 0, 0, 1, 0, -1 ],
+        "int_exceptions" : [ 1, -2 ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r2",
+      "value" : {
+        "ints" : [ 0, 0, 1, 0, -1 ],
+        "int_exceptions" : [ 1, -1, 0 ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r3",
+      "value" : {
+        "ints" : [ ],
+        "int_exceptions" : [ 1, -2 ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r4",
+      "value" : {
+        "ints" : [ 0, 0, 1, 0, -1 ],
+        "int_exceptions" : [ ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r5",
+      "value" : {
+        "ints" : null,
+        "int_exceptions" : [ 1, -2 ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r6",
+      "value" : {
+        "ints" : [ 0, 0, 1, 0, -1 ],
+        "int_exceptions" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "r1",
+      "value" : {
+        "RESULT" : [ 0, -1 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r2",
+      "value" : {
+        "RESULT" : [ ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r3",
+      "value" : {
+        "RESULT" : [ ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r4",
+      "value" : {
+        "RESULT" : [ 0, 1, -1 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r5",
+      "value" : {
+        "RESULT" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r6",
+      "value" : {
+        "RESULT" : null
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (id STRING KEY, ints ARRAY<INT>, int_exceptions ARRAY<INT>) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT id, array_except(ints, int_exceptions) as result FROM INPUT;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_except_with_primitive_type/6.0.0_1591248420625/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_except_with_primitive_type/6.0.0_1591248420625/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_intersect_with_literals/6.0.0_1591248420757/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_intersect_with_literals/6.0.0_1591248420757/plan.json
@@ -1,0 +1,126 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID STRING KEY, DUMMY INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` STRING KEY, `DUMMY` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.ID ID,\n  ARRAY_INTERSECT(ARRAY['foo', 'bar', 'foo'], ARRAY['foo', 'baz']) A1\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `A1` ARRAY<STRING>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY, `DUMMY` INTEGER"
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "ARRAY_INTERSECT(ARRAY['foo', 'bar', 'foo'], ARRAY['foo', 'baz']) AS A1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.error.classifier.regex" : ""
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_intersect_with_literals/6.0.0_1591248420757/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_intersect_with_literals/6.0.0_1591248420757/spec.json
@@ -1,0 +1,75 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1591248420757,
+  "path" : "query-validation-tests\\array-set-functions.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<DUMMY INT> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<A1 ARRAY<VARCHAR>> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "array_intersect with literals",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "r1",
+      "value" : {
+        "dummy" : 0
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r2",
+      "value" : {
+        "dummy" : 0
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "r1",
+      "value" : {
+        "A1" : [ "foo" ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r2",
+      "value" : {
+        "A1" : [ "foo" ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (id STRING KEY, dummy INTEGER) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT id, array_intersect(array['foo', 'bar', 'foo'], array['foo', 'baz']) as a1 FROM INPUT;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_intersect_with_literals/6.0.0_1591248420757/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_intersect_with_literals/6.0.0_1591248420757/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_intersect_with_primitive_type/6.0.0_1591248420890/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_intersect_with_primitive_type/6.0.0_1591248420890/plan.json
@@ -1,0 +1,126 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID STRING KEY, ARR1 ARRAY<INTEGER>, ARR2 ARRAY<INTEGER>) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` STRING KEY, `ARR1` ARRAY<INTEGER>, `ARR2` ARRAY<INTEGER>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.ID ID,\n  ARRAY_INTERSECT(INPUT.ARR1, INPUT.ARR2) RESULT\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `RESULT` ARRAY<INTEGER>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY, `ARR1` ARRAY<INTEGER>, `ARR2` ARRAY<INTEGER>"
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "ARRAY_INTERSECT(ARR1, ARR2) AS RESULT" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.error.classifier.regex" : ""
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_intersect_with_primitive_type/6.0.0_1591248420890/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_intersect_with_primitive_type/6.0.0_1591248420890/spec.json
@@ -1,0 +1,129 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1591248420890,
+  "path" : "query-validation-tests\\array-set-functions.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<ARR1 ARRAY<INT>, ARR2 ARRAY<INT>> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<RESULT ARRAY<INT>> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "array_intersect with primitive type",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "r1",
+      "value" : {
+        "arr1" : [ 0, 0, 1, 0, -1 ],
+        "arr2" : [ 1, -2, 0 ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r2",
+      "value" : {
+        "arr1" : [ 0, 0, 1, 0, -1 ],
+        "arr2" : [ 3, 4 ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r3",
+      "value" : {
+        "arr1" : [ ],
+        "arr2" : [ 1, -2 ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r4",
+      "value" : {
+        "arr1" : [ 0, 0, 1, 0, -1 ],
+        "arr2" : [ ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r5",
+      "value" : {
+        "arr1" : null,
+        "arr2" : [ 1, -2 ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r6",
+      "value" : {
+        "arr1" : [ 0, 0, 1, 0, -1 ],
+        "arr2" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "r1",
+      "value" : {
+        "RESULT" : [ 0, 1 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r2",
+      "value" : {
+        "RESULT" : [ ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r3",
+      "value" : {
+        "RESULT" : [ ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r4",
+      "value" : {
+        "RESULT" : [ ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r5",
+      "value" : {
+        "RESULT" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r6",
+      "value" : {
+        "RESULT" : null
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (id STRING KEY, arr1 ARRAY<INT>, arr2 ARRAY<INT>) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT id, array_intersect(arr1, arr2) as result FROM INPUT;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_intersect_with_primitive_type/6.0.0_1591248420890/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_intersect_with_primitive_type/6.0.0_1591248420890/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_union_with_literals/6.0.0_1591248421025/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_union_with_literals/6.0.0_1591248421025/plan.json
@@ -1,0 +1,126 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID STRING KEY, DUMMY INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` STRING KEY, `DUMMY` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.ID ID,\n  ARRAY_UNION(ARRAY['foo', 'bar', 'foo'], ARRAY['foo', 'baz']) A1\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `A1` ARRAY<STRING>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY, `DUMMY` INTEGER"
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "ARRAY_UNION(ARRAY['foo', 'bar', 'foo'], ARRAY['foo', 'baz']) AS A1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.error.classifier.regex" : ""
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_union_with_literals/6.0.0_1591248421025/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_union_with_literals/6.0.0_1591248421025/spec.json
@@ -1,0 +1,75 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1591248421025,
+  "path" : "query-validation-tests\\array-set-functions.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<DUMMY INT> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<A1 ARRAY<VARCHAR>> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "array_union with literals",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "r1",
+      "value" : {
+        "dummy" : 0
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r2",
+      "value" : {
+        "dummy" : 0
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "r1",
+      "value" : {
+        "A1" : [ "foo", "bar", "baz" ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r2",
+      "value" : {
+        "A1" : [ "foo", "bar", "baz" ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (id STRING KEY, dummy INTEGER) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT id, array_union(array['foo', 'bar', 'foo'], array['foo', 'baz']) as a1 FROM INPUT;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_union_with_literals/6.0.0_1591248421025/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_union_with_literals/6.0.0_1591248421025/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_union_with_primitive_type/6.0.0_1591248421244/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_union_with_primitive_type/6.0.0_1591248421244/plan.json
@@ -1,0 +1,126 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID STRING KEY, ARR1 ARRAY<INTEGER>, ARR2 ARRAY<INTEGER>) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` STRING KEY, `ARR1` ARRAY<INTEGER>, `ARR2` ARRAY<INTEGER>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.ID ID,\n  ARRAY_UNION(INPUT.ARR1, INPUT.ARR2) RESULT\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `RESULT` ARRAY<INTEGER>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY, `ARR1` ARRAY<INTEGER>, `ARR2` ARRAY<INTEGER>"
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "ARRAY_UNION(ARR1, ARR2) AS RESULT" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.error.classifier.regex" : ""
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_union_with_primitive_type/6.0.0_1591248421244/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_union_with_primitive_type/6.0.0_1591248421244/spec.json
@@ -1,0 +1,129 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1591248421244,
+  "path" : "query-validation-tests\\array-set-functions.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<ARR1 ARRAY<INT>, ARR2 ARRAY<INT>> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<RESULT ARRAY<INT>> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "array_union with primitive type",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "r1",
+      "value" : {
+        "arr1" : [ 0, 0, 1, 0, -1 ],
+        "arr2" : [ 1, -2, 0 ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r2",
+      "value" : {
+        "arr1" : [ 0, 0, 1, 0, -1 ],
+        "arr2" : [ 3, 4 ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r3",
+      "value" : {
+        "arr1" : [ ],
+        "arr2" : [ 1, -2 ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r4",
+      "value" : {
+        "arr1" : [ 0, 0, 1, 0, -1 ],
+        "arr2" : [ ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r5",
+      "value" : {
+        "arr1" : null,
+        "arr2" : [ 1, -2 ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r6",
+      "value" : {
+        "arr1" : [ 0, 0, 1, 0, -1 ],
+        "arr2" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "r1",
+      "value" : {
+        "RESULT" : [ 0, 1, -1, -2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r2",
+      "value" : {
+        "RESULT" : [ 0, 1, -1, 3, 4 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r3",
+      "value" : {
+        "RESULT" : [ 1, -2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r4",
+      "value" : {
+        "RESULT" : [ 0, 1, -1 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r5",
+      "value" : {
+        "RESULT" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r6",
+      "value" : {
+        "RESULT" : null
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (id STRING KEY, arr1 ARRAY<INT>, arr2 ARRAY<INT>) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT id, array_union(arr1, arr2) as result FROM INPUT;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_union_with_primitive_type/6.0.0_1591248421244/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-set-functions_-_array_union_with_primitive_type/6.0.0_1591248421244/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/array-set-functions.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/array-set-functions.json
@@ -1,0 +1,176 @@
+{
+  "comments": [
+    "Tests covering the use of UDFs for set-like operations on arrays."
+  ],
+  "tests": [
+    {
+      "name": "array_distinct with literals",
+      "statements": [
+        "CREATE STREAM INPUT (id STRING KEY, dummy INTEGER) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT id, array_distinct(array['foo', 'bar', 'foo']) as a1 FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "r1", "value": {"dummy": 0 }},
+        {"topic": "test_topic", "key": "r2", "value": {"dummy": 0 }}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "r1", "value": {"A1": ["foo","bar"]}},
+        {"topic": "OUTPUT", "key": "r2", "value": {"A1": ["foo","bar"]}}
+      ]
+    },
+    {
+      "name": "array_distinct with primitive types",
+      "statements": [
+        "CREATE STREAM INPUT (id STRING KEY, bools ARRAY<BOOLEAN>, ints ARRAY<INT>, bigints ARRAY<BIGINT>, doubles ARRAY<DOUBLE>, strings ARRAY<STRING>, decimals ARRAY<DECIMAL(2,1)>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT id, array_distinct(bools) as bools_dist, array_distinct(ints) as ints_dist, array_distinct(bigints) as bigints_dist, array_distinct(doubles) as doubles_dist, array_distinct(strings) as strings_dist, array_distinct(decimals) as decimals_dist FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "r1", "value": {"bools": [false, true, false], "ints": [0,0,1,0,-1], "bigints": [345,-123,345], "doubles": [0.0, 0.2, -12345.678, 0.2], "strings": ["foo", "bar", "foo"], "decimals": [1.0, -0.2, 1.0, -9.9]}},
+        {"topic": "test_topic", "key": "r2", "value": {"bools": [null, false, true], "ints": [0,null,1,0,-1], "bigints": [null,-123], "doubles": [0.3, -12345.678, null, 0.3], "strings": ["foo", "Food", null, "food"], "decimals": [1.0, 1.1, 1.1, -0.2, null, 1.0]}},
+        {"topic": "test_topic", "key": "r3", "value": {"bools": [], "ints": [], "bigints": [], "doubles": [], "strings": [], "decimals": []}},
+        {"topic": "test_topic", "key": "r4", "value": {"bools": null, "ints": null, "bigints": null, "doubles": null, "strings": null, "decimals": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "r1", "value": {"BOOLS_DIST": [false, true], "INTS_DIST": [0,1,-1], "BIGINTS_DIST": [345,-123], "DOUBLES_DIST": [0.0,0.2,-12345.678], "STRINGS_DIST": ["foo","bar"], "DECIMALS_DIST": [1.0, -0.2, -9.9]}},
+        {"topic": "OUTPUT", "key": "r2", "value": {"BOOLS_DIST": [null,false,true], "INTS_DIST": [0,null,1,-1], "BIGINTS_DIST": [null,-123], "DOUBLES_DIST": [0.3,-12345.678,null], "STRINGS_DIST": ["foo", "Food", null, "food"], "DECIMALS_DIST": [1.0,1.1,-0.2,null]}},
+        {"topic": "OUTPUT", "key": "r3", "value": {"BOOLS_DIST": [], "INTS_DIST": [], "BIGINTS_DIST": [], "DOUBLES_DIST": [], "STRINGS_DIST": [], "DECIMALS_DIST": []}},
+        {"topic": "OUTPUT", "key": "r4", "value": {"BOOLS_DIST": null, "INTS_DIST": null, "BIGINTS_DIST": null, "DOUBLES_DIST": null, "STRINGS_DIST": null, "DECIMALS_DIST": null}}
+      ]
+    },
+    {
+      "name": "array_distinct with complex types",
+      "statements": [
+        "CREATE STREAM INPUT (id STRING KEY, lists ARRAY<ARRAY<STRING>>, maps ARRAY<MAP<STRING,INT>>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT id, array_distinct(lists) as lists_dist, array_distinct(maps) as maps_dist FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "r1", "value": {"lists": [ ["foo", "bar", "foo"], ["foo", "bar", "foo"], ["foo"] ], "maps": [ {"apple": 1, "banana": 2}, {"apple": 3, "banana": 4}, {"apple": 1, "banana": 2} ] }},
+        {"topic": "test_topic", "key": "r2", "value": {"lists": [ ["foo", null], ["foo", "bar"], ["foo"] ], "maps": [ {"apple": null, "banana": 2}, {"apple": 1, "banana": 2}, {"apple": 1, "banana": 2} ] }},
+        {"topic": "test_topic", "key": "r3", "value": {"lists": [ null, ["foo"] ], "maps": [ {"apple": 1, "banana": 2}, null] }},
+        {"topic": "test_topic", "key": "r4", "value": {"lists": [ ], "maps": [ ] }},
+        {"topic": "test_topic", "key": "r5", "value": {"lists": null, "maps": null }}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "r1", "value": {"LISTS_DIST": [ ["foo","bar","foo"], ["foo"] ], "MAPS_DIST": [{"apple": 1, "banana": 2}, {"apple": 3, "banana": 4} ] }},
+        {"topic": "OUTPUT", "key": "r2", "value": {"LISTS_DIST": [ ["foo", null], ["foo","bar"], ["foo"] ], "MAPS_DIST": [{"apple": null, "banana": 2}, {"apple": 1, "banana": 2} ] }},
+        {"topic": "OUTPUT", "key": "r3", "value": {"LISTS_DIST": [ null, ["foo"] ], "MAPS_DIST": [ {"apple": 1, "banana": 2}, null ] }},
+        {"topic": "OUTPUT", "key": "r4", "value": {"LISTS_DIST": [ ], "MAPS_DIST": [ ] }},
+        {"topic": "OUTPUT", "key": "r5", "value": {"LISTS_DIST": null, "MAPS_DIST": null }}
+      ]
+    },
+    {
+      "name": "array_except with literals",
+      "statements": [
+        "CREATE STREAM INPUT (id STRING KEY, dummy INTEGER) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT id, array_except(array['foo', 'bar', 'foo'], array['bar', 'baz']) as a1 FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "r1", "value": {"dummy": 0 }},
+        {"topic": "test_topic", "key": "r2", "value": {"dummy": 0 }}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "r1", "value": {"A1": ["foo"]}},
+        {"topic": "OUTPUT", "key": "r2", "value": {"A1": ["foo"]}}
+      ]
+    },
+    {
+      "name": "array_except with primitive type",
+      "statements": [
+        "CREATE STREAM INPUT (id STRING KEY, ints ARRAY<INT>, int_exceptions ARRAY<INT>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT id, array_except(ints, int_exceptions) as result FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "r1", "value": {"ints": [0,0,1,0,-1], "int_exceptions": [1,-2]}},
+        {"topic": "test_topic", "key": "r2", "value": {"ints": [0,0,1,0,-1], "int_exceptions": [1,-1,0]}},
+        {"topic": "test_topic", "key": "r3", "value": {"ints": [], "int_exceptions": [1,-2]}},
+        {"topic": "test_topic", "key": "r4", "value": {"ints": [0,0,1,0,-1], "int_exceptions": []}},
+        {"topic": "test_topic", "key": "r5", "value": {"ints": null, "int_exceptions": [1,-2]}},
+        {"topic": "test_topic", "key": "r6", "value": {"ints": [0,0,1,0,-1], "int_exceptions": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "r1", "value": {"RESULT": [0,-1] }},
+        {"topic": "OUTPUT", "key": "r2", "value": {"RESULT": [] }},
+        {"topic": "OUTPUT", "key": "r3", "value": {"RESULT": [] }},
+        {"topic": "OUTPUT", "key": "r4", "value": {"RESULT": [0,1,-1] }},
+        {"topic": "OUTPUT", "key": "r5", "value": {"RESULT": null }},
+        {"topic": "OUTPUT", "key": "r6", "value": {"RESULT": null }}
+      ]
+    },
+    {
+      "name": "array_intersect with literals",
+      "statements": [
+        "CREATE STREAM INPUT (id STRING KEY, dummy INTEGER) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT id, array_intersect(array['foo', 'bar', 'foo'], array['foo', 'baz']) as a1 FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "r1", "value": {"dummy": 0 }},
+        {"topic": "test_topic", "key": "r2", "value": {"dummy": 0 }}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "r1", "value": {"A1": ["foo"]}},
+        {"topic": "OUTPUT", "key": "r2", "value": {"A1": ["foo"]}}
+      ]
+    },
+    {
+      "name": "array_intersect with primitive type",
+      "statements": [
+        "CREATE STREAM INPUT (id STRING KEY, arr1 ARRAY<INT>, arr2 ARRAY<INT>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT id, array_intersect(arr1, arr2) as result FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "r1", "value": {"arr1": [0,0,1,0,-1], "arr2": [1,-2,0]}},
+        {"topic": "test_topic", "key": "r2", "value": {"arr1": [0,0,1,0,-1], "arr2": [3,4]}},
+        {"topic": "test_topic", "key": "r3", "value": {"arr1": [], "arr2": [1,-2]}},
+        {"topic": "test_topic", "key": "r4", "value": {"arr1": [0,0,1,0,-1], "arr2": []}},
+        {"topic": "test_topic", "key": "r5", "value": {"arr1": null, "arr2": [1,-2]}},
+        {"topic": "test_topic", "key": "r6", "value": {"arr1": [0,0,1,0,-1], "arr2": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "r1", "value": {"RESULT": [0,1] }},
+        {"topic": "OUTPUT", "key": "r2", "value": {"RESULT": [] }},
+        {"topic": "OUTPUT", "key": "r3", "value": {"RESULT": [] }},
+        {"topic": "OUTPUT", "key": "r4", "value": {"RESULT": [] }},
+        {"topic": "OUTPUT", "key": "r5", "value": {"RESULT": null }},
+        {"topic": "OUTPUT", "key": "r6", "value": {"RESULT": null }}
+      ]
+    },
+    {
+      "name": "array_union with literals",
+      "statements": [
+        "CREATE STREAM INPUT (id STRING KEY, dummy INTEGER) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT id, array_union(array['foo', 'bar', 'foo'], array['foo', 'baz']) as a1 FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "r1", "value": {"dummy": 0 }},
+        {"topic": "test_topic", "key": "r2", "value": {"dummy": 0 }}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "r1", "value": {"A1": ["foo", "bar", "baz"]}},
+        {"topic": "OUTPUT", "key": "r2", "value": {"A1": ["foo", "bar", "baz"]}}
+      ]
+    },
+    {
+      "name": "array_union with primitive type",
+      "statements": [
+        "CREATE STREAM INPUT (id STRING KEY, arr1 ARRAY<INT>, arr2 ARRAY<INT>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT id, array_union(arr1, arr2) as result FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "r1", "value": {"arr1": [0,0,1,0,-1], "arr2": [1,-2,0]}},
+        {"topic": "test_topic", "key": "r2", "value": {"arr1": [0,0,1,0,-1], "arr2": [3,4]}},
+        {"topic": "test_topic", "key": "r3", "value": {"arr1": [], "arr2": [1,-2]}},
+        {"topic": "test_topic", "key": "r4", "value": {"arr1": [0,0,1,0,-1], "arr2": []}},
+        {"topic": "test_topic", "key": "r5", "value": {"arr1": null, "arr2": [1,-2]}},
+        {"topic": "test_topic", "key": "r6", "value": {"arr1": [0,0,1,0,-1], "arr2": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "r1", "value": {"RESULT": [0,1,-1,-2] }},
+        {"topic": "OUTPUT", "key": "r2", "value": {"RESULT": [0,1,-1,3,4] }},
+        {"topic": "OUTPUT", "key": "r3", "value": {"RESULT": [1,-2] }},
+        {"topic": "OUTPUT", "key": "r4", "value": {"RESULT": [0,1,-1] }},
+        {"topic": "OUTPUT", "key": "r5", "value": {"RESULT": null }},
+        {"topic": "OUTPUT", "key": "r6", "value": {"RESULT": null }}
+      ]
+    }   
+  ]
+}


### PR DESCRIPTION
Four new UDFs, implementing set-like operations on Array fields,inspired by the similarly-named functions in Presto (and others):

- `array_distinct(array)`
- `array_except(array1, array2)`
- `array_intersect(array1, array2)`
- `array_union(array1, array2)`

This is a revised and updated version of these functions and their tests, which were originally proposed long ago  in PR #1611 and blocked at that time by limited scope for handling collections of generics in the UDF invocation framework. 

Review feedback from the original PR incorporated herein, along with QTTs and historical plans.