### PR TITLE
feat: include row count in SHOW TOPICS EXTENDED

### DIFF
--- a/docs/developer-guide/ksqldb-reference/show-topics.md
+++ b/docs/developer-guide/ksqldb-reference/show-topics.md
@@ -35,7 +35,8 @@ and their active consumer counts.
 between each of the topic partition's latest and earliest offset. 
 
 
-For non-compacted topics, for example those normally backing a stream, this number is the _actual_ 
+For non-compacted topics, like those normally backing a stream, this number is the _actual_ 
+
 row count in the topic. 
 
 For compacted topics, like those normally backing a table, this number is the _maximum_ row 

--- a/docs/developer-guide/ksqldb-reference/show-topics.md
+++ b/docs/developer-guide/ksqldb-reference/show-topics.md
@@ -38,7 +38,8 @@ between each of the topic partition's latest and earliest offset.
 For non-compacted topics, for example those normally backing a stream, this number is the _actual_ 
 row count in the topic. 
 
-For compacted topics, for example those normally backing a table, this number is the _maximum_ row 
+For compacted topics, like those normally backing a table, this number is the _maximum_ row 
+
 count possible in the table. Key compaction likely mean the _actual_ number of rows is much less.  
 
 Example

--- a/docs/developer-guide/ksqldb-reference/show-topics.md
+++ b/docs/developer-guide/ksqldb-reference/show-topics.md
@@ -30,31 +30,41 @@ and their active consumer counts.
 
 `SHOW ALL TOPICS` lists all topics, including hidden topics.
 
+`SHOW TOPICS EXTENDED` includes additional information about each topic, including the 
+`Max Row Count`. This is intended as a guide only. It is calculated as the sum of the difference 
+between each of topic partition's latest and earliest offset. 
+
+For non-compacted topics, for example those normally backing a stream, this number is the _actual_ 
+row count in the topic. 
+
+For compacted topics, for example those normally backing a table, this number is the _maximum_ row 
+count possible in the table. Key compaction likely mean the _actual_ number of rows is much less.  
+
 Example
 -------
 
 ```sql
 ksql> SHOW TOPICS;
 
- Kafka Topic                                                                           | Partitions | Partition Replicas
---------------------------------------------------------------------------------------------------------
+ Kafka Topic                                                                           | Partitions | Replicas
+--------------------------------------------------------------------------------------------------------------
  default_ksql_processing_log                                                           | 1          | 1
  pageviews                                                                             | 1          | 1
  users                                                                                 | 1          | 1
---------------------------------------------------------------------------------------------------------
+--------------------------------------------------------------------------------------------------------------
 ```
 
 
 ```sql
 ksql> SHOW ALL TOPICS;
 
- Kafka Topic                                                                           | Partitions | Partition Replicas
---------------------------------------------------------------------------------------------------------
+ Kafka Topic                                                                           | Partitions | Replicas
+--------------------------------------------------------------------------------------------------------------
  _confluent-ksql-default__command_topic                                                | 1          | 1
  _confluent-ksql-default_query_CTAS_USERS_0-Aggregate-Aggregate-Materialize-changelog  | 1          | 1
  _confluent-ksql-default_query_CTAS_USERS_0-Aggregate-GroupBy-repartition              | 1          | 1
  default_ksql_processing_log                                                           | 1          | 1
  pageviews                                                                             | 1          | 1
  users                                                                                 | 1          | 1
---------------------------------------------------------------------------------------------------------
+--------------------------------------------------------------------------------------------------------------
 ```

--- a/docs/developer-guide/ksqldb-reference/show-topics.md
+++ b/docs/developer-guide/ksqldb-reference/show-topics.md
@@ -32,7 +32,8 @@ and their active consumer counts.
 
 `SHOW TOPICS EXTENDED` includes additional information about each topic, including the 
 `Max Row Count`. This is intended as a guide only. It is calculated as the sum of the difference 
