### PR TITLE
test: add meta tests to ensure user error

### DIFF
--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestGeneratorTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestGeneratorTest.java
@@ -15,6 +15,10 @@
 
 package io.confluent.ksql.test.planned;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
 import io.confluent.ksql.test.QueryTranslationTest;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -23,6 +27,9 @@ public class PlannedTestGeneratorTest {
 
   /**
    * Run this test to generate new query plans for the {@link QueryTranslationTest} test cases.
+   *
+   * <p>NB: You'll need to temporarily comment out the {@code @Ignore} annotation to run the test,
+   * but make sure you put it back afterwards!
    *
    * <p>Ensure only the test plans you expected have changed, then check the new query plans in
    * with your change. Otherwise, {@link PlannedTestsUpToDateTest} fill fail if there are missing
@@ -33,5 +40,18 @@ public class PlannedTestGeneratorTest {
   public void manuallyGeneratePlans() {
     PlannedTestGenerator.generatePlans(QueryTranslationTest.findTestCases()
         .filter(PlannedTestUtils::isNotExcluded));
+  }
+
+  @Test
+  public void shouldNotCheckInThisClassWithTheAboveTestEnabled() throws Exception {
+    final Ignore ignoreAnnotation = this.getClass()
+        .getMethod("manuallyGeneratePlans")
+        .getAnnotation(Ignore.class);
+
+    assertThat(
+        "Ensure you add back the @Ignore annotation above before committing your change.",
+        ignoreAnnotation,
+        is(notNullValue())
+    );
   }
 }

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestRewriterTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestRewriterTest.java
@@ -15,6 +15,10 @@
 
 package io.confluent.ksql.test.planned;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -22,6 +26,9 @@ public class PlannedTestRewriterTest {
 
   /**
    * Re-write ALL existing test plans.
+   *
+   * <p>NB: You'll need to temporarily comment out the {@code @Ignore} annotation to run the test,
+   * but make sure you put it back afterwards!
    *
    * <p>You almost certainly do NOT want to do this as historical plans should be IMMUTABLE.
    * The only time this is really valid is if you have fixed a bug in the testing framework
@@ -32,5 +39,18 @@ public class PlannedTestRewriterTest {
   public void rewritePlans() {
     new PlannedTestRewriter(PlannedTestRewriter.FULL)
         .rewriteTestCasePlans(new TestCasePlanLoader().all());
+  }
+
+  @Test
+  public void shouldNotCheckInThisClassWithTheAboveTestEnabled() throws Exception {
+    final Ignore ignoreAnnotation = this.getClass()
+        .getMethod("rewritePlans")
+        .getAnnotation(Ignore.class);
+
+    assertThat(
+        "Ensure you add back the @Ignore annotation above before committing your change.",
+        ignoreAnnotation,
+        is(notNullValue())
+    );
   }
 }


### PR DESCRIPTION
### Description 

We've two 'tests' that should never be enabled in the main build.  This change adds meta-tests to ensure that they are not enabled.

### Testing done 

test only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

