### PR TITLE
fix: set Schema Registry port in tutorials docker compose

### DIFF
--- a/docs/tutorials/docker-compose.yml
+++ b/docs/tutorials/docker-compose.yml
@@ -36,6 +36,8 @@ services:
     depends_on:
       - zookeeper
       - kafka
+    ports:
+      - "8081:8081"
     environment:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: zookeeper:32181


### PR DESCRIPTION
### Description 

Otherwise, ksqlDB can't contact the SR.

(Reported by: https://stackoverflow.com/questions/62234258/ksql-avro-format-in-quickstart-gives-error/62343431#62343431)

# MERGE TO 6.0.0 ?

### Testing done 

Manually tested it works once set.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

