### PR TITLE
docs: cherry-pick: remove server endpoint + API links from client docs (MINOR) (DOCS-4734)

### DIFF
--- a/docs/developer-guide/ksqldb-clients/java-client.md
+++ b/docs/developer-guide/ksqldb-clients/java-client.md
@@ -15,7 +15,7 @@ Soon the client will also support persistent queries and admin operations such a
     [View the Java client API documentation](api/index.html)
 
 The client sends requests to the recently added HTTP2 server endpoints: pull and push queries are served by
-the [`/query-stream` endpoint](TODO), and inserts are served by the [`/inserts-stream` endpoint](TODO).
+the `/query-stream` endpoint, and inserts are served by the `/inserts-stream` endpoint.
 The client is compatible only with ksqlDB deployments that are on version 0.10.0 or later.
 
 Use the Java client to:
@@ -104,7 +104,7 @@ public class ExampleApp {
 }
 ```
 
-For additional client options, see [the API reference](TODO).
+For additional client options, see the API reference.
 
 Receive query results one row at a time (streamQuery())<a name="stream-query"></a>
 ----------------------------------------------------------------------------------
@@ -135,7 +135,7 @@ public interface Client {
 You can use this method to issue both push and pull queries, but the usage pattern is better for push queries.
 For pull queries, consider [the `executeQuery()` method](./execute-query.md) instead. 
 
-Query properties can be passed as an optional second argument. For more information, see the [client API reference](TODO).
+Query properties can be passed as an optional second argument. For more information, see the client API reference.
 
 By default, push queries return only newly arriving rows. To start from the beginning of the stream or table,
 set the `auto.offset.reset` property to `earliest`.
@@ -206,7 +206,7 @@ client.streamQuery("SELECT * FROM MY_STREAM EMIT CHANGES;")
 To consume records one-at-a-time in a synchronous fashion, use the `poll()` method on the query result object.
 If `poll()` is called with no arguments, it blocks until a new row becomes available or the query is terminated.
 You can also pass a `Duration` argument to `poll()`, which causes `poll()` to return `null` if no new rows are received by the time the duration has elapsed.
-For more information, see the [API reference](TODO).
+For more information, see the API reference.
 
 ```java
 StreamedQueryResult streamedQueryResult = client.streamQuery("SELECT * FROM MY_STREAM EMIT CHANGES;").get();
@@ -249,7 +249,7 @@ public interface Client {
 This method is suitable for both pull queries and for terminating push queries, for example, queries that have a `LIMIT` clause).
 For non-terminating push queries, use [the `streamQuery()` method](./stream-query.md) instead.
 
-Query properties can be passed as an optional second argument. For more information, see the [client API reference](TODO).
+Query properties can be passed as an optional second argument. For more information, see the client API reference.
 
 By default, push queries return only newly arriving rows. To start from the beginning of the stream or table,
 set the `auto.offset.reset` property to `earliest`.


### PR DESCRIPTION
From https://github.com/confluentinc/ksql/pull/5668.