### PR TITLE
fix: allow empty structs in schema inference

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/schema/connect/SqlSchemaFormatter.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/schema/connect/SqlSchemaFormatter.java
@@ -161,6 +161,9 @@ public final class SqlSchemaFormatter implements SchemaFormatter {
     }
 
     public String visitStruct(final Schema schema, final List<? extends String> fields) {
+      if (fields.isEmpty()) {
+        return "STRUCT< >";
+      }
       return fields.stream()
           .collect(Collectors.joining(", ", STRUCT_START, STRUCTURED_END));
     }

--- a/ksqldb-common/src/test/java/io/confluent/ksql/schema/connect/SqlSchemaFormatterTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/schema/connect/SqlSchemaFormatterTest.java
@@ -173,6 +173,15 @@ public class SqlSchemaFormatterTest {
   }
 
   @Test
+  public void shouldFormatEmptyStruct() {
+    // Given:
+    final Schema struct = SchemaBuilder.struct().optional().build();
+
+    // Then:
+    assertThat(DEFAULT.format(struct), is("STRUCT< >"));
+  }
+
+  @Test
   public void shouldFormatStruct() {
     // Given:
     final Schema structSchema = SchemaBuilder.struct()

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorFunctionalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorFunctionalTest.java
@@ -397,6 +397,12 @@ public class DefaultSchemaInjectorFunctionalTest {
   }
 
   @Test
+  public void shouldInferEmptyStruct() {
+    final Schema emptyStruct = SchemaBuilder.struct().optional().build();
+    shouldInferConnectType(emptyStruct, emptyStruct);
+  }
+
+  @Test
   public void shouldInferComplexConnectSchema() {
     final Schema arrayInner = SchemaBuilder.struct()
         .field("arrayInner1", Schema.OPTIONAL_STRING_SCHEMA)

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/create-struct_-_empty_struct_creation/5.5.0_1581572087372/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/create-struct_-_empty_struct_creation/5.5.0_1581572087372/spec.json
@@ -101,7 +101,7 @@
   } ],
   "schemas" : {
     "CSAS_BIG_STRUCT_0.KsqlTopic.Source" : "STRUCT<COL1 VARCHAR> NOT NULL",
-    "CSAS_BIG_STRUCT_0.BIG_STRUCT" : "STRUCT<S STRUCT<>> NOT NULL"
+    "CSAS_BIG_STRUCT_0.BIG_STRUCT" : "STRUCT<S STRUCT< >> NOT NULL"
   },
   "configs" : {
     "ksql.extension.dir" : "ext",


### PR DESCRIPTION
### Description 
Previously, empty structs would be formatted as `STRUCT<>` in the `SqlSchemaFormatter` (which for some reason is used independently of `SqlFormatter`, we should dig into that) which would cause parsing to fail because `<>` is it's own symbol for "not equal to".

This code path was not used in master after https://github.com/confluentinc/ksql/pull/4637 so it was no longer happening. That change has a relatively large surface area, so for the backport I am making the most targeted change possible to address the edge case.

### Testing done 
Added a unit test, which fails before this fix.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

