### PR TITLE
Agg no value columns

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/AggregateAnalyzer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/AggregateAnalyzer.java
@@ -244,7 +244,7 @@ public class AggregateAnalyzer {
     private void enforceAggregateRules() {
       if (aggregateAnalysis.getAggregateFunctions().isEmpty()) {
         throw new KsqlException(
-            "GROUP BY requires columns using aggregate functions in SELECT clause.");
+            "GROUP BY requires aggregate functions in either the SELECT or HAVING clause.");
       }
 
       final String unmatchedSelects = nonAggSelectsNotPartOfGroupBy.stream()

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -550,8 +550,8 @@ public class LogicalPlanner {
           .collect(Collectors.toList());
     } else {
       // Transient query:
-      // Transient queries only return value columns, so must leave key columns in the value:
-      valueColumns = projectionSchema.value();
+      // Transient queries only return value columns, so must have key columns in the value:
+      valueColumns = projectionSchema.columns();
     }
 
     final Builder builder = LogicalSchema.builder();

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -548,6 +548,10 @@ public class LogicalPlanner {
       valueColumns = projectionSchema.value().stream()
           .filter(col -> !keyColumnNames.contains(col.name()))
           .collect(Collectors.toList());
+
+      if (valueColumns.isEmpty()) {
+        throw new KsqlException("The projection contains no value columns.");
+      }
     } else {
       // Transient query:
       // Transient queries only return value columns, so must have key columns in the value:

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_udafs_only_in_having_(stream-_table)/6.0.0_1591618121193/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_udafs_only_in_having_(stream-_table)/6.0.0_1591618121193/plan.json
@@ -1,0 +1,171 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (NAME STRING) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`NAME` STRING",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.NAME NAME,\n  LEN(INPUT.NAME) LEN\nFROM INPUT INPUT\nGROUP BY INPUT.NAME\nHAVING (COUNT(INPUT.NAME) = 2)\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`NAME` STRING KEY, `LEN` INTEGER",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableFilterV1",
+            "properties" : {
+              "queryContext" : "Aggregate/HavingFilter"
+            },
+            "source" : {
+              "@type" : "streamAggregateV1",
+              "properties" : {
+                "queryContext" : "Aggregate/Aggregate"
+              },
+              "source" : {
+                "@type" : "streamGroupByV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/GroupBy"
+                },
+                "source" : {
+                  "@type" : "streamSelectV1",
+                  "properties" : {
+                    "queryContext" : "Aggregate/Prepare"
+                  },
+                  "source" : {
+                    "@type" : "streamSourceV1",
+                    "properties" : {
+                      "queryContext" : "KsqlTopic/Source"
+                    },
+                    "topicName" : "test_topic",
+                    "formats" : {
+                      "keyFormat" : {
+                        "format" : "KAFKA"
+                      },
+                      "valueFormat" : {
+                        "format" : "JSON"
+                      }
+                    },
+                    "sourceSchema" : "`NAME` STRING"
+                  },
+                  "selectExpressions" : [ "NAME AS NAME" ]
+                },
+                "internalFormats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "groupByExpressions" : [ "NAME" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              },
+              "nonAggregateColumns" : [ "NAME" ],
+              "aggregationFunctions" : [ "COUNT(NAME)" ]
+            },
+            "filterExpression" : "(KSQL_AGG_VARIABLE_0 = 2)"
+          },
+          "keyColumnNames" : [ "NAME" ],
+          "selectExpressions" : [ "LEN(NAME) AS LEN" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.error.classifier.regex" : ""
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_udafs_only_in_having_(stream-_table)/6.0.0_1591618121193/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_udafs_only_in_having_(stream-_table)/6.0.0_1591618121193/spec.json
@@ -1,0 +1,113 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1591618121193,
+  "path" : "query-validation-tests/group-by.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<NAME VARCHAR> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : "STRUCT<NAME VARCHAR> NOT NULL",
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : "STRUCT<NAME VARCHAR, KSQL_AGG_VARIABLE_0 BIGINT> NOT NULL",
+    "CTAS_OUTPUT_0.OUTPUT" : "STRUCT<LEN INT> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "udafs only in having (stream->table)",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "",
+      "value" : {
+        "NAME" : "bob"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "",
+      "value" : {
+        "NAME" : "bob"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "",
+      "value" : {
+        "NAME" : "bob"
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "bob",
+      "value" : null
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "bob",
+      "value" : {
+        "LEN" : 3
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "bob",
+      "value" : null
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (NAME STRING) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT NAME, LEN(NAME) AS LEN FROM INPUT GROUP BY NAME HAVING COUNT(NAME) = 2;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "table",
+        "schema" : "NAME STRING KEY, LEN INT",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        }
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_udafs_only_in_having_(stream-_table)/6.0.0_1591618121193/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_udafs_only_in_having_(stream-_table)/6.0.0_1591618121193/topology
@@ -1,0 +1,49 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-HavingFilter-ApplyPredicate
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-HavingFilter-ApplyPredicate (stores: [])
+      --> Aggregate-HavingFilter-Filter
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-HavingFilter-Filter (stores: [])
+      --> Aggregate-HavingFilter-PostProcess
+      <-- Aggregate-HavingFilter-ApplyPredicate
+    Processor: Aggregate-HavingFilter-PostProcess (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-HavingFilter-Filter
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000014
+      <-- Aggregate-HavingFilter-PostProcess
+    Processor: KTABLE-TOSTREAM-0000000014 (stores: [])
+      --> KSTREAM-SINK-0000000015
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000015 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000014
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
@@ -37,6 +37,52 @@
       }
     },
     {
+      "name": "udafs only in having (stream->table)",
+      "statements": [
+        "CREATE STREAM INPUT (NAME STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT NAME, LEN(NAME) AS LEN FROM INPUT GROUP BY NAME HAVING COUNT(NAME) = 2;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "value": {"NAME": "bob"}},
+        {"topic": "test_topic", "value": {"NAME": "bob"}},
+        {"topic": "test_topic", "value": {"NAME": "bob"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "bob", "value": null},
+        {"topic": "OUTPUT", "key": "bob", "value": {"LEN": 3}},
+        {"topic": "OUTPUT", "key": "bob", "value": null}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "keyFormat": {"format": "KAFKA"}, "schema": "NAME STRING KEY, LEN INT"}
+        ]
+      }
+    },
+    {
+      "name": "all columns - repartition (stream->table)",
+      "comment": "Currently, at least one value column is required...",
+      "statements": [
+        "CREATE STREAM INPUT (NAME STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT NAME FROM INPUT GROUP BY NAME HAVING COUNT(NAME) = 1;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The projection contains no value columns."
+      }
+    },
+    {
+      "name": "all columns - no repartition (stream->table)",
+      "comment": "Currently, at least one value column is required...",
+      "statements": [
+        "CREATE STREAM INPUT (NAME STRING KEY, V0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT NAME FROM INPUT GROUP BY NAME HAVING COUNT(NAME) = 1;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The projection contains no value columns."
+      }
+    },
+    {
       "name": "value column (stream->table)",
       "statements": [
         "CREATE STREAM TEST (ID INT KEY, data STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
@@ -1909,14 +1955,14 @@
       }
     },
     {
-      "name": "with projection without aggregate functions (stream->table)",
+      "name": "without aggregate functions (stream->table)",
       "statements": [
         "CREATE STREAM TEST (K STRING KEY, d1 VARCHAR, d2 INT) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
         "CREATE TABLE OUTPUT AS SELECT SUBSTRING(d1, 1, 2) FROM TEST GROUP BY d2;"
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "GROUP BY requires columns using aggregate functions in SELECT clause."
+        "message": "GROUP BY requires aggregate functions in either the SELECT or HAVING clause."
       }
     },
     {

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
@@ -429,7 +429,7 @@
       ]
     },
     {
-      "name": "windowed group by - key in projection",
+      "name": "windowed group by - repartition - key in projection",
       "statements": [
         "CREATE STREAM TEST (K INT KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "SELECT ID, count(1) as count FROM test WINDOW TUMBLING (SIZE 1 SECOND) group by ID EMIT CHANGES LIMIT 2;"
@@ -444,6 +444,26 @@
           {"header":{"schema":"`ID` INTEGER, `COUNT` BIGINT"}},
           {"row":{"columns":[2, 1]}},
           {"row":{"columns":[2, 1]}},
+          {"finalMessage":"Limit Reached"}
+        ]}
+      ]
+    },
+    {
+      "name": "windowed group by - no-repartition - key in projection",
+      "statements": [
+        "CREATE STREAM TEST (K INT KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "SELECT K, COUNT(1) AS count FROM TEST WINDOW TUMBLING (SIZE 1 SECOND) GROUP BY K EMIT CHANGES LIMIT 2;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"ID": 2}, "timestamp": 10345},
+        {"topic": "test_topic", "key": 1, "value": {"Id": 2}, "timestamp": 13251}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`K` INTEGER, `COUNT` BIGINT"}},
+          {"row":{"columns":[0, 1]}},
+          {"row":{"columns":[1, 1]}},
           {"finalMessage":"Limit Reached"}
         ]}
       ]
