### PR TITLE
fix: ensure only deserializable cmds are written to command topic

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -165,7 +165,7 @@ public class KsqlResource implements KsqlConfigurable {
         injectorFactory,
         ksqlEngine::createSandbox,
         config,
-        new ValidatedCommandFactory(config)
+        new ValidatedCommandFactory()
     );
 
     this.handler = new RequestHandler(
@@ -176,7 +176,7 @@ public class KsqlResource implements KsqlConfigurable {
             distributedCmdResponseTimeout,
             injectorFactory,
             authorizationValidator,
-            new ValidatedCommandFactory(config),
+            new ValidatedCommandFactory(),
             errorHandler
         ),
         ksqlEngine,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -77,7 +77,7 @@ import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.engine.KsqlEngineTestUtil;
 import io.confluent.ksql.engine.KsqlPlan;
 import io.confluent.ksql.exception.KsqlTopicAuthorizationException;
-import io.confluent.ksql.execution.ddl.commands.DdlCommand;
+import io.confluent.ksql.execution.ddl.commands.DropSourceCommand;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
 import io.confluent.ksql.function.InternalFunctionRegistry;
@@ -1977,7 +1977,7 @@ public class KsqlResourceTest {
     when(sandbox.plan(any(), any())).thenAnswer(
         i -> KsqlPlan.ddlPlanCurrent(
             ((ConfiguredStatement<?>) i.getArgument(1)).getStatementText(),
-            mock(DdlCommand.class)
+            new DropSourceCommand(SourceName.of("bob"))
         )
     );
     when(ksqlEngine.createSandbox(any())).thenReturn(sandbox);


### PR DESCRIPTION
### Description 

fixes: https://github.com/confluentinc/ksql/issues/5643

Ensures all commands written to the command topic can be deserialized before writing them.

A non-deserializable command causes the command runner thread to die.
Even restarting the server won't help as the server will stop when it hits the non-deserializable command again.

This adds some level of protection.

(I know I'd previously been against this, but ... meh... maybe I was wrong ;) )

Submitting a statement to the server which the server finds it can't deserialize now results in an error and the command is, importantly, not added to the command queue:

```bash
ksql> CREATE TABLE OUTPUT as SELECT 1 as k, count(1) AS ID FROM INPUT group by 1;
Did not write the command to the command topic as it could not be deserialized. This is a bug! Please raise a Github issue containing the series of commands you ran to get to this point.
```

### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

