### PR TITLE
fix: improve print topic

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PrintPublisher.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PrintPublisher.java
@@ -32,8 +32,6 @@ import java.util.AbstractCollection;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -112,8 +110,8 @@ public class PrintPublisher implements Flow.Publisher<Collection<String>> {
           return null;
         }
 
-        final Collection<Supplier<String>> formatted = formatter.format(records);
-        final Collection<Supplier<String>> limited = new LimitIntervalCollection<>(
+        final Collection<String> formatted = formatter.format(records);
+        final Collection<String> limited = new LimitIntervalCollection<>(
             formatted,
             printTopic.getLimit().orElse(Integer.MAX_VALUE) - numWritten,
             printTopic.getIntervalValue(),
@@ -128,9 +126,7 @@ public class PrintPublisher implements Flow.Publisher<Collection<String>> {
           setDone();
         }
 
-        return limited.stream()
-            .map(Supplier::get)
-            .collect(Collectors.toList());
+        return limited;
       } catch (final Exception e) {
         setError(e);
         return null;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriter.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.OptionalInt;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.utils.Bytes;
@@ -113,16 +112,16 @@ public class TopicStreamWriter implements StreamingOutput {
           continue;
         }
 
-        final List<Supplier<String>> values = formatter.format(records.records(topicName));
+        final List<String> values = formatter.format(records.records(topicName));
         if (values.isEmpty()) {
           continue;
         }
 
         final List<String> toOutput = new ArrayList<>();
-        for (final Supplier<String> value : values) {
+        for (final String value : values) {
           if (messagesPolled++ % interval == 0) {
             messagesWritten++;
-            toOutput.add(value.get());
+            toOutput.add(value);
           }
 
           if (limitReached.test(messagesWritten)) {


### PR DESCRIPTION
### Description 

PRINT topic tries to determine the format of a topic's key and value.  Sometimes it can mis-detect the key. For example, if the key is a string, and the first value is `Die Hard` (as bytes) then it would interpret this as a `BIGINT` as its eight bytes.  Once it seems more rows it will likely work out the key is a `STRING`, (assuming at least one key is not 8bytes long.

With this change PRINT will process the whole batch of messages retrieved from the broker to determine the formats and only then output them. This makes it much more likely it will output the first few rows with the right formats, at the cost of formatting all the rows in the batch, even if the user only wanted to see one or two.

A good example of this can be seen in our own [Tumbling Windows tutorial](https://kafka-tutorials.confluent.io/create-tumbling-windows/ksql.html).  It includes PRINT topic output that looks like this:

```
Key format: HOPPING(KAFKA_STRING) or TUMBLING(KAFKA_STRING)
Value format: AVRO
rowtime: 2019/07/09 01:00:00.000 Z, key: [4929582456461423204@1562630400000/-], value: {"TITLE": "Die Hard", "RATING_COUNT": 1, "WINDOW_START": 1562630400000, "WINDOW_END": 1562652000000}
rowtime: 2019/07/09 05:00:00.000 Z, key: [4929582456461423204@1562630400000/-], value: {"TITLE": "Die Hard", "RATING_COUNT": 2, "WINDOW_START": 1562630400000, "WINDOW_END": 1562652000000}
rowtime: 2019/07/09 07:00:00.000 Z, key: [4929582456461423204@1562652000000/-], value: {"TITLE": "Die Hard", "RATING_COUNT": 1, "WINDOW_START": 1562652000000, "WINDOW_END": 1562673600000}
rowtime: 2019/07/09 09:00:00.000 Z, key: [Tree of Life@1562652000000/-], value: {"TITLE": "Tree of Life", "RATING_COUNT": 1, "WINDOW_START": 1562652000000, "WINDOW_END": 1562673600000}
rowtime: 2019/07/09 09:00:00.000 Z, key: [Tree of Life@1562652000000/-], value: {"TITLE": "Tree of Life", "RATING_COUNT": 2, "WINDOW_START": 1562652000000, "WINDOW_END": 1562673600000}
rowtime: 2019/07/09 12:00:00.000 Z, key: [A Walk in the Clouds@1562673600000/-], value: {"TITLE": "A Walk in the Clouds", "RATING_COUNT": 1, "WINDOW_START": 1562673600000, "WINDOW_END": 1562695200000}
rowtime: 2019/07/09 15:00:00.000 Z, key: [A Walk in the Clouds@1562673600000/-], value: {"TITLE": "A Walk in the Clouds", "RATING_COUNT": 2, "WINDOW_START": 1562673600000, "WINDOW_END": 1562695200000}
rowtime: 2019/07/09 22:00:00.000 Z, key: [A Walk in the Clouds@1562695200000/-], value: {"TITLE": "A Walk in the Clouds", "RATING_COUNT": 1, "WINDOW_START": 1562695200000, "WINDOW_END": 1562716800000}
rowtime: 2019/07/09 05:00:00.000 Z, key: [The Big Lebowski@1562630400000/-], value: {"TITLE": "The Big Lebowski", "RATING_COUNT": 1, "WINDOW_START": 1562630400000, "WINDOW_END": 1562652000000}
rowtime: 2019/07/09 05:00:00.000 Z, key: [The Big Lebowski@1562630400000/-], value: {"TITLE": "The Big Lebowski", "RATING_COUNT": 2, "WINDOW_START": 1562630400000, "WINDOW_END": 1562652000000}
rowtime: 2019/07/09 18:00:00.000 Z, key: [Super Mario Bros.@1562695200000/-], value: {"TITLE": "Super Mario Bros.", "RATING_COUNT": 1, "WINDOW_START": 1562695200000, "WINDOW_END": 1562716800000}
Topic printing ceased
```

The first three rows are incorrectly being formatted as a windowed BIGINT, when the actual key is `Die Hard`.

This PR will mean the output is more correctly:

```
Key format: HOPPING(KAFKA_STRING) or TUMBLING(KAFKA_STRING)
Value format: AVRO
rowtime: 2019/07/09 01:00:00.000 Z, key: [Die Hard@1562630400000/-], value: {"TITLE": "Die Hard", "RATING_COUNT": 1, "WINDOW_START": 1562630400000, "WINDOW_END": 1562652000000}
rowtime: 2019/07/09 05:00:00.000 Z, key: [Die Hard@1562630400000/-], value: {"TITLE": "Die Hard", "RATING_COUNT": 2, "WINDOW_START": 1562630400000, "WINDOW_END": 1562652000000}
rowtime: 2019/07/09 07:00:00.000 Z, key: [Die Hard@1562652000000/-], value: {"TITLE": "Die Hard", "RATING_COUNT": 1, "WINDOW_START": 1562652000000, "WINDOW_END": 1562673600000}
rowtime: 2019/07/09 09:00:00.000 Z, key: [Tree of Life@1562652000000/-], value: {"TITLE": "Tree of Life", "RATING_COUNT": 1, "WINDOW_START": 1562652000000, "WINDOW_END": 1562673600000}
rowtime: 2019/07/09 09:00:00.000 Z, key: [Tree of Life@1562652000000/-], value: {"TITLE": "Tree of Life", "RATING_COUNT": 2, "WINDOW_START": 1562652000000, "WINDOW_END": 1562673600000}
rowtime: 2019/07/09 12:00:00.000 Z, key: [A Walk in the Clouds@1562673600000/-], value: {"TITLE": "A Walk in the Clouds", "RATING_COUNT": 1, "WINDOW_START": 1562673600000, "WINDOW_END": 1562695200000}
rowtime: 2019/07/09 15:00:00.000 Z, key: [A Walk in the Clouds@1562673600000/-], value: {"TITLE": "A Walk in the Clouds", "RATING_COUNT": 2, "WINDOW_START": 1562673600000, "WINDOW_END": 1562695200000}
rowtime: 2019/07/09 22:00:00.000 Z, key: [A Walk in the Clouds@1562695200000/-], value: {"TITLE": "A Walk in the Clouds", "RATING_COUNT": 1, "WINDOW_START": 1562695200000, "WINDOW_END": 1562716800000}
rowtime: 2019/07/09 05:00:00.000 Z, key: [The Big Lebowski@1562630400000/-], value: {"TITLE": "The Big Lebowski", "RATING_COUNT": 1, "WINDOW_START": 1562630400000, "WINDOW_END": 1562652000000}
rowtime: 2019/07/09 05:00:00.000 Z, key: [The Big Lebowski@1562630400000/-], value: {"TITLE": "The Big Lebowski", "RATING_COUNT": 2, "WINDOW_START": 1562630400000, "WINDOW_END": 1562652000000}
rowtime: 2019/07/09 18:00:00.000 Z, key: [Super Mario Bros.@1562695200000/-], value: {"TITLE": "Super Mario Bros.", "RATING_COUNT": 1, "WINDOW_START": 1562695200000, "WINDOW_END": 1562716800000}
Topic printing ceased
```

This change will also help with, though not entirely fix, https://github.com/confluentinc/ksql/issues/5514.  Even with this fix is it still possible to misdetect a while batch of records as windowed strings, when they are actually strings. However, ever record would need to have window bounds.


### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

