### PR TITLE
fix: don't fail if broker does not support AuthorizedOperations

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaClusterUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaClusterUtil.java
@@ -28,6 +28,7 @@ import org.apache.kafka.clients.admin.DescribeClusterOptions;
 import org.apache.kafka.clients.admin.DescribeClusterResult;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,6 +48,8 @@ public final class KafkaClusterUtil {
       );
 
       return authorizedOperations.authorizedOperations().get() != null;
+    } catch (final UnsupportedVersionException e) {
+      return false;
     } catch (final Exception e) {
       throw new KsqlServerException("Could not get Kafka authorized operations!", e);
     }


### PR DESCRIPTION
### Description 

Old version of kafka brokers (e.g. AK 1.1.0) don't support this describe operation and will cause the ksqlDB cluster to fail to startup. This PR prevents that.

### Testing done 
Unit testing & hit debug point to make sure that the branch was being hit

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

