### PR TITLE
refactor: move queryID generator out of physical plan

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
@@ -140,6 +140,10 @@ final class EngineContext {
     return parser.parse(sql);
   }
 
+  QueryIdGenerator idGenerator() {
+    return queryIdGenerator;
+  }
+
   PreparedStatement<?> prepare(final ParsedStatement stmt) {
     try {
       final PreparedStatement<?> preparedStatement = parser.prepare(stmt, metaStore);
@@ -158,8 +162,8 @@ final class EngineContext {
   QueryEngine createQueryEngine(final ServiceContext serviceContext) {
     return new QueryEngine(
         serviceContext,
-        processingLogContext,
-        queryIdGenerator);
+        processingLogContext
+    );
   }
 
   QueryExecutor createQueryExecutor(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -203,11 +203,17 @@ final class EngineExecutor {
         statement.getStatementText(),
         Optional.of(outputNode)
     );
+    final QueryId queryId = QueryIdUtil.buildId(
+        engineContext.getMetaStore(),
+        engineContext.idGenerator(),
+        outputNode
+    );
     final PhysicalPlan physicalPlan = queryEngine.buildPhysicalPlan(
         logicalPlan,
         ksqlConfig,
         overriddenProperties,
-        engineContext.getMetaStore()
+        engineContext.getMetaStore(),
+        queryId
     );
     return new ExecutorPlans(logicalPlan, physicalPlan);
   }
@@ -228,7 +234,7 @@ final class EngineExecutor {
       final String sql,
       final KsqlStructuredDataOutputNode outputNode
   ) {
-    if (!outputNode.isDoCreateInto()) {
+    if (!outputNode.createInto()) {
       validateExistingSink(outputNode);
       return Optional.empty();
     }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryEngine.java
@@ -27,7 +27,7 @@ import io.confluent.ksql.physical.PhysicalPlanBuilder;
 import io.confluent.ksql.planner.LogicalPlanNode;
 import io.confluent.ksql.planner.LogicalPlanner;
 import io.confluent.ksql.planner.plan.OutputNode;
-import io.confluent.ksql.query.id.QueryIdGenerator;
+import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.SerdeOptions;
 import io.confluent.ksql.services.ServiceContext;
@@ -44,19 +44,16 @@ class QueryEngine {
 
   private final ServiceContext serviceContext;
   private final ProcessingLogContext processingLogContext;
-  private final QueryIdGenerator queryIdGenerator;
 
   QueryEngine(
       final ServiceContext serviceContext,
-      final ProcessingLogContext processingLogContext,
-      final QueryIdGenerator queryIdGenerator
+      final ProcessingLogContext processingLogContext
   ) {
     this.serviceContext = Objects.requireNonNull(serviceContext, "serviceContext");
     this.processingLogContext = Objects.requireNonNull(
         processingLogContext,
         "processingLogContext"
     );
-    this.queryIdGenerator = Objects.requireNonNull(queryIdGenerator, "queryIdGenerator");
   }
 
   static OutputNode buildQueryLogicalPlan(
@@ -81,7 +78,8 @@ class QueryEngine {
       final LogicalPlanNode logicalPlanNode,
       final KsqlConfig ksqlConfig,
       final Map<String, Object> overriddenProperties,
-      final MutableMetaStore metaStore
+      final MutableMetaStore metaStore,
+      final QueryId queryId
   ) {
 
     final StreamsBuilder builder = new StreamsBuilder();
@@ -92,10 +90,9 @@ class QueryEngine {
         ksqlConfig.cloneWithPropertyOverwrite(overriddenProperties),
         serviceContext,
         processingLogContext,
-        metaStore,
-        queryIdGenerator
+        metaStore
     );
 
-    return physicalPlanBuilder.buildPhysicalPlan(logicalPlanNode);
+    return physicalPlanBuilder.buildPhysicalPlan(logicalPlanNode, queryId);
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryIdUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryIdUtil.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.engine;
+
+import com.google.common.collect.Iterables;
+import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.planner.plan.KsqlStructuredDataOutputNode;
+import io.confluent.ksql.planner.plan.OutputNode;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.query.id.QueryIdGenerator;
+import io.confluent.ksql.util.KsqlException;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Utility for constructing {@link QueryId}s - separate from {@code EngineExecutor} for
+ * easy access to unit testing.
+ */
+final class QueryIdUtil {
+
+  private QueryIdUtil() {
+  }
+
+  /**
+   * Builds a {@link QueryId} for a physical plan specification.
+   *
+   * @param metaStore   the meta store representing the current state of the engine
+   * @param idGenerator generates query ids
+   * @param outputNode  the logical plan
+   * @return the {@link QueryId} to be used
+   */
+  static QueryId buildId(
+      final MetaStore metaStore,
+      final QueryIdGenerator idGenerator,
+      final OutputNode outputNode
+  ) {
+    if (!outputNode.getSinkName().isPresent()) {
+      return new QueryId(String.valueOf(Math.abs(ThreadLocalRandom.current().nextLong())));
+    }
+
+    final KsqlStructuredDataOutputNode structured = (KsqlStructuredDataOutputNode) outputNode;
+    if (!structured.createInto()) {
+      return new QueryId("INSERTQUERY_" + idGenerator.getNext());
+    }
+
+    final SourceName sink = outputNode.getSinkName().get();
+    final Set<String> queriesForSink = metaStore.getQueriesWithSink(sink);
+    if (queriesForSink.size() > 1) {
+      throw new KsqlException("REPLACE for sink " + sink + " is not supported because there are "
+          + "multiple queries writing into it: " + queriesForSink);
+    } else if (!queriesForSink.isEmpty()) {
+      return new QueryId(Iterables.getOnlyElement(queriesForSink));
+    }
+
+    final String suffix = outputNode.getId().toString().toUpperCase() + "_" + idGenerator.getNext();
+    return new QueryId(
+        outputNode.getNodeOutputType() == DataSourceType.KTABLE
+            ? "CTAS_" + suffix
+            : "CSAS_" + suffix
+    );
+  }
+
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryIdUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryIdUtil.java
@@ -67,7 +67,8 @@ final class QueryIdUtil {
       return new QueryId(Iterables.getOnlyElement(queriesForSink));
     }
 
-    final String suffix = outputNode.getId().toString().toUpperCase() + "_" + idGenerator.getNext();
+    final String suffix = outputNode.getId().toString().toUpperCase()
+        + "_" + idGenerator.getNext().toUpperCase();
     return new QueryId(
         outputNode.getNodeOutputType() == DataSourceType.KTABLE
             ? "CTAS_" + suffix

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
@@ -21,7 +21,6 @@ import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.planner.LogicalPlanNode;
 import io.confluent.ksql.planner.plan.OutputNode;
 import io.confluent.ksql.query.QueryId;
-import io.confluent.ksql.query.id.QueryIdGenerator;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.structured.SchemaKStream;
@@ -36,15 +35,13 @@ public class PhysicalPlanBuilder {
   private final ServiceContext serviceContext;
   private final ProcessingLogContext processingLogContext;
   private final FunctionRegistry functionRegistry;
-  private final QueryIdGenerator queryIdGenerator;
 
   public PhysicalPlanBuilder(
       final StreamsBuilder builder,
       final KsqlConfig ksqlConfig,
       final ServiceContext serviceContext,
       final ProcessingLogContext processingLogContext,
-      final FunctionRegistry functionRegistry,
-      final QueryIdGenerator queryIdGenerator
+      final FunctionRegistry functionRegistry
   ) {
     this.builder = Objects.requireNonNull(builder, "builder");
     this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig");
@@ -53,14 +50,14 @@ public class PhysicalPlanBuilder {
         processingLogContext,
         "processingLogContext");
     this.functionRegistry = Objects.requireNonNull(functionRegistry, "functionRegistry");
-    this.queryIdGenerator = Objects.requireNonNull(queryIdGenerator, "queryIdGenerator");
   }
 
-  public PhysicalPlan buildPhysicalPlan(final LogicalPlanNode logicalPlanNode) {
+  public PhysicalPlan buildPhysicalPlan(
+      final LogicalPlanNode logicalPlanNode,
+      final QueryId queryId
+  ) {
     final OutputNode outputNode = logicalPlanNode.getNode()
         .orElseThrow(() -> new IllegalArgumentException("Need an output node to build a plan"));
-
-    final QueryId queryId = outputNode.getQueryId(queryIdGenerator);
 
     final KsqlQueryBuilder ksqlQueryBuilder = KsqlQueryBuilder.of(
         builder,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlBareOutputNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlBareOutputNode.java
@@ -17,13 +17,11 @@ package io.confluent.ksql.planner.plan;
 
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.timestamp.TimestampColumn;
-import io.confluent.ksql.query.QueryId;
-import io.confluent.ksql.query.id.QueryIdGenerator;
+import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.structured.SchemaKStream;
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.concurrent.ThreadLocalRandom;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class KsqlBareOutputNode extends OutputNode {
@@ -39,8 +37,8 @@ public class KsqlBareOutputNode extends OutputNode {
   }
 
   @Override
-  public QueryId getQueryId(final QueryIdGenerator queryIdGenerator) {
-    return new QueryId(String.valueOf(Math.abs(ThreadLocalRandom.current().nextLong())));
+  public Optional<SourceName> getSinkName() {
+    return Optional.empty();
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.planner.plan;
 
-import static io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.ImmutableSet;
@@ -25,8 +24,6 @@ import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.execution.timestamp.TimestampColumn;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
-import io.confluent.ksql.query.QueryId;
-import io.confluent.ksql.query.id.QueryIdGenerator;
 import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.SerdeOption;
@@ -66,7 +63,7 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
     validate(source, intoSourceName);
   }
 
-  public boolean isDoCreateInto() {
+  public boolean createInto() {
     return doCreateInto;
   }
 
@@ -83,15 +80,8 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
   }
 
   @Override
-  public QueryId getQueryId(final QueryIdGenerator queryIdGenerator) {
-    final String base = queryIdGenerator.getNext().toUpperCase();
-    if (!doCreateInto) {
-      return new QueryId("INSERTQUERY_" + base);
-    }
-    if (getNodeOutputType().equals(DataSourceType.KTABLE)) {
-      return new QueryId("CTAS_" + getId().toString().toUpperCase() + "_" + base);
-    }
-    return new QueryId("CSAS_" + getId().toString().toUpperCase() + "_" + base);
+  public Optional<SourceName> getSinkName() {
+    return Optional.of(intoSourceName);
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/OutputNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/OutputNode.java
@@ -18,8 +18,7 @@ package io.confluent.ksql.planner.plan;
 import static java.util.Objects.requireNonNull;
 
 import io.confluent.ksql.execution.timestamp.TimestampColumn;
-import io.confluent.ksql.query.QueryId;
-import io.confluent.ksql.query.id.QueryIdGenerator;
+import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -59,5 +58,5 @@ public abstract class OutputNode extends SingleSourcePlanNode {
     return timestampColumn;
   }
 
-  public abstract QueryId getQueryId(QueryIdGenerator queryIdGenerator);
+  public abstract Optional<SourceName> getSinkName();
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/QueryIdUtilTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/QueryIdUtilTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.engine;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableSet;
+import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.planner.plan.KsqlBareOutputNode;
+import io.confluent.ksql.planner.plan.KsqlStructuredDataOutputNode;
+import io.confluent.ksql.planner.plan.PlanNodeId;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.query.id.QueryIdGenerator;
+import io.confluent.ksql.util.KsqlException;
+import java.util.Optional;
+import java.util.stream.IntStream;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class QueryIdUtilTest {
+
+  private static final SourceName SINK = SourceName.of("SINK");
+
+  @Mock
+  private KsqlBareOutputNode transientPlan;
+  @Mock
+  private KsqlStructuredDataOutputNode plan;
+  @Mock
+  private QueryIdGenerator idGenerator;
+  @Mock
+  private MetaStore metaStore;
+
+  @Test
+  public void shouldGenerateUniqueRandomIdsForTransientQueries() {
+    // Given:
+    when(transientPlan.getSinkName()).thenReturn(Optional.empty());
+
+    // When:
+    long numUniqueIds = IntStream.range(0, 100)
+        .mapToObj(i -> QueryIdUtil.buildId(metaStore, idGenerator, transientPlan))
+        .distinct()
+        .count();
+
+    // Then:
+    assertThat(numUniqueIds, is(100L));
+  }
+
+  @Test
+  public void shouldComputeQueryIdCorrectlyForInsertInto() {
+    // Given:
+    when(plan.getSinkName()).thenReturn(Optional.of(SINK));
+    when(idGenerator.getNext()).thenReturn("1");
+
+    // When:
+    final QueryId queryId = QueryIdUtil.buildId(metaStore, idGenerator, plan);
+
+    // Then:
+    assertThat(queryId, is(new QueryId("INSERTQUERY_1")));
+  }
+
+  @Test
+  public void shouldComputeQueryIdCorrectlyForNewStream() {
+    // Given:
+    when(plan.getSinkName()).thenReturn(Optional.of(SINK));
+    when(plan.getId()).thenReturn(new PlanNodeId("FOO"));
+    when(plan.getNodeOutputType()).thenReturn(DataSourceType.KSTREAM);
+    when(plan.createInto()).thenReturn(true);
+    when(idGenerator.getNext()).thenReturn("1");
+    when(metaStore.getQueriesWithSink(SINK)).thenReturn(ImmutableSet.of());
+
+    // When:
+    final QueryId queryId = QueryIdUtil.buildId(metaStore, idGenerator, plan);
+
+    // Then:
+    assertThat(queryId, is(new QueryId("CSAS_FOO_1")));
+  }
+
+  @Test
+  public void shouldComputeQueryIdCorrectlyForNewTable() {
+    // Given:
+    when(plan.getSinkName()).thenReturn(Optional.of(SINK));
+    when(plan.getId()).thenReturn(new PlanNodeId("FOO"));
+    when(plan.getNodeOutputType()).thenReturn(DataSourceType.KTABLE);
+    when(plan.createInto()).thenReturn(true);
+    when(idGenerator.getNext()).thenReturn("1");
+    when(metaStore.getQueriesWithSink(SINK)).thenReturn(ImmutableSet.of());
+
+    // When:
+    final QueryId queryId = QueryIdUtil.buildId(metaStore, idGenerator, plan);
+
+    // Then:
+    assertThat(queryId, is(new QueryId("CTAS_FOO_1")));
+  }
+
+  @Test
+  public void shouldReuseExistingQueryId() {
+    // Given:
+    when(plan.getSinkName()).thenReturn(Optional.of(SINK));
+    when(plan.createInto()).thenReturn(true);
+    when(metaStore.getQueriesWithSink(SINK)).thenReturn(ImmutableSet.of("CTAS_FOO_10"));
+
+    // When:
+    final QueryId queryId = QueryIdUtil.buildId(metaStore, idGenerator, plan);
+
+    // Then:
+    assertThat(queryId, is(new QueryId("CTAS_FOO_10")));
+  }
+
+  @Test
+  public void shouldThrowIfMultipleQueriesExist() {
+    // Given:
+    when(plan.getSinkName()).thenReturn(Optional.of(SINK));
+    when(plan.createInto()).thenReturn(true);
+    when(metaStore.getQueriesWithSink(SINK)).thenReturn(ImmutableSet.of("CTAS_FOO_1", "INSERTQUERY_1"));
+
+    // When:
+    final KsqlException e = assertThrows(KsqlException.class, () -> QueryIdUtil.buildId(metaStore, idGenerator, plan));
+
+    // Then:
+    assertThat(e.getMessage(), containsString("there are multiple queries writing"));
+  }
+
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/FunctionNameValidatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/FunctionNameValidatorTest.java
@@ -43,7 +43,7 @@ public class FunctionNameValidatorTest {
   }
 
   @Test
-  public void shouldNotAllowKsqlReservedWordsExceptSubstringAndConcat() {
+  public void shouldNotAllowKsqlReservedWordsExceptSubstringAndConcatAndReplace() {
     final Vocabulary vocabulary = SqlBaseParser.VOCABULARY;
     final int maxTokenType = vocabulary.getMaxTokenType();
     for(int i = 0; i < maxTokenType; i++) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
@@ -23,8 +23,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableSet;
@@ -36,8 +34,6 @@ import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.name.ColumnName;
-import io.confluent.ksql.query.QueryId;
-import io.confluent.ksql.query.id.QueryIdGenerator;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.structured.SchemaKStream;
@@ -46,9 +42,7 @@ import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.MetaStoreFixture;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -131,24 +125,6 @@ public class KsqlBareOutputNodeTest {
         valueColumn(ColumnName.of("COL0"), SqlTypes.BIGINT),
         valueColumn(ColumnName.of("COL2"), SqlTypes.STRING),
         valueColumn(ColumnName.of("COL3"), SqlTypes.DOUBLE)));
-  }
-
-  @Test
-  public void shouldComputeQueryIdCorrectly() {
-    // Given:
-    final KsqlBareOutputNode node
-        = (KsqlBareOutputNode) AnalysisTestUtil
-        .buildLogicalPlan(ksqlConfig, "select col0 from test1 EMIT CHANGES;", metaStore);
-    final QueryIdGenerator queryIdGenerator = mock(QueryIdGenerator.class);
-
-    // When:
-    final Set<QueryId> ids = IntStream.range(0, 100)
-        .mapToObj(i -> node.getQueryId(queryIdGenerator))
-        .collect(Collectors.toSet());
-
-    // Then:
-    assertThat(ids.size(), equalTo(100));
-    verifyNoMoreInteractions(queryIdGenerator);
   }
 
   private TopologyDescription.Node getNodeByName(final String nodeName) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/testutils/AnalysisTestUtil.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/testutils/AnalysisTestUtil.java
@@ -28,7 +28,6 @@ import io.confluent.ksql.parser.tree.Sink;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.planner.LogicalPlanner;
 import io.confluent.ksql.planner.plan.OutputNode;
-import io.confluent.ksql.query.id.SequentialQueryIdGenerator;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlParserTestUtil;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/testutils/AnalysisTestUtil.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/testutils/AnalysisTestUtil.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.parser.tree.Sink;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.planner.LogicalPlanner;
 import io.confluent.ksql.planner.plan.OutputNode;
+import io.confluent.ksql.query.id.SequentialQueryIdGenerator;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlParserTestUtil;
@@ -57,7 +58,8 @@ public final class AnalysisTestUtil {
     private final Analysis analysis;
 
     private Analyzer(final String queryStr, final MetaStore metaStore) {
-      final QueryAnalyzer queryAnalyzer = new QueryAnalyzer(metaStore, "", SerdeOption.none());
+      final QueryAnalyzer queryAnalyzer = new QueryAnalyzer(
+          metaStore, "", SerdeOption.none());
       final Statement statement = parseStatement(queryStr, metaStore);
       final Query query = statement instanceof QueryContainer
           ? ((QueryContainer) statement).getQuery()

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateAsSelect.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateAsSelect.java
@@ -85,6 +85,11 @@ public abstract class CreateAsSelect extends Statement implements QueryContainer
   }
 
   @Override
+  public Sink getSink() {
+    return Sink.of(getName(), true, isOrReplace(), getProperties());
+  }
+
+  @Override
   public int hashCode() {
     return Objects.hash(name, query, properties, notExists, getClass());
   }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStreamAsSelect.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStreamAsSelect.java
@@ -52,11 +52,6 @@ public class CreateStreamAsSelect extends CreateAsSelect {
   }
 
   @Override
-  public Sink getSink() {
-    return Sink.of(getName(), true, getProperties());
-  }
-
-  @Override
   public CreateAsSelect copyWith(final CreateSourceAsProperties properties) {
     return new CreateStreamAsSelect(this, properties);
   }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTableAsSelect.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTableAsSelect.java
@@ -63,11 +63,6 @@ public class CreateTableAsSelect extends CreateAsSelect {
   }
 
   @Override
-  public Sink getSink() {
-    return Sink.of(getName(), true, getProperties());
-  }
-
-  @Override
   public String toString() {
     return "CreateTableAsSelect{" + super.toString() + '}';
   }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/InsertInto.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/InsertInto.java
@@ -61,7 +61,7 @@ public class InsertInto
 
   @Override
   public Sink getSink() {
-    return Sink.of(target, false, CreateSourceAsProperties.none());
+    return Sink.of(target, false, false, CreateSourceAsProperties.none());
   }
 
   @Override

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/Sink.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/Sink.java
@@ -28,32 +28,37 @@ import io.confluent.ksql.parser.properties.with.CreateSourceAsProperties;
 public final class Sink {
 
   private final SourceName name;
-  private final boolean createSink;
   private final CreateSourceAsProperties properties;
+  private final boolean replaces;
+  private final boolean createSink;
 
   /**
    * Info about the sink of a query.
    *
    * @param name the name of the sink.
    * @param createSink indicates if name should be created, (CSAS/CTAS), or not (INSERT INTO).
+   * @param replaces indicates whether or not there is an existing query that populates this sync,
+   *                 which will be replaced as part of a query upgrade
    * @param properties properties of the sink.
    * @return the pojo.
    */
   public static Sink of(
       final SourceName name,
       final boolean createSink,
+      final boolean replaces,
       final CreateSourceAsProperties properties
   ) {
-    return new Sink(name, createSink, properties);
+    return new Sink(name, createSink, replaces, properties);
   }
 
   private Sink(
       final SourceName name,
       final boolean createSink,
-      final CreateSourceAsProperties properties
-  ) {
+      final boolean replaces,
+      final CreateSourceAsProperties properties) {
     this.name = requireNonNull(name, "name");
     this.properties = requireNonNull(properties, "properties");
+    this.replaces = replaces;
     this.createSink = createSink;
   }
 
@@ -63,6 +68,10 @@ public final class Sink {
 
   public boolean shouldCreateSink() {
     return createSink;
+  }
+
+  public boolean shouldReplace() {
+    return replaces;
   }
 
   public CreateSourceAsProperties getProperties() {


### PR DESCRIPTION
### Description 
This is a minor refactor which moves queryID generation outside of the physical plan into a place that is better suited for "replace" style queries which reuse the existing queryID. The query id generation is now done in `EngineExecutor` (there is also no queryId generation in `QueryMetadata` anymore.

### Testing done 
Non-functional change, moved unit tests as appropriate. 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

