### PR TITLE
test: fix flaky ClientIntegrationTest#shouldListQueries() (MINOR)

### DIFF
--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
@@ -720,19 +720,14 @@ public class ClientIntegrationTest {
     // When
     final List<QueryInfo> queries = client.listQueries().get();
 
-    assertThat(queries, hasSize(1));
-    System.out.println("id: " + queries.get(0).getId());
-    System.out.println("sql: " + queries.get(0).getSql());
-    System.out.println("sink: " + queries.get(0).getSink().get());
-    System.out.println("sinkTopic: " + queries.get(0).getSinkTopic().get());
-    System.out.println("type: " + queries.get(0).getQueryType());
-    assertThat(queries.get(0).getId(), is("CTAS_" + AGG_TABLE + "_0"));
-    assertThat(queries.get(0).getSql(), is("CREATE TABLE " + AGG_TABLE + " WITH (KAFKA_TOPIC='" + AGG_TABLE + "', PARTITIONS=1, REPLICAS=1) AS SELECT\n"
-        + "  " + TEST_STREAM + ".STR STR,\n"
-        + "  LATEST_BY_OFFSET(" + TEST_STREAM + ".LONG) LONG\n"
-        + "FROM " + TEST_STREAM + " " + TEST_STREAM + "\n"
-        + "GROUP BY " + TEST_STREAM + ".STR\n"
-        + "EMIT CHANGES;"));
+    System.out.println("num queries: " + queries.size());
+    for (QueryInfo query : queries) {
+      System.out.println("id: " + query.getId());
+      System.out.println("sql: " + query.getSql());
+      System.out.println("sink: " + query.getSink().get());
+      System.out.println("sinkTopic: " + query.getSinkTopic().get());
+      System.out.println("type: " + query.getQueryType());
+    }
 
     // Then
     assertThat(queries, contains(persistentQueryInfo(

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
@@ -720,6 +720,20 @@ public class ClientIntegrationTest {
     // When
     final List<QueryInfo> queries = client.listQueries().get();
 
+    assertThat(queries, hasSize(1));
+    System.out.println("id: " + queries.get(0).getId());
+    System.out.println("sql: " + queries.get(0).getSql());
+    System.out.println("sink: " + queries.get(0).getSink().get());
+    System.out.println("sinkTopic: " + queries.get(0).getSinkTopic().get());
+    System.out.println("type: " + queries.get(0).getQueryType());
+    assertThat(queries.get(0).getId(), is("CTAS_" + AGG_TABLE + "_0"));
+    assertThat(queries.get(0).getSql(), is("CREATE TABLE " + AGG_TABLE + " WITH (KAFKA_TOPIC='" + AGG_TABLE + "', PARTITIONS=1, REPLICAS=1) AS SELECT\n"
+        + "  " + TEST_STREAM + ".STR STR,\n"
+        + "  LATEST_BY_OFFSET(" + TEST_STREAM + ".LONG) LONG\n"
+        + "FROM " + TEST_STREAM + " " + TEST_STREAM + "\n"
+        + "GROUP BY " + TEST_STREAM + ".STR\n"
+        + "EMIT CHANGES;"));
+
     // Then
     assertThat(queries, contains(persistentQueryInfo(
         "CTAS_" + AGG_TABLE + "_0",

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
@@ -716,7 +716,6 @@ public class ClientIntegrationTest {
     ));
   }
 
-  @Ignore // temporarily disable while flakiness is being investigated
   @Test
   public void shouldListQueries() throws Exception {
     // When

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
@@ -684,7 +684,7 @@ public class ClientIntegrationTest {
     final List<StreamInfo> streams = client.listStreams().get();
 
     // Then
-    assertThat(streams, containsInAnyOrder(
+    assertThat("" + streams, streams, containsInAnyOrder(
         streamForProvider(TEST_DATA_PROVIDER),
         streamForProvider(EMPTY_TEST_DATA_PROVIDER),
         streamForProvider(EMPTY_TEST_DATA_PROVIDER_2)
@@ -697,7 +697,7 @@ public class ClientIntegrationTest {
     final List<TableInfo> tables = client.listTables().get();
 
     // Then
-    assertThat(tables, contains(tableInfo(AGG_TABLE, AGG_TABLE, "JSON", false)));
+    assertThat("" + tables, tables, contains(tableInfo(AGG_TABLE, AGG_TABLE, "JSON", false)));
   }
 
   @SuppressWarnings("unchecked")
@@ -707,7 +707,7 @@ public class ClientIntegrationTest {
     final List<TopicInfo> topics = client.listTopics().get();
 
     // Then
-    assertThat(topics, containsInAnyOrder(
+    assertThat("" + topics, topics, containsInAnyOrder(
         topicInfo(TEST_TOPIC),
         topicInfo(EMPTY_TEST_TOPIC),
         topicInfo(EMPTY_TEST_TOPIC_2),


### PR DESCRIPTION
### Description 

The recently added ClientIntegrationTest#shouldListQueries() previously sometimes failed because queries started (and terminated) by other tests took time to actually be removed from the server's metastore, as this process is async after termination. This caused ClientIntegrationTest#shouldListQueries() to fail because the test checked that there was only one query in the metastore. This PR fixes the flakiness by switching to assertThatEventually() instead of assertThat().

### Testing done 

Test-only change. Ran the test a bunch of times locally and didn't see any failures.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

