### PR TITLE
feat: support WINDOWEND in WHERE of pull queries

### DIFF
--- a/docs/concepts/queries/pull.md
+++ b/docs/concepts/queries/pull.md
@@ -38,7 +38,7 @@ Pull query features and limitations
   by key.
 - WHERE clauses can only have constraints on the key column for non-windowed tables.
 
-- In addition, windowed tables support bounds on WINDOWSTART using operators
+- In addition, windowed tables support bounds on `WINDOWSTART` and `WINDOWEND` using operators
   `<=`, `<`, `=`, `>`, `>=`.
 - JOIN, PARTITION BY, GROUP BY and WINDOW clauses aren't supported.
 - SELECT statements can contain column arithmetic and function calls.
@@ -53,7 +53,7 @@ timestamp within the specified time window.
 ```sql
 SELECT * FROM user_location
   WHERE userId = 'user19r7t33'
-    AND '2019-10-02T21:31:16' <= WINDOWSTART AND WINDOWSTART <= '2019-10-03T21:31:16';
+    AND '2019-10-02T21:31:16' <= WINDOWSTART AND WINDOWEND <= '2019-10-03T21:31:16';
 ```
 
 API Reference

--- a/docs/developer-guide/ksqldb-reference/select-pull-query.md
+++ b/docs/developer-guide/ksqldb-reference/select-pull-query.md
@@ -36,7 +36,7 @@ Execute a pull query by sending an HTTP request to the ksqlDB REST API, and
 the API responds with a single response.  
 
 The WHERE clause must contain a single primary-key to retrieve and may
-optionally include bounds on WINDOWSTART if the materialized table is windowed.
+optionally include bounds on `WINDOWSTART` and `WINDOWEND` if the materialized table is windowed.
 
 Example
 -------
@@ -44,17 +44,17 @@ Example
 ```sql
 SELECT * FROM pageviews_by_region
   WHERE regionId = 'Region_1'
-    AND 1570051876000 <= WINDOWSTART AND WINDOWSTART <= 1570138276000;
+    AND 1570051876000 <= WINDOWSTART AND WINDOWEND <= 1570138276000;
 ```
 
-When writing logical expressions using `WINDOWSTART`, you can use ISO-8601
+When writing logical expressions using `WINDOWSTART` or `WINDOWEND`, you can use ISO-8601
 formatted datestrings to represent date times. For example, the previous
 query is equivalent to the following:
 
 ```sql
 SELECT * FROM pageviews_by_region
   WHERE regionId = 'Region_1'
-    AND '2019-10-02T21:31:16' <= WINDOWSTART AND WINDOWSTART <= '2019-10-03T21:31:16';
+    AND '2019-10-02T21:31:16' <= WINDOWSTART AND WINDOWEND <= '2019-10-03T21:31:16';
 ```
 
 You can specify time zones within the datestring. For example,
@@ -62,5 +62,5 @@ You can specify time zones within the datestring. For example,
 specified within the datestring, then timestamps are interpreted in the UTC
 time zone.
 
-If no bounds are placed on `WINDOWSTART`, rows are returned for all windows
+If no bounds are placed on `WINDOWSTART` or `WINDOWEND`, rows are returned for all windows
 in the windowed table.

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
@@ -320,7 +320,7 @@ public class KsMaterializationFunctionalTest {
       final Struct key = asKeyStruct(k.key(), query.getPhysicalSchema());
 
       final List<WindowedRow> resultAtWindowStart =
-          withRetry(() -> table.get(key, Range.singleton(w.start())));
+          withRetry(() -> table.get(key, Range.singleton(w.start()), Range.all()));
 
       assertThat("at exact window start", resultAtWindowStart, hasSize(1));
       assertThat(resultAtWindowStart.get(0).schema(), is(schema));
@@ -328,13 +328,17 @@ public class KsMaterializationFunctionalTest {
       assertThat(resultAtWindowStart.get(0).key(), is(key));
       assertThat(resultAtWindowStart.get(0).value(), is(v));
 
+      final List<WindowedRow> resultAtWindowEnd =
+          withRetry(() -> table.get(key, Range.all(), Range.singleton(w.end())));
+      assertThat("at exact window end", resultAtWindowEnd, hasSize(1));
+
       final List<WindowedRow> resultFromRange = withRetry(() -> withRetry(() -> table
-          .get(key, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1)))));
+          .get(key, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1)), Range.all())));
 
       assertThat("range including window start", resultFromRange, is(resultAtWindowStart));
 
       final List<WindowedRow> resultPast = withRetry(() -> table
-          .get(key, Range.closed(w.start().plusMillis(1), w.start().plusMillis(1))));
+          .get(key, Range.closed(w.start().plusMillis(1), w.start().plusMillis(1)), Range.all()));
       assertThat("past start", resultPast, is(empty())
       );
     });
