### PR TITLE
fix: disallow requests to /inserts-stream if insert values disabled

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
@@ -249,7 +249,7 @@ public class InsertValuesExecutor {
 
     if (canBeDisabledByConfig && !isEnabled) {
       throw new KsqlException("The server has disabled INSERT INTO ... VALUES functionality. "
-          + "To enable it, restart your KSQL-server "
+          + "To enable it, restart your ksqlDB server "
           + "with 'ksql.insert.into.values.enabled'=true");
     }
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/InsertsStreamEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/InsertsStreamEndpoint.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.api.impl;
 
+import static io.confluent.ksql.rest.Errors.ERROR_CODE_BAD_REQUEST;
 import static io.confluent.ksql.rest.Errors.ERROR_CODE_BAD_STATEMENT;
 
 import io.confluent.ksql.api.server.InsertResult;
@@ -53,6 +54,12 @@ public class InsertsStreamEndpoint {
       final WorkerExecutor workerExecutor,
       final ServiceContext serviceContext) {
     VertxUtils.checkIsWorker();
+    if (!ksqlConfig.getBoolean(KsqlConfig.KSQL_INSERT_INTO_VALUES_ENABLED)) {
+      throw new KsqlApiException("The server has disabled INSERT INTO ... VALUES functionality. "
+          + "To enable it, restart your ksqlDB server "
+          + "with 'ksql.insert.into.values.enabled'=true",
+          ERROR_CODE_BAD_REQUEST);
+    }
     final DataSource dataSource = getDataSource(ksqlEngine.getMetaStore(),
         SourceName.of(target));
     if (dataSource.getDataSourceType() == DataSourceType.KTABLE) {


### PR DESCRIPTION
### Description 

Fixes https://github.com/confluentinc/ksql/issues/5590. This will also need to be backported to 5.5.x.

### Testing done 

Not sure what makes sense in terms of automated testing. Endpoint-specific code currently can only be tested with integration tests, not unit tests. Because this functionality requires different server configs, we'd have to add a separate integration test file just for this, which feels really heavy-weight. @purplefox do you have recommendations?

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

