### PR TITLE
chore: switch to non-deprecated streams config

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -369,7 +369,7 @@ public class KsqlConfig extends AbstractConfig {
       COMPATIBILITY_BREAKING_STREAMS_CONFIGS = ImmutableList.of(
           // Turn on optimizations by default, unless the user explicitly disables in config:
           new CompatibilityBreakingStreamsConfig(
-            StreamsConfig.TOPOLOGY_OPTIMIZATION,
+            StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG,
             StreamsConfig.OPTIMIZE,
             StreamsConfig.OPTIMIZE)
   );

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
@@ -420,7 +420,7 @@ public class QueryExecutorTest {
   private void shouldUseProvidedOptimizationConfig(final Object value) {
     // Given:
     final Map<String, Object> properties =
-        Collections.singletonMap(StreamsConfig.TOPOLOGY_OPTIMIZATION, value);
+        Collections.singletonMap(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, value);
     when(ksqlConfig.getKsqlStreamConfigProps(anyString())).thenReturn(properties);
 
     // When:
@@ -435,7 +435,7 @@ public class QueryExecutorTest {
 
     // Then:
     final Map<String, Object> captured = capturedStreamsProperties();
-    assertThat(captured.get(StreamsConfig.TOPOLOGY_OPTIMIZATION), equalTo(value));
+    assertThat(captured.get(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG), equalTo(value));
   }
 
   @Test


### PR DESCRIPTION
### Description 

Fix the master build by switching ksqlDB code to use the non-deprecated streams config

### Testing done 

none

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

