### PR TITLE
chore: fix metrics context labels

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -102,7 +102,9 @@ public class KsqlConfig extends AbstractConfig {
   public static final String FAIL_ON_PRODUCTION_ERROR_CONFIG = "ksql.fail.on.production.error";
 
   public static final String
-      KSQL_SERVICE_ID_CONFIG = "ksql.service.id";
+      SERVICE_ID = "service.id";
+  public static final String
+      KSQL_SERVICE_ID_CONFIG = "ksql." + SERVICE_ID;
   public static final String
       KSQL_SERVICE_ID_DEFAULT = "default_";
 

--- a/ksqldb-common/src/test/java/io/confluent/ksql/metrics/MetricCollectorsTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/metrics/MetricCollectorsTest.java
@@ -78,7 +78,7 @@ public class MetricCollectorsTest {
         .thenReturn(Collections.singletonList(mockReporter));
     when(ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG)).thenReturn("ksql-id");
 
-    MetricCollectors.addConfigurableReporter(ksqlConfig);
+    MetricCollectors.addConfigurableReporter(ksqlConfig, "kafka");
     final List<MetricsReporter> reporters = MetricCollectors.getMetrics().reporters();
     assertThat(reporters, hasItem(mockReporter));
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -85,6 +85,7 @@ import io.confluent.ksql.security.KsqlAuthorizationValidatorFactory;
 import io.confluent.ksql.security.KsqlDefaultSecurityExtension;
 import io.confluent.ksql.security.KsqlSecurityContext;
 import io.confluent.ksql.security.KsqlSecurityExtension;
+import io.confluent.ksql.services.KafkaClusterUtil;
 import io.confluent.ksql.services.LazyServiceContext;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.SimpleKsqlClient;
@@ -262,7 +263,8 @@ public final class KsqlRestApplication implements Executable {
         serviceContext,
         this.restConfig,
         this.ksqlConfigNoPort);
-    MetricCollectors.addConfigurableReporter(ksqlConfigNoPort);
+    MetricCollectors.addConfigurableReporter(
+        ksqlConfigNoPort, KafkaClusterUtil.getKafkaClusterId(serviceContext));
     log.debug("ksqlDB API server instance created");
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -263,8 +263,6 @@ public final class KsqlRestApplication implements Executable {
         serviceContext,
         this.restConfig,
         this.ksqlConfigNoPort);
-    MetricCollectors.addConfigurableReporter(
-        ksqlConfigNoPort, KafkaClusterUtil.getKafkaClusterId(serviceContext));
     log.debug("ksqlDB API server instance created");
   }
 
@@ -407,6 +405,8 @@ public final class KsqlRestApplication implements Executable {
   }
 
   private void initialize(final KsqlConfig configWithApplicationServer) {
+    MetricCollectors.addConfigurableReporter(
+        ksqlConfigNoPort, KafkaClusterUtil.getKafkaClusterId(serviceContext));
     rocksDBConfigSetterHandler.accept(ksqlConfigNoPort);
 
     registerCommandTopic();

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
@@ -40,6 +40,7 @@ import io.confluent.ksql.parser.tree.SetProperty;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.UnsetProperty;
 import io.confluent.ksql.properties.PropertyOverrider;
+import io.confluent.ksql.services.KafkaClusterUtil;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.statement.Injector;
@@ -104,7 +105,8 @@ public class StandaloneExecutor implements Executable {
     this.failOnNoQueries = failOnNoQueries;
     this.versionChecker = requireNonNull(versionChecker, "versionChecker");
     this.injectorFactory = requireNonNull(injectorFactory, "injectorFactory");
-    MetricCollectors.addConfigurableReporter(ksqlConfig);
+    MetricCollectors.addConfigurableReporter(
+        ksqlConfig, KafkaClusterUtil.getKafkaClusterId(serviceContext));
   }
 
   public void startAsync() {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
@@ -97,7 +97,11 @@ import java.util.Properties;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.DescribeClusterResult;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
@@ -238,6 +242,8 @@ public class StandaloneExecutorTest {
   @Mock
   private KafkaTopicClient kafkaTopicClient;
   @Mock
+  private AdminClient adminClient;
+  @Mock
   private BiFunction<KsqlExecutionContext, ServiceContext, Injector> injectorFactory;
   @Mock
   private Injector schemaInjector;
@@ -257,6 +263,12 @@ public class StandaloneExecutorTest {
     queriesFile = Paths.get(TestUtils.tempFile().getPath());
     givenQueryFileContains("something");
 
+    final DescribeClusterResult mockDescribeResults = mock(DescribeClusterResult.class);
+    final KafkaFuture<String> kafkaFuture = mock(KafkaFuture.class);
+    when(kafkaFuture.get(anyLong(), any())).thenReturn("cluster-id");
+    when(mockDescribeResults.clusterId()).thenReturn(kafkaFuture);
+    when(adminClient.describeCluster()).thenReturn(mockDescribeResults);
+    when(serviceContext.getAdminClient()).thenReturn(adminClient);
     when(serviceContext.getTopicClient()).thenReturn(kafkaTopicClient);
 
     when(ksqlEngine.parse(any())).thenReturn(ImmutableList.of(PARSED_STMT_0));


### PR DESCRIPTION
### Description 

- lower case the resource type
- add `metrics.context.resource.kafka.cluster.id` to configs 
- change `metrics.context.resource.ksql.service.id` to `metrics.context.resource.service.id` to prevent redundant labeling

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