@@ -369,7 +373,7 @@ public class KsMaterializationFunctionalTest {
       final Struct key = asKeyStruct(k.key(), query.getPhysicalSchema());
 
       final List<WindowedRow> resultAtWindowStart =
-          withRetry(() -> table.get(key, Range.singleton(w.start())));
+          withRetry(() -> table.get(key, Range.singleton(w.start()), Range.all()));
 
       assertThat("at exact window start", resultAtWindowStart, hasSize(1));
       assertThat(resultAtWindowStart.get(0).schema(), is(schema));
@@ -377,13 +381,17 @@ public class KsMaterializationFunctionalTest {
       assertThat(resultAtWindowStart.get(0).key(), is(key));
       assertThat(resultAtWindowStart.get(0).value(), is(v));
 
+      final List<WindowedRow> resultAtWindowEnd =
+          withRetry(() -> table.get(key, Range.all(), Range.singleton(w.end())));
+      assertThat("at exact window end", resultAtWindowEnd, hasSize(1));
+
       final List<WindowedRow> resultFromRange = withRetry(() -> table
-          .get(key, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1))));
+          .get(key, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1)), Range.all()));
 
       assertThat("range including window start", resultFromRange, is(resultAtWindowStart));
 
       final List<WindowedRow> resultPast = withRetry(() -> table
-          .get(key, Range.closed(w.start().plusMillis(1), w.start().plusMillis(1))));
+          .get(key, Range.closed(w.start().plusMillis(1), w.start().plusMillis(1)), Range.all()));
 
       assertThat("past start", resultPast, is(empty()));
     });
@@ -417,7 +425,7 @@ public class KsMaterializationFunctionalTest {
       final Struct key = asKeyStruct(k.key(), query.getPhysicalSchema());
 
       final List<WindowedRow> resultAtWindowStart =
-          withRetry(() -> table.get(key, Range.singleton(w.start())));
+          withRetry(() -> table.get(key, Range.singleton(w.start()), Range.all()));
 
       assertThat("at exact window start", resultAtWindowStart, hasSize(1));
       assertThat(resultAtWindowStart.get(0).schema(), is(schema));
@@ -425,12 +433,16 @@ public class KsMaterializationFunctionalTest {
       assertThat(resultAtWindowStart.get(0).key(), is(key));
       assertThat(resultAtWindowStart.get(0).value(), is(v));
 
+      final List<WindowedRow> resultAtWindowEnd =
+          withRetry(() -> table.get(key, Range.all(), Range.singleton(w.end())));
+      assertThat("at exact window end", resultAtWindowEnd, hasSize(1));
+
       final List<WindowedRow> resultFromRange = withRetry(() -> table
-          .get(key, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1))));
+          .get(key, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1)), Range.all()));
       assertThat("range including window start", resultFromRange, is(resultAtWindowStart));
 
       final List<WindowedRow> resultPast = withRetry(() -> table
-          .get(key, Range.closed(w.start().plusMillis(1), w.start().plusMillis(1))));
+          .get(key, Range.closed(w.start().plusMillis(1), w.start().plusMillis(1)), Range.all()));
       assertThat("past start", resultPast, is(empty()));
     });
   }
