### PR TITLE
docs: fix broken link to log4j-secure.properties (DOCS-4649)

### DIFF
--- a/docs/developer-guide/test-and-debug/processing-log.md
+++ b/docs/developer-guide/test-and-debug/processing-log.md
@@ -85,9 +85,9 @@ log4j.logger.processing=OFF
 ```
 
 !!! note
-    To enable security for the KSQL Processing Log, assign log4j properties
+    To enable security for the ksqlDB Processing Log, assign log4j properties
     as shown in
-    [log4j-secure.properties](https://github.com/confluentinc/cp-demo/blob/master/scripts/security/log4j-secure.properties).
+    [log4j-secure.properties](https://github.com/confluentinc/cp-demo/blob/master/scripts/helper/log4j-secure.properties).
 
 Log Schema
 ----------


### PR DESCRIPTION
The target moved 14 days ago when cp-demo was refactored.

Cherry-pick to master, 0.10.0-ksqldb, 0.9.0-ksqldb, 0.8.1-ksqldb, and 0.7.1-ksqldb.  