### PR TITLE
fix: set retention.ms to -1 instead of Long.MAX_VALUE

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtils.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtils.java
@@ -35,7 +35,7 @@ public final class KsqlInternalTopicUtils {
   private static final Logger log = LoggerFactory.getLogger(KsqlInternalTopicUtils.class);
 
   private static final int INTERNAL_TOPIC_PARTITION_COUNT = 1;
-  private static final long INTERNAL_TOPIC_RETENTION_MS = Long.MAX_VALUE;
+  private static final long INTERNAL_TOPIC_RETENTION_MS = -1;
 
   private static final ImmutableMap<String, ?> INTERNAL_TOPIC_CONFIG = ImmutableMap.of(
       TopicConfig.RETENTION_MS_CONFIG, INTERNAL_TOPIC_RETENTION_MS,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtilsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtilsTest.java
@@ -54,7 +54,7 @@ public class KsqlInternalTopicUtilsTest {
   private static final boolean ENABLE_UNCLEAN_ELECTION = false;
 
   private final Map<String, ?> commandTopicConfig = ImmutableMap.of(
-      TopicConfig.RETENTION_MS_CONFIG, Long.MAX_VALUE,
+      TopicConfig.RETENTION_MS_CONFIG, -1L,
       TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE,
       TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, INSYNC_REPLICAS,
       TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, ENABLE_UNCLEAN_ELECTION);
@@ -119,7 +119,7 @@ public class KsqlInternalTopicUtilsTest {
 
     // Then:
     verify(topicClient).addTopicConfig(TOPIC_NAME, ImmutableMap.of(
-        TopicConfig.RETENTION_MS_CONFIG, Long.MAX_VALUE,
+        TopicConfig.RETENTION_MS_CONFIG, -1L,
         TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE
     ));
   }


### PR DESCRIPTION
### Description 

There may be a bug with Kafka's handling of `Long.MAX_VALUE` as a topic retention. This PR is defensive in setting it to the documented value for infinite retention: `-1`

### Testing done 

Unit testing, and spun up a new ksql server:
```
Topic: _confluent-ksql-default__command_topic	PartitionCount: 1	ReplicationFactor: 1	Configs: min.insync.replicas=1,cleanup.policy=delete,segment.bytes=1073741824,retention.ms=-1,unclean.leader.election.enable=false
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