@@ -644,7 +656,9 @@ public class KsMaterializationFunctionalTest {
   ) {
     rows.forEach(record -> {
       final Struct key = asKeyStruct(record.key().key(), query.getPhysicalSchema());
-      final List<WindowedRow> resultAtWindowStart = withRetry(() -> table.get(key, Range.all()));
+      final List<WindowedRow> resultAtWindowStart =
+          withRetry(() -> table.get(key, Range.all(), Range.all()));
+
       assertThat("Should have fewer windows retained",
           resultAtWindowStart,
           hasSize(expectedWindows.size()));

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
@@ -414,6 +414,45 @@
       ]
     },
     {
+      "name": "tumbling windowed single key lookup with window start-end range",
+      "statements": [
+        "CREATE STREAM INPUT (ID STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ID;",
+        "SELECT ID, WINDOWSTART, WINDOWEND, ROWTIME, COUNT FROM AGGREGATE WHERE 100 <= WindowStart AND WindowEnd < 200000 AND ID='10';",
+        "SELECT ID, WINDOWSTART, WINDOWEND, ROWTIME, COUNT FROM AGGREGATE WHERE 12000 <= WindowStart AND WindowEnd < 14000 AND ID='10';",
+        "SELECT ID, WINDOWSTART, WINDOWEND, ROWTIME, COUNT FROM AGGREGATE WHERE 12000 < WindowStart AND WindowEnd <= 15000 AND ID='10';",
+        "SELECT ID, WINDOWSTART, WINDOWEND, ROWTIME, COUNT FROM AGGREGATE WHERE WindowStart > 17000 AND 11234756356 > WindowEnd AND ID='10';"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12001, "key": "11", "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 12211, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 14253, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 15364, "key": "10", "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `ROWTIME` BIGINT, `COUNT` BIGINT"}},
+          {"row":{"columns":["10", 12000, 13000, 12345, 2]}},
+          {"row":{"columns":["10", 14000, 15000, 14253, 1]}},
+          {"row":{"columns":["10", 15000, 16000, 15364, 1]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `ROWTIME` BIGINT, `COUNT` BIGINT"}},
+          {"row":{"columns":["10", 12000, 13000, 12345, 2]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `ROWTIME` BIGINT, `COUNT` BIGINT"}},
+          {"row":{"columns":["10", 14000, 15000, 14253, 1]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `ROWTIME` BIGINT, `COUNT` BIGINT"}}
+        ]}
+      ]
+    },
+    {
       "name": "hopping windowed single key lookup with window start range",
       "statements": [
         "CREATE STREAM INPUT (ID STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
@@ -421,6 +460,42 @@
         "SELECT ID, WINDOWSTART, WINDOWEND, ROWTIME, COUNT FROM AGGREGATE WHERE ID='10' AND 7000 <= WindowStart AND WindowStart < 11000;",
         "SELECT ID, WINDOWSTART, WINDOWEND, ROWTIME, COUNT FROM AGGREGATE WHERE ID='10' AND 7000 < WindowStart AND WindowStart <= 11000;",
         "SELECT ID, WINDOWSTART, WINDOWEND, ROWTIME, COUNT FROM AGGREGATE WHERE ID='10' AND 13001 <= WindowStart AND WindowStart < 11234756356;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 10021, "key": "11", "value": {}},
+        {"topic": "test_topic", "timestamp": 10345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 13251, "key": "10", "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `ROWTIME` BIGINT, `COUNT` BIGINT"}},
+          {"row":{"columns":["10", 7000, 12000, 10345, 1]}},
+          {"row":{"columns":["10", 8000, 13000, 10345, 1]}},
+          {"row":{"columns":["10", 9000, 14000, 13251, 2]}},
+          {"row":{"columns":["10", 10000, 15000, 13251, 2]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `ROWTIME` BIGINT, `COUNT` BIGINT"}},
+          {"row":{"columns":["10", 8000, 13000, 10345, 1]}},
+          {"row":{"columns":["10", 9000, 14000, 13251, 2]}},
+          {"row":{"columns":["10", 10000, 15000, 13251, 2]}},
+          {"row":{"columns":["10", 11000, 16000, 13251, 1]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `ROWTIME` BIGINT, `COUNT` BIGINT"}}
+        ]}
+      ]
+    },
+    {
+      "name": "hopping windowed single key lookup with window start-end range",
+      "statements": [
+        "CREATE STREAM INPUT (ID STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT WINDOW HOPPING(SIZE 5 SECOND, ADVANCE BY 1 SECONDS) GROUP BY ID;",
+        "SELECT ID, WINDOWSTART, WINDOWEND, ROWTIME, COUNT FROM AGGREGATE WHERE ID='10' AND 7000 <= WindowStart AND WindowEnd < 16000;",
+        "SELECT ID, WINDOWSTART, WINDOWEND, ROWTIME, COUNT FROM AGGREGATE WHERE ID='10' AND 7000 < WindowStart AND WindowEnd <= 16000;",
+        "SELECT ID, WINDOWSTART, WINDOWEND, ROWTIME, COUNT FROM AGGREGATE WHERE ID='10' AND 13001 <= WindowStart AND WindowEnd < 11234756356;"
       ],
       "inputs": [
         {"topic": "test_topic", "timestamp": 10021, "key": "11", "value": {}},
@@ -483,7 +558,40 @@
       ]
     },
     {
-      "name": "tumbling windowed single key lookup with unbounded window start",
+      "name": "session windowed single key lookup with window start-end range",
+      "statements": [
+        "CREATE STREAM INPUT (ID STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT WINDOW SESSION(5 SECOND) GROUP BY ID;",
+        "SELECT ID, WINDOWSTART, WINDOWEND, ROWTIME, COUNT FROM AGGREGATE WHERE ID='10' AND 10 <= WindowStart AND WindowEnd < 200000;",
+        "SELECT ID, WINDOWSTART, WINDOWEND, ROWTIME, COUNT FROM AGGREGATE WHERE ID='10' AND 8001 <= WindowStart AND WindowEnd < 19444;",
+        "SELECT ID, WINDOWSTART, WINDOWEND, ROWTIME, COUNT FROM AGGREGATE WHERE ID='10' AND 8001 < WindowStart AND WindowEnd <= 19444;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": "11", "value": {}},
+        {"topic": "test_topic", "timestamp": 8001, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 10456, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 19444, "key": "10", "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `ROWTIME` BIGINT, `COUNT` BIGINT"}},
+          {"row":{"columns":["10", 8001, 10456, 10456, 2]}},
+          {"row":{"columns":["10", 19444, 19444, 19444, 1]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `ROWTIME` BIGINT, `COUNT` BIGINT"}},
+          {"row":{"columns":["10", 8001, 10456, 10456, 2]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `ROWTIME` BIGINT, `COUNT` BIGINT"}},
+          {"row":{"columns":["10", 19444, 19444, 19444, 1]}}
+        ]}
+      ]
+    },
+    {
+      "name": "tumbling windowed single key lookup without window bounds",
       "statements": [
         "CREATE STREAM INPUT (ID STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ID;",
@@ -505,7 +613,7 @@
       ]
     },
     {
-      "name": "hopping windowed single key lookup with unbounded window start",
+      "name": "hopping windowed single key lookup without window bounds",
       "statements": [
         "CREATE STREAM INPUT (ID STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT WINDOW HOPPING(SIZE 4 SECOND, ADVANCE BY 1 SECONDS) GROUP BY ID;",
@@ -532,7 +640,7 @@
       ]
     },
     {
-      "name": "session windowed single key lookup with unbounded window start",
+      "name": "session windowed single key lookup without window bounds",
       "statements": [
         "CREATE STREAM INPUT (ID STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT WINDOW SESSION(10 SECOND) GROUP BY ID;",
@@ -721,10 +829,11 @@
       "statements": [
         "CREATE STREAM INPUT (ID STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ID;",
-        "SELECT * FROM AGGREGATE WHERE ID='10' AND WindowStart='2020-02-23T23:45:12.000';"
+        "SELECT * FROM AGGREGATE WHERE ID='10' AND WindowStart>='2020-02-23T23:45:12.000' AND WindowEnd<'2020-02-23T23:55:12.000';"
       ],
       "inputs": [
         {"topic": "test_topic", "timestamp": 1582501512456, "key": "11", "value": {}},
+        {"topic": "test_topic", "timestamp": 1582501512456, "key": "10", "value": {}},
         {"topic": "test_topic", "timestamp": 1582501512456, "key": "10", "value": {}}
       ],
       "responses": [
@@ -1001,6 +1110,19 @@
       }
     },
     {
+      "name": "fail if WINDOWEND used in non-windowed pull query",
+      "statements": [
+        "CREATE STREAM INPUT (ID STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE ID='10' AND WINDOWEND=10;"
+      ],
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
+        "message": "WHERE column 'WINDOWEND' cannot be resolved",
+        "status": 400
+      }
+    },
+    {
       "name": "window bounds in projection UDF",
       "statements": [
         "CREATE STREAM INPUT (ID STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
@@ -1118,6 +1240,260 @@
         "message": "Pull queries are not supported on streams.",
         "status": 400
       }
+    },
+    {
+      "name": "window start lower bound",
+      "statements": [
+        "CREATE STREAM INPUT (ID STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE ID='10' AND 13000 <= WindowStart;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 11345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 13345, "key": "10", "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":["10",13000,14000,1]}}
+        ]}
+      ]
+    },
+    {
+      "name": "window end lower bound",
+      "statements": [
+        "CREATE STREAM INPUT (ID STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE ID='10' AND 14000 <= WindowEnd;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 11345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 13345, "key": "10", "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":["10",13000,14000,1]}}
+        ]}
+      ]
+    },
+    {
+      "name": "window start upper bound",
+      "statements": [
+        "CREATE STREAM INPUT (ID STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE ID='10' AND WindowStart <= 12000;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 11345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 13345, "key": "10", "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":["10",11000,12000,1]}},
+          {"row":{"columns":["10",12000,13000,1]}}
+        ]}
+      ]
+    },
+    {
+      "name": "window end upper bound",
+      "statements": [
+        "CREATE STREAM INPUT (ID STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE ID='10' AND WindowEnd <= 13000;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 11345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 13345, "key": "10", "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":["10",11000,12000,1]}},
+          {"row":{"columns":["10",12000,13000,1]}}
+        ]}
+      ]
+    },
+    {
+      "name": "window range - start-start",
+      "statements": [
+        "CREATE STREAM INPUT (ID STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE ID='10' AND 12000 <= WindowStart AND WindowStart < 13000;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 11345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 13345, "key": "10", "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":["10",12000,13000,1]}}
+        ]}
+      ]
+    },
+    {
+      "name": "window range - end-end",
+      "statements": [
+        "CREATE STREAM INPUT (ID STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE ID='10' AND 13000 <= WindowEnd AND WindowEnd < 14000;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 11345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 13345, "key": "10", "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":["10",12000,13000,1]}}
+        ]}
+      ]
+    },
+    {
+      "name": "window range - start-end",
+      "statements": [
+        "CREATE STREAM INPUT (ID STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE ID='10' AND 12000 <= WindowStart AND WindowEnd < 14000;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 11345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 13345, "key": "10", "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":["10",12000,13000,1]}}
+        ]}
+      ]
+    },
+    {
+      "name": "window range - end-start",
+      "statements": [
+        "CREATE STREAM INPUT (ID STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE ID='10' AND 13000 <= WindowEnd AND WindowStart < 13000;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 11345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 13345, "key": "10", "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":["10",12000,13000,1]}}
+        ]}
+      ]
+    },
+    {
+      "name": "window range - double lower bound - start highest",
+      "statements": [
+        "CREATE STREAM INPUT (ID STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE ID='10' AND 13000 <=WindowStart AND 13000 <= WindowEnd;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 11345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 13345, "key": "10", "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":["10",13000,14000,1]}}
+        ]}
+      ]
+    },
+    {
+      "name": "window range - double lower bound - end highest",
+      "statements": [
+        "CREATE STREAM INPUT (ID STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE ID='10' AND 12000 <=WindowStart AND 14000 <= WindowEnd;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 11345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 13345, "key": "10", "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":["10",13000,14000,1]}}
+        ]}
+      ]
+    },
+    {
+      "name": "window range - double upper bound - start lowest",
+      "statements": [
+        "CREATE STREAM INPUT (ID STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE ID='10' AND WindowStart < 12000 AND WindowEnd < 14000;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 11345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 13345, "key": "10", "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":["10",11000,12000,1]}}
+        ]}
+      ]
+    },
+    {
+      "name": "window range - double upper bound - end lowest",
+      "statements": [
+        "CREATE STREAM INPUT (ID STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE ID='10' AND WindowStart <= 12000 AND WindowEnd < 13000;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 11345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 13345, "key": "10", "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":["10",11000,12000,1]}}
+        ]}
+      ]
     }
   ]
 }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/KsqlMaterialization.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/KsqlMaterialization.java
