### PR TITLE
docs: cherry-pick "add back server endpoint + API links to client docs"

### DIFF
--- a/docs/developer-guide/ksqldb-clients/java-client.md
+++ b/docs/developer-guide/ksqldb-clients/java-client.md
@@ -15,7 +15,8 @@ Soon the client will also support persistent queries and admin operations such a
     [View the Java client API documentation](api/index.html)
 
 The client sends requests to the recently added HTTP2 server endpoints: pull and push queries are served by
-the `/query-stream` endpoint, and inserts are served by the `/inserts-stream` endpoint.
+the [`/query-stream` endpoint](../../developer-guide/ksqldb-rest-api/streaming-endpoint.md#executing-pull-or-push-queries),
+and inserts are served by the [`/inserts-stream` endpoint](../../developer-guide/ksqldb-rest-api/streaming-endpoint.md#inserting-rows-into-an-existing-stream).
 The client is compatible only with ksqlDB deployments that are on version 0.10.0 or later.
 
 Use the Java client to:
@@ -104,7 +105,7 @@ public class ExampleApp {
 }
 ```
 
-For additional client options, see the API reference.
+For additional client options, see the [API reference](api/io/confluent/ksql/api/client/ClientOptions.html).
 
 Receive query results one row at a time (streamQuery())<a name="stream-query"></a>
 ----------------------------------------------------------------------------------
@@ -135,7 +136,7 @@ public interface Client {
 You can use this method to issue both push and pull queries, but the usage pattern is better for push queries.
 For pull queries, consider [the `executeQuery()` method](./execute-query.md) instead. 
 
-Query properties can be passed as an optional second argument. For more information, see the client API reference.
+Query properties can be passed as an optional second argument. For more information, see the [client API reference](api/io/confluent/ksql/api/client/Client.html#streamQuery(java.lang.String,java.util.Map)).
 
 By default, push queries return only newly arriving rows. To start from the beginning of the stream or table,
 set the `auto.offset.reset` property to `earliest`.
@@ -206,7 +207,7 @@ client.streamQuery("SELECT * FROM MY_STREAM EMIT CHANGES;")
 To consume records one-at-a-time in a synchronous fashion, use the `poll()` method on the query result object.
 If `poll()` is called with no arguments, it blocks until a new row becomes available or the query is terminated.
 You can also pass a `Duration` argument to `poll()`, which causes `poll()` to return `null` if no new rows are received by the time the duration has elapsed.
-For more information, see the API reference.
+For more information, see the [API reference](api/io/confluent/ksql/api/client/StreamedQueryResult.html#poll(java.time.Duration)).
 
 ```java
 StreamedQueryResult streamedQueryResult = client.streamQuery("SELECT * FROM MY_STREAM EMIT CHANGES;").get();
@@ -249,7 +250,7 @@ public interface Client {
 This method is suitable for both pull queries and for terminating push queries, for example, queries that have a `LIMIT` clause).
 For non-terminating push queries, use [the `streamQuery()` method](./stream-query.md) instead.
 
-Query properties can be passed as an optional second argument. For more information, see the client API reference.
+Query properties can be passed as an optional second argument. For more information, see the [client API reference](api/io/confluent/ksql/api/client/Client.html#executeQuery(java.lang.String,java.util.Map)).
 
 By default, push queries return only newly arriving rows. To start from the beginning of the stream or table,
 set the `auto.offset.reset` property to `earliest`.


### PR DESCRIPTION
### Description 

Cherry-pick https://github.com/confluentinc/ksql/pull/5699 to live docs branch.

### Testing done 

Docs-only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

