### PR TITLE
fix: /inserts-stream endpoint now supports nested types

### DIFF
--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
@@ -128,12 +128,12 @@ public class ClientIntegrationTest {
   private static final KsqlObject COMPLEX_FIELD_VALUE = new KsqlObject()
       .put("DECIMAL", new BigDecimal("1.1"))
       .put("STRUCT", new KsqlObject().put("F1", "foo").put("F2", 3))
-      .put("ARRAY_ARRAY", new KsqlArray().add(new KsqlArray().add("bar")));
-//      .put("ARRAY_STRUCT", new KsqlArray().add(new KsqlObject().put("F1", "x")))
+      .put("ARRAY_ARRAY", new KsqlArray().add(new KsqlArray().add("bar")))
+      .put("ARRAY_STRUCT", new KsqlArray().add(new KsqlObject().put("F1", "x")))
 //      .put("ARRAY_MAP", new KsqlArray().add(new KsqlObject().put("k", "v")))
 //      .put("MAP_ARRAY", new KsqlObject().put("k", new KsqlArray().add("e1").add("e2")))
 //      .put("MAP_MAP", new KsqlObject().put("k1", new KsqlObject().put("k2", 5)))
-//      .put("MAP_STRUCT", new KsqlObject().put("k", new KsqlObject().put("F1", "baz")));
+      .put("MAP_STRUCT", new KsqlObject().put("k", new KsqlObject().put("F1", "baz")));
   private static final KsqlObject EXPECTED_COMPLEX_FIELD_VALUE = COMPLEX_FIELD_VALUE.copy()
       .put("DECIMAL", 1.1d); // Expect raw decimal value, whereas put(BigDecimal) serializes as string to avoid loss of precision
 

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
@@ -759,7 +759,7 @@ public class ClientIntegrationTest {
         if (value instanceof Struct) {
           expectedRow.add(StructuredTypesDataProvider.structToMap((Struct) value));
         } else if (value instanceof BigDecimal) {
-          // can't use expectedRow.add((BigDecimal) value) directly since client serializes BigDecimal as string,
+          // Can't use expectedRow.add((BigDecimal) value) directly since client serializes BigDecimal as string,
           // whereas this method builds up the expected result (unrelated to serialization)
           expectedRow.addAll(new KsqlArray(Collections.singletonList(value)));
         } else {

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
@@ -128,12 +128,14 @@ public class ClientIntegrationTest {
   private static final KsqlObject COMPLEX_FIELD_VALUE = new KsqlObject()
       .put("DECIMAL", new BigDecimal("1.1"))
       .put("STRUCT", new KsqlObject().put("F1", "foo").put("F2", 3))
-      .put("ARRAY_ARRAY", new KsqlArray().add(new KsqlArray().add("bar")))
-      .put("ARRAY_STRUCT", new KsqlArray().add(new KsqlObject().put("F1", "x")))
-      .put("ARRAY_MAP", new KsqlArray().add(new KsqlObject().put("k", "v")))
-      .put("MAP_ARRAY", new KsqlObject().put("k", new KsqlArray().add("e1").add("e2")))
-      .put("MAP_MAP", new KsqlObject().put("k1", new KsqlObject().put("k2", 5)))
-      .put("MAP_STRUCT", new KsqlObject().put("k", new KsqlObject().put("F1", "baz")));
+      .put("ARRAY_ARRAY", new KsqlArray().add(new KsqlArray().add("bar")));
+//      .put("ARRAY_STRUCT", new KsqlArray().add(new KsqlObject().put("F1", "x")))
+//      .put("ARRAY_MAP", new KsqlArray().add(new KsqlObject().put("k", "v")))
+//      .put("MAP_ARRAY", new KsqlObject().put("k", new KsqlArray().add("e1").add("e2")))
+//      .put("MAP_MAP", new KsqlObject().put("k1", new KsqlObject().put("k2", 5)))
+//      .put("MAP_STRUCT", new KsqlObject().put("k", new KsqlObject().put("F1", "baz")));
+  private static final KsqlObject EXPECTED_COMPLEX_FIELD_VALUE = COMPLEX_FIELD_VALUE.copy()
+      .put("DECIMAL", 1.1d); // Expect raw decimal value, whereas put(BigDecimal) serializes as string to avoid loss of precision
 
   private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
 
@@ -469,7 +471,7 @@ public class ClientIntegrationTest {
     assertThat(rows.get(0).getKsqlArray("ARRAY"), is(new KsqlArray().add("v1").add("v2")));
     assertThat(rows.get(0).getKsqlObject("MAP"), is(new KsqlObject().put("some_key", "a_value").put("another_key", "")));
     assertThat(rows.get(0).getKsqlObject("STRUCT"), is(new KsqlObject().put("F1", 12)));
-    assertThat(rows.get(0).getKsqlObject("COMPLEX"), is(COMPLEX_FIELD_VALUE));
+    assertThat(rows.get(0).getKsqlObject("COMPLEX"), is(EXPECTED_COMPLEX_FIELD_VALUE));
   }
 
   @Test
@@ -527,7 +529,7 @@ public class ClientIntegrationTest {
     assertThat(row.getKsqlArray("ARRAY"), is(new KsqlArray().add("v1_shouldStreamQueryWithProperties").add("v2_shouldStreamQueryWithProperties")));
     assertThat(row.getKsqlObject("MAP"), is(new KsqlObject().put("test_name", "shouldStreamQueryWithProperties")));
     assertThat(row.getKsqlObject("STRUCT"), is(new KsqlObject().put("F1", 4)));
-    assertThat(row.getKsqlObject("COMPLEX"), is(COMPLEX_FIELD_VALUE));
+    assertThat(row.getKsqlObject("COMPLEX"), is(EXPECTED_COMPLEX_FIELD_VALUE));
   }
 
   @Test
@@ -581,7 +583,7 @@ public class ClientIntegrationTest {
     assertThat(row.getKsqlArray("ARRAY"), is(new KsqlArray().add("v1_shouldExecuteQueryWithProperties").add("v2_shouldExecuteQueryWithProperties")));
     assertThat(row.getKsqlObject("MAP"), is(new KsqlObject().put("test_name", "shouldExecuteQueryWithProperties")));
     assertThat(row.getKsqlObject("STRUCT"), is(new KsqlObject().put("F1", 4)));
-    assertThat(row.getKsqlObject("COMPLEX"), is(COMPLEX_FIELD_VALUE));
+    assertThat(row.getKsqlObject("COMPLEX"), is(EXPECTED_COMPLEX_FIELD_VALUE));
   }
 
   private Client createClient() {

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
@@ -130,9 +130,9 @@ public class ClientIntegrationTest {
       .put("STRUCT", new KsqlObject().put("F1", "foo").put("F2", 3))
       .put("ARRAY_ARRAY", new KsqlArray().add(new KsqlArray().add("bar")))
       .put("ARRAY_STRUCT", new KsqlArray().add(new KsqlObject().put("F1", "x")))
-//      .put("ARRAY_MAP", new KsqlArray().add(new KsqlObject().put("k", "v")))
-//      .put("MAP_ARRAY", new KsqlObject().put("k", new KsqlArray().add("e1").add("e2")))
-//      .put("MAP_MAP", new KsqlObject().put("k1", new KsqlObject().put("k2", 5)))
+      .put("ARRAY_MAP", new KsqlArray().add(new KsqlObject().put("k", 10)))
+      .put("MAP_ARRAY", new KsqlObject().put("k", new KsqlArray().add("e1").add("e2")))
+      .put("MAP_MAP", new KsqlObject().put("k1", new KsqlObject().put("k2", 5)))
       .put("MAP_STRUCT", new KsqlObject().put("k", new KsqlObject().put("F1", "baz")));
   private static final KsqlObject EXPECTED_COMPLEX_FIELD_VALUE = COMPLEX_FIELD_VALUE.copy()
       .put("DECIMAL", 1.1d); // Expect raw decimal value, whereas put(BigDecimal) serializes as string to avoid loss of precision

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/StructuredTypesDataProvider.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/StructuredTypesDataProvider.java
@@ -126,7 +126,6 @@ public class StructuredTypesDataProvider extends TestDataProvider<String> {
     return struct;
   }
 
-  // TODO: make these more interesting
   private static Struct generateComplexStruct(final int i) {
     final Struct complexStruct = new Struct(COMPLEX_FIELD_SCHEMA);
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/StructuredTypesDataProvider.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/StructuredTypesDataProvider.java
@@ -27,8 +27,13 @@ import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.SerdeOption;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 
 public class StructuredTypesDataProvider extends TestDataProvider<String> {
@@ -40,33 +45,115 @@ public class StructuredTypesDataProvider extends TestDataProvider<String> {
       .valueColumn(ColumnName.of("ARRAY"), SqlTypes.array(SqlTypes.STRING))
       .valueColumn(ColumnName.of("MAP"), SqlTypes.map(SqlTypes.STRING))
       .valueColumn(ColumnName.of("STRUCT"), SqlTypes.struct().field("F1", SqlTypes.INTEGER).build())
+      .valueColumn(ColumnName.of("COMPLEX"), SqlTypes.struct()
+          .field("DECIMAL", SqlTypes.decimal(2, 1))
+          .field("STRUCT", SqlTypes.struct()
+              .field("F1", SqlTypes.STRING)
+              .field("F2", SqlTypes.INTEGER)
+              .build())
+          .field("ARRAY_ARRAY", SqlTypes.array(SqlTypes.array(SqlTypes.STRING)))
+          .field("ARRAY_STRUCT", SqlTypes.array(SqlTypes.struct().field("F1", SqlTypes.STRING).build()))
+          .field("ARRAY_MAP", SqlTypes.array(SqlTypes.map(SqlTypes.BIGINT)))
+          .field("MAP_ARRAY", SqlTypes.map(SqlTypes.array(SqlTypes.STRING)))
+          .field("MAP_MAP", SqlTypes.map(SqlTypes.map(SqlTypes.INTEGER)))
+          .field("MAP_STRUCT", SqlTypes.map(SqlTypes.struct().field("F1", SqlTypes.STRING).build()))
+          .build()
+      )
       .build();
 
   private static final PhysicalSchema PHYSICAL_SCHEMA = PhysicalSchema
       .from(LOGICAL_SCHEMA, SerdeOption.none());
 
+  private static final Schema STRUCT_FIELD_SCHEMA = LOGICAL_SCHEMA.valueConnectSchema().field("STRUCT").schema();
+  private static final Schema COMPLEX_FIELD_SCHEMA = LOGICAL_SCHEMA.valueConnectSchema().field("COMPLEX").schema();
+
   private static final Multimap<String, GenericRow> ROWS = ImmutableListMultimap
       .<String, GenericRow>builder()
-      .put("FOO", genericRow(1L, new BigDecimal("1.11"), Collections.singletonList("a"), Collections.singletonMap("k1", "v1"), generateStruct(2)))
-      .put("BAR", genericRow(2L, new BigDecimal("2.22"), Collections.emptyList(), Collections.emptyMap(), generateStruct(3)))
-      .put("BAZ", genericRow(3L, new BigDecimal("30.33"), Collections.singletonList("b"), Collections.emptyMap(), generateStruct(null)))
-      .put("BUZZ", genericRow(4L, new BigDecimal("40.44"), ImmutableList.of("c", "d"), Collections.emptyMap(), generateStruct(88)))
+      .put("FOO", genericRow(1L, new BigDecimal("1.11"), Collections.singletonList("a"), Collections.singletonMap("k1", "v1"), generateStruct(2), generateComplexStruct(0)))
+      .put("BAR", genericRow(2L, new BigDecimal("2.22"), Collections.emptyList(), Collections.emptyMap(), generateStruct(3), generateComplexStruct(1)))
+      .put("BAZ", genericRow(3L, new BigDecimal("30.33"), Collections.singletonList("b"), Collections.emptyMap(), generateStruct(null), generateComplexStruct(2)))
+      .put("BUZZ", genericRow(4L, new BigDecimal("40.44"), ImmutableList.of("c", "d"), Collections.emptyMap(), generateStruct(88), generateComplexStruct(3)))
       // Additional entries for repeated keys
-      .put("BAZ", genericRow(5L, new BigDecimal("12"), ImmutableList.of("e"), ImmutableMap.of("k1", "v1", "k2", "v2"), generateStruct(0)))
-      .put("BUZZ", genericRow(6L, new BigDecimal("10.1"), ImmutableList.of("f", "g"), Collections.emptyMap(), generateStruct(null)))
+      .put("BAZ", genericRow(5L, new BigDecimal("12"), ImmutableList.of("e"), ImmutableMap.of("k1", "v1", "k2", "v2"), generateStruct(0), generateComplexStruct(4)))
+      .put("BUZZ", genericRow(6L, new BigDecimal("10.1"), ImmutableList.of("f", "g"), Collections.emptyMap(), generateStruct(null), generateComplexStruct(5)))
       .build();
 
   public StructuredTypesDataProvider() {
     super("STRUCTURED_TYPES", PHYSICAL_SCHEMA, ROWS);
   }
 
-  public static Map<String, Integer> structToMap(final Struct struct) {
-    return Collections.singletonMap("F1", struct.getInt32("F1"));
+  @SuppressWarnings("unchecked")
+  public static Map<String, Object> structToMap(final Struct struct) {
+    return (Map<String, Object>) structToMapHelper(struct);
+  }
+
+  private static Object structToMapHelper(final Object value) {
+    if (value instanceof Struct) {
+      final Struct struct = (Struct) value;
+
+      final Map<String, Object> result = new HashMap<>();
+      for (final Field field : struct.schema().fields()) {
+        result.put(field.name(), structToMapHelper(struct.get(field)));
+      }
+
+      return result;
+    } else if (value instanceof List) {
+      final List<?> list = (List<?>) value;
+
+      final List<Object> result = new ArrayList<>();
+      for (final Object o : list) {
+        result.add(structToMapHelper(o));
+      }
+
+      return result;
+    } else if (value instanceof Map) {
+      final Map<?, ?> map = (Map<?, ?>) value;
+
+      final Map<String, Object> result = new HashMap<>();
+      for (final Map.Entry<?, ?> entry : map.entrySet()) {
+        result.put(entry.getKey().toString(), structToMapHelper(entry.getValue()));
+      }
+
+      return result;
+    } else {
+      return value;
+    }
   }
 
   private static Struct generateStruct(final Integer value) {
-    final Struct struct = new Struct(LOGICAL_SCHEMA.valueConnectSchema().field("STRUCT").schema());
+    final Struct struct = new Struct(STRUCT_FIELD_SCHEMA);
     struct.put("F1", value);
     return struct;
+  }
+
+  // TODO: make these more interesting
+  private static Struct generateComplexStruct(final int i) {
+    final Struct complexStruct = new Struct(COMPLEX_FIELD_SCHEMA);
+
+    complexStruct.put("DECIMAL", new BigDecimal(i));
+
+    final Struct struct = new Struct(COMPLEX_FIELD_SCHEMA.field("STRUCT").schema());
+    struct.put("F1", "v" + i);
+    struct.put("F2", i);
+    complexStruct.put("STRUCT", struct);
+
+    complexStruct.put("ARRAY_ARRAY", ImmutableList.of(ImmutableList.of("foo")));
+
+    final Struct arrayStruct = new Struct(COMPLEX_FIELD_SCHEMA.field("ARRAY_STRUCT").schema().valueSchema());
+    arrayStruct.put("F1", "v" + i);
+    complexStruct.put("ARRAY_STRUCT", ImmutableList.of(arrayStruct));
+
+    // TODO: figure out what's wrong
+//    complexStruct.put("ARRAY_MAP", ImmutableList.of(ImmutableMap.of("k1", i)));
+
+    complexStruct.put("MAP_ARRAY", ImmutableMap.of("k", ImmutableList.of("v" + i)));
+
+    complexStruct.put("MAP_MAP", ImmutableMap.of("k", ImmutableMap.of("k", i)));
+
+    final Struct mapStruct = new Struct(COMPLEX_FIELD_SCHEMA.field("MAP_STRUCT").schema().valueSchema());
+    mapStruct.put("F1", "v" + i);
+    complexStruct.put("MAP_STRUCT", ImmutableMap.of("k", mapStruct));
+
+    return complexStruct;
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/StructuredTypesDataProvider.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/StructuredTypesDataProvider.java
@@ -53,9 +53,9 @@ public class StructuredTypesDataProvider extends TestDataProvider<String> {
               .build())
           .field("ARRAY_ARRAY", SqlTypes.array(SqlTypes.array(SqlTypes.STRING)))
           .field("ARRAY_STRUCT", SqlTypes.array(SqlTypes.struct().field("F1", SqlTypes.STRING).build()))
-//          .field("ARRAY_MAP", SqlTypes.array(SqlTypes.map(SqlTypes.BIGINT)))
-//          .field("MAP_ARRAY", SqlTypes.map(SqlTypes.array(SqlTypes.STRING)))
-//          .field("MAP_MAP", SqlTypes.map(SqlTypes.map(SqlTypes.INTEGER)))
+          .field("ARRAY_MAP", SqlTypes.array(SqlTypes.map(SqlTypes.INTEGER)))
+          .field("MAP_ARRAY", SqlTypes.map(SqlTypes.array(SqlTypes.STRING)))
+          .field("MAP_MAP", SqlTypes.map(SqlTypes.map(SqlTypes.INTEGER)))
           .field("MAP_STRUCT", SqlTypes.map(SqlTypes.struct().field("F1", SqlTypes.STRING).build()))
           .build()
       )
@@ -143,13 +143,12 @@ public class StructuredTypesDataProvider extends TestDataProvider<String> {
     arrayStruct.put("F1", "v" + i);
     complexStruct.put("ARRAY_STRUCT", ImmutableList.of(arrayStruct));
 
-    // TODO: figure out what's wrong
-//    complexStruct.put("ARRAY_MAP", ImmutableList.of(ImmutableMap.of("k1", i)));
+    complexStruct.put("ARRAY_MAP", ImmutableList.of(ImmutableMap.of("k1", i)));
 
-//    complexStruct.put("MAP_ARRAY", ImmutableMap.of("k", ImmutableList.of("v" + i)));
-//
-//    complexStruct.put("MAP_MAP", ImmutableMap.of("k", ImmutableMap.of("k", i)));
-//
+    complexStruct.put("MAP_ARRAY", ImmutableMap.of("k", ImmutableList.of("v" + i)));
+
+    complexStruct.put("MAP_MAP", ImmutableMap.of("k", ImmutableMap.of("k", i)));
+
     final Struct mapStruct = new Struct(COMPLEX_FIELD_SCHEMA.field("MAP_STRUCT").schema().valueSchema());
     mapStruct.put("F1", "v" + i);
     complexStruct.put("MAP_STRUCT", ImmutableMap.of("k", mapStruct));

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/StructuredTypesDataProvider.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/StructuredTypesDataProvider.java
@@ -52,11 +52,11 @@ public class StructuredTypesDataProvider extends TestDataProvider<String> {
               .field("F2", SqlTypes.INTEGER)
               .build())
           .field("ARRAY_ARRAY", SqlTypes.array(SqlTypes.array(SqlTypes.STRING)))
-          .field("ARRAY_STRUCT", SqlTypes.array(SqlTypes.struct().field("F1", SqlTypes.STRING).build()))
-          .field("ARRAY_MAP", SqlTypes.array(SqlTypes.map(SqlTypes.BIGINT)))
-          .field("MAP_ARRAY", SqlTypes.map(SqlTypes.array(SqlTypes.STRING)))
-          .field("MAP_MAP", SqlTypes.map(SqlTypes.map(SqlTypes.INTEGER)))
-          .field("MAP_STRUCT", SqlTypes.map(SqlTypes.struct().field("F1", SqlTypes.STRING).build()))
+//          .field("ARRAY_STRUCT", SqlTypes.array(SqlTypes.struct().field("F1", SqlTypes.STRING).build()))
+//          .field("ARRAY_MAP", SqlTypes.array(SqlTypes.map(SqlTypes.BIGINT)))
+//          .field("MAP_ARRAY", SqlTypes.map(SqlTypes.array(SqlTypes.STRING)))
+//          .field("MAP_MAP", SqlTypes.map(SqlTypes.map(SqlTypes.INTEGER)))
+//          .field("MAP_STRUCT", SqlTypes.map(SqlTypes.struct().field("F1", SqlTypes.STRING).build()))
           .build()
       )
       .build();
@@ -139,20 +139,20 @@ public class StructuredTypesDataProvider extends TestDataProvider<String> {
 
     complexStruct.put("ARRAY_ARRAY", ImmutableList.of(ImmutableList.of("foo")));
 
-    final Struct arrayStruct = new Struct(COMPLEX_FIELD_SCHEMA.field("ARRAY_STRUCT").schema().valueSchema());
-    arrayStruct.put("F1", "v" + i);
-    complexStruct.put("ARRAY_STRUCT", ImmutableList.of(arrayStruct));
+//    final Struct arrayStruct = new Struct(COMPLEX_FIELD_SCHEMA.field("ARRAY_STRUCT").schema().valueSchema());
+//    arrayStruct.put("F1", "v" + i);
+//    complexStruct.put("ARRAY_STRUCT", ImmutableList.of(arrayStruct));
 
     // TODO: figure out what's wrong
 //    complexStruct.put("ARRAY_MAP", ImmutableList.of(ImmutableMap.of("k1", i)));
 
-    complexStruct.put("MAP_ARRAY", ImmutableMap.of("k", ImmutableList.of("v" + i)));
-
-    complexStruct.put("MAP_MAP", ImmutableMap.of("k", ImmutableMap.of("k", i)));
-
-    final Struct mapStruct = new Struct(COMPLEX_FIELD_SCHEMA.field("MAP_STRUCT").schema().valueSchema());
-    mapStruct.put("F1", "v" + i);
-    complexStruct.put("MAP_STRUCT", ImmutableMap.of("k", mapStruct));
+//    complexStruct.put("MAP_ARRAY", ImmutableMap.of("k", ImmutableList.of("v" + i)));
+//
+//    complexStruct.put("MAP_MAP", ImmutableMap.of("k", ImmutableMap.of("k", i)));
+//
+//    final Struct mapStruct = new Struct(COMPLEX_FIELD_SCHEMA.field("MAP_STRUCT").schema().valueSchema());
+//    mapStruct.put("F1", "v" + i);
+//    complexStruct.put("MAP_STRUCT", ImmutableMap.of("k", mapStruct));
 
     return complexStruct;
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/StructuredTypesDataProvider.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/StructuredTypesDataProvider.java
@@ -52,11 +52,11 @@ public class StructuredTypesDataProvider extends TestDataProvider<String> {
               .field("F2", SqlTypes.INTEGER)
               .build())
           .field("ARRAY_ARRAY", SqlTypes.array(SqlTypes.array(SqlTypes.STRING)))
-//          .field("ARRAY_STRUCT", SqlTypes.array(SqlTypes.struct().field("F1", SqlTypes.STRING).build()))
+          .field("ARRAY_STRUCT", SqlTypes.array(SqlTypes.struct().field("F1", SqlTypes.STRING).build()))
 //          .field("ARRAY_MAP", SqlTypes.array(SqlTypes.map(SqlTypes.BIGINT)))
 //          .field("MAP_ARRAY", SqlTypes.map(SqlTypes.array(SqlTypes.STRING)))
 //          .field("MAP_MAP", SqlTypes.map(SqlTypes.map(SqlTypes.INTEGER)))
-//          .field("MAP_STRUCT", SqlTypes.map(SqlTypes.struct().field("F1", SqlTypes.STRING).build()))
+          .field("MAP_STRUCT", SqlTypes.map(SqlTypes.struct().field("F1", SqlTypes.STRING).build()))
           .build()
       )
       .build();
@@ -139,9 +139,9 @@ public class StructuredTypesDataProvider extends TestDataProvider<String> {
 
     complexStruct.put("ARRAY_ARRAY", ImmutableList.of(ImmutableList.of("foo")));
 
-//    final Struct arrayStruct = new Struct(COMPLEX_FIELD_SCHEMA.field("ARRAY_STRUCT").schema().valueSchema());
-//    arrayStruct.put("F1", "v" + i);
-//    complexStruct.put("ARRAY_STRUCT", ImmutableList.of(arrayStruct));
+    final Struct arrayStruct = new Struct(COMPLEX_FIELD_SCHEMA.field("ARRAY_STRUCT").schema().valueSchema());
+    arrayStruct.put("F1", "v" + i);
+    complexStruct.put("ARRAY_STRUCT", ImmutableList.of(arrayStruct));
 
     // TODO: figure out what's wrong
 //    complexStruct.put("ARRAY_MAP", ImmutableList.of(ImmutableMap.of("k1", i)));
@@ -150,9 +150,9 @@ public class StructuredTypesDataProvider extends TestDataProvider<String> {
 //
 //    complexStruct.put("MAP_MAP", ImmutableMap.of("k", ImmutableMap.of("k", i)));
 //
-//    final Struct mapStruct = new Struct(COMPLEX_FIELD_SCHEMA.field("MAP_STRUCT").schema().valueSchema());
-//    mapStruct.put("F1", "v" + i);
-//    complexStruct.put("MAP_STRUCT", ImmutableMap.of("k", mapStruct));
+    final Struct mapStruct = new Struct(COMPLEX_FIELD_SCHEMA.field("MAP_STRUCT").schema().valueSchema());
+    mapStruct.put("F1", "v" + i);
+    complexStruct.put("MAP_STRUCT", ImmutableMap.of("k", mapStruct));
 
     return complexStruct;
   }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercer.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercer.java
@@ -238,6 +238,8 @@ public enum DefaultSqlValueCoercer implements SqlValueCoercer {
     private final Map<String, Object> map;
 
     JsonStructObject(final JsonObject obj) {
+      // Coercion of JsonObject fields is case-insensitive, as this code path does not go through
+      // the parser (which handles case sensitivity automatically for Connect Structs)
       this.map = ParserUtil.convertMapKeyCase(obj.getMap());
     }
 

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercer.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercer.java
@@ -125,9 +125,9 @@ public enum DefaultSqlValueCoercer implements SqlValueCoercer {
   private Result coerceStruct(final Object value, final SqlStruct targetType) {
     final StructObject struct;
     if (value instanceof Struct) {
-      struct = new ConnectStructObject((Struct) value);
+      struct = ConnectStructObject.of((Struct) value);
     } else if (value instanceof JsonObject) {
-      struct = new JsonStructObject((JsonObject) value);
+      struct = JsonStructObject.of((JsonObject) value);
     } else {
       return Result.failure();
     }
@@ -165,9 +165,9 @@ public enum DefaultSqlValueCoercer implements SqlValueCoercer {
   private Result coerceArray(final Object value, final SqlArray targetType) {
     final ListObject list;
     if (value instanceof List<?>) {
-      list = new JavaListObject((List<?>) value);
+      list = JavaListObject.of((List<?>) value);
     } else if (value instanceof JsonArray) {
-      list = new JsonListObject((JsonArray) value);
+      list = JsonListObject.of((JsonArray) value);
     } else {
       return Result.failure();
     }
@@ -188,9 +188,9 @@ public enum DefaultSqlValueCoercer implements SqlValueCoercer {
   private Result coerceMap(final Object value, final SqlMap targetType) {
     final MapObject map;
     if (value instanceof Map<?, ?>) {
-      map = new JavaMapObject((Map<?, ?>) value);
+      map = JavaMapObject.of((Map<?, ?>) value);
     } else if (value instanceof JsonObject) {
-      map = new JsonMapObject((JsonObject) value);
+      map = JsonMapObject.of((JsonObject) value);
     } else {
       return Result.failure();
     }
@@ -215,11 +215,11 @@ public enum DefaultSqlValueCoercer implements SqlValueCoercer {
     Object get(int index);
   }
 
-  private static class JavaListObject implements ListObject {
+  private static final class JavaListObject implements ListObject {
 
     private final List<?> list;
 
-    JavaListObject(final List<?> list) {
+    private JavaListObject(final List<?> list) {
       this.list = list;
     }
 
@@ -232,13 +232,17 @@ public enum DefaultSqlValueCoercer implements SqlValueCoercer {
     public Object get(final int index) {
       return list.get(index);
     }
+
+    static JavaListObject of(final List<?> list) {
+      return new JavaListObject(list);
+    }
   }
 
-  private static class JsonListObject implements ListObject {
+  private static final class JsonListObject implements ListObject {
 
     private final JsonArray array;
 
-    JsonListObject(final JsonArray array) {
+    private JsonListObject(final JsonArray array) {
       this.array = array;
     }
 
@@ -251,6 +255,10 @@ public enum DefaultSqlValueCoercer implements SqlValueCoercer {
     public Object get(final int index) {
       return array.getValue(index);
     }
+
+    static JsonListObject of(final JsonArray array) {
+      return new JsonListObject(array);
+    }
   }
 
   private interface MapObject {
@@ -259,11 +267,11 @@ public enum DefaultSqlValueCoercer implements SqlValueCoercer {
     Object get(Object key);
   }
 
-  private static class JavaMapObject implements MapObject {
+  private static final class JavaMapObject implements MapObject {
 
     private final Map<?, ?> map;
 
-    JavaMapObject(final Map<?, ?> map) {
+    private JavaMapObject(final Map<?, ?> map) {
       this.map = map;
     }
 
@@ -276,13 +284,17 @@ public enum DefaultSqlValueCoercer implements SqlValueCoercer {
     public Object get(final Object key) {
       return map.get(key);
     }
+
+    static JavaMapObject of(final Map<?, ?> map) {
+      return new JavaMapObject(map);
+    }
   }
 
-  private static class JsonMapObject implements MapObject {
+  private static final class JsonMapObject implements MapObject {
 
     private final JsonObject obj;
 
-    JsonMapObject(final JsonObject obj) {
+    private JsonMapObject(final JsonObject obj) {
       this.obj = obj;
     }
 
@@ -295,6 +307,10 @@ public enum DefaultSqlValueCoercer implements SqlValueCoercer {
     public Object get(final Object key) {
       return obj.getValue(key.toString());
     }
+
+    static JsonMapObject of(final JsonObject obj) {
+      return new JsonMapObject(obj);
+    }
   }
 
   private interface StructObject {
@@ -303,11 +319,11 @@ public enum DefaultSqlValueCoercer implements SqlValueCoercer {
     Object get(Field field);
   }
 
-  private static class ConnectStructObject implements StructObject {
+  private static final class ConnectStructObject implements StructObject {
 
     private final Struct struct;
 
-    ConnectStructObject(final Struct struct) {
+    private ConnectStructObject(final Struct struct) {
       this.struct = struct;
     }
 
@@ -320,13 +336,17 @@ public enum DefaultSqlValueCoercer implements SqlValueCoercer {
     public Object get(final Field field) {
       return struct.get(field);
     }
+
+    static ConnectStructObject of(final Struct struct) {
+      return new ConnectStructObject(struct);
+    }
   }
 
-  private static class JsonStructObject implements StructObject {
+  private static final class JsonStructObject implements StructObject {
 
     private final JsonObject obj;
 
-    JsonStructObject(final JsonObject obj) {
+    private JsonStructObject(final JsonObject obj) {
       // Coercion of JsonObject fields is case-insensitive, as this code path does not go through
       // the parser (which handles case sensitivity automatically for Connect Structs)
       this.obj = ParserUtil.convertJsonFieldCase(obj);
@@ -340,6 +360,10 @@ public enum DefaultSqlValueCoercer implements SqlValueCoercer {
     @Override
     public Object get(final Field field) {
       return obj.getValue(field.name());
+    }
+
+    static JsonStructObject of(final JsonObject obj) {
+      return new JsonStructObject(obj);
     }
   }
 }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercer.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercer.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.schema.ksql;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.schema.ksql.types.SqlArray;
 import io.confluent.ksql.schema.ksql.types.SqlBaseType;
@@ -61,8 +62,13 @@ public enum DefaultSqlValueCoercer implements SqlValueCoercer {
 
   private final boolean allowCastStringAndDoubleToDecimal;
 
-  private DefaultSqlValueCoercer(final boolean allowCastStringAndDoubleToDecimal) {
+  DefaultSqlValueCoercer(final boolean allowCastStringAndDoubleToDecimal) {
     this.allowCastStringAndDoubleToDecimal = allowCastStringAndDoubleToDecimal;
+  }
+
+  @VisibleForTesting
+  boolean isAllowCastStringAndDoubleToDecimal() {
+    return allowCastStringAndDoubleToDecimal;
   }
 
   @Override

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercer.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercer.java
@@ -235,22 +235,22 @@ public enum DefaultSqlValueCoercer implements SqlValueCoercer {
 
   private static class JsonStructObject implements StructObject {
 
-    private final Map<String, Object> map;
+    private final JsonObject obj;
 
     JsonStructObject(final JsonObject obj) {
       // Coercion of JsonObject fields is case-insensitive, as this code path does not go through
       // the parser (which handles case sensitivity automatically for Connect Structs)
-      this.map = ParserUtil.convertMapKeyCase(obj.getMap());
+      this.obj = ParserUtil.convertJsonFieldCase(obj);
     }
 
     @Override
     public boolean contains(final Field field) {
-      return map.containsKey(field.name());
+      return obj.containsKey(field.name());
     }
 
     @Override
     public Object get(final Field field) {
-      return map.get(field.name());
+      return obj.getValue(field.name());
     }
   }
 }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercer.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercer.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.schema.ksql.types.SqlStruct;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.DecimalUtil;
+import io.confluent.ksql.util.ParserUtil;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -199,10 +200,11 @@ public enum DefaultSqlValueCoercer implements SqlValueCoercer {
 
   private static class MapStructObject implements StructObject {
 
-    private final Map<?, ?> map;
+    private final Map<String, Object> map;
 
+    @SuppressWarnings("unchecked") // TODO: how to avoid?
     MapStructObject(final Map<?, ?> map) {
-      this.map = map;
+      this.map = ParserUtil.convertMapKeyCase((Map<String, Object>) map);
     }
 
     @Override

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
@@ -32,6 +32,7 @@ import io.confluent.ksql.parser.SqlBaseParser.IntegerLiteralContext;
 import io.confluent.ksql.parser.SqlBaseParser.NumberContext;
 import io.confluent.ksql.parser.SqlBaseParser.SourceNameContext;
 import io.confluent.ksql.parser.exception.ParseFailedException;
+import io.vertx.core.json.JsonObject;
 import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
@@ -191,9 +192,9 @@ public final class ParserUtil {
     return Optional.of(new NodeLocation(token.getLine(), token.getCharPositionInLine()));
   }
 
-  public static Map<String, Object> convertMapKeyCase(final Map<String, Object> map) {
+  public static JsonObject convertJsonFieldCase(final JsonObject obj) {
     final Map<String, Object> convertedMap = new HashMap<>();
-    for (Map.Entry<String, Object> entry : map.entrySet()) {
+    for (Map.Entry<String, Object> entry : obj.getMap().entrySet()) {
       final String key;
       try {
         key = ParserUtil.getIdentifierText(entry.getKey());
@@ -209,6 +210,6 @@ public final class ParserUtil {
       }
       convertedMap.put(key, entry.getValue());
     }
-    return convertedMap;
+    return new JsonObject(convertedMap);
   }
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercerTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercerTest.java
@@ -30,6 +30,8 @@ import io.confluent.ksql.schema.ksql.types.SqlBaseType;
 import io.confluent.ksql.schema.ksql.types.SqlMap;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collections;
@@ -187,6 +189,11 @@ public class DefaultSqlValueCoercerTest {
         is(Result.of(ImmutableList.of(1.1d))));
     assertThat(coercer.coerce(Collections.singletonList(null), arrayType),
         is(Result.of(Collections.singletonList(null))));
+
+    assertThat(coercer.coerce(new JsonArray().add(1), arrayType), is(Result.of(ImmutableList.of(1d))));
+    assertThat(coercer.coerce(new JsonArray().add(1L), arrayType), is(Result.of(ImmutableList.of(1d))));
+    assertThat(coercer.coerce(new JsonArray().add(1.1), arrayType), is(Result.of(ImmutableList.of(1.1d))));
+    assertThat(coercer.coerce(new JsonArray().addNull(), arrayType), is(Result.of(Collections.singletonList(null))));
   }
 
   @Test
@@ -196,6 +203,7 @@ public class DefaultSqlValueCoercerTest {
     assertThat(coercer.coerce(1L, arrayType), is(Result.failure()));
     assertThat(coercer.coerce("foo", arrayType), is(Result.failure()));
     assertThat(coercer.coerce(ImmutableMap.of("foo", 1), arrayType), is(Result.failure()));
+    assertThat(coercer.coerce(new JsonObject().put("foo", 1), arrayType), is(Result.failure()));
   }
 
   @Test
@@ -207,6 +215,11 @@ public class DefaultSqlValueCoercerTest {
         is(Result.of(ImmutableMap.of("foo", 1.1d))));
     assertThat(coercer.coerce(Collections.singletonMap("foo", null), mapType),
         is(Result.of(Collections.singletonMap("foo", null))));
+
+    assertThat(coercer.coerce(new JsonObject().put("foo", 1), mapType), is(Result.of(ImmutableMap.of("foo", 1d))));
+    assertThat(coercer.coerce(new JsonObject().put("foo", 1L), mapType), is(Result.of(ImmutableMap.of("foo", 1d))));
+    assertThat(coercer.coerce(new JsonObject().put("foo", 1.1), mapType), is(Result.of(ImmutableMap.of("foo", 1.1d))));
+    assertThat(coercer.coerce(new JsonObject().putNull("foo"), mapType), is(Result.of(Collections.singletonMap("foo", null))));
   }
 
   @Test
@@ -216,6 +229,7 @@ public class DefaultSqlValueCoercerTest {
     assertThat(coercer.coerce(1L, mapType), is(Result.failure()));
     assertThat(coercer.coerce("foo", mapType), is(Result.failure()));
     assertThat(coercer.coerce(ImmutableList.of("foo"), mapType), is(Result.failure()));
+    assertThat(coercer.coerce(new JsonArray().add("foo"), mapType), is(Result.failure()));
   }
 
   @SuppressWarnings({"unchecked", "OptionalGetWithoutIsPresent"})
@@ -270,6 +284,15 @@ public class DefaultSqlValueCoercerTest {
     final Optional<Struct> coerced = (Optional<Struct>) result.value();
     assertThat(coerced.get().get("foo"), is("val1"));
     assertThat(coerced.get().get("bar"), nullValue());
+  }
+
+  @Test
+  public void shouldNotCoerceToStruct() {
+    // Given:
+    final SqlType structType = SqlTypes.struct().field("foo", SqlTypes.STRING).build();
+
+    // When / Then:
+    assertThat(coercer.coerce(ImmutableMap.of("foo", "bar"), structType), is(Result.failure()));
   }
 
   @Test
@@ -330,6 +353,221 @@ public class DefaultSqlValueCoercerTest {
           is(Result.failure())
       ));
     }
+  }
+
+  @SuppressWarnings({"unchecked", "OptionalGetWithoutIsPresent"})
+  @Test
+  public void shouldCoerceJsonObjectToStruct() {
+    // Given:
+    final SqlType structType = SqlTypes.struct()
+        .field("FOO", SqlTypes.BIGINT)
+        .field("NULL", SqlTypes.BIGINT)
+        .build();
+
+    // When:
+    final Result result = coercer.coerce(new JsonObject().put("FOO", 12), structType);
+
+    // Then:
+    assertThat("", !result.failed());
+    final Struct coerced = ((Optional<Struct>) result.value()).get();
+    assertThat(coerced.get("FOO"), is(12L));
+    assertThat(coerced.get("NULL"), is(nullValue()));
+  }
+
+  @SuppressWarnings({"unchecked", "OptionalGetWithoutIsPresent"})
+  @Test
+  public void shouldCoerceJsonObjectToNestedStruct() {
+    // Given:
+    final SqlType structType = SqlTypes.struct()
+        .field("F1", SqlTypes.struct()
+            .field("G1", SqlTypes.BIGINT)
+            .field("NULL", SqlTypes.BIGINT)
+            .build())
+        .field("F2", SqlTypes.array(SqlTypes.STRING))
+        .field("F3", SqlTypes.map(SqlTypes.STRING))
+        .build();
+    final JsonObject obj = new JsonObject()
+        .put("F1", new JsonObject().put("G1", 12))
+        .put("F2", new JsonArray().add("v1").add("v2"))
+        .put("F3", new JsonObject().put("k1", "v1"));
+
+    // When:
+    final Result result = coercer.coerce(obj, structType);
+
+    // Then:
+    assertThat("", !result.failed());
+    final Struct coerced = ((Optional<Struct>) result.value()).get();
+
+    final Struct innerStruct = (Struct) coerced.get("F1");
+    assertThat(innerStruct.get("G1"), is(12L));
+    assertThat(innerStruct.get("NULL"), is(nullValue()));
+
+    final List<?> innerList = (List<?>) coerced.get("F2");
+    assertThat(innerList, is(ImmutableList.of("v1", "v2")));
+
+    final Map<?, ?> innerMap = (Map<?, ?>) coerced.get("F3");
+    assertThat(innerMap, is(ImmutableMap.of("k1", "v1")));
+  }
+
+  @SuppressWarnings({"unchecked", "OptionalGetWithoutIsPresent"})
+  @Test
+  public void shouldCoerceJsonObjectToNestedMap() {
+    // Given:
+    final SqlType mapType = SqlTypes.map(SqlTypes.struct()
+        .field("F1", SqlTypes.BIGINT)
+        .field("F2", SqlTypes.STRING)
+        .build());
+    final JsonObject obj = new JsonObject()
+        .put("k1", new JsonObject().put("F1", 1).put("F2", "foo"))
+        .put("k2", new JsonObject().put("F1", 2))
+        .put("k3", new JsonObject())
+        .putNull("k4");
+
+    // When:
+    final Result result = coercer.coerce(obj, mapType);
+
+    // Then:
+    assertThat("", !result.failed());
+    final Map<?, ?> coerced = ((Optional<Map<?, ?>>) result.value()).get();
+    assertThat(((Struct) coerced.get("k1")).get("F1"), is(1L));
+    assertThat(((Struct) coerced.get("k1")).get("F2"), is("foo"));
+    assertThat(((Struct) coerced.get("k2")).get("F1"), is(2L));
+    assertThat(((Struct) coerced.get("k2")).get("F2"), is(nullValue()));
+    assertThat(((Struct) coerced.get("k3")).get("F1"), is(nullValue()));
+    assertThat(((Struct) coerced.get("k3")).get("F2"), is(nullValue()));
+    assertThat(coerced.get("k4"), is(nullValue()));
+  }
+
+  @SuppressWarnings({"unchecked", "OptionalGetWithoutIsPresent"})
+  @Test
+  public void shouldCoerceJsonArrayToNestedArray() {
+    // Given:
+    final SqlType arrayType = SqlTypes.array(SqlTypes.struct()
+        .field("F1", SqlTypes.BIGINT)
+        .field("F2", SqlTypes.STRING)
+        .build());
+    final JsonArray array = new JsonArray()
+        .add(new JsonObject().put("F1", 1).put("F2", "foo"))
+        .add(new JsonObject().put("F1", 2))
+        .add(new JsonObject())
+        .addNull();
+
+    // When:
+    final Result result = coercer.coerce(array, arrayType);
+
+    // Then:
+    assertThat("", !result.failed());
+    final List<?> coerced = ((Optional<List<?>>) result.value()).get();
+    assertThat(((Struct) coerced.get(0)).get("F1"), is(1L));
+    assertThat(((Struct) coerced.get(0)).get("F2"), is("foo"));
+    assertThat(((Struct) coerced.get(1)).get("F1"), is(2L));
+    assertThat(((Struct) coerced.get(1)).get("F2"), is(nullValue()));
+    assertThat(((Struct) coerced.get(2)).get("F1"), is(nullValue()));
+    assertThat(((Struct) coerced.get(2)).get("F2"), is(nullValue()));
+    assertThat(coerced.get(3), is(nullValue()));
+  }
+
+  @SuppressWarnings({"unchecked", "OptionalGetWithoutIsPresent"})
+  @Test
+  public void shouldCoerceJsonStructToNestedDecimal() {
+    // Given:
+    final SqlType structType = SqlTypes.struct()
+        .field("INT", SqlTypes.decimal(2, 1))
+        .field("LONG", SqlTypes.decimal(2, 1))
+        .field("STRING", SqlTypes.decimal(2, 1))
+        .field("DOUBLE", SqlTypes.decimal(2, 1))
+        .build();
+    final JsonObject obj = new JsonObject()
+        .put("INT", 1)
+        .put("LONG", 1L);
+    if (coercer.isAllowCastStringAndDoubleToDecimal()) {
+      obj.put("STRING", "1.1")
+          .put("DOUBLE", 1.2);
+    }
+
+    // When:
+    final Result result = coercer.coerce(obj, structType);
+
+    // Then:
+    assertThat("", !result.failed());
+    final Struct coerced = ((Optional<Struct>) result.value()).get();
+    assertThat(coerced.get("INT"), is(new BigDecimal("1.0")));
+    assertThat(coerced.get("LONG"), is(new BigDecimal("1.0")));
+    if (coercer.isAllowCastStringAndDoubleToDecimal()) {
+      assertThat(coerced.get("STRING"), is(new BigDecimal("1.1")));
+      assertThat(coerced.get("DOUBLE"), is(new BigDecimal("1.2")));
+    }
+  }
+
+  @SuppressWarnings({"unchecked", "OptionalGetWithoutIsPresent"})
+  @Test
+  public void shouldCoerceJsonStructWithCaseInsensitiveFields() {
+    // Given:
+    final SqlType structType = SqlTypes.struct()
+        .field("FOO", SqlTypes.BIGINT)
+        .field("foo", SqlTypes.STRING)
+        .field("bar", SqlTypes.STRING)
+        .build();
+    final JsonObject obj = new JsonObject()
+        .put("foo", 12)
+        .put("`foo`", "v1")
+        .put("\"bar\"", "v2");
+
+    // When:
+    final Result result = coercer.coerce(obj, structType);
+
+    // Then:
+    assertThat("", !result.failed());
+    final Struct coerced = ((Optional<Struct>) result.value()).get();
+    assertThat(coerced.get("FOO"), is(12L));
+    assertThat(coerced.get("foo"), is("v1"));
+    assertThat(coerced.get("bar"), is("v2"));
+  }
+
+  @SuppressWarnings({"unchecked", "OptionalGetWithoutIsPresent"})
+  @Test
+  public void shouldCoerceNestedJsonStructWithCaseInsensitiveFields() {
+    // Given:
+    final SqlType structType = SqlTypes.struct().field("F1", SqlTypes.struct()
+        .field("FOO", SqlTypes.BIGINT)
+        .field("foo", SqlTypes.STRING)
+        .field("bar", SqlTypes.STRING)
+        .build()).build();
+    final JsonObject obj = new JsonObject().put("F1", new JsonObject()
+        .put("foo", 12)
+        .put("`foo`", "v1")
+        .put("\"bar\"", "v2"));
+
+    // When:
+    final Result result = coercer.coerce(obj, structType);
+
+    // Then:
+    assertThat("", !result.failed());
+    final Struct coerced = ((Optional<Struct>) result.value()).get();
+    final Struct innerStruct = ((Struct) coerced.get("F1"));
+    assertThat(innerStruct.get("FOO"), is(12L));
+    assertThat(innerStruct.get("foo"), is("v1"));
+    assertThat(innerStruct.get("bar"), is("v2"));
+  }
+
+  @SuppressWarnings({"unchecked", "OptionalGetWithoutIsPresent"})
+  @Test
+  public void shouldCoerceNestedJsonMapWithCaseSensitiveKeys() {
+    // Given:
+    final SqlType structType = SqlTypes.struct()
+        .field("F1", SqlTypes.map(SqlTypes.BIGINT))
+        .build();
+    final JsonObject obj = new JsonObject().put("F1", new JsonObject().put("foo", 12));
+
+    // When:
+    final Result result = coercer.coerce(obj, structType);
+
+    // Then:
+    assertThat("", !result.failed());
+    final Struct coerced = ((Optional<Struct>) result.value()).get();
+    final Map<?, ?> innerMap = ((Map<?, ?>) coerced.get("F1"));
+    assertThat(innerMap.get("foo"), is(12L));
+    assertThat(innerMap.get("FOO"), is(nullValue()));
   }
 
   private static boolean coercionShouldBeSupported(

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/InsertsStreamEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/InsertsStreamEndpoint.java
@@ -21,7 +21,6 @@ import static io.confluent.ksql.rest.Errors.ERROR_CODE_BAD_STATEMENT;
 import io.confluent.ksql.api.server.InsertResult;
 import io.confluent.ksql.api.server.InsertsStreamSubscriber;
 import io.confluent.ksql.api.server.KsqlApiException;
-import io.confluent.ksql.api.server.ServerUtils;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
@@ -29,6 +28,7 @@ import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.ParserUtil;
 import io.confluent.ksql.util.ReservedInternalTopics;
 import io.confluent.ksql.util.VertxUtils;
 import io.vertx.core.Context;
@@ -65,7 +65,7 @@ public class InsertsStreamEndpoint {
 
     final String target;
     try {
-      target = ServerUtils.getIdentifierText(caseInsensitiveTarget);
+      target = ParserUtil.getIdentifierText(caseInsensitiveTarget);
     } catch (IllegalArgumentException e) {
       throw new KsqlApiException(
           "Invalid target name: " + e.getMessage(), ERROR_CODE_BAD_STATEMENT);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/InsertsSubscriber.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/InsertsSubscriber.java
@@ -55,7 +55,7 @@ public final class InsertsSubscriber extends BaseSubscriber<JsonObject> implemen
 
   private static final Logger log = LoggerFactory.getLogger(InsertsSubscriber.class);
   private static final int REQUEST_BATCH_SIZE = 200;
-  private static final SqlValueCoercer SQL_VALUE_COERCER = DefaultSqlValueCoercer.INSTANCE;
+  private static final SqlValueCoercer SQL_VALUE_COERCER = DefaultSqlValueCoercer.API_INSTANCE;
 
   private final Producer<byte[], byte[]> producer;
   private final DataSource dataSource;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/KeyValueExtractor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/KeyValueExtractor.java
@@ -22,16 +22,11 @@ import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.schema.ksql.SqlValueCoercer;
-import io.confluent.ksql.schema.ksql.types.SqlDecimal;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.util.ParserUtil;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Struct;
 
@@ -85,20 +80,6 @@ public final class KeyValueExtractor {
       final SqlType sqlType,
       final SqlValueCoercer sqlValueCoercer
   ) {
-    if (sqlType instanceof SqlDecimal) {
-      // We have to handle this manually as SqlValueCoercer doesn't seem to do it
-      final SqlDecimal decType = (SqlDecimal) sqlType;
-      if (value instanceof Double) {
-        return new BigDecimal(String.valueOf(value))
-            .setScale(decType.getScale(), RoundingMode.HALF_UP);
-      } else if (value instanceof String) {
-        return new BigDecimal((String) value).setScale(decType.getScale(), RoundingMode.HALF_UP);
-      } else if (value instanceof Integer) {
-        return new BigDecimal((Integer) value).setScale(decType.getScale(), RoundingMode.HALF_UP);
-      } else if (value instanceof Long) {
-        return new BigDecimal((Long) value).setScale(decType.getScale(), RoundingMode.HALF_UP);
-      }
-    }
     return sqlValueCoercer.coerce(value, sqlType)
         .orElseThrow(() -> new KsqlApiException(
             String.format("Can't coerce a field of type %s (%s) into type %s", value.getClass(),

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/KeyValueExtractor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/KeyValueExtractor.java
@@ -68,8 +68,7 @@ public final class KeyValueExtractor {
 
   static JsonObject convertColumnNameCase(final JsonObject jsonObjectWithCaseInsensitiveFields) {
     try {
-      return new JsonObject(
-          ParserUtil.convertMapKeyCase(jsonObjectWithCaseInsensitiveFields.getMap()));
+      return ParserUtil.convertJsonFieldCase(jsonObjectWithCaseInsensitiveFields);
     } catch (IllegalArgumentException e) {
       throw new KsqlApiException(e.getMessage(), Errors.ERROR_CODE_BAD_REQUEST);
     }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/KeyValueExtractor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/KeyValueExtractor.java
@@ -99,19 +99,10 @@ public final class KeyValueExtractor {
         return new BigDecimal((Long) value).setScale(decType.getScale(), RoundingMode.HALF_UP);
       }
     }
-    final Object rawValue;
-    if (value instanceof JsonArray) {
-      rawValue = ((JsonArray) value).getList();
-    } else if (value instanceof JsonObject) {
-      rawValue = ((JsonObject) value).getMap();
-    } else {
-      rawValue = value;
-    }
-    return sqlValueCoercer.coerce(rawValue, sqlType)
-
+    return sqlValueCoercer.coerce(value, sqlType)
         .orElseThrow(() -> new KsqlApiException(
-            String.format("Can't coerce a field of type %s (%s) into type %s", rawValue.getClass(),
-                rawValue, sqlType),
+            String.format("Can't coerce a field of type %s (%s) into type %s", value.getClass(),
+                value, sqlType),
             Errors.ERROR_CODE_BAD_REQUEST))
         .orElse(null);
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerUtils.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerUtils.java
@@ -97,20 +97,6 @@ public final class ServerUtils {
     return out.toString();
   }
 
-  // See ParserUtil#getIdentifierText()
-  public static String getIdentifierText(final String text) {
-    if (text.isEmpty()) {
-      return "";
-    }
-
-    final char firstChar = text.charAt(0);
-    if (firstChar == '`' || firstChar == '"') {
-      return unquote(text, firstChar);
-    }
-
-    return text.toUpperCase();
-  }
-
   public static boolean checkHttp2(final RoutingContext routingContext) {
     if (routingContext.request().version() != HttpVersion.HTTP_2) {
       routingContext.fail(BAD_REQUEST.code(),
@@ -144,29 +130,5 @@ public final class ServerUtils {
             + " Please consult the server logs for more information.",
         ERROR_CODE_SERVER_ERROR));
     return null;
-  }
-
-  private static String unquote(final String value, final char quote) {
-    if (value.charAt(0) != quote) {
-      throw new IllegalStateException("Value must begin with quote");
-    }
-    if (value.charAt(value.length() - 1) != quote || value.length() < 2) {
-      throw new IllegalArgumentException("Expected matching quote at end of value");
-    }
-
-    int i = 1;
-    while (i < value.length() - 1) {
-      if (value.charAt(i) == quote) {
-        if (value.charAt(i + 1) != quote || i + 1 == value.length() - 1) {
-          throw new IllegalArgumentException("Un-escaped quote in middle of value at index " + i);
-        }
-        i += 2;
-      } else {
-        i++;
-      }
-    }
-
-    return value.substring(1, value.length() - 1)
-        .replace("" + quote + quote, "" + quote);
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
@@ -152,9 +152,9 @@ public class ApiIntegrationTest {
     // Then:
     assertThat(response.rows, hasSize(2));
     assertThat(response.responseObject.getJsonArray("columnNames"), is(
-        new JsonArray().add("STR").add("LONG").add("DEC").add("ARRAY").add("MAP")));
+        new JsonArray().add("STR").add("LONG").add("DEC").add("ARRAY").add("MAP").add("STRUCT")));
     assertThat(response.responseObject.getJsonArray("columnTypes"), is(
-        new JsonArray().add("STRING").add("BIGINT").add("DECIMAL(4, 2)").add("ARRAY<STRING>").add("MAP<STRING, STRING>")));
+        new JsonArray().add("STRING").add("BIGINT").add("DECIMAL(4, 2)").add("ARRAY<STRING>").add("MAP<STRING, STRING>").add("STRUCT<`F1` INTEGER>")));
     assertThat(response.responseObject.getString("queryId"), is(notNullValue()));
   }
 
@@ -333,7 +333,8 @@ public class ApiIntegrationTest {
           .put("LONG", 1000 + i)
           .put("DEC", i + 0.11) // JsonObject does not accept BigDecimal
           .put("ARRAY", new JsonArray().add("a_" + i).add("b_" + i))
-          .put("MAP", new JsonObject().put("k1", "v1_" + i).put("k2", "v2_" + i));
+          .put("MAP", new JsonObject().put("k1", "v1_" + i).put("k2", "v2_" + i))
+          .put("STRUCT", new JsonObject().put("F1", i));
       bodyBuffer.appendBuffer(row.toBuffer()).appendString("\n");
     }
 
@@ -365,7 +366,8 @@ public class ApiIntegrationTest {
         .put("LONG", 1000)
         .put("DEC", 12.21) // JsonObject does not accept BigDecimal
         .put("ARRAY", new JsonArray().add("a").add("b"))
-        .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"));
+        .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"))
+        .put("STRUCT", new JsonObject().put("F1", 3));
 
     // Then:
     shouldFailToInsert(row, ERROR_CODE_BAD_REQUEST,
@@ -381,7 +383,8 @@ public class ApiIntegrationTest {
         .put("LONG", 1000)
         .put("DEC", 12.21) // JsonObject does not accept BigDecimal
         .put("ARRAY", new JsonArray().add("a").add("b"))
-        .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"));
+        .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"))
+        .put("STRUCT", new JsonObject().put("F1", 3));
 
     // Then:
     shouldFailToInsert(row, ERROR_CODE_BAD_REQUEST,
@@ -397,7 +400,8 @@ public class ApiIntegrationTest {
         .put("LONG", "not a number")
         .put("DEC", 12.21) // JsonObject does not accept BigDecimal
         .put("ARRAY", new JsonArray().add("a").add("b"))
-        .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"));
+        .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"))
+        .put("STRUCT", new JsonObject().put("F1", 3));
 
     // Then:
     shouldFailToInsert(row, ERROR_CODE_BAD_REQUEST,
@@ -412,7 +416,8 @@ public class ApiIntegrationTest {
         .put("STR", "HELLO")
         .put("DEC", 12.21) // JsonObject does not accept BigDecimal
         .put("ARRAY", new JsonArray().add("a").add("b"))
-        .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"));
+        .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"))
+        .put("STRUCT", new JsonObject().put("F1", 3));
 
     // Then:
     shouldInsert(row);
@@ -427,7 +432,8 @@ public class ApiIntegrationTest {
         .put("str", "HELLO")
         .put("dec", 12.21) // JsonObject does not accept BigDecimal
         .put("array", new JsonArray().add("a").add("b"))
-        .put("map", new JsonObject().put("k1", "v1").put("k2", "v2"));
+        .put("map", new JsonObject().put("k1", "v1").put("k2", "v2"))
+        .put("struct", new JsonObject().put("f1", 3));
 
     // Then:
     shouldInsert(target, row);
@@ -442,7 +448,8 @@ public class ApiIntegrationTest {
         .put("LONG", 1000L)
         .put("DEC", 12.21) // JsonObject does not accept BigDecimal
         .put("ARRAY", new JsonArray().add("a").add("b"))
-        .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"));
+        .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"))
+        .put("STRUCT", new JsonObject().put("F1", 3));
 
     // Then: request fails because stream name is invalid
     shouldRejectInsertRequest(target, row, "Cannot insert values into an unknown stream: " + target);
@@ -457,7 +464,8 @@ public class ApiIntegrationTest {
         .put("LONG", 1000L)
         .put("DEC", 12.21) // JsonObject does not accept BigDecimal
         .put("ARRAY", new JsonArray().add("a").add("b"))
-        .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"));
+        .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"))
+        .put("STRUCT", new JsonObject().put("F1", 3));
 
     // Then: request fails because stream name is invalid
     shouldRejectInsertRequest(target, row, "Cannot insert values into an unknown stream: `" + TEST_STREAM.toLowerCase() + "`");
@@ -471,7 +479,8 @@ public class ApiIntegrationTest {
         .put("LONG", 1000L)
         .put("DEC", 12.21) // JsonObject does not accept BigDecimal
         .put("ARRAY", new JsonArray().add("a").add("b"))
-        .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"));
+        .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"))
+        .put("STRUCT", new JsonObject().put("F1", 3));
 
     // Then: request fails because column name is incorrect
     shouldFailToInsert(row, ERROR_CODE_BAD_REQUEST, "Key field must be specified: STR");
@@ -485,7 +494,8 @@ public class ApiIntegrationTest {
         .put("LONG", 1000L)
         .put("DEC", 12.21) // JsonObject does not accept BigDecimal
         .put("ARRAY", new JsonArray().add("a").add("b"))
-        .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"));
+        .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"))
+        .put("STRUCT", new JsonObject().put("F1", 3));
 
     // Then: request fails because column name is incorrect
     shouldFailToInsert(row, ERROR_CODE_BAD_REQUEST, "Key field must be specified: STR");
@@ -521,7 +531,8 @@ public class ApiIntegrationTest {
         .put("LONG", 2000L)
         .put("DEC", 12.34) // JsonObject does not accept BigDecimal
         .put("ARRAY", new JsonArray().add("a_shouldExecutePushQueryFromLatestOffset"))
-        .put("MAP", new JsonObject().put("k1", "v1_shouldExecutePushQueryFromLatestOffset"));
+        .put("MAP", new JsonObject().put("k1", "v1_shouldExecutePushQueryFromLatestOffset"))
+        .put("STRUCT", new JsonObject().put("F1", 3));
 
     // Insert a new row and wait for it to arrive
     assertThatEventually(() -> {
@@ -543,6 +554,7 @@ public class ApiIntegrationTest {
     assertThat(queryResponse.rows.get(0).getDouble(2), is(12.34));
     assertThat(queryResponse.rows.get(0).getJsonArray(3), is(new JsonArray().add("a_shouldExecutePushQueryFromLatestOffset")));
     assertThat(queryResponse.rows.get(0).getJsonObject(4), is(new JsonObject().put("k1", "v1_shouldExecutePushQueryFromLatestOffset")));
+    assertThat(queryResponse.rows.get(0).getJsonObject(5), is(new JsonObject().put("F1", 3)));
 
     // Check that query is cleaned up on the server
     assertThatEventually(engine::numberOfLiveQueries, is(1));

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
@@ -80,6 +80,16 @@ public class ApiIntegrationTest {
   private static final Credentials NORMAL_USER = VALID_USER2;
   private static final String AN_AGG_KEY = "FOO";
 
+  private static final JsonObject COMPLEX_FIELD_VALUE = new JsonObject()
+      .put("DECIMAL", 1.1) // JsonObject does not accept BigDecimal
+      .put("STRUCT", new JsonObject().put("F1", "foo").put("F2", 3))
+      .put("ARRAY_ARRAY", new JsonArray().add(new JsonArray().add("bar")))
+      .put("ARRAY_STRUCT", new JsonArray().add(new JsonObject().put("F1", "x")))
+      .put("ARRAY_MAP", new JsonArray().add(new JsonObject().put("k", 10)))
+      .put("MAP_ARRAY", new JsonObject().put("k", new JsonArray().add("e1").add("e2")))
+      .put("MAP_MAP", new JsonObject().put("k1", new JsonObject().put("k2", 5)))
+      .put("MAP_STRUCT", new JsonObject().put("k", new JsonObject().put("F1", "baz")));
+
   private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.builder()
       .withKafkaCluster(
           EmbeddedSingleNodeKafkaCluster.newBuilder()
@@ -152,9 +162,13 @@ public class ApiIntegrationTest {
     // Then:
     assertThat(response.rows, hasSize(2));
     assertThat(response.responseObject.getJsonArray("columnNames"), is(
-        new JsonArray().add("STR").add("LONG").add("DEC").add("ARRAY").add("MAP").add("STRUCT")));
+        new JsonArray().add("STR").add("LONG").add("DEC").add("ARRAY").add("MAP").add("STRUCT").add("COMPLEX")));
     assertThat(response.responseObject.getJsonArray("columnTypes"), is(
-        new JsonArray().add("STRING").add("BIGINT").add("DECIMAL(4, 2)").add("ARRAY<STRING>").add("MAP<STRING, STRING>").add("STRUCT<`F1` INTEGER>")));
+        new JsonArray().add("STRING").add("BIGINT").add("DECIMAL(4, 2)").add("ARRAY<STRING>").add("MAP<STRING, STRING>").add("STRUCT<`F1` INTEGER>")
+            .add("STRUCT<`DECIMAL` DECIMAL(2, 1), `STRUCT` STRUCT<`F1` STRING, `F2` INTEGER>, "
+                + "`ARRAY_ARRAY` ARRAY<ARRAY<STRING>>, `ARRAY_STRUCT` ARRAY<STRUCT<`F1` STRING>>, "
+                + "`ARRAY_MAP` ARRAY<MAP<STRING, INTEGER>>, `MAP_ARRAY` MAP<STRING, ARRAY<STRING>>, "
+                + "`MAP_MAP` MAP<STRING, MAP<STRING, INTEGER>>, `MAP_STRUCT` MAP<STRING, STRUCT<`F1` STRING>>>")));
     assertThat(response.responseObject.getString("queryId"), is(notNullValue()));
   }
 
@@ -334,7 +348,8 @@ public class ApiIntegrationTest {
           .put("DEC", i + 0.11) // JsonObject does not accept BigDecimal
           .put("ARRAY", new JsonArray().add("a_" + i).add("b_" + i))
           .put("MAP", new JsonObject().put("k1", "v1_" + i).put("k2", "v2_" + i))
-          .put("STRUCT", new JsonObject().put("F1", i));
+          .put("STRUCT", new JsonObject().put("F1", i))
+          .put("COMPLEX", COMPLEX_FIELD_VALUE);
       bodyBuffer.appendBuffer(row.toBuffer()).appendString("\n");
     }
 
@@ -367,7 +382,8 @@ public class ApiIntegrationTest {
         .put("DEC", 12.21) // JsonObject does not accept BigDecimal
         .put("ARRAY", new JsonArray().add("a").add("b"))
         .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"))
-        .put("STRUCT", new JsonObject().put("F1", 3));
+        .put("STRUCT", new JsonObject().put("F1", 3))
+        .put("COMPLEX", COMPLEX_FIELD_VALUE);
 
     // Then:
     shouldFailToInsert(row, ERROR_CODE_BAD_REQUEST,
@@ -384,7 +400,8 @@ public class ApiIntegrationTest {
         .put("DEC", 12.21) // JsonObject does not accept BigDecimal
         .put("ARRAY", new JsonArray().add("a").add("b"))
         .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"))
-        .put("STRUCT", new JsonObject().put("F1", 3));
+        .put("STRUCT", new JsonObject().put("F1", 3))
+        .put("COMPLEX", COMPLEX_FIELD_VALUE);
 
     // Then:
     shouldFailToInsert(row, ERROR_CODE_BAD_REQUEST,
@@ -401,7 +418,8 @@ public class ApiIntegrationTest {
         .put("DEC", 12.21) // JsonObject does not accept BigDecimal
         .put("ARRAY", new JsonArray().add("a").add("b"))
         .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"))
-        .put("STRUCT", new JsonObject().put("F1", 3));
+        .put("STRUCT", new JsonObject().put("F1", 3))
+        .put("COMPLEX", COMPLEX_FIELD_VALUE);
 
     // Then:
     shouldFailToInsert(row, ERROR_CODE_BAD_REQUEST,
@@ -417,7 +435,8 @@ public class ApiIntegrationTest {
         .put("DEC", 12.21) // JsonObject does not accept BigDecimal
         .put("ARRAY", new JsonArray().add("a").add("b"))
         .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"))
-        .put("STRUCT", new JsonObject().put("F1", 3));
+        .put("STRUCT", new JsonObject().put("F1", 3))
+        .put("COMPLEX", COMPLEX_FIELD_VALUE);
 
     // Then:
     shouldInsert(row);
@@ -433,7 +452,8 @@ public class ApiIntegrationTest {
         .put("dec", 12.21) // JsonObject does not accept BigDecimal
         .put("array", new JsonArray().add("a").add("b"))
         .put("map", new JsonObject().put("k1", "v1").put("k2", "v2"))
-        .put("struct", new JsonObject().put("f1", 3));
+        .put("struct", new JsonObject().put("f1", 3))
+        .put("COMPLEX", COMPLEX_FIELD_VALUE);
 
     // Then:
     shouldInsert(target, row);
@@ -449,7 +469,8 @@ public class ApiIntegrationTest {
         .put("DEC", 12.21) // JsonObject does not accept BigDecimal
         .put("ARRAY", new JsonArray().add("a").add("b"))
         .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"))
-        .put("STRUCT", new JsonObject().put("F1", 3));
+        .put("STRUCT", new JsonObject().put("F1", 3))
+        .put("COMPLEX", COMPLEX_FIELD_VALUE);
 
     // Then: request fails because stream name is invalid
     shouldRejectInsertRequest(target, row, "Cannot insert values into an unknown stream: " + target);
@@ -465,7 +486,8 @@ public class ApiIntegrationTest {
         .put("DEC", 12.21) // JsonObject does not accept BigDecimal
         .put("ARRAY", new JsonArray().add("a").add("b"))
         .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"))
-        .put("STRUCT", new JsonObject().put("F1", 3));
+        .put("STRUCT", new JsonObject().put("F1", 3))
+        .put("COMPLEX", COMPLEX_FIELD_VALUE);
 
     // Then: request fails because stream name is invalid
     shouldRejectInsertRequest(target, row, "Cannot insert values into an unknown stream: `" + TEST_STREAM.toLowerCase() + "`");
@@ -480,7 +502,8 @@ public class ApiIntegrationTest {
         .put("DEC", 12.21) // JsonObject does not accept BigDecimal
         .put("ARRAY", new JsonArray().add("a").add("b"))
         .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"))
-        .put("STRUCT", new JsonObject().put("F1", 3));
+        .put("STRUCT", new JsonObject().put("F1", 3))
+        .put("COMPLEX", COMPLEX_FIELD_VALUE);
 
     // Then: request fails because column name is incorrect
     shouldFailToInsert(row, ERROR_CODE_BAD_REQUEST, "Key field must be specified: STR");
@@ -495,7 +518,8 @@ public class ApiIntegrationTest {
         .put("DEC", 12.21) // JsonObject does not accept BigDecimal
         .put("ARRAY", new JsonArray().add("a").add("b"))
         .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"))
-        .put("STRUCT", new JsonObject().put("F1", 3));
+        .put("STRUCT", new JsonObject().put("F1", 3))
+        .put("COMPLEX", COMPLEX_FIELD_VALUE);
 
     // Then: request fails because column name is incorrect
     shouldFailToInsert(row, ERROR_CODE_BAD_REQUEST, "Key field must be specified: STR");
@@ -532,7 +556,8 @@ public class ApiIntegrationTest {
         .put("DEC", 12.34) // JsonObject does not accept BigDecimal
         .put("ARRAY", new JsonArray().add("a_shouldExecutePushQueryFromLatestOffset"))
         .put("MAP", new JsonObject().put("k1", "v1_shouldExecutePushQueryFromLatestOffset"))
-        .put("STRUCT", new JsonObject().put("F1", 3));
+        .put("STRUCT", new JsonObject().put("F1", 3))
+        .put("COMPLEX", COMPLEX_FIELD_VALUE);
 
     // Insert a new row and wait for it to arrive
     assertThatEventually(() -> {
@@ -555,6 +580,7 @@ public class ApiIntegrationTest {
     assertThat(queryResponse.rows.get(0).getJsonArray(3), is(new JsonArray().add("a_shouldExecutePushQueryFromLatestOffset")));
     assertThat(queryResponse.rows.get(0).getJsonObject(4), is(new JsonObject().put("k1", "v1_shouldExecutePushQueryFromLatestOffset")));
     assertThat(queryResponse.rows.get(0).getJsonObject(5), is(new JsonObject().put("F1", 3)));
+    assertThat(queryResponse.rows.get(0).getJsonObject(6), is(COMPLEX_FIELD_VALUE));
 
     // Check that query is cleaned up on the server
     assertThatEventually(engine::numberOfLiveQueries, is(1));


### PR DESCRIPTION
### Description 

Fixes https://github.com/confluentinc/ksql/issues/5620 and adds a lot more test coverage, not only for structs for also for other nested types: array of arrays, array of maps, array of structs, map of arrays, map of maps, map of structs, etc.

This fix turned out to be a lot larger than I had hoped in order to accommodate the following constraints of the /inserts-stream endpoint:
- column names are case-insensitive (unless quoted)
- struct field names are case-insensitive (unless quoted)
- map keys are case-sensitive
- struct and map types are both represented as JsonObject (KsqlObject for client)
- strings and doubles may be coerced to decimal types only for the /inserts-stream endpoint, not other uses of DefaultSqlValueCoercer. This constraint is required as JsonObject does not support BigDecimal
- client serializes BigDecimal for insert requests as strings, due to the constraint above

### Testing done 

Unit + integration tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

