### PR TITLE
docs: cherry-pick: fix broken links in ksqldb-clients content (DOCS-4757)

### DIFF
--- a/docs/developer-guide/joins/partition-data.md
+++ b/docs/developer-guide/joins/partition-data.md
@@ -38,7 +38,7 @@ correct key and partitioning.
 ksqlDB requires keys to use the `KAFKA` format. For more information, see
 [Serialization Formats](../serialization.md#serialization-formats). If internally
 repartitioning, ksqlDB uses the correct format. If the data in your {{ site.ak }} topics 
-does not have a suitable key format, see [Key Requirements](syntax-reference.md#key-requirements).
+does not have a suitable key format, see [Key Requirements](../syntax-reference.md#key-requirements).
 
 The KAFKA format doesn't support serializing the column name within the data, so the key column name is 
 not important for joins. The key column type is important: for the join to be valid,
@@ -169,7 +169,7 @@ if these ordering guarantees are acceptable.
 
 !!! important
       If the PARTITION BY expression evaluates to NULL, the resulting row is produced to a
-      random partition. You many want to use [COALESCE](../syntax-reference#coalesce) to wrap
+      random partition. You many want to use [COALESCE](../ksqldb-reference/scalar-functions.md#coalesce) to wrap
       the expression and convert any NULL values to a default value, for example,
       `PARTITION BY COALESCE(MY_UDF_THAT_MAY_FAIL(Col0), 0)`.
 

--- a/docs/developer-guide/ksqldb-clients/java-client.md
+++ b/docs/developer-guide/ksqldb-clients/java-client.md
@@ -134,7 +134,8 @@ public interface Client {
 ```
 
 You can use this method to issue both push and pull queries, but the usage pattern is better for push queries.
-For pull queries, consider [the `executeQuery()` method](./execute-query.md) instead. 
+For pull queries, consider using the [`executeQuery()`](api/io/confluent/ksql/api/client/Client.html#executeQuery(java.lang.String))
+method instead.
 
 Query properties can be passed as an optional second argument. For more information, see the [client API reference](api/io/confluent/ksql/api/client/Client.html#streamQuery(java.lang.String,java.util.Map)).
 
@@ -247,10 +248,13 @@ public interface Client {
 }
 ```
 
-This method is suitable for both pull queries and for terminating push queries, for example, queries that have a `LIMIT` clause).
-For non-terminating push queries, use [the `streamQuery()` method](./stream-query.md) instead.
+This method is suitable for both pull queries and for terminating push queries,
+for example, queries that have a `LIMIT` clause). For non-terminating push queries,
+use the [`streamQuery()`](api/io/confluent/ksql/api/client/Client.html#streamQuery(java.lang.String,java.util.Map))
+method instead.
 
-Query properties can be passed as an optional second argument. For more information, see the [client API reference](api/io/confluent/ksql/api/client/Client.html#executeQuery(java.lang.String,java.util.Map)).
+Query properties can be passed as an optional second argument. For more
+information, see the [client API reference](api/io/confluent/ksql/api/client/Client.html#executeQuery(java.lang.String,java.util.Map)).
 
 By default, push queries return only newly arriving rows. To start from the beginning of the stream or table,
 set the `auto.offset.reset` property to `earliest`.
@@ -295,7 +299,8 @@ public interface Client {
 ```
 
 The query ID is obtained from the query result response object when the client issues push queries,
-by using either the [`streamQuery()`](./stream-query.md) or [`executeQuery()`](./execute-query.md) methods.
+by using either the [`streamQuery()`](api/io/confluent/ksql/api/client/Client.html#streamQuery(java.lang.String,java.util.Map))
+or [`executeQuery()`](api/io/confluent/ksql/api/client/Client.html#executeQuery(java.lang.String,java.util.Map)) methods.
 
 ### Example Usage ###
 


### PR DESCRIPTION
From https://github.com/confluentinc/ksql/pull/5708.