### PR TITLE
chore: change log level of re-configure internal topic to WARN

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtils.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtils.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.rest.util;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlConfig;
+import java.util.Map;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.config.TopicConfig;
 import org.slf4j.Logger;
@@ -119,11 +120,14 @@ public final class KsqlInternalTopicUtils {
           name, replicationFactor);
     }
 
+    final Map<String, String> existingConfig = topicClient.getTopicConfig(name);
     if (topicClient.addTopicConfig(name, INTERNAL_TOPIC_CONFIG)) {
-      log.info(
-          "Corrected retention.ms on ksql internal topic. topic:{}, retention.ms:{}",
+      log.warn(
+          "Topic {} was created with or modified to have an invalid configuration: {} "
+              + "- overriding the following configurations: {}",
           name,
-          INTERNAL_TOPIC_RETENTION_MS);
+          existingConfig,
+          INTERNAL_TOPIC_CONFIG);
     }
   }
 }


### PR DESCRIPTION
### Description 

A misconfigured internal topic is something that can cause problems to a ksql cluster (e.g. missing retention on the command topic). This patch bumps of the level to WARN to make the message stand out a little more.

### Testing done 

No functionality change

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

