### PR TITLE
chore: Remove use of deprecated Jackson API in 5.4.x

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/json/ArrayContainsKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/json/ArrayContainsKudf.java
@@ -26,6 +26,7 @@ import static com.fasterxml.jackson.core.JsonToken.VALUE_STRING;
 import static com.fasterxml.jackson.core.JsonToken.VALUE_TRUE;
 
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonFactoryBuilder;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import io.confluent.ksql.function.KsqlFunctionException;
@@ -38,8 +39,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class ArrayContainsKudf implements Kudf {
-  private static final JsonFactory JSON_FACTORY =
-      new JsonFactory().disable(CANONICALIZE_FIELD_NAMES);
+  private static final JsonFactory JSON_FACTORY = new JsonFactoryBuilder()
+      .disable(CANONICALIZE_FIELD_NAMES)
+      .build();
 
   interface Matcher {
     boolean matches(JsonParser parser, Object searchValue) throws IOException;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/ConfigTopicKeyTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/ConfigTopicKeyTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThrows;
 
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import com.google.common.testing.EqualsTester;
 import io.confluent.ksql.rest.server.computation.ConfigTopicKey.StringKey;
 import io.confluent.ksql.rest.util.InternalTopicJsonSerdeUtil;
@@ -79,7 +80,7 @@ public class ConfigTopicKeyTest {
     @Override
     public boolean matchesSafely(final Exception e) {
       return e instanceof SerializationException
-          && e.getCause() instanceof InvalidDefinitionException
+          && e.getCause() instanceof InvalidDefinitionException || e.getCause() instanceof ValueInstantiationException
           && exceptionClass.isInstance(e.getCause().getCause())
           && e.getCause().getCause().getMessage().contains(msg);
     }


### PR DESCRIPTION
### Description 
Port of https://github.com/confluentinc/ksql/pull/4671 to the 5.4.x release branch, required by upgrades in jackson and avro described in: confluentinc/common#269

### Testing done 
Relying on existing tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

