### PR TITLE
docs: update links in client docs (MINOR)

### DIFF
--- a/docs/developer-guide/ksqldb-clients/java-client.md
+++ b/docs/developer-guide/ksqldb-clients/java-client.md
@@ -134,7 +134,7 @@ public interface Client {
 ```
 
 You can use this method to issue both push and pull queries, but the usage pattern is better for push queries.
-For pull queries, consider using the [`executeQuery()`](api/io/confluent/ksql/api/client/Client.html#executeQuery(java.lang.String))
+For pull queries, consider using the [`executeQuery()`](#execute-query)
 method instead.
 
 Query properties can be passed as an optional second argument. For more information, see the [client API reference](api/io/confluent/ksql/api/client/Client.html#streamQuery(java.lang.String,java.util.Map)).
@@ -250,7 +250,7 @@ public interface Client {
 
 This method is suitable for both pull queries and for terminating push queries,
 for example, queries that have a `LIMIT` clause). For non-terminating push queries,
-use the [`streamQuery()`](api/io/confluent/ksql/api/client/Client.html#streamQuery(java.lang.String,java.util.Map))
+use the [`streamQuery()`](#stream-query)
 method instead.
 
 Query properties can be passed as an optional second argument. For more
@@ -299,8 +299,7 @@ public interface Client {
 ```
 
 The query ID is obtained from the query result response object when the client issues push queries,
-by using either the [`streamQuery()`](api/io/confluent/ksql/api/client/Client.html#streamQuery(java.lang.String,java.util.Map))
-or [`executeQuery()`](api/io/confluent/ksql/api/client/Client.html#executeQuery(java.lang.String,java.util.Map)) methods.
+by using either the [`streamQuery()`](#stream-query) or [`executeQuery()`](#execute-query) methods.
 
 ### Example Usage ###
 


### PR DESCRIPTION
### Description 

^ to link to docs rather than API docs. I think it's preferable to keep the users within the actual docs, especially since the docs for each section link to the relevant API docs page as well. 

### Testing done 

Docs-only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