@@ -151,8 +151,12 @@ class KsqlMaterialization implements Materialization {
     }
 
     @Override
-    public List<WindowedRow> get(final Struct key, final Range<Instant> windowStart) {
-      final List<WindowedRow> result = table.get(key, windowStart);
+    public List<WindowedRow> get(
+        final Struct key,
+        final Range<Instant> windowStart,
+        final Range<Instant> windowEnd
+    ) {
+      final List<WindowedRow> result = table.get(key, windowStart, windowEnd);
 
       final Builder<WindowedRow> builder = ImmutableList.builder();
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/MaterializedWindowedTable.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/MaterializedWindowedTable.java
@@ -31,7 +31,8 @@ public interface MaterializedWindowedTable {
    *
    * @param key the key to look up.
    * @param windowStart the bounds on the window's start time.
+   * @param windowEnd the bounds on the window's end time.
    * @return the rows for the key that exist within the range.
    */
-  List<WindowedRow> get(Struct key, Range<Instant> windowStart);
+  List<WindowedRow> get(Struct key, Range<Instant> windowStart, Range<Instant> windowEnd);
 }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedSessionTable.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedSessionTable.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Objects;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.kstream.Window;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
@@ -46,13 +47,14 @@ class KsMaterializedSessionTable implements MaterializedWindowedTable {
   @Override
   public List<WindowedRow> get(
       final Struct key,
-      final Range<Instant> windowStart
+      final Range<Instant> windowStart,
+      final Range<Instant> windowEnd
   ) {
     try {
       final ReadOnlySessionStore<Struct, GenericRow> store = stateStore
           .store(QueryableStoreTypes.sessionStore());
 
-      return findSession(store, key, windowStart);
+      return findSession(store, key, windowStart, windowEnd);
     } catch (final Exception e) {
       throw new MaterializationException("Failed to get value from materialized table", e);
     }
@@ -61,7 +63,8 @@ class KsMaterializedSessionTable implements MaterializedWindowedTable {
   private List<WindowedRow> findSession(
       final ReadOnlySessionStore<Struct, GenericRow> store,
       final Struct key,
-      final Range<Instant> windowStart
+      final Range<Instant> windowStart,
+      final Range<Instant> windowEnd
   ) {
     try (KeyValueIterator<Windowed<Struct>, GenericRow> it = store.fetch(key)) {
 
@@ -69,20 +72,26 @@ class KsMaterializedSessionTable implements MaterializedWindowedTable {
 
       while (it.hasNext()) {
         final KeyValue<Windowed<Struct>, GenericRow> next = it.next();
+        final Window wnd = next.key.window();
 
-        if (windowStart.contains(next.key.window().startTime())) {
-
-          final long rowTime = next.key.window().end();
-
-          final WindowedRow row = WindowedRow.of(
-              stateStore.schema(),
-              next.key,
-              next.value,
-              rowTime
-          );
-
-          builder.add(row);
+        if (!windowStart.contains(wnd.startTime())) {
+          continue;
         }
+
+        if (!windowEnd.contains((wnd.endTime()))) {
+          continue;
+        }
+
+        final long rowTime = wnd.end();
+
+        final WindowedRow row = WindowedRow.of(
+            stateStore.schema(),
+            next.key,
+            next.value,
+            rowTime
+        );
+
+        builder.add(row);
       }
 
       return builder.build();

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedSessionTable.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedSessionTable.java
@@ -78,7 +78,7 @@ class KsMaterializedSessionTable implements MaterializedWindowedTable {
           continue;
         }
 
-        if (!windowEnd.contains((wnd.endTime()))) {
+        if (!windowEnd.contains(wnd.endTime())) {
           continue;
         }
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedWindowTable.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedWindowTable.java
@@ -51,19 +51,16 @@ class KsMaterializedWindowTable implements MaterializedWindowedTable {
   @Override
   public List<WindowedRow> get(
       final Struct key,
-      final Range<Instant> windowStartBounds
+      final Range<Instant> windowStartBounds,
+      final Range<Instant> windowEndBounds
   ) {
     try {
       final ReadOnlyWindowStore<Struct, ValueAndTimestamp<GenericRow>> store = stateStore
           .store(QueryableStoreTypes.timestampedWindowStore());
 
-      final Instant lower = windowStartBounds.hasLowerBound()
-          ? windowStartBounds.lowerEndpoint()
-          : Instant.ofEpochMilli(0);
+      final Instant lower = calculateLowerBound(windowStartBounds, windowEndBounds);
 
-      final Instant upper = windowStartBounds.hasUpperBound()
-          ? windowStartBounds.upperEndpoint()
-          : Instant.ofEpochMilli(Long.MAX_VALUE);
+      final Instant upper = calculateUpperBound(windowStartBounds, windowEndBounds);
 
       try (WindowStoreIterator<ValueAndTimestamp<GenericRow>> it = store.fetch(key, lower, upper)) {
 
@@ -71,24 +68,28 @@ class KsMaterializedWindowTable implements MaterializedWindowedTable {
 
         while (it.hasNext()) {
           final KeyValue<Long, ValueAndTimestamp<GenericRow>> next = it.next();
+
           final Instant windowStart = Instant.ofEpochMilli(next.key);
-
-          if (windowStartBounds.contains(windowStart)) {
-
-            final Instant windowEnd = windowStart.plus(windowSize);
-
-            final TimeWindow window =
-                new TimeWindow(windowStart.toEpochMilli(), windowEnd.toEpochMilli());
-
-            final WindowedRow row = WindowedRow.of(
-                stateStore.schema(),
-                new Windowed<>(key, window),
-                next.value.value(),
-                next.value.timestamp()
-            );
-
-            builder.add(row);
+          if (!windowStartBounds.contains(windowStart)) {
+            continue;
           }
+
+          final Instant windowEnd = windowStart.plus(windowSize);
+          if (!windowEndBounds.contains(windowEnd)) {
+            continue;
+          }
+
+          final TimeWindow window =
+              new TimeWindow(windowStart.toEpochMilli(), windowEnd.toEpochMilli());
+
+          final WindowedRow row = WindowedRow.of(
+              stateStore.schema(),
+              new Windowed<>(key, window),
+              next.value.value(),
+              next.value.timestamp()
+          );
+
+          builder.add(row);
         }
 
         return builder.build();
@@ -96,5 +97,35 @@ class KsMaterializedWindowTable implements MaterializedWindowedTable {
     } catch (final Exception e) {
       throw new MaterializationException("Failed to get value from materialized table", e);
     }
+  }
+
+  private Instant calculateUpperBound(
+      final Range<Instant> windowStartBounds,
+      final Range<Instant> windowEndBounds
+  ) {
+    final Instant start = windowStartBounds.hasUpperBound()
+        ? windowStartBounds.upperEndpoint()
+        : Instant.ofEpochMilli(Long.MAX_VALUE);
+
+    final Instant end = windowEndBounds.hasUpperBound()
+        ? windowEndBounds.upperEndpoint().minus(windowSize)
+        : Instant.ofEpochMilli(Long.MAX_VALUE);
+
+    return start.compareTo(end) < 0 ? start : end;
+  }
+
+  private Instant calculateLowerBound(
+      final Range<Instant> windowStartBounds,
+      final Range<Instant> windowEndBounds
+  ) {
+    final Instant start = windowStartBounds.hasLowerBound()
+        ? windowStartBounds.lowerEndpoint()
+        : Instant.ofEpochMilli(0);
+
+    final Instant end = windowEndBounds.hasLowerBound()
+        ? windowEndBounds.lowerEndpoint().minus(windowSize)
+        : Instant.ofEpochMilli(0);
+
+    return start.compareTo(end) < 0 ? end : start;
   }
 }

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedWindowTableTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedWindowTableTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -69,9 +70,16 @@ public class KsMaterializedWindowTableTest {
   private static final Struct A_KEY = StructKeyUtil
       .keyBuilder(ColumnName.of("K0"), SqlTypes.STRING).build("x");
 
+  protected static final Instant NOW = Instant.now();
+
   private static final Range<Instant> WINDOW_START_BOUNDS = Range.closed(
-      Instant.now(),
-      Instant.now().plusSeconds(10)
+      NOW,
+      NOW.plusSeconds(10)
+  );
+
+  private static final Range<Instant> WINDOW_END_BOUNDS = Range.closed(
+      NOW.plusSeconds(5).plus(WINDOW_SIZE),
+      NOW.plusSeconds(15).plus(WINDOW_SIZE)
   );
 
   private static final ValueAndTimestamp<GenericRow> VALUE_1 = ValueAndTimestamp
@@ -117,7 +125,7 @@ public class KsMaterializedWindowTableTest {
     // When:
     final Exception e = assertThrows(
         MaterializationException.class,
-        () -> table.get(A_KEY, WINDOW_START_BOUNDS)
+        () -> table.get(A_KEY, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS)
     );
 
     // Then:
@@ -135,7 +143,7 @@ public class KsMaterializedWindowTableTest {
     // When:
     final Exception e = assertThrows(
         MaterializationException.class,
-        () -> table.get(A_KEY, WINDOW_START_BOUNDS)
+        () -> table.get(A_KEY, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS)
     );
 
     // Then:
@@ -147,30 +155,147 @@ public class KsMaterializedWindowTableTest {
   @Test
   public void shouldGetStoreWithCorrectParams() {
     // When:
-    table.get(A_KEY, WINDOW_START_BOUNDS);
+    table.get(A_KEY, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS);
 
     // Then:
     verify(stateStore).store(storeTypeCaptor.capture());
-    assertThat(storeTypeCaptor.getValue().getClass().getSimpleName(), is("TimestampedWindowStoreType"));
+    assertThat(storeTypeCaptor.getValue().getClass().getSimpleName(),
+        is("TimestampedWindowStoreType"));
   }
 
   @Test
-  public void shouldFetchWithCorrectParams() {
+  public void shouldFetchWithCorrectKey() {
+    // Given:
     // When:
-    table.get(A_KEY, WINDOW_START_BOUNDS);
+    table.get(A_KEY, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS);
+
+    // Then:
+    verify(tableStore).fetch(eq(A_KEY), any(), any());
+  }
+
+  @Test
+  public void shouldFetchWithNoBounds() {
+    // When:
+    table.get(A_KEY, Range.all(), Range.all());
 
     // Then:
     verify(tableStore).fetch(
-        A_KEY,
-        WINDOW_START_BOUNDS.lowerEndpoint(),
-        WINDOW_START_BOUNDS.upperEndpoint()
+        any(),
+        eq(Instant.ofEpochMilli(0)),
+        eq(Instant.ofEpochMilli(Long.MAX_VALUE))
     );
+  }
+
+  @Test
+  public void shouldFetchWithOnlyStartBounds() {
+    // When:
+    table.get(A_KEY, WINDOW_START_BOUNDS, Range.all());
+
+    // Then:
+    verify(tableStore).fetch(
+        any(),
+        eq(WINDOW_START_BOUNDS.lowerEndpoint()),
+        eq(WINDOW_START_BOUNDS.upperEndpoint())
+    );
+  }
+
+  @Test
+  public void shouldFetchWithOnlyEndBounds() {
+    // When:
+    table.get(A_KEY, Range.all(), WINDOW_END_BOUNDS);
+
+    // Then:
+    verify(tableStore).fetch(
+        any(),
+        eq(WINDOW_END_BOUNDS.lowerEndpoint().minus(WINDOW_SIZE)),
+        eq(WINDOW_END_BOUNDS.upperEndpoint().minus(WINDOW_SIZE))
+    );
+  }
+
+  @Test
+  public void shouldFetchWithStartLowerBoundIfHighest() {
+    // Given:
+    final Range<Instant> startBounds = Range.closed(
+        NOW.plusSeconds(5),
+        NOW.plusSeconds(10)
+    );
+
+    final Range<Instant> endBounds = Range.closed(
+        NOW,
+        NOW.plusSeconds(15).plus(WINDOW_SIZE)
+    );
+
+    // When:
+    table.get(A_KEY, startBounds, endBounds);
+
+    // Then:
+    verify(tableStore).fetch(any(), eq(startBounds.lowerEndpoint()), any());
+  }
+
+  @Test
+  public void shouldFetchWithEndLowerBoundIfHighest() {
+    // Given:
+    final Range<Instant> startBounds = Range.closed(
+        NOW,
+        NOW.plusSeconds(10)
+    );
+
+    final Range<Instant> endBounds = Range.closed(
+        NOW.plusSeconds(5).plus(WINDOW_SIZE),
+        NOW.plusSeconds(15).plus(WINDOW_SIZE)
+    );
+
+    // When:
+    table.get(A_KEY, startBounds, endBounds);
+
+    // Then:
+    verify(tableStore).fetch(any(), eq(endBounds.lowerEndpoint().minus(WINDOW_SIZE)), any());
+  }
+
+  @Test
+  public void shouldFetchWithStartUpperBoundIfLowest() {
+    // Given:
+    final Range<Instant> startBounds = Range.closed(
+        NOW,
+        NOW.plusSeconds(10)
+    );
+
+    final Range<Instant> endBounds = Range.closed(
+        NOW.plusSeconds(5).plus(WINDOW_SIZE),
+        NOW.plusSeconds(15).plus(WINDOW_SIZE)
+    );
+
+    // When:
+    table.get(A_KEY, startBounds, endBounds);
+
+    // Then:
+    verify(tableStore).fetch(any(), any(), eq(startBounds.upperEndpoint()));
+  }
+
+  @Test
+  public void shouldFetchWithEndUpperBoundIfLowest() {
+    // Given:
+    final Range<Instant> startBounds = Range.closed(
+        NOW,
+        NOW.plusSeconds(20)
+    );
+
+    final Range<Instant> endBounds = Range.closed(
+        NOW.plusSeconds(5),
+        NOW.plusSeconds(10)
+    );
+
+    // When:
+    table.get(A_KEY, startBounds, endBounds);
+
+    // Then:
+    verify(tableStore).fetch(any(), any(), eq(endBounds.upperEndpoint().minus(WINDOW_SIZE)));
   }
 
   @Test
   public void shouldCloseIterator() {
     // When:
-    table.get(A_KEY, WINDOW_START_BOUNDS);
+    table.get(A_KEY, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS);
 
     // Then:
     verify(fetchIterator).close();
@@ -179,18 +304,18 @@ public class KsMaterializedWindowTableTest {
   @Test
   public void shouldReturnEmptyIfKeyNotPresent() {
     // When:
-    final List<?> result = table.get(A_KEY, WINDOW_START_BOUNDS);
+    final List<?> result = table.get(A_KEY, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS);
 
     // Then:
     assertThat(result, is(empty()));
   }
 
   @Test
-  public void shouldReturnValuesForClosedBounds() {
+  public void shouldReturnValuesForClosedStartBounds() {
     // Given:
-    final Range<Instant> bounds = Range.closed(
-        Instant.now(),
-        Instant.now().plusSeconds(10)
+    final Range<Instant> start = Range.closed(
+        NOW,
+        NOW.plusSeconds(10)
     );
 
     when(fetchIterator.hasNext())
@@ -199,26 +324,26 @@ public class KsMaterializedWindowTableTest {
         .thenReturn(false);
 
     when(fetchIterator.next())
-        .thenReturn(new KeyValue<>(bounds.lowerEndpoint().toEpochMilli(), VALUE_1))
-        .thenReturn(new KeyValue<>(bounds.upperEndpoint().toEpochMilli(), VALUE_2))
+        .thenReturn(new KeyValue<>(start.lowerEndpoint().toEpochMilli(), VALUE_1))
+        .thenReturn(new KeyValue<>(start.upperEndpoint().toEpochMilli(), VALUE_2))
         .thenThrow(new AssertionError());
 
     when(tableStore.fetch(any(), any(), any())).thenReturn(fetchIterator);
 
     // When:
-    final List<WindowedRow> result = table.get(A_KEY, bounds);
+    final List<WindowedRow> result = table.get(A_KEY, start, Range.all());
 
     // Then:
     assertThat(result, contains(
         WindowedRow.of(
             SCHEMA,
-            windowedKey(bounds.lowerEndpoint()),
+            windowedKey(start.lowerEndpoint()),
             VALUE_1.value(),
             VALUE_1.timestamp()
         ),
         WindowedRow.of(
             SCHEMA,
-            windowedKey(bounds.upperEndpoint()),
+            windowedKey(start.upperEndpoint()),
             VALUE_2.value(),
             VALUE_2.timestamp()
         )
@@ -226,11 +351,56 @@ public class KsMaterializedWindowTableTest {
   }
 
   @Test
-  public void shouldReturnValuesForOpenBounds() {
+  public void shouldReturnValuesForClosedEndBounds() {
     // Given:
-    final Range<Instant> bounds = Range.open(
-        Instant.now(),
-        Instant.now().plusSeconds(10)
+    final Range<Instant> end = Range.closed(
+        NOW,
+        NOW.plusSeconds(10)
+    );
+
+    final Range<Instant> startEqiv = Range.closed(
+        end.lowerEndpoint().minus(WINDOW_SIZE),
+        end.lowerEndpoint().minus(WINDOW_SIZE)
+    );
+
+    when(fetchIterator.hasNext())
+        .thenReturn(true)
+        .thenReturn(true)
+        .thenReturn(false);
+
+    when(fetchIterator.next())
+        .thenReturn(new KeyValue<>(startEqiv.lowerEndpoint().toEpochMilli(), VALUE_1))
+        .thenReturn(new KeyValue<>(startEqiv.upperEndpoint().toEpochMilli(), VALUE_2))
+        .thenThrow(new AssertionError());
+
+    when(tableStore.fetch(any(), any(), any())).thenReturn(fetchIterator);
+
+    // When:
+    final List<WindowedRow> result = table.get(A_KEY, Range.all(), end);
+
+    // Then:
+    assertThat(result, contains(
+        WindowedRow.of(
+            SCHEMA,
+            windowedKey(startEqiv.lowerEndpoint()),
+            VALUE_1.value(),
+            VALUE_1.timestamp()
+        ),
+        WindowedRow.of(
+            SCHEMA,
+            windowedKey(startEqiv.upperEndpoint()),
+            VALUE_2.value(),
+            VALUE_2.timestamp()
+        )
+    ));
+  }
+
+  @Test
+  public void shouldReturnValuesForOpenStartBounds() {
+    // Given:
+    final Range<Instant> start = Range.open(
+        NOW,
+        NOW.plusSeconds(10)
     );
 
     when(fetchIterator.hasNext())
@@ -240,21 +410,63 @@ public class KsMaterializedWindowTableTest {
         .thenReturn(false);
 
     when(fetchIterator.next())
-        .thenReturn(new KeyValue<>(bounds.lowerEndpoint().toEpochMilli(), VALUE_1))
-        .thenReturn(new KeyValue<>(bounds.lowerEndpoint().plusMillis(1).toEpochMilli(), VALUE_2))
-        .thenReturn(new KeyValue<>(bounds.upperEndpoint().toEpochMilli(), VALUE_3))
+        .thenReturn(new KeyValue<>(start.lowerEndpoint().toEpochMilli(), VALUE_1))
+        .thenReturn(new KeyValue<>(start.lowerEndpoint().plusMillis(1).toEpochMilli(), VALUE_2))
+        .thenReturn(new KeyValue<>(start.upperEndpoint().toEpochMilli(), VALUE_3))
         .thenThrow(new AssertionError());
 
     when(tableStore.fetch(any(), any(), any())).thenReturn(fetchIterator);
 
     // When:
-    final List<WindowedRow> result = table.get(A_KEY, bounds);
+    final List<WindowedRow> result = table.get(A_KEY, start, Range.all());
 
     // Then:
     assertThat(result, contains(
         WindowedRow.of(
             SCHEMA,
-            windowedKey(bounds.lowerEndpoint().plusMillis(1)),
+            windowedKey(start.lowerEndpoint().plusMillis(1)),
+            VALUE_2.value(),
+            VALUE_2.timestamp()
+        )
+    ));
+  }
+
+  @Test
+  public void shouldReturnValuesForOpenEndBounds() {
+    // Given:
+    final Range<Instant> end = Range.open(
+        NOW,
+        NOW.plusSeconds(10)
+    );
+
+    final Range<Instant> startEquiv = Range.open(
+        end.lowerEndpoint().minus(WINDOW_SIZE),
+        end.upperEndpoint().minus(WINDOW_SIZE)
+    );
+
+    when(fetchIterator.hasNext())
+        .thenReturn(true)
+        .thenReturn(true)
+        .thenReturn(true)
+        .thenReturn(false);
+
+    when(fetchIterator.next())
+        .thenReturn(new KeyValue<>(startEquiv.lowerEndpoint().toEpochMilli(), VALUE_1))
+        .thenReturn(
+            new KeyValue<>(startEquiv.lowerEndpoint().plusMillis(1).toEpochMilli(), VALUE_2))
+        .thenReturn(new KeyValue<>(startEquiv.upperEndpoint().toEpochMilli(), VALUE_3))
+        .thenThrow(new AssertionError());
+
+    when(tableStore.fetch(any(), any(), any())).thenReturn(fetchIterator);
+
+    // When:
+    final List<WindowedRow> result = table.get(A_KEY, Range.all(), end);
+
+    // Then:
+    assertThat(result, contains(
+        WindowedRow.of(
+            SCHEMA,
+            windowedKey(startEquiv.lowerEndpoint().plusMillis(1)),
             VALUE_2.value(),
             VALUE_2.timestamp()
         )
@@ -281,7 +493,7 @@ public class KsMaterializedWindowTableTest {
     when(tableStore.fetch(any(), any(), any())).thenReturn(fetchIterator);
 
     // When:
-    final List<WindowedRow> result = table.get(A_KEY, WINDOW_START_BOUNDS);
+    final List<WindowedRow> result = table.get(A_KEY, Range.all(), Range.all());
 
     // Then:
     assertThat(result, contains(
@@ -309,7 +521,7 @@ public class KsMaterializedWindowTableTest {
   @Test
   public void shouldSupportRangeAll() {
     // When:
-    table.get(A_KEY, Range.all());
+    table.get(A_KEY, Range.all(), Range.all());
 
     // Then:
     verify(tableStore).fetch(


### PR DESCRIPTION
### Description 

fixes: https://github.com/confluentinc/ksql/issues/5666

Pull queries can now reference WINDOWEND in their WHERE clause, (assuming the source is windowed):

```sql
SELECT * FROM T
   WHERE id = 10
   AND 134874632 <= WINDOWSTART AND WINDOWEND < 134891111;
```

### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