-between each of topic partition's latest and earliest offset. 
+between each of the topic partition's latest and earliest offset. 
+
 
 For non-compacted topics, for example those normally backing a stream, this number is the _actual_ 
 row count in the topic. 

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/KafkaTopicsListTableBuilder.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/KafkaTopicsListTableBuilder.java
@@ -27,10 +27,12 @@ import org.apache.commons.lang3.StringUtils;
 public class KafkaTopicsListTableBuilder {
 
   public static class SimpleBuilder implements TableBuilder<KafkaTopicsList> {
+
     private static final List<String> HEADERS = ImmutableList.of(
         "Kafka Topic",
         "Partitions",
-        "Partition Replicas");
+        "Replicas"
+    );
 
     @Override
     public Table buildTable(final KafkaTopicsList entity) {
@@ -48,12 +50,15 @@ public class KafkaTopicsListTableBuilder {
   }
 
   public static class ExtendedBuilder implements TableBuilder<KafkaTopicsListExtended> {
+
     private static final List<String> HEADERS = ImmutableList.of(
         "Kafka Topic",
         "Partitions",
-        "Partition Replicas",
+        "Replicas",
+        "Max Row Count",
         "Consumers",
-        "ConsumerGroups");
+        "ConsumerGroups"
+    );
 
     @Override
     public Table buildTable(final KafkaTopicsListExtended entity) {
@@ -62,6 +67,7 @@ public class KafkaTopicsListTableBuilder {
               t.getName(),
               Integer.toString(t.getReplicaInfo().size()),
               getTopicReplicaInfo(t.getReplicaInfo()),
+              Long.toString(t.getMaxMsgCount()),
               Integer.toString(t.getConsumerCount()),
               Integer.toString(t.getConsumerGroupCount())));
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/FakeKafkaTopicClient.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/FakeKafkaTopicClient.java
@@ -33,6 +33,7 @@ import java.util.stream.IntStream;
 import org.apache.kafka.clients.admin.CreateTopicsOptions;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
@@ -168,6 +169,11 @@ public class FakeKafkaTopicClient implements KafkaTopicClient {
     }
 
     return fakeTopic.getDescription();
+  }
+
+  @Override
+  public Map<TopicPartition, Long> maxMsgCounts(final Set<TopicPartition> partitions) {
+    return Collections.emptyMap();
   }
 
   @Override

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/services/KafkaTopicClient.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/services/KafkaTopicClient.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.kafka.clients.admin.CreateTopicsOptions;
 import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.TopicPartition;
 
 /**
  * Note: all methods are synchronous, i.e. they wait for responses from Kafka before returning.
@@ -159,6 +160,13 @@ public interface KafkaTopicClient {
   default TopicDescription describeTopic(final String topicName) {
     return describeTopics(ImmutableList.of(topicName)).get(topicName);
   }
+
+  /**
+   * Get the maximum number of messages in a partition, i.e. latestOffset - earliestOffset.
+   *
+   * <p>For compacted topics the actual number of messages in the partition could be much less.
+   */
+  Map<TopicPartition, Long> maxMsgCounts(Set<TopicPartition> partitions);
 
   /**
    * Call to get the config of a topic.

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/stubs/StubKafkaTopicClient.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/stubs/StubKafkaTopicClient.java
@@ -35,6 +35,7 @@ import java.util.stream.IntStream;
 import org.apache.kafka.clients.admin.CreateTopicsOptions;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
@@ -150,6 +151,11 @@ public class StubKafkaTopicClient implements KafkaTopicClient {
     }
 
     return stubTopic.getDescription();
+  }
+
+  @Override
+  public Map<TopicPartition, Long> maxMsgCounts(final Set<TopicPartition> partitions) {
+    return Collections.emptyMap();
   }
 
   @Override

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KafkaTopicInfo.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KafkaTopicInfo.java
@@ -55,11 +55,12 @@ public class KafkaTopicInfo {
       return false;
     }
     final KafkaTopicInfo that = (KafkaTopicInfo) o;
-    return Objects.equals(name, that.name);
+    return Objects.equals(name, that.name)
+        && Objects.equals(replicaInfo, that.replicaInfo);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name);
+    return Objects.hash(name, replicaInfo);
   }
 }

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KafkaTopicInfoExtended.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KafkaTopicInfoExtended.java
@@ -30,11 +30,13 @@ public class KafkaTopicInfoExtended {
   private final List<Integer> replicaInfo;
   private final int consumerGroupCount;
   private final int consumerCount;
+  private final long maxMsgCount;
 
   @JsonCreator
   public KafkaTopicInfoExtended(
       @JsonProperty("name") final String name,
       @JsonProperty("replicaInfo") final List<Integer> replicaInfo,
+      @JsonProperty("maxMsgCount") final Long maxMsgCount, // Add v 0.11
       @JsonProperty("consumerCount") final int consumerCount,
       @JsonProperty("consumerGroupCount") final int consumerGroupCount
   ) {
@@ -42,6 +44,7 @@ public class KafkaTopicInfoExtended {
     this.replicaInfo = replicaInfo;
     this.consumerGroupCount = consumerGroupCount;
     this.consumerCount = consumerCount;
+    this.maxMsgCount = maxMsgCount == null ? 0L : maxMsgCount; // Old servers don't include this.
   }
 
   public String getName() {
@@ -60,6 +63,10 @@ public class KafkaTopicInfoExtended {
     return consumerGroupCount;
   }
 
+  public long getMaxMsgCount() {
+    return maxMsgCount;
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -69,11 +76,15 @@ public class KafkaTopicInfoExtended {
       return false;
     }
     final KafkaTopicInfoExtended that = (KafkaTopicInfoExtended) o;
-    return Objects.equals(name, that.name);
+    return consumerGroupCount == that.consumerGroupCount
+        && consumerCount == that.consumerCount
+        && maxMsgCount == that.maxMsgCount
+        && Objects.equals(name, that.name)
+        && Objects.equals(replicaInfo, that.replicaInfo);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name);
+    return Objects.hash(name, replicaInfo, consumerGroupCount, consumerCount, maxMsgCount);
   }
 }

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KafkaTopicsListExtended.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KafkaTopicsListExtended.java
@@ -52,11 +52,11 @@ public class KafkaTopicsListExtended extends KsqlEntity {
       return false;
     }
     final KafkaTopicsListExtended that = (KafkaTopicsListExtended) o;
-    return Objects.equals(getTopics(), that.getTopics());
+    return Objects.equals(topics, that.topics);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getTopics());
+    return Objects.hash(topics);
   }
 }


### PR DESCRIPTION
### Description 

While investigating issues I've always thought it would be useful if the output of `SHOW TOPICS EXTENDED` included the number of records within the topic.

With this change, it now does... ish!

The record count is calculated as the difference between the earliest and latest offsets. For non-compacted topics this shows the number of records in the topic.
For compacted topics this shows the maximum number of records that can be in the topic, though compaction may have reduced this number. This is why the number is reported as `Max` row count. It is intended as an indication only, i.e. to help with debugging etc.

### old output:

```
ksql> SHOW TOPICS EXTENDED;

 Kafka Topic                    | Partitions | Partition Replicas | Consumers | ConsumerGroups
----------------------------------------------------------------------------------------------
 default_ksql_processing_log    | 1          | 1                  | 0         | 0
 pageviews                      | 1          | 1                  | 0         | 0
 users                          | 1          | 1                  | 0         | 0
----------------------------------------------------------------------------------------------
```

### new output:

```
ksql> SHOW TOPICS EXTENDED;

 Kafka Topic                    | Partitions | Replicas | Max Row Count | Consumers | ConsumerGroups
----------------------------------------------------------------------------------------------------
 default_ksql_processing_log    | 1          | 1        | 0             | 0         | 0
 pageviews                      | 1          | 1        | 2345          | 0         | 0
 users                          | 1          | 1        | 25            | 0         | 0
-----------------------------------------------------------------------------------------------------
```

### Testing done 

Manual + unit + integration

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

