### PR TITLE
chore: fix regression in group by query is key in projection

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -550,8 +550,8 @@ public class LogicalPlanner {
           .collect(Collectors.toList());
     } else {
       // Transient query:
-      // Transient queries only return value columns, so must leave key columns in the value:
-      valueColumns = projectionSchema.value();
+      // Transient queries only return value columns, so must have key columns in the value:
+      valueColumns = projectionSchema.columns();
     }
 
     final Builder builder = LogicalSchema.builder();

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
@@ -429,7 +429,7 @@
       ]
     },
     {
-      "name": "windowed group by - key in projection",
+      "name": "windowed group by - repartition - key in projection",
       "statements": [
         "CREATE STREAM TEST (K INT KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "SELECT ID, count(1) as count FROM test WINDOW TUMBLING (SIZE 1 SECOND) group by ID EMIT CHANGES LIMIT 2;"
@@ -444,6 +444,26 @@
           {"header":{"schema":"`ID` INTEGER, `COUNT` BIGINT"}},
           {"row":{"columns":[2, 1]}},
           {"row":{"columns":[2, 1]}},
+          {"finalMessage":"Limit Reached"}
+        ]}
+      ]
+    },
+    {
+      "name": "windowed group by - no-repartition - key in projection",
+      "statements": [
+        "CREATE STREAM TEST (K INT KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "SELECT K, COUNT(1) AS count FROM TEST WINDOW TUMBLING (SIZE 1 SECOND) GROUP BY K EMIT CHANGES LIMIT 2;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"ID": 2}, "timestamp": 10345},
+        {"topic": "test_topic", "key": 1, "value": {"Id": 2}, "timestamp": 13251}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`K` INTEGER, `COUNT` BIGINT"}},
+          {"row":{"columns":[0, 1]}},
+          {"row":{"columns":[1, 1]}},
           {"finalMessage":"Limit Reached"}
         ]}
       ]
@@ -533,7 +553,7 @@
       }
     },
     {
-      "name": "Zero limit",
+      "name": "zero limit",
       "statements": [
         "CREATE STREAM INPUT (K STRING KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "SELECT * FROM INPUT EMIT CHANGES LIMIT 0;"


### PR DESCRIPTION
### Description 

fixes: https://github.com/confluentinc/ksql/issues/5558

Tracked the issue down to a missing test case: can recreate the above issue by having a group by on the current key, i.e. no repartition needed, with the key in the projection.

### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