@@ -533,7 +553,7 @@
       }
     },
     {
-      "name": "Zero limit",
+      "name": "zero limit",
       "statements": [
         "CREATE STREAM INPUT (K STRING KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "SELECT * FROM INPUT EMIT CHANGES LIMIT 0;"

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
@@ -4,6 +4,66 @@
   ],
   "tests": [
     {
+      "name": "only key column",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "SELECT K FROM INPUT EMIT CHANGES LIMIT 2;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": "11", "value": {"id": 100}},
+        {"topic": "test_topic", "timestamp": 12365, "key": "12", "value": {"id": 101}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`K` STRING"}},
+          {"row":{"columns":["11"]}},
+          {"row":{"columns":["12"]}},
+          {"finalMessage":"Limit Reached"}
+        ]}
+      ]
+    },
+    {
+      "name": "only value column",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "SELECT ID FROM INPUT EMIT CHANGES LIMIT 2;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": "11", "value": {"id": 100}},
+        {"topic": "test_topic", "timestamp": 12365, "key": "12", "value": {"id": 101}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER"}},
+          {"row":{"columns":[100]}},
+          {"row":{"columns":[101]}},
+          {"finalMessage":"Limit Reached"}
+        ]}
+      ]
+    },
+    {
+      "name": "only literal",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "SELECT 1 AS I FROM INPUT EMIT CHANGES LIMIT 2;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": "11", "value": {"id": 100}},
+        {"topic": "test_topic", "timestamp": 12365, "key": "12", "value": {"id": 101}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`I` INTEGER"}},
+          {"row":{"columns":[1]}},
+          {"row":{"columns":[1]}},
+          {"finalMessage":"Limit Reached"}
+        ]}
+      ]
+    },
+    {
       "name": "explicit ROWTIME",
       "statements": [
         "CREATE STREAM INPUT (K STRING KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
@@ -504,6 +564,27 @@
           {"header":{"schema":"`COUNT` BIGINT"}},
           {"row":{"columns":[1]}},
           {"row":{"columns":[2]}},
+          {"finalMessage":"Limit Reached"}
+        ]}
+      ]
+    },
+    {
+      "name": "aggregate with no value columns",
+      "statements": [
+        "CREATE STREAM TEST (K INT KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "SELECT K FROM test GROUP BY K HAVING COUNT(K) > 1 EMIT CHANGES LIMIT 2;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {}, "timestamp": 10345},
+        {"topic": "test_topic", "key": 0, "value": {}, "timestamp": 13251},
+        {"topic": "test_topic", "key": 0, "value": {}, "timestamp": 13253}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`K` INTEGER"}},
+          {"row":{"columns":[0]}},
+          {"row":{"columns":[0]}},
           {"finalMessage":"Limit Reached"}
         ]}
       ]


### PR DESCRIPTION
### Description 

Note: stacked on top of https://github.com/confluentinc/ksql/pull/5566. Review that first!

fixes: #5557

Previously, a query such as:

```sql
CREATE TABLE OUTPUT AS
  SELECT ID FROM INPUT
  GROUP BY ID
  HAVING SUM(COUNT) > 10;
```

Would have resulted in a schema of `ROWKEY STRING KEY, ID INT`. With the introduction of the 'any key name' feature the `ID` in the projection is no longer a value column: its a key column, so the resulting schema is: `ID INT KEY`, i.e. it has no value columns.

ksqlDB currently doesn't support data sources with no value columns. Hence the 'fix' here is to reject the above query with the error `The projection contains no value columns.`.  A longer term fix may be to support sources with no value columns: #5564.

The change includes tests to ensure transient push queries _do_ support queries that pull back no value columns.

### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

