### PR TITLE
chore: /query-stream endpoint now defaults to auto.offset.reset=latest

### DIFF
--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTlsMutualAuthTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTlsMutualAuthTest.java
@@ -27,14 +27,15 @@ public class ClientTlsMutualAuthTest extends ClientTlsTest {
 
   @Override
   protected KsqlRestConfig createServerConfig() {
-    final Map<String, Object> config = serverConfigWithTls();
-    config.put(
+    KsqlRestConfig config = super.createServerConfig();
+    Map<String, Object> origs = config.originals();
+    origs.put(
         KsqlRestConfig.SSL_CLIENT_AUTHENTICATION_CONFIG,
         KsqlRestConfig.SSL_CLIENT_AUTHENTICATION_REQUIRED
     );
-    config.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, TRUST_STORE_PATH);
-    config.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, TRUST_STORE_PASSWORD);
-    return new KsqlRestConfig(config);
+    origs.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, TRUST_STORE_PATH);
+    origs.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, TRUST_STORE_PASSWORD);
+    return new KsqlRestConfig(origs);
   }
 
   @Override

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTlsTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTlsTest.java
@@ -46,7 +46,12 @@ public class ClientTlsTest extends ClientTest {
 
   @Override
   protected KsqlRestConfig createServerConfig() {
-    return new KsqlRestConfig(serverConfigWithTls());
+    KsqlRestConfig config = super.createServerConfig();
+    Map<String, Object> origs = config.originals();
+    origs.put(KsqlRestConfig.LISTENERS_CONFIG, "https://localhost:0");
+    origs.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, KEY_STORE_PATH);
+    origs.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, KEY_STORE_PASSWORD);
+    return new KsqlRestConfig(origs);
   }
 
   @Override
@@ -84,15 +89,5 @@ public class ClientTlsTest extends ClientTest {
         .setUseTls(true)
         .setVerifyHost(false)
         .setUseAlpn(true);
-  }
-
-  protected static Map<String, Object> serverConfigWithTls() {
-    Map<String, Object> config = new HashMap<>();
-    config.put(KsqlRestConfig.LISTENERS_CONFIG, "https://localhost:0");
-    config.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, KEY_STORE_PATH);
-    config.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, KEY_STORE_PASSWORD);
-    config.put(KsqlRestConfig.VERTICLE_INSTANCES, 4);
-
-    return config;
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
@@ -65,11 +65,6 @@ public class QueryEndpoint {
     // Must be run on worker as all this stuff is slow
     VertxUtils.checkIsWorker();
 
-    if (!properties.containsKey("auto.offset.reset")
-        && !properties.containsKey("ksql.streams.auto.offset.reset")) {
-      properties.put("auto.offset.reset", "earliest");
-    }
-
     final ConfiguredStatement<Query> statement = createStatement(sql, properties.getMap());
 
     if (statement.getStatement().isPullQuery()) {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/PullQueryRunner.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/PullQueryRunner.java
@@ -57,7 +57,7 @@ public class PullQueryRunner extends BasePerfRunner {
   private static final String DEFAULT_PULL_QUERY = "select * from foo where rowkey=123;";
   private static final JsonObject DEFAULT_PULL_QUERY_REQUEST_BODY = new JsonObject()
       .put("sql", DEFAULT_PULL_QUERY)
-      .put("properties", new JsonObject());
+      .put("properties", new JsonObject().put("auto.offset.reset", "earliest"));
   private static final List<GenericRow> DEFAULT_ROWS = generateResults();
   private static final int MAX_CONCURRENT_REQUESTS = 100;
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/QueryStreamRunner.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/QueryStreamRunner.java
@@ -53,7 +53,7 @@ public class QueryStreamRunner extends BasePerfRunner {
   private static final String DEFAULT_PUSH_QUERY = "select * from foo emit changes;";
   private static final JsonObject DEFAULT_PUSH_QUERY_REQUEST_BODY = new JsonObject()
       .put("sql", DEFAULT_PUSH_QUERY)
-      .put("properties", new JsonObject());
+      .put("properties", new JsonObject().put("auto.offset.reset", "earliest"));
 
   public static void main(String[] args) {
     new QueryStreamRunner().go();


### PR DESCRIPTION
### Description 

Fixes https://github.com/confluentinc/ksql/issues/5586

BREAKING CHANGE: The /query-stream endpoint previously defaulted to using auto.offset.reset=earliest. With this change, the new default is auto.offset.reset=latest, consistent with the /query endpoint and the ksqlDB CLI.

### Testing done 

Unit and integration tests continue to pass.

There's no test coverage for this default at the moment, since TestKsqlRestApp (used for all integration tests) sets `auto.offset.reset=earliest` on the server. As a result, the old default was also not tested and there is no testing regression in this PR, though we should consider plugging the gap in the future.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

