### PR TITLE
docs: fix embedded connect tutorial for key syntax changes (MINOR)

### DIFF
--- a/docs/tutorials/embedded-connect.md
+++ b/docs/tutorials/embedded-connect.md
@@ -249,7 +249,7 @@ columns.
 
 ```sql
 CREATE TABLE driverProfiles (
-  driver_id INTEGER KEY,
+  driver_id INTEGER PRIMARY KEY,
   make STRING,
   model STRING,
   year INTEGER,


### PR DESCRIPTION
### Description 

The embedded connect tutorial was mostly updated for the new key syntax changes in https://github.com/confluentinc/ksql/pull/5363 but a spot was missed.

### Testing done 

Ran through tutorial with new image.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

