### PR TITLE
test: temporarily disable flaky test while it's being investigated

### DIFF
--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
@@ -93,6 +93,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
@@ -715,6 +716,7 @@ public class ClientIntegrationTest {
     ));
   }
 
+  @Ignore // temporarily disable while flakiness is being investigated
   @Test
   public void shouldListQueries() throws Exception {
     // When


### PR DESCRIPTION
### Description 

We've seen some flaky failures of the recently added `ClientIntegrationTest#shouldListQueries()` integration test. This PR temporarily disables the test while I investigate offline, in order to not affect master (and PR) builds.

### Testing done 

N/A

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

