### PR TITLE
fix: make stream and column names case-insensitive in /inserts-stream

### DIFF
--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
@@ -434,14 +434,14 @@ public class ClientIntegrationTest {
   public void shouldInsertInto() throws Exception {
     // Given
     final KsqlObject insertRow = new KsqlObject()
-        .put("STR", "HELLO")
-        .put("LONG", 100L)
+        .put("str", "HELLO") // Column names are case-insensitive
+        .put("`LONG`", 100L) // Quotes may be used to preserve case-sensitivity
         .put("DEC", new BigDecimal("13.31"))
         .put("ARRAY", new KsqlArray().add("v1").add("v2"))
         .put("MAP", new KsqlObject().put("some_key", "a_value").put("another_key", ""));
 
     // When
-    client.insertInto(EMPTY_TEST_STREAM, insertRow).get();
+    client.insertInto(EMPTY_TEST_STREAM.toLowerCase(), insertRow).get(); // Stream name is case-insensitive
 
     // Then: should receive new row
     final String query = "SELECT * FROM " + EMPTY_TEST_STREAM + " EMIT CHANGES LIMIT 1;";

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/InsertsSubscriber.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/InsertsSubscriber.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.api.impl;
 
+import static io.confluent.ksql.api.impl.KeyValueExtractor.convertColumnNameCase;
+
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.api.server.InsertResult;
 import io.confluent.ksql.api.server.InsertsStreamSubscriber;
@@ -132,9 +134,11 @@ public final class InsertsSubscriber extends BaseSubscriber<JsonObject> implemen
   }
 
   @Override
-  protected void handleValue(final JsonObject jsonObject) {
+  protected void handleValue(final JsonObject jsonObjectWithCaseInsensitiveFields) {
 
     try {
+      final JsonObject jsonObject = convertColumnNameCase(jsonObjectWithCaseInsensitiveFields);
+
       final Struct key = extractKey(jsonObject);
       final GenericRow values = extractValues(jsonObject);
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
@@ -21,6 +21,7 @@ import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 import static io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster.VALID_USER2;
 import static io.confluent.ksql.util.KsqlConfig.KSQL_STREAMS_PREFIX;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -432,6 +433,35 @@ public class ApiIntegrationTest {
   }
 
   @Test
+  public void shouldTreatInsertTargetAsCaseSensitiveIfQuoted() {
+    // Given:
+    String target = "`" + TEST_STREAM.toLowerCase() + "`";
+    JsonObject row = new JsonObject()
+        .put("STR", "HELLO")
+        .put("LONG", 1000L)
+        .put("DEC", 12.21) // JsonObject does not accept BigDecimal
+        .put("ARRAY", new JsonArray().add("a").add("b"))
+        .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"));
+
+    // Then: request fails because stream name is invalid
+    shouldRejectInsertRequest(target, row, "Cannot insert values into an unknown stream: " + target);
+  }
+
+  @Test
+  public void shouldTreatInsertColumnNamesAsCaseSensitiveIfQuoted() {
+    // Given:
+    JsonObject row = new JsonObject()
+        .put("\"str\"", "HELLO")
+        .put("LONG", 1000L)
+        .put("DEC", 12.21) // JsonObject does not accept BigDecimal
+        .put("ARRAY", new JsonArray().add("a").add("b"))
+        .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"));
+
+    // Then: request fails because column name is incorrect
+    shouldFailToInsert(row, ERROR_CODE_BAD_REQUEST, "Key field must be specified: STR");
+  }
+
+  @Test
   public void shouldExecutePushQueryFromLatestOffset() {
 
     KsqlEngine engine = (KsqlEngine) REST_APP.getEngine();
@@ -509,15 +539,7 @@ public class ApiIntegrationTest {
   }
 
   private void shouldFailToInsert(final JsonObject row, final int errorCode, final String message) {
-    JsonObject properties = new JsonObject();
-    JsonObject requestBody = new JsonObject()
-        .put("target", TEST_STREAM).put("properties", properties);
-    Buffer bodyBuffer = requestBody.toBuffer();
-    bodyBuffer.appendString("\n");
-
-    bodyBuffer.appendBuffer(row.toBuffer()).appendString("\n");
-
-    HttpResponse<Buffer> response = sendRequest("/inserts-stream", bodyBuffer);
+    final HttpResponse<Buffer> response = makeInsertsRequest(TEST_STREAM, row);
 
     assertThat(response.statusCode(), is(200));
 
@@ -534,6 +556,27 @@ public class ApiIntegrationTest {
   }
 
   private void shouldInsert(final String target, final JsonObject row) {
+    HttpResponse<Buffer> response = makeInsertsRequest(target, row);
+
+    assertThat(response.statusCode(), is(200));
+
+    InsertsResponse insertsResponse = new InsertsResponse(response.bodyAsString());
+    assertThat(insertsResponse.acks, hasSize(1));
+    assertThat(insertsResponse.error, is(nullValue()));
+  }
+
+  private void shouldRejectInsertRequest(final String target, final JsonObject row, final String message) {
+    HttpResponse<Buffer> response = makeInsertsRequest(target, row);
+
+    assertThat(response.statusCode(), is(400));
+    assertThat(response.statusMessage(), is("Bad Request"));
+
+    QueryResponse queryResponse = new QueryResponse(response.bodyAsString());
+    assertThat(queryResponse.responseObject.getInteger("error_code"), is(ERROR_CODE_BAD_STATEMENT));
+    assertThat(queryResponse.responseObject.getString("message"), containsString(message));
+  }
+
+  private HttpResponse<Buffer> makeInsertsRequest(final String target, final JsonObject row) {
     JsonObject properties = new JsonObject();
     JsonObject requestBody = new JsonObject()
         .put("target", target).put("properties", properties);
@@ -542,13 +585,7 @@ public class ApiIntegrationTest {
 
     bodyBuffer.appendBuffer(row.toBuffer()).appendString("\n");
 
-    HttpResponse<Buffer> response = sendRequest("/inserts-stream", bodyBuffer);
-
-    assertThat(response.statusCode(), is(200));
-
-    InsertsResponse insertsResponse = new InsertsResponse(response.bodyAsString());
-    assertThat(insertsResponse.acks, hasSize(1));
-    assertThat(insertsResponse.error, is(nullValue()));
+    return sendRequest("/inserts-stream", bodyBuffer);
   }
 
   private WebClient createClient() {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
@@ -417,6 +417,21 @@ public class ApiIntegrationTest {
   }
 
   @Test
+  public void shouldInsertWithCaseInsensitivity() {
+
+    // Given: lowercase fields names and stream name
+    String target = TEST_STREAM.toLowerCase();
+    JsonObject row = new JsonObject()
+        .put("str", "HELLO")
+        .put("dec", 12.21) // JsonObject does not accept BigDecimal
+        .put("array", new JsonArray().add("a").add("b"))
+        .put("map", new JsonObject().put("k1", "v1").put("k2", "v2"));
+
+    // Then:
+    shouldInsert(target, row);
+  }
+
+  @Test
   public void shouldExecutePushQueryFromLatestOffset() {
 
     KsqlEngine engine = (KsqlEngine) REST_APP.getEngine();
@@ -515,9 +530,13 @@ public class ApiIntegrationTest {
   }
 
   private void shouldInsert(final JsonObject row) {
+    shouldInsert(TEST_STREAM, row);
+  }
+
+  private void shouldInsert(final String target, final JsonObject row) {
     JsonObject properties = new JsonObject();
     JsonObject requestBody = new JsonObject()
-        .put("target", TEST_STREAM).put("properties", properties);
+        .put("target", target).put("properties", properties);
     Buffer bodyBuffer = requestBody.toBuffer();
     bodyBuffer.appendString("\n");
 


### PR DESCRIPTION
### Description 

The stream name and column names provided to the `/inserts-stream` endpoint are both currently case-sensitive, meaning an attempted insert into a stream with name `foo` will fail if the stream actually has name `FOO` in the metastore (e.g., if the stream were created with `create stream foo ...`). The same holds for column names as well. This PR updates the `/inserts-stream` endpoint to be case-insensitive by default, in order to be consistent with the rest of ksqlDB.

BREAKING CHANGE: Stream name and column names provided to the `/inserts-stream` endpoint are no longer case-sensitive. Instead, they will be upper-cased by default. To preserve case-sensitivity, surround the names with double-quotes or backticks.

### Testing done 

Added integration tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

