### PR TITLE
chore: add CREATE OR RPLEACE to the syntax

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/StatementRewriter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/StatementRewriter.java
@@ -386,6 +386,7 @@ public final class StatementRewriter<C> {
           node.getName(),
           (Query) rewriter.apply(node.getQuery(), context),
           node.isNotExists(),
+          node.isOrReplace(),
           node.getProperties()
       );
     }
@@ -418,6 +419,7 @@ public final class StatementRewriter<C> {
           node.getName(),
           (Query) rewriter.apply(node.getQuery(), context),
           node.isNotExists(),
+          node.isOrReplace(),
           node.getProperties()
       );
     }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/FunctionNameValidator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/FunctionNameValidator.java
@@ -44,7 +44,7 @@ class FunctionNameValidator implements Predicate<String> {
 
   // These are in the reserved words set, but we already use them for function names
   private static final Set<String> ALLOWED_KSQL_WORDS
-      = ImmutableSet.copyOf(Arrays.asList("concat", "substring"));
+      = ImmutableSet.copyOf(Arrays.asList("concat", "substring", "replace"));
 
   private static final Set<String> KSQL_RESERVED_WORDS = createFromVocabulary();
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CommandFactoriesTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CommandFactoriesTest.java
@@ -157,7 +157,7 @@ public class CommandFactoriesTest {
   @Test
   public void shouldCreateCommandForCreateStream() {
     // Given:
-    final CreateStream statement = new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
+    final CreateStream statement = new CreateStream(SOME_NAME, SOME_ELEMENTS, false, true, withProperties);
 
     // When:
     final DdlCommand result = commandFactories
@@ -170,7 +170,7 @@ public class CommandFactoriesTest {
   @Test
   public void shouldCreateCommandForStreamWithOverriddenProperties() {
     // Given:
-    final CreateStream statement = new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
+    final CreateStream statement = new CreateStream(SOME_NAME, SOME_ELEMENTS, false, true, withProperties);
 
     // When:
     commandFactories.create(sqlExpression, statement, ksqlConfig, OVERRIDES);
@@ -187,7 +187,7 @@ public class CommandFactoriesTest {
         TableElements.of(
             tableElement(Namespace.VALUE, "COL1", new Type(SqlTypes.BIGINT)),
             tableElement(Namespace.VALUE, "COL2", new Type(SqlTypes.STRING))),
-        true, withProperties);
+        false, true, withProperties);
 
     // When:
     final DdlCommand result = commandFactories
@@ -205,7 +205,7 @@ public class CommandFactoriesTest {
         TableElements.of(
             tableElement(Namespace.VALUE, "COL1", new Type(SqlTypes.BIGINT)),
             tableElement(Namespace.VALUE, "COL2", new Type(SqlTypes.STRING))),
-        true, withProperties);
+        false, true, withProperties);
 
     // When:
     commandFactories.create(sqlExpression, statement, ksqlConfig, OVERRIDES);
@@ -304,7 +304,7 @@ public class CommandFactoriesTest {
     );
 
     final DdlStatement statement =
-        new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
+        new CreateStream(SOME_NAME, SOME_ELEMENTS, false, true, withProperties);
 
     // When:
     final DdlCommand cmd = commandFactories
@@ -329,7 +329,7 @@ public class CommandFactoriesTest {
     );
 
     final DdlStatement statement =
-        new CreateTable(SOME_NAME, ELEMENTS_WITH_PK, true, withProperties);
+        new CreateTable(SOME_NAME, ELEMENTS_WITH_PK, false, true, withProperties);
 
     // When:
     final DdlCommand cmd = commandFactories

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceFactoryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceFactoryTest.java
@@ -180,7 +180,7 @@ public class CreateSourceFactoryTest {
   public void shouldCreateCommandForCreateStream() {
     // Given:
     final CreateStream ddlStatement =
-        new CreateStream(SOME_NAME, STREAM_ELEMENTS, true, withProperties);
+        new CreateStream(SOME_NAME, STREAM_ELEMENTS, false, true, withProperties);
 
     // When:
     final CreateStreamCommand result = createSourceFactory
@@ -198,7 +198,7 @@ public class CreateSourceFactoryTest {
         TableElements.of(
             tableElement(PRIMARY_KEY, "COL1", new Type(BIGINT)),
             tableElement(VALUE, "COL2", new Type(SqlTypes.STRING))),
-        true, withProperties);
+        false, true, withProperties);
 
     // When:
     final CreateTableCommand result = createSourceFactory
@@ -223,7 +223,7 @@ public class CreateSourceFactoryTest {
     givenProperty(CommonCreateConfigs.WRAP_SINGLE_VALUE, new BooleanLiteral("false"));
 
     final CreateStream statement =
-        new CreateStream(SOME_NAME, ONE_ELEMENT, true, withProperties);
+        new CreateStream(SOME_NAME, ONE_ELEMENT, false, true, withProperties);
 
     // When:
     final CreateStreamCommand cmd = createSourceFactory
@@ -244,7 +244,7 @@ public class CreateSourceFactoryTest {
     ));
 
     final CreateStream statement =
-        new CreateStream(SOME_NAME, ONE_ELEMENT, true, withProperties);
+        new CreateStream(SOME_NAME, ONE_ELEMENT, false, true, withProperties);
 
     // When:
     final CreateStreamCommand cmd = createSourceFactory
@@ -258,7 +258,7 @@ public class CreateSourceFactoryTest {
   public void shouldCreateStreamCommandWithSingleValueWrappingFromDefaultConfig() {
     // Given:
     final CreateStream statement =
-        new CreateStream(SOME_NAME, ONE_ELEMENT, true, withProperties);
+        new CreateStream(SOME_NAME, ONE_ELEMENT, false, true, withProperties);
 
     // When:
     final CreateStreamCommand cmd = createSourceFactory
@@ -282,7 +282,7 @@ public class CreateSourceFactoryTest {
     givenProperty(CommonCreateConfigs.WRAP_SINGLE_VALUE, new BooleanLiteral("false"));
 
     final CreateTable statement =
-        new CreateTable(SOME_NAME, TABLE_ELEMENTS_1_VALUE, true, withProperties);
+        new CreateTable(SOME_NAME, TABLE_ELEMENTS_1_VALUE, false, true, withProperties);
 
     // When:
     final CreateTableCommand cmd = createSourceFactory
@@ -302,7 +302,7 @@ public class CreateSourceFactoryTest {
     ));
 
     final CreateTable statement =
-        new CreateTable(SOME_NAME, TABLE_ELEMENTS_1_VALUE, true, withProperties);
+        new CreateTable(SOME_NAME, TABLE_ELEMENTS_1_VALUE, false, true, withProperties);
 
     // When:
     final CreateTableCommand cmd = createSourceFactory
@@ -316,7 +316,7 @@ public class CreateSourceFactoryTest {
   public void shouldCreateTableCommandWithSingleValueWrappingFromDefaultConfig() {
     // Given:
     final CreateTable statement =
-        new CreateTable(SOME_NAME, TABLE_ELEMENTS_1_VALUE, true, withProperties);
+        new CreateTable(SOME_NAME, TABLE_ELEMENTS_1_VALUE, false, true, withProperties);
 
     // When:
     final CreateTableCommand cmd = createSourceFactory
@@ -330,7 +330,7 @@ public class CreateSourceFactoryTest {
   public void shouldThrowOnNoElementsInCreateStream() {
     // Given:
     final CreateStream statement
-        = new CreateStream(SOME_NAME, TableElements.of(), true, withProperties);
+        = new CreateStream(SOME_NAME, TableElements.of(), false, true, withProperties);
 
     // When:
     final Exception e = assertThrows(
@@ -347,7 +347,7 @@ public class CreateSourceFactoryTest {
   public void shouldThrowOnNoElementsInCreateTable() {
     // Given:
     final CreateTable statement
-        = new CreateTable(SOME_NAME, TableElements.of(), true, withProperties);
+        = new CreateTable(SOME_NAME, TableElements.of(), false, true, withProperties);
 
     // When:
     final Exception e = assertThrows(
@@ -364,7 +364,7 @@ public class CreateSourceFactoryTest {
   public void shouldNotThrowWhenThereAreElementsInCreateStream() {
     // Given:
     final CreateStream statement =
-        new CreateStream(SOME_NAME, ONE_ELEMENT, true, withProperties);
+        new CreateStream(SOME_NAME, ONE_ELEMENT, false, true, withProperties);
 
     // When:
     createSourceFactory.createStreamCommand(statement, ksqlConfig);
@@ -376,7 +376,7 @@ public class CreateSourceFactoryTest {
   public void shouldNotThrowWhenThereAreElementsInCreateTable() {
     // Given:
     final CreateTable statement =
-        new CreateTable(SOME_NAME, TABLE_ELEMENTS_1_VALUE, true, withProperties);
+        new CreateTable(SOME_NAME, TABLE_ELEMENTS_1_VALUE, false, true, withProperties);
 
     // When:
     createSourceFactory.createTableCommand(statement, ksqlConfig);
@@ -389,7 +389,7 @@ public class CreateSourceFactoryTest {
     // Given:
     when(topicClient.isTopicExists(any())).thenReturn(false);
     final CreateStream statement =
-        new CreateStream(SOME_NAME, ONE_ELEMENT, true, withProperties);
+        new CreateStream(SOME_NAME, ONE_ELEMENT, false, true, withProperties);
 
     // When:
     final Exception e = assertThrows(
@@ -407,7 +407,7 @@ public class CreateSourceFactoryTest {
   public void shouldNotThrowIfTopicDoesExist() {
     // Given:
     final CreateStream statement =
-        new CreateStream(SOME_NAME, ONE_ELEMENT, true, withProperties);
+        new CreateStream(SOME_NAME, ONE_ELEMENT, false, true, withProperties);
 
     // When:
     createSourceFactory.createStreamCommand(statement, ksqlConfig);
@@ -424,7 +424,7 @@ public class CreateSourceFactoryTest {
         new StringLiteral("`will-not-find-me`")
     );
     final CreateStream statement =
-        new CreateStream(SOME_NAME, ONE_ELEMENT, true, withProperties);
+        new CreateStream(SOME_NAME, ONE_ELEMENT, false, true, withProperties);
 
     // When:
     final Exception e = assertThrows(
@@ -442,7 +442,7 @@ public class CreateSourceFactoryTest {
   public void shouldBuildSerdeOptionsForStream() {
     // Given:
     givenCommandFactoriesWithMocks();
-    final CreateStream statement = new CreateStream(SOME_NAME, ONE_ELEMENT, true, withProperties);
+    final CreateStream statement = new CreateStream(SOME_NAME, ONE_ELEMENT, false, true, withProperties);
     final LogicalSchema schema = LogicalSchema.builder()
         .valueColumn(ColumnName.of("bob"), SqlTypes.STRING)
         .build();
@@ -472,7 +472,7 @@ public class CreateSourceFactoryTest {
         new StringLiteral(quote(ELEMENT2.getName().text()))
     );
     final CreateStream statement =
-        new CreateStream(SOME_NAME, STREAM_ELEMENTS, true, withProperties);
+        new CreateStream(SOME_NAME, STREAM_ELEMENTS, false, true, withProperties);
 
     // When:
     final CreateStreamCommand cmd = createSourceFactory.createStreamCommand(
@@ -497,7 +497,7 @@ public class CreateSourceFactoryTest {
         new StringLiteral(quote(ELEMENT2.getName().text()))
     );
     final CreateTable statement =
-        new CreateTable(SOME_NAME, TABLE_ELEMENTS, true, withProperties);
+        new CreateTable(SOME_NAME, TABLE_ELEMENTS, false, true, withProperties);
 
     // When:
     final CreateTableCommand cmd = createSourceFactory.createTableCommand(
@@ -524,7 +524,7 @@ public class CreateSourceFactoryTest {
         new StringLiteral("%s")
     ));
     final CreateStream statement =
-        new CreateStream(SOME_NAME, STREAM_ELEMENTS, true, withProperties);
+        new CreateStream(SOME_NAME, STREAM_ELEMENTS, false, true, withProperties);
 
     // When:
     final CreateStreamCommand cmd = createSourceFactory.createStreamCommand(
@@ -544,7 +544,7 @@ public class CreateSourceFactoryTest {
   @Test
   public void shouldBuildSchemaWithImplicitKeyFieldForStream() {
     // Given:
-    final CreateStream statement = new CreateStream(SOME_NAME, STREAM_ELEMENTS, true,
+    final CreateStream statement = new CreateStream(SOME_NAME, STREAM_ELEMENTS, false, true,
         withProperties);
 
     // When:
@@ -567,6 +567,7 @@ public class CreateSourceFactoryTest {
             ELEMENT1,
             ELEMENT2
         ),
+        false,
         true,
         withProperties
     );
@@ -590,7 +591,7 @@ public class CreateSourceFactoryTest {
   public void shouldValidateKeyFormatCanHandleKeySchema() {
     // Given:
     givenCommandFactoriesWithMocks();
-    final CreateStream statement = new CreateStream(SOME_NAME, STREAM_ELEMENTS, true,
+    final CreateStream statement = new CreateStream(SOME_NAME, STREAM_ELEMENTS, false, true,
         withProperties);
 
     when(keySerdeFactory.create(
@@ -617,7 +618,7 @@ public class CreateSourceFactoryTest {
   public void shouldCreateValueSerdeToValidateValueFormatCanHandleValueSchema() {
     // Given:
     givenCommandFactoriesWithMocks();
-    final CreateTable statement = new CreateTable(SOME_NAME, TABLE_ELEMENTS, true,
+    final CreateTable statement = new CreateTable(SOME_NAME, TABLE_ELEMENTS, false, true,
         withProperties);
 
     when(valueSerdeFactory.create(
@@ -642,7 +643,7 @@ public class CreateSourceFactoryTest {
 
   @Test
   public void shouldDefaultToKafkaKeySerdeForStream() {
-    final CreateStream statement = new CreateStream(SOME_NAME, ONE_ELEMENT, true, withProperties);
+    final CreateStream statement = new CreateStream(SOME_NAME, ONE_ELEMENT, false, true, withProperties);
 
     // When:
     final CreateStreamCommand cmd = createSourceFactory.createStreamCommand(
@@ -661,7 +662,7 @@ public class CreateSourceFactoryTest {
     givenCommandFactoriesWithMocks();
     givenProperty("VALUE_FORMAT", new StringLiteral("Avro"));
     givenProperty("value_avro_schema_full_name", new StringLiteral("full.schema.name"));
-    final CreateStream statement = new CreateStream(SOME_NAME, ONE_ELEMENT, true, withProperties);
+    final CreateStream statement = new CreateStream(SOME_NAME, ONE_ELEMENT, false, true, withProperties);
 
     // When:
     final CreateStreamCommand cmd = createSourceFactory.createStreamCommand(
@@ -679,7 +680,7 @@ public class CreateSourceFactoryTest {
   public void shouldHandleSessionWindowedKeyForStream() {
     // Given:
     givenProperty("window_type", new StringLiteral("session"));
-    final CreateStream statement = new CreateStream(SOME_NAME, ONE_ELEMENT, true, withProperties);
+    final CreateStream statement = new CreateStream(SOME_NAME, ONE_ELEMENT, false, true, withProperties);
 
     // When:
     final CreateStreamCommand cmd = createSourceFactory.createStreamCommand(
@@ -699,7 +700,7 @@ public class CreateSourceFactoryTest {
         "window_type", new StringLiteral("tumbling"),
         "window_size", new StringLiteral("1 MINUTE")
     ));
-    final CreateStream statement = new CreateStream(SOME_NAME, ONE_ELEMENT, true, withProperties);
+    final CreateStream statement = new CreateStream(SOME_NAME, ONE_ELEMENT, false, true, withProperties);
 
     // When:
     final CreateStreamCommand cmd = createSourceFactory.createStreamCommand(
@@ -722,7 +723,7 @@ public class CreateSourceFactoryTest {
         "window_type", new StringLiteral("Hopping"),
         "window_size", new StringLiteral("2 SECONDS")
     ));
-    final CreateStream statement = new CreateStream(SOME_NAME, ONE_ELEMENT, true, withProperties);
+    final CreateStream statement = new CreateStream(SOME_NAME, ONE_ELEMENT, false, true, withProperties);
 
     // When:
     final CreateStreamCommand cmd = createSourceFactory.createStreamCommand(
@@ -744,6 +745,7 @@ public class CreateSourceFactoryTest {
     final CreateStream statement = new CreateStream(
         SOME_NAME,
         TableElements.of(tableElement(VALUE, ROWTIME_NAME.text(), new Type(BIGINT))),
+        false,
         true,
         withProperties
     );
@@ -765,6 +767,7 @@ public class CreateSourceFactoryTest {
     final CreateStream statement = new CreateStream(
         SOME_NAME,
         TableElements.of(tableElement(Namespace.KEY, ROWTIME_NAME.text(), new Type(BIGINT))),
+        false,
         true,
         withProperties
     );
@@ -786,6 +789,7 @@ public class CreateSourceFactoryTest {
     final CreateStream statement = new CreateStream(
         SOME_NAME,
         TableElements.of(tableElement(VALUE, WINDOWSTART_NAME.text(), new Type(BIGINT))),
+        false,
         true,
         withProperties
     );
@@ -807,6 +811,7 @@ public class CreateSourceFactoryTest {
     final CreateStream statement = new CreateStream(
         SOME_NAME,
         TableElements.of(tableElement(VALUE, WINDOWEND_NAME.text(), new Type(BIGINT))),
+        false,
         true,
         withProperties
     );
@@ -828,6 +833,7 @@ public class CreateSourceFactoryTest {
     final CreateStream statement = new CreateStream(
         SOME_NAME,
         TableElements.of(tableElement(KEY, ROWKEY_NAME.text(), new Type(SqlTypes.STRING))),
+        false,
         true,
         withProperties
     );
@@ -844,6 +850,7 @@ public class CreateSourceFactoryTest {
     final CreateStream statement = new CreateStream(
         SOME_NAME,
         TableElements.of(tableElement(KEY, ROWKEY_NAME.text(), new Type(SqlTypes.INTEGER))),
+        false,
         true,
         withProperties
     );
@@ -864,6 +871,7 @@ public class CreateSourceFactoryTest {
     final CreateStream statement = new CreateStream(
         SOME_NAME,
         TableElements.of(tableElement(KEY, "someKey", new Type(SqlTypes.STRING))),
+        false,
         true,
         withProperties
     );
@@ -886,7 +894,7 @@ public class CreateSourceFactoryTest {
     ));
 
     final CreateTable statement =
-        new CreateTable(SOME_NAME, ONE_ELEMENT, true, withProperties);
+        new CreateTable(SOME_NAME, ONE_ELEMENT, false, true, withProperties);
 
     // When:
     final Exception e = assertThrows(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/StatementRewriterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/StatementRewriterTest.java
@@ -537,6 +537,7 @@ public class StatementRewriterTest {
         sourceName,
         TableElements.of(tableElement1, tableElement2),
         false,
+        false,
         sourceProperties
     );
     when(mockRewriter.apply(tableElement1, context)).thenReturn(rewrittenTableElement1);
@@ -553,6 +554,7 @@ public class StatementRewriterTest {
                 location,
                 sourceName,
                 TableElements.of(rewrittenTableElement1, rewrittenTableElement2),
+                false,
                 false,
                 sourceProperties
             )
@@ -578,6 +580,7 @@ public class StatementRewriterTest {
         sourceName,
         query,
         false,
+        false,
         csasProperties
     );
     when(mockRewriter.apply(query, context)).thenReturn(rewrittenQuery);
@@ -592,6 +595,7 @@ public class StatementRewriterTest {
                 sourceName,
                 rewrittenQuery,
                 false,
+                false,
                 csasProperties
             )
         )
@@ -604,6 +608,7 @@ public class StatementRewriterTest {
         location,
         sourceName,
         query,
+        false,
         false,
         csasProperties
     );
@@ -619,6 +624,7 @@ public class StatementRewriterTest {
                 location,
                 sourceName,
                 rewrittenQuery,
+                false,
                 false,
                 csasProperties
             )
@@ -649,6 +655,7 @@ public class StatementRewriterTest {
         sourceName,
         TableElements.of(tableElement1, tableElement2),
         false,
+        false,
         sourceProperties
     );
     when(mockRewriter.apply(tableElement1, context)).thenReturn(rewrittenTableElement1);
@@ -665,6 +672,7 @@ public class StatementRewriterTest {
                 location,
                 sourceName,
                 TableElements.of(rewrittenTableElement1, rewrittenTableElement2),
+                false,
                 false,
                 sourceProperties
             )
@@ -691,6 +699,7 @@ public class StatementRewriterTest {
         sourceName,
         query,
         false,
+        false,
         csasProperties
     );
     when(mockRewriter.apply(query, context)).thenReturn(rewrittenQuery);
@@ -706,6 +715,7 @@ public class StatementRewriterTest {
                 location,
                 sourceName,
                 rewrittenQuery,
+                false,
                 false,
                 csasProperties
             )

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/FunctionNameValidatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/FunctionNameValidatorTest.java
@@ -50,7 +50,8 @@ public class FunctionNameValidatorTest {
       final String symbolicName = vocabulary.getSymbolicName(i);
       if (symbolicName != null) {
         if (symbolicName.equalsIgnoreCase("substring")
-            || symbolicName.equalsIgnoreCase("concat")) {
+            || symbolicName.equalsIgnoreCase("concat")
+            || symbolicName.equalsIgnoreCase("replace")) {
           assertTrue(validator.test(symbolicName));
         } else {
           assertFalse(validator.test(symbolicName));

--- a/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -49,15 +49,15 @@ statement
     | TERMINATE ALL                                                         #terminateQuery
     | SET STRING EQ STRING                                                  #setProperty
     | UNSET STRING                                                          #unsetProperty
-    | CREATE STREAM (IF NOT EXISTS)? sourceName
+    | CREATE (OR REPLACE)? STREAM (IF NOT EXISTS)? sourceName
                 (tableElements)?
                 (WITH tableProperties)?                                     #createStream
-    | CREATE STREAM (IF NOT EXISTS)? sourceName
+    | CREATE (OR REPLACE)? STREAM (IF NOT EXISTS)? sourceName
             (WITH tableProperties)? AS query                                #createStreamAs
-    | CREATE TABLE (IF NOT EXISTS)? sourceName
+    | CREATE (OR REPLACE)? TABLE (IF NOT EXISTS)? sourceName
                     (tableElements)?
                     (WITH tableProperties)?                                 #createTable
-    | CREATE TABLE (IF NOT EXISTS)? sourceName
+    | CREATE (OR REPLACE)? TABLE (IF NOT EXISTS)? sourceName
             (WITH tableProperties)? AS query                                #createTableAs
     | CREATE (SINK | SOURCE) CONNECTOR identifier WITH tableProperties      #createConnector
     | INSERT INTO sourceName query                                          #insertInto
@@ -336,6 +336,7 @@ nonReserved
     | EMIT
     | CHANGES
     | ESCAPE
+    | REPLACE
     ;
 
 EMIT: 'EMIT';
@@ -463,6 +464,7 @@ NAMESPACE: 'NAMESPACE';
 MATERIALIZED: 'MATERIALIZED';
 VIEW: 'VIEW';
 PRIMARY: 'PRIMARY';
+REPLACE: 'REPLACE';
 
 IF: 'IF';
 

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -253,10 +253,15 @@ public class AstBuilder {
 
       final Map<String, Literal> properties = processTableProperties(context.tableProperties());
 
+      if (context.REPLACE() != null) {
+        throw new UnsupportedOperationException("CREATE OR REPLACE is not yet supported.");
+      }
+
       return new CreateTable(
           getLocation(context),
           ParserUtil.getSourceName(context.sourceName()),
           TableElements.of(elements),
+          context.REPLACE() != null,
           context.EXISTS() != null,
           CreateSourceProperties.from(properties)
       );
@@ -270,10 +275,15 @@ public class AstBuilder {
 
       final Map<String, Literal> properties = processTableProperties(context.tableProperties());
 
+      if (context.REPLACE() != null) {
+        throw new UnsupportedOperationException("CREATE OR REPLACE is not yet supported.");
+      }
+
       return new CreateStream(
           getLocation(context),
           ParserUtil.getSourceName(context.sourceName()),
           TableElements.of(elements),
+          context.REPLACE() != null,
           context.EXISTS() != null,
           CreateSourceProperties.from(properties)
       );
@@ -285,11 +295,16 @@ public class AstBuilder {
 
       final Query query = withinPersistentQuery(() -> visitQuery(context.query()));
 
+      if (context.REPLACE() != null) {
+        throw new UnsupportedOperationException("CREATE OR REPLACE is not yet supported.");
+      }
+
       return new CreateStreamAsSelect(
           getLocation(context),
           ParserUtil.getSourceName(context.sourceName()),
           query,
           context.EXISTS() != null,
+          context.REPLACE() != null,
           CreateSourceAsProperties.from(properties)
       );
     }
@@ -300,11 +315,16 @@ public class AstBuilder {
 
       final Query query = withinPersistentQuery(() -> visitQuery(context.query()));
 
+      if (context.REPLACE() != null) {
+        throw new UnsupportedOperationException("CREATE OR REPLACE is not yet supported.");
+      }
+
       return new CreateTableAsSelect(
           getLocation(context),
           ParserUtil.getSourceName(context.sourceName()),
           query,
           context.EXISTS() != null,
+          context.REPLACE() != null,
           CreateSourceAsProperties.from(properties)
       );
     }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
@@ -234,15 +234,13 @@ public final class SqlFormatter {
 
     @Override
     protected Void visitCreateStream(final CreateStream node, final Integer indent) {
-      builder.append("CREATE STREAM ");
-      formatCreate(node);
+      formatCreate(node, "STREAM");
       return null;
     }
 
     @Override
     protected Void visitCreateTable(final CreateTable node, final Integer indent) {
-      builder.append("CREATE TABLE ");
-      formatCreate(node);
+      formatCreate(node, "TABLE");
       return null;
     }
 
@@ -277,8 +275,7 @@ public final class SqlFormatter {
         final CreateStreamAsSelect node,
         final Integer indent
     ) {
-      builder.append("CREATE STREAM ");
-      formatCreateAs(node, indent);
+      formatCreateAs("STREAM", node, indent);
       return null;
     }
 
@@ -287,8 +284,7 @@ public final class SqlFormatter {
         final CreateTableAsSelect node,
         final Integer indent
     ) {
-      builder.append("CREATE TABLE ");
-      formatCreateAs(node, indent);
+      formatCreateAs("TABLE", node, indent);
       return null;
     }
 
@@ -452,7 +448,16 @@ public final class SqlFormatter {
       return Strings.repeat(INDENT, indent);
     }
 
-    private void formatCreate(final CreateSource node) {
+    private void formatCreate(final CreateSource node, final String type) {
+      builder.append("CREATE ");
+
+      if (node.isOrReplace()) {
+        builder.append("OR REPLACE ");
+      }
+
+      builder.append(type);
+      builder.append(" ");
+
       if (node.isNotExists()) {
         builder.append("IF NOT EXISTS ");
       }
@@ -481,7 +486,20 @@ public final class SqlFormatter {
       builder.append(";");
     }
 
-    private void formatCreateAs(final CreateAsSelect node, final Integer indent) {
+    private void formatCreateAs(
+        final String source,
+        final CreateAsSelect node,
+        final Integer indent
+    ) {
+      builder.append("CREATE ");
+
+      if (node.isOrReplace()) {
+        builder.append("OR REPLACE ");
+      }
+
+      builder.append(source);
+      builder.append(" ");
+
       if (node.isNotExists()) {
         builder.append("IF NOT EXISTS ");
       }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateAsSelect.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateAsSelect.java
@@ -35,7 +35,8 @@ public abstract class CreateAsSelect extends Statement implements QueryContainer
       final Optional<NodeLocation> location,
       final SourceName name,
       final Query query,
-      final boolean orReplace, final boolean notExists,
+      final boolean orReplace,
+      final boolean notExists,
       final CreateSourceAsProperties properties
   ) {
     super(location);

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateAsSelect.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateAsSelect.java
@@ -27,6 +27,7 @@ public abstract class CreateAsSelect extends Statement implements QueryContainer
 
   private final SourceName name;
   private final Query query;
+  private final boolean orReplace;
   private final boolean notExists;
   private final CreateSourceAsProperties properties;
 
@@ -34,12 +35,13 @@ public abstract class CreateAsSelect extends Statement implements QueryContainer
       final Optional<NodeLocation> location,
       final SourceName name,
       final Query query,
-      final boolean notExists,
+      final boolean orReplace, final boolean notExists,
       final CreateSourceAsProperties properties
   ) {
     super(location);
     this.name = requireNonNull(name, "name");
     this.query = requireNonNull(query, "query");
+    this.orReplace = orReplace;
     this.notExists = notExists;
     this.properties = requireNonNull(properties, "properties");
   }
@@ -52,6 +54,7 @@ public abstract class CreateAsSelect extends Statement implements QueryContainer
         other.getLocation(),
         other.name,
         other.query,
+        other.orReplace,
         other.notExists,
         properties
     );
@@ -70,6 +73,10 @@ public abstract class CreateAsSelect extends Statement implements QueryContainer
 
   public boolean isNotExists() {
     return notExists;
+  }
+
+  public boolean isOrReplace() {
+    return orReplace;
   }
 
   public CreateSourceAsProperties getProperties() {
@@ -93,6 +100,7 @@ public abstract class CreateAsSelect extends Statement implements QueryContainer
     return Objects.equals(name, o.name)
         && Objects.equals(query, o.query)
         && Objects.equals(notExists, o.notExists)
+        && Objects.equals(orReplace, o.orReplace)
         && Objects.equals(properties, o.properties);
   }
 
@@ -101,6 +109,7 @@ public abstract class CreateAsSelect extends Statement implements QueryContainer
     return "CreateAsSelect{" + "name=" + name
         + ", query=" + query
         + ", notExists=" + notExists
+        + ", orReplace =" + orReplace
         + ", properties=" + properties
         + '}';
   }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateSource.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateSource.java
@@ -34,17 +34,20 @@ public abstract class CreateSource extends Statement {
   private final TableElements elements;
   private final boolean notExists;
   private final CreateSourceProperties properties;
+  private final boolean orReplace;
 
   CreateSource(
       final Optional<NodeLocation> location,
       final SourceName name,
       final TableElements elements,
+      final boolean orReplace,
       final boolean notExists,
       final CreateSourceProperties properties
   ) {
     super(location);
     this.name = requireNonNull(name, "name");
     this.elements = requireNonNull(elements, "elements");
+    this.orReplace = orReplace;
     this.notExists = notExists;
     this.properties = requireNonNull(properties, "properties");
 
@@ -63,6 +66,10 @@ public abstract class CreateSource extends Statement {
     return elements;
   }
 
+  public boolean isOrReplace() {
+    return orReplace;
+  }
+
   public boolean isNotExists() {
     return notExists;
   }
@@ -71,7 +78,7 @@ public abstract class CreateSource extends Statement {
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, elements, notExists, properties);
+    return Objects.hash(name, elements, orReplace, notExists, properties);
   }
 
   @Override
@@ -84,6 +91,7 @@ public abstract class CreateSource extends Statement {
     }
     final CreateSource that = (CreateSource) o;
     return notExists == that.notExists
+        && orReplace == that.orReplace
         && Objects.equals(name, that.name)
         && Objects.equals(elements, that.elements)
         && Objects.equals(properties, that.properties);

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStream.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStream.java
@@ -31,20 +31,22 @@ public class CreateStream extends CreateSource implements ExecutableDdlStatement
   public CreateStream(
       final SourceName name,
       final TableElements elements,
+      final boolean orReplace,
       final boolean notExists,
       final CreateSourceProperties properties
   ) {
-    this(Optional.empty(), name, elements, notExists, properties);
+    this(Optional.empty(), name, elements, orReplace, notExists, properties);
   }
 
   public CreateStream(
       final Optional<NodeLocation> location,
       final SourceName name,
       final TableElements elements,
+      final boolean orReplace,
       final boolean notExists,
       final CreateSourceProperties properties
   ) {
-    super(location, name, elements, notExists, properties);
+    super(location, name, elements, orReplace, notExists, properties);
 
     throwOnPrimaryKeys(elements);
   }
@@ -58,6 +60,7 @@ public class CreateStream extends CreateSource implements ExecutableDdlStatement
         getLocation(),
         getName(),
         elements,
+        isOrReplace(),
         isNotExists(),
         properties);
   }
@@ -83,6 +86,7 @@ public class CreateStream extends CreateSource implements ExecutableDdlStatement
     return toStringHelper(this)
         .add("name", getName())
         .add("elements", getElements())
+        .add("orReplace", isOrReplace())
         .add("notExists", isNotExists())
         .add("properties", getProperties())
         .toString();

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStreamAsSelect.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStreamAsSelect.java
@@ -28,9 +28,10 @@ public class CreateStreamAsSelect extends CreateAsSelect {
       final SourceName name,
       final Query query,
       final boolean notExists,
+      final boolean orReplace,
       final CreateSourceAsProperties properties
   ) {
-    this(Optional.empty(), name, query, notExists, properties);
+    this(Optional.empty(), name, query, notExists, orReplace, properties);
   }
 
   public CreateStreamAsSelect(
@@ -38,8 +39,9 @@ public class CreateStreamAsSelect extends CreateAsSelect {
       final SourceName name,
       final Query query,
       final boolean notExists,
+      final boolean orReplace,
       final CreateSourceAsProperties properties) {
-    super(location, name, query, notExists, properties);
+    super(location, name, query, orReplace, notExists, properties);
   }
 
   private CreateStreamAsSelect(

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTable.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTable.java
@@ -31,20 +31,22 @@ public class CreateTable extends CreateSource implements ExecutableDdlStatement 
   public CreateTable(
       final SourceName name,
       final TableElements elements,
+      final boolean orReplace,
       final boolean notExists,
       final CreateSourceProperties properties
   ) {
-    this(Optional.empty(), name, elements, notExists, properties);
+    this(Optional.empty(), name, elements, orReplace, notExists, properties);
   }
 
   public CreateTable(
       final Optional<NodeLocation> location,
       final SourceName name,
       final TableElements elements,
+      final boolean orReplace,
       final boolean notExists,
       final CreateSourceProperties properties
   ) {
-    super(location, name, elements, notExists, properties);
+    super(location, name, elements, orReplace, notExists, properties);
 
     throwOnNonPrimaryKeys(elements);
   }
@@ -58,6 +60,7 @@ public class CreateTable extends CreateSource implements ExecutableDdlStatement 
         getLocation(),
         getName(),
         elements,
+        isOrReplace(),
         isNotExists(),
         properties);
   }
@@ -83,6 +86,7 @@ public class CreateTable extends CreateSource implements ExecutableDdlStatement 
     return toStringHelper(this)
         .add("name", getName())
         .add("elements", getElements())
+        .add("orReplace", isOrReplace())
         .add("notExists", isNotExists())
         .add("properties", getProperties())
         .toString();

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTableAsSelect.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTableAsSelect.java
@@ -28,9 +28,10 @@ public class CreateTableAsSelect extends CreateAsSelect {
       final SourceName name,
       final Query query,
       final boolean notExists,
+      final boolean orReplace,
       final CreateSourceAsProperties properties
   ) {
-    this(Optional.empty(), name, query, notExists, properties);
+    this(Optional.empty(), name, query, notExists, orReplace, properties);
   }
 
   public CreateTableAsSelect(
@@ -38,9 +39,10 @@ public class CreateTableAsSelect extends CreateAsSelect {
       final SourceName name,
       final Query query,
       final boolean notExists,
+      final boolean orReplace,
       final CreateSourceAsProperties properties
   ) {
-    super(location, name, query, notExists, properties);
+    super(location, name, query, orReplace, notExists, properties);
   }
 
   private CreateTableAsSelect(

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
@@ -36,9 +36,11 @@ import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTable;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.parser.exception.ParseFailedException;
 import io.confluent.ksql.parser.properties.with.CreateSourceProperties;
 import io.confluent.ksql.parser.tree.AliasedRelation;
 import io.confluent.ksql.parser.tree.CreateStream;
+import io.confluent.ksql.parser.tree.CreateStreamAsSelect;
 import io.confluent.ksql.parser.tree.CreateTable;
 import io.confluent.ksql.parser.tree.DropStream;
 import io.confluent.ksql.parser.tree.DropTable;
@@ -48,6 +50,7 @@ import io.confluent.ksql.parser.tree.JoinOn;
 import io.confluent.ksql.parser.tree.JoinedSource;
 import io.confluent.ksql.parser.tree.ListStreams;
 import io.confluent.ksql.parser.tree.ListTables;
+import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.Table;
 import io.confluent.ksql.parser.tree.TableElement;
@@ -255,7 +258,7 @@ public class SqlFormatterTest {
   }
 
   @Test
-  public void shouldFormatCreateOrReplaceStreameStatement() {
+  public void shouldFormatCreateOrReplaceStreamStatement() {
     // Given:
     final CreateSourceProperties props = CreateSourceProperties.from(
         new ImmutableMap.Builder<String, Literal>()
@@ -525,7 +528,7 @@ public class SqlFormatterTest {
         + "FROM ADDRESS A\nEMIT CHANGES"));
   }
 
-  @Test
+  @Test(expected = ParseFailedException.class)
   public void shouldFormatReplaceSelectQueryCorrectly() {
     final String statementString =
         "CREATE OR REPLACE STREAM S AS SELECT a.address->city FROM address a;";

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateSourceTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateSourceTest.java
@@ -77,7 +77,7 @@ public class CreateSourceTest {
     // When:
     final ParseFailedException e = assertThrows(
         ParseFailedException.class,
-        () -> new TestCreateSource(Optional.empty(), SOME_NAME, multipleKeys, false, SOME_PROPS)
+        () -> new TestCreateSource(Optional.empty(), SOME_NAME, multipleKeys, false, false, SOME_PROPS)
     );
 
     // Then:
@@ -91,10 +91,11 @@ public class CreateSourceTest {
         final Optional<NodeLocation> location,
         final SourceName name,
         final TableElements elements,
+        final boolean orReplace,
         final boolean notExists,
         final CreateSourceProperties properties
     ) {
-      super(location, name, elements, notExists, properties);
+      super(location, name, elements, orReplace, notExists, properties);
     }
 
     @Override

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateStreamAsSelectTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateStreamAsSelectTest.java
@@ -41,22 +41,24 @@ public class CreateStreamAsSelectTest {
     new EqualsTester()
         .addEqualityGroup(
             // Note: At the moment location does not take part in equality testing
-            new CreateStreamAsSelect(SOME_NAME, SOME_QUERY, true, SOME_PROPS),
-            new CreateStreamAsSelect(Optional.of(SOME_LOCATION), SOME_NAME, SOME_QUERY, true,
-                SOME_PROPS)
+            new CreateStreamAsSelect(SOME_NAME, SOME_QUERY, true, true, SOME_PROPS),
+            new CreateStreamAsSelect(Optional.of(SOME_LOCATION), SOME_NAME, SOME_QUERY, true, true, SOME_PROPS)
         )
         .addEqualityGroup(
-            new CreateStreamAsSelect(SourceName.of("diff"), SOME_QUERY, true, SOME_PROPS
+            new CreateStreamAsSelect(Optional.of(SOME_LOCATION), SOME_NAME, SOME_QUERY, true, false, SOME_PROPS)
+        )
+        .addEqualityGroup(
+            new CreateStreamAsSelect(SourceName.of("diff"), SOME_QUERY, true, true, SOME_PROPS
             )
         )
         .addEqualityGroup(
-            new CreateStreamAsSelect(SOME_NAME, mock(Query.class), true, SOME_PROPS)
+            new CreateStreamAsSelect(SOME_NAME, mock(Query.class), true, true, SOME_PROPS)
         )
         .addEqualityGroup(
-            new CreateStreamAsSelect(SOME_NAME, SOME_QUERY, false, SOME_PROPS)
+            new CreateStreamAsSelect(SOME_NAME, SOME_QUERY, false, true, SOME_PROPS)
         )
         .addEqualityGroup(
-            new CreateStreamAsSelect(SOME_NAME, SOME_QUERY, true, CreateSourceAsProperties.none()
+            new CreateStreamAsSelect(SOME_NAME, SOME_QUERY, true, true, CreateSourceAsProperties.none()
             )
         )
         .testEquals();

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateStreamTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateStreamTest.java
@@ -60,22 +60,25 @@ public class CreateStreamTest {
     new EqualsTester()
         .addEqualityGroup(
             // Note: At the moment location does not take part in equality testing
-            new CreateStream(SOME_NAME, SOME_ELEMENTS, true, SOME_PROPS),
-            new CreateStream(SOME_NAME, SOME_ELEMENTS, true, SOME_PROPS),
-            new CreateStream(Optional.of(SOME_LOCATION), SOME_NAME, SOME_ELEMENTS, true, SOME_PROPS),
-            new CreateStream(Optional.of(OTHER_LOCATION), SOME_NAME, SOME_ELEMENTS, true, SOME_PROPS)
+            new CreateStream(SOME_NAME, SOME_ELEMENTS, false, true, SOME_PROPS),
+            new CreateStream(SOME_NAME, SOME_ELEMENTS, false, true, SOME_PROPS),
+            new CreateStream(Optional.of(SOME_LOCATION), SOME_NAME, SOME_ELEMENTS, false, true, SOME_PROPS),
+            new CreateStream(Optional.of(OTHER_LOCATION), SOME_NAME, SOME_ELEMENTS, false, true, SOME_PROPS)
         )
         .addEqualityGroup(
-            new CreateStream(SourceName.of("jim"), SOME_ELEMENTS, true, SOME_PROPS)
+            new CreateStream(SourceName.of("jim"), SOME_ELEMENTS, false, true, SOME_PROPS)
         )
         .addEqualityGroup(
-            new CreateStream(SOME_NAME, TableElements.of(), true, SOME_PROPS)
+            new CreateStream(SOME_NAME, TableElements.of(), false, true, SOME_PROPS)
         )
         .addEqualityGroup(
-            new CreateStream(SOME_NAME, SOME_ELEMENTS, false, SOME_PROPS)
+            new CreateStream(SOME_NAME, SOME_ELEMENTS, true, true, SOME_PROPS)
         )
         .addEqualityGroup(
-            new CreateStream(SOME_NAME, SOME_ELEMENTS, true, OTHER_PROPS)
+            new CreateStream(SOME_NAME, SOME_ELEMENTS, false, false, SOME_PROPS)
+        )
+        .addEqualityGroup(
+            new CreateStream(SOME_NAME, SOME_ELEMENTS, false, true, OTHER_PROPS)
         )
         .testEquals();
   }
@@ -104,7 +107,7 @@ public class CreateStreamTest {
     // When:
     final ParseFailedException e = assertThrows(
         ParseFailedException.class,
-        () -> new CreateStream(SOME_NAME, invalidElements, false, SOME_PROPS)
+        () -> new CreateStream(SOME_NAME, invalidElements, false, false, SOME_PROPS)
     );
 
     // Then:

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateTableAsSelectTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateTableAsSelectTest.java
@@ -41,23 +41,26 @@ public class CreateTableAsSelectTest {
     new EqualsTester()
         .addEqualityGroup(
             // Note: At the moment location does not take part in equality testing
-            new CreateTableAsSelect(SOME_NAME, SOME_QUERY, true, SOME_PROPS),
-            new CreateTableAsSelect(Optional.of(SOME_LOCATION), SOME_NAME, SOME_QUERY, true, SOME_PROPS)
+            new CreateTableAsSelect(SOME_NAME, SOME_QUERY, true, true, SOME_PROPS),
+            new CreateTableAsSelect(Optional.of(SOME_LOCATION), SOME_NAME, SOME_QUERY, true, true, SOME_PROPS)
         )
         .addEqualityGroup(
-            new CreateTableAsSelect(SourceName.of("diff"), SOME_QUERY, true, SOME_PROPS)
+            new CreateTableAsSelect(SOME_NAME, SOME_QUERY, true, false, SOME_PROPS)
         )
         .addEqualityGroup(
-            new CreateTableAsSelect(SOME_NAME, mock(Query.class), true, SOME_PROPS)
+            new CreateTableAsSelect(SourceName.of("diff"), SOME_QUERY, true, true, SOME_PROPS)
         )
         .addEqualityGroup(
-            new CreateTableAsSelect(SOME_NAME, SOME_QUERY, false, SOME_PROPS)
+            new CreateTableAsSelect(SOME_NAME, mock(Query.class), true, true, SOME_PROPS)
         )
         .addEqualityGroup(
-            new CreateTableAsSelect(SOME_NAME, SOME_QUERY, true, CreateSourceAsProperties.none())
+            new CreateTableAsSelect(SOME_NAME, SOME_QUERY, false, true, SOME_PROPS)
         )
         .addEqualityGroup(
-            new CreateStreamAsSelect(SOME_NAME, SOME_QUERY, true, CreateSourceAsProperties.none())
+            new CreateTableAsSelect(SOME_NAME, SOME_QUERY, true, true, CreateSourceAsProperties.none())
+        )
+        .addEqualityGroup(
+            new CreateStreamAsSelect(SOME_NAME, SOME_QUERY, true, true, CreateSourceAsProperties.none())
         )
         .testEquals();
   }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateTableTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateTableTest.java
@@ -60,22 +60,25 @@ public class CreateTableTest {
     new EqualsTester()
         .addEqualityGroup(
             // Note: At the moment location does not take part in equality testing
-            new CreateTable(SOME_NAME, SOME_ELEMENTS, true, SOME_PROPS),
-            new CreateTable(SOME_NAME, SOME_ELEMENTS, true, SOME_PROPS),
-            new CreateTable(Optional.of(SOME_LOCATION), SOME_NAME, SOME_ELEMENTS, true, SOME_PROPS),
-            new CreateTable(Optional.of(OTHER_LOCATION), SOME_NAME, SOME_ELEMENTS, true, SOME_PROPS)
+            new CreateTable(SOME_NAME, SOME_ELEMENTS, false, true, SOME_PROPS),
+            new CreateTable(SOME_NAME, SOME_ELEMENTS, false, true, SOME_PROPS),
+            new CreateTable(Optional.of(SOME_LOCATION), SOME_NAME, SOME_ELEMENTS, false, true, SOME_PROPS),
+            new CreateTable(Optional.of(OTHER_LOCATION), SOME_NAME, SOME_ELEMENTS, false, true, SOME_PROPS)
         )
         .addEqualityGroup(
-            new CreateTable(SourceName.of("jim"), SOME_ELEMENTS, true, SOME_PROPS)
+            new CreateTable(SourceName.of("jim"), SOME_ELEMENTS, false, true, SOME_PROPS)
         )
         .addEqualityGroup(
-            new CreateTable(SOME_NAME, TableElements.of(), true, SOME_PROPS)
+            new CreateTable(SOME_NAME, TableElements.of(), false, true, SOME_PROPS)
         )
         .addEqualityGroup(
-            new CreateTable(SOME_NAME, SOME_ELEMENTS, false, SOME_PROPS)
+            new CreateTable(SOME_NAME, SOME_ELEMENTS, false, false, SOME_PROPS)
         )
         .addEqualityGroup(
-            new CreateTable(SOME_NAME, SOME_ELEMENTS, true, OTHER_PROPS)
+            new CreateTable(SOME_NAME, SOME_ELEMENTS, true, true, SOME_PROPS)
+        )
+        .addEqualityGroup(
+            new CreateTable(SOME_NAME, SOME_ELEMENTS, false, true, OTHER_PROPS)
         )
         .testEquals();
   }
@@ -104,7 +107,7 @@ public class CreateTableTest {
     // When:
     final ParseFailedException e = assertThrows(
         ParseFailedException.class,
-        () -> new CreateTable(SOME_NAME, invalidElements, false, SOME_PROPS)
+        () -> new CreateTable(SOME_NAME, invalidElements, false, false, SOME_PROPS)
     );
 
     // Then:

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
@@ -143,7 +143,7 @@ public class StandaloneExecutorTest {
   );
 
   private static final CreateStream CREATE_STREAM = new CreateStream(
-      SOME_NAME, SOME_ELEMENTS, true, JSON_PROPS);
+      SOME_NAME, SOME_ELEMENTS, false, true, JSON_PROPS);
 
   private static final CreateStreamAsSelect CREATE_STREAM_AS_SELECT = new CreateStreamAsSelect(
       SourceName.of("stream"),
@@ -160,6 +160,7 @@ public class StandaloneExecutorTest {
           false,
           OptionalInt.empty()
       ),
+      false,
       false,
       CreateSourceAsProperties.none()
   );
@@ -190,6 +191,7 @@ public class StandaloneExecutorTest {
       .of("sql 0", new CreateStream(
           SourceName.of("CS 0"),
           SOME_ELEMENTS,
+          false,
           true,
           JSON_PROPS
       ));
@@ -201,6 +203,7 @@ public class StandaloneExecutorTest {
       .of("sql 1", new CreateStream(
           SourceName.of("CS 1"),
           SOME_ELEMENTS,
+          false,
           true,
           JSON_PROPS
       ));
@@ -504,7 +507,7 @@ public class StandaloneExecutorTest {
   public void shouldRunCsStatement() {
     // Given:
     final PreparedStatement<CreateStream> cs = PreparedStatement.of("CS",
-        new CreateStream(SOME_NAME, SOME_ELEMENTS, false, JSON_PROPS));
+        new CreateStream(SOME_NAME, SOME_ELEMENTS, false, false, JSON_PROPS));
 
     givenQueryFileParsesTo(cs);
 
@@ -519,7 +522,7 @@ public class StandaloneExecutorTest {
   public void shouldRunCtStatement() {
     // Given:
     final PreparedStatement<CreateTable> ct = PreparedStatement.of("CT",
-        new CreateTable(SOME_NAME, SOME_ELEMENTS, false, JSON_PROPS));
+        new CreateTable(SOME_NAME, SOME_ELEMENTS, false, false, JSON_PROPS));
 
     givenQueryFileParsesTo(ct);
 
@@ -537,7 +540,7 @@ public class StandaloneExecutorTest {
         new SetProperty(Optional.empty(), ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"));
 
     final PreparedStatement<CreateStream> cs = PreparedStatement.of("CS",
-        new CreateStream(SOME_NAME, SOME_ELEMENTS, false, JSON_PROPS));
+        new CreateStream(SOME_NAME, SOME_ELEMENTS, false, false, JSON_PROPS));
 
     givenQueryFileParsesTo(setProp, cs);
 
@@ -560,7 +563,7 @@ public class StandaloneExecutorTest {
         new SetProperty(Optional.empty(), ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"));
 
     final PreparedStatement<CreateStream> cs = PreparedStatement.of("CS",
-        new CreateStream(SOME_NAME, SOME_ELEMENTS, false, JSON_PROPS));
+        new CreateStream(SOME_NAME, SOME_ELEMENTS, false, false, JSON_PROPS));
 
     givenQueryFileParsesTo(cs, setProp);
 
@@ -585,7 +588,7 @@ public class StandaloneExecutorTest {
         new UnsetProperty(Optional.empty(), ConsumerConfig.AUTO_OFFSET_RESET_CONFIG));
 
     final PreparedStatement<CreateStream> cs = PreparedStatement.of("CS",
-        new CreateStream(SOME_NAME, SOME_ELEMENTS, false, JSON_PROPS));
+        new CreateStream(SOME_NAME, SOME_ELEMENTS, false, false, JSON_PROPS));
 
     final ConfiguredStatement<?> configured = ConfiguredStatement.of(cs, emptyMap(), ksqlConfig);
 
@@ -602,7 +605,7 @@ public class StandaloneExecutorTest {
   public void shouldRunCsasStatements() {
     // Given:
     final PreparedStatement<?> csas = PreparedStatement.of("CSAS1",
-        new CreateStreamAsSelect(SOME_NAME, query, false, CreateSourceAsProperties.none()));
+        new CreateStreamAsSelect(SOME_NAME, query, false, false, CreateSourceAsProperties.none()));
     final ConfiguredStatement<?> configured = ConfiguredStatement.of(csas, emptyMap(), ksqlConfig);
     givenQueryFileParsesTo(csas);
 
@@ -620,7 +623,7 @@ public class StandaloneExecutorTest {
   public void shouldRunCtasStatements() {
     // Given:
     final PreparedStatement<?> ctas = PreparedStatement.of("CTAS",
-        new CreateTableAsSelect(SOME_NAME, query, false, CreateSourceAsProperties.none()));
+        new CreateTableAsSelect(SOME_NAME, query, false, false, CreateSourceAsProperties.none()));
     final ConfiguredStatement<?> configured = ConfiguredStatement.of(ctas, emptyMap(), ksqlConfig);
 
     givenQueryFileParsesTo(ctas);
@@ -774,7 +777,7 @@ public class StandaloneExecutorTest {
   public void shouldThrowOnCreateStatementWithNoElements() {
     // Given:
     final PreparedStatement<CreateStream> cs = PreparedStatement.of("CS",
-        new CreateStream(SOME_NAME, TableElements.of(), false, JSON_PROPS));
+        new CreateStream(SOME_NAME, TableElements.of(), false, false, JSON_PROPS));
 
     givenQueryFileParsesTo(cs);
 
@@ -792,7 +795,7 @@ public class StandaloneExecutorTest {
   public void shouldSupportSchemaInference() {
     // Given:
     final PreparedStatement<CreateStream> cs = PreparedStatement.of("CS",
-        new CreateStream(SOME_NAME, TableElements.of(), false, AVRO_PROPS));
+        new CreateStream(SOME_NAME, TableElements.of(), false, false, AVRO_PROPS));
 
     givenQueryFileParsesTo(cs);
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/DistributingExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/DistributingExecutorTest.java
@@ -90,6 +90,7 @@ public class DistributingExecutorTest {
       SourceName.of("TEST"),
       TableElements.of(),
       false,
+      false,
       CreateSourceProperties.from(ImmutableMap.of(
           CommonCreateConfigs.KAFKA_TOPIC_NAME_PROPERTY, new StringLiteral("topic"),
           CommonCreateConfigs.VALUE_FORMAT_PROPERTY, new StringLiteral("json")

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -221,6 +221,7 @@ public class KsqlResourceTest {
       new CreateStream(
           SourceName.of("bob"),
           SOME_ELEMENTS,
+          false,
           true,
           CreateSourceProperties.from(ImmutableMap.of(
               "KAFKA_TOPIC", new StringLiteral("orders-topic"),
@@ -237,6 +238,7 @@ public class KsqlResourceTest {
       new CreateStream(
           SourceName.of("john"),
           SOME_ELEMENTS,
+          false,
           true,
           CreateSourceProperties.from(ImmutableMap.of(
               "KAFKA_TOPIC", new StringLiteral("orders-topic"),


### PR DESCRIPTION
### Description 
Adds the syntax for `CREATE OR REPLACE`

### Testing done 
Unit testing and end-to-end UX testing:

```
ksql> CREATE OR REPLACE STREAM FOO (id VARCHAR) WITH (KAFKA_TOPIC='foo', VALUE_FORMAT='json', partitions=1);
Failed to prepare statement: CREATE OR REPLACE is not yet supported.
```


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

