### PR TITLE
fix: earliest/latest_by_offset should accept nulls

### DIFF
--- a/docs/concepts/functions.md
+++ b/docs/concepts/functions.md
@@ -359,6 +359,8 @@ enables you to define UDAFs like `average`, as shown in the following example.
 When you create a UDAF, use the `map` method to provide the logic that
 transforms an intermediate aggregate value to the returned value.
 
+The `merge` method is only called when merging sessions when session windowing is used.
+
 ##### Example UDAF class
 
 The following class creates a UDAF named `my_average`. The name of the UDAF

--- a/docs/developer-guide/ksqldb-reference/aggregate-functions.md
+++ b/docs/developer-guide/ksqldb-reference/aggregate-functions.md
@@ -107,11 +107,15 @@ EARLIEST_BY_OFFSET(col1, [ignoreNulls])
 
 Stream
 
-Return the earliest value for a given column. 'Earliest' is defined as the value in the partition
-with the lowest offset. 
+Return the earliest value for the specified column. The earliest value in the partition
 
-Optional parameter `ignoreNulls`, (since 0.13.0), controls if nulls are ignored or not. Defaulting
-to ignoring null values.
+has the lowest offset. 
+
+
+The optional `ignoreNulls` parameter, available since version 0.13.0, controls whether nulls are ignored. The default
+
+is to ignore null values.
+
 
 
 Since: 0.13.0
@@ -122,11 +126,15 @@ EARLIEST_BY_OFFSET(col1, earliestN, [ignoreNulls])
 
 Stream
 
-Return the earliest N values for a given column as an `ARRAY`. 'Earliest' is defined as the values 
-in the partition with the lowest offsets.
+Return the earliest _N_ values for the specified column as an `ARRAY`. The earliest values
 
-Optional parameter `ignoreNulls` controls if nulls are ignored or not. Defaulting
-to ignoring null values.
+in the partition have the lowest offsets.
+
+
+The optional `ignoreNulls` parameter controls whether nulls are ignored. The default
+
+is to ignore null values.
+
 
 ## `HISTOGRAM`
 
@@ -160,11 +168,15 @@ LATEST_BY_OFFSET(col1, [ignoreNulls])
 
 Stream
 
-Return the latest value for a given column. 'Latest' is defined as the value in the partition
-with the greatest offset. 
+Return the latest value for the specified column. The latest value in the partition
 
-Optional parameter `ignoreNulls`, (since 0.13.0), controls if nulls are ignored or not. Defaulting
-to ignoring null values.
+has the largest offset. 
+
+
+The optional `ignoreNulls` parameter, available since version 0.13.0, controls whether nulls are ignored. The default
+
+is to ignore null values.
+
 
 Since: 0.13.0
 
@@ -174,10 +186,13 @@ LATEST_BY_OFFSET(col1, latestN, [ignoreNulls])
 
 Stream
 
-Returns the latest N values for a given column as an `ARRAY`. 'Latest' is defined
-with the greatest offset.
+Returns the latest _N_ values for the specified column as an `ARRAY`. The latest values have
 
-Optional parameter `ignoreNulls` controls if nulls are ignored or not. Defaulting to ignoring 
+the largest offset.
+
+
+The optional `ignoreNulls` parameter controls whether nulls are ignored. The default is to ignore
+
 null values. 
 
 ## `MAX`

--- a/docs/developer-guide/ksqldb-reference/aggregate-functions.md
+++ b/docs/developer-guide/ksqldb-reference/aggregate-functions.md
@@ -102,26 +102,31 @@ to estimate cardinalities of 10^9 with a typical standard error of 2%.
 Since: 0.10.0
 
 ```sql
-EARLIEST_BY_OFFSET(col1)
+EARLIEST_BY_OFFSET(col1, [ignoreNulls])
 ```
 
 Stream
 
-Return the earliest value for a given column. Earliest here is defined as the value in the partition
-with the lowest offset. Rows that have `col1` set to null are ignored.
+Return the earliest value for a given column. 'Earliest' is defined as the value in the partition
+with the lowest offset. 
+
+Optional parameter `ignoreNulls`, (since 0.13.0), controls if nulls are ignored or not. Defaulting
+to ignoring null values.
 
 
 Since: 0.13.0
 
 ```sql
-EARLIEST_BY_OFFSET(col1,earliestN)
+EARLIEST_BY_OFFSET(col1, earliestN, [ignoreNulls])
 ```
 
 Stream
 
-Return the earliest N values for a given column. Earliest here is defined as the values in the partition
-with the lowest offsets. Rows that have `col1` set to null are ignored.
+Return the earliest N values for a given column as an `ARRAY`. 'Earliest' is defined as the values 
+in the partition with the lowest offsets.
 
+Optional parameter `ignoreNulls` controls if nulls are ignored or not. Defaulting
+to ignoring null values.
 
 ## `HISTOGRAM`
 
@@ -150,24 +155,30 @@ the order they were originally processed.
 Since: 0.8.0
 
 ```sql
-LATEST_BY_OFFSET(col1)
+LATEST_BY_OFFSET(col1, [ignoreNulls])
 ```
 
 Stream
 
-Return the latest value for a given column. Latest here is defined as the value in the partition
-with the greatest offset. Rows that have `col1` set to null are ignored.
+Return the latest value for a given column. 'Latest' is defined as the value in the partition
+with the greatest offset. 
+
+Optional parameter `ignoreNulls`, (since 0.13.0), controls if nulls are ignored or not. Defaulting
+to ignoring null values.
 
 Since: 0.13.0
 
 ```sql
-LATEST_BY_OFFSET(col1,latestN)
+LATEST_BY_OFFSET(col1, latestN, [ignoreNulls])
 ```
 
 Stream
 
-Returns the latest N values for a given column as an array of values. Latest here is also defined
-with the greatest offset. Rows that have `col1` set to null are ignored.
+Returns the latest N values for a given column as an `ARRAY`. 'Latest' is defined
+with the greatest offset.
+
+Optional parameter `ignoreNulls` controls if nulls are ignored or not. Defaulting to ignoring 
+null values. 
 
 ## `MAX`
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/EarliestByOffset.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/EarliestByOffset.java
@@ -15,15 +15,15 @@
 
 package io.confluent.ksql.function.udaf.offset;
 
-import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.INTERMEDIATE_STRUCT_COMPARATOR;
-import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.SEQ_FIELD;
-import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.STRUCT_BOOLEAN;
-import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.STRUCT_DOUBLE;
-import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.STRUCT_INTEGER;
-import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.STRUCT_LONG;
-import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.STRUCT_STRING;
-import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.VAL_FIELD;
+import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.INTERMEDIATE_STRUCT_COMPARATOR;
+import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_BOOLEAN;
+import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_DOUBLE;
+import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_INTEGER;
+import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_LONG;
+import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_STRING;
+import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.VAL_FIELD;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udaf.Udaf;
 import io.confluent.ksql.function.udaf.UdafDescription;
@@ -54,93 +54,182 @@ public final class EarliestByOffset {
   @UdafFactory(description = "return the earliest value of an integer column",
       aggregateSchema = "STRUCT<SEQ BIGINT, VAL INT>")
   public static Udaf<Integer, Struct, Integer> earliestInteger() {
-    return earliest(STRUCT_INTEGER);
+    return earliestInteger(true);
+  }
+
+  @UdafFactory(description = "return the earliest value of an integer column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL INT>")
+  public static Udaf<Integer, Struct, Integer> earliestInteger(final boolean ignoreNulls) {
+    return earliest(STRUCT_INTEGER, ignoreNulls);
   }
 
   @UdafFactory(description = "return the earliest N values of an integer column",
       aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL INT>>")
   public static Udaf<Integer, List<Struct>, List<Integer>> earliestIntegers(final int earliestN) {
-    return earliestN(STRUCT_INTEGER, earliestN);
+    return earliestIntegers(earliestN, true);
+  }
+
+  @UdafFactory(description = "return the earliest N values of an integer column",
+      aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL INT>>")
+  public static Udaf<Integer, List<Struct>, List<Integer>> earliestIntegers(
+      final int earliestN,
+      final boolean ignoreNulls
+  ) {
+    return earliestN(STRUCT_INTEGER, earliestN, ignoreNulls);
   }
 
   @UdafFactory(description = "return the earliest value of an big integer column",
       aggregateSchema = "STRUCT<SEQ BIGINT, VAL BIGINT>")
   public static Udaf<Long, Struct, Long> earliestLong() {
-    return earliest(STRUCT_LONG);
+    return earliestLong(true);
   }
-  
+
+  @UdafFactory(description = "return the earliest value of an big integer column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL BIGINT>")
+  public static Udaf<Long, Struct, Long> earliestLong(final boolean ignoreNulls) {
+    return earliest(STRUCT_LONG, ignoreNulls);
+  }
+
   @UdafFactory(description = "return the earliest N values of an long column",
       aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL BIGINT>>")
   public static Udaf<Long, List<Struct>, List<Long>> earliestLongs(final int earliestN) {
-    return earliestN(STRUCT_LONG, earliestN);
+    return earliestLongs(earliestN, true);
+  }
+
+  @UdafFactory(description = "return the earliest N values of an long column",
+      aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL BIGINT>>")
+  public static Udaf<Long, List<Struct>, List<Long>> earliestLongs(
+      final int earliestN,
+      final boolean ignoreNulls
+  ) {
+    return earliestN(STRUCT_LONG, earliestN, ignoreNulls);
   }
 
   @UdafFactory(description = "return the earliest value of a double column",
       aggregateSchema = "STRUCT<SEQ BIGINT, VAL DOUBLE>")
   public static Udaf<Double, Struct, Double> earliestDouble() {
-    return earliest(STRUCT_DOUBLE);
+    return earliestDouble(true);
   }
-  
+
+  @UdafFactory(description = "return the earliest value of a double column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL DOUBLE>")
+  public static Udaf<Double, Struct, Double> earliestDouble(final boolean ignoreNulls) {
+    return earliest(STRUCT_DOUBLE, ignoreNulls);
+  }
+
   @UdafFactory(description = "return the earliest N values of a double column",
       aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL DOUBLE>>")
   public static Udaf<Double, List<Struct>, List<Double>> earliestDoubles(final int earliestN) {
-    return earliestN(STRUCT_DOUBLE, earliestN);
+    return earliestDoubles(earliestN, true);
+  }
+
+  @UdafFactory(description = "return the earliest N values of a double column",
+      aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL DOUBLE>>")
+  public static Udaf<Double, List<Struct>, List<Double>> earliestDoubles(
+      final int earliestN,
+      final boolean ignoreNulls
+  ) {
+    return earliestN(STRUCT_DOUBLE, earliestN, ignoreNulls);
   }
 
   @UdafFactory(description = "return the earliest value of a boolean column",
       aggregateSchema = "STRUCT<SEQ BIGINT, VAL BOOLEAN>")
   public static Udaf<Boolean, Struct, Boolean> earliestBoolean() {
-    return earliest(STRUCT_BOOLEAN);
+    return earliestBoolean(true);
   }
-  
+
+  @UdafFactory(description = "return the earliest value of a boolean column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL BOOLEAN>")
+  public static Udaf<Boolean, Struct, Boolean> earliestBoolean(final boolean ignoreNulls) {
+    return earliest(STRUCT_BOOLEAN, ignoreNulls);
+  }
+
   @UdafFactory(description = "return the earliest N values of a boolean column",
       aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL BOOLEAN>>")
   public static Udaf<Boolean, List<Struct>, List<Boolean>> earliestBooleans(final int earliestN) {
-    return earliestN(STRUCT_BOOLEAN, earliestN);
+    return earliestBooleans(earliestN, true);
+  }
+
+  @UdafFactory(description = "return the earliest N values of a boolean column",
+      aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL BOOLEAN>>")
+  public static Udaf<Boolean, List<Struct>, List<Boolean>> earliestBooleans(
+      final int earliestN,
+      final boolean ignoreNulls
+  ) {
+    return earliestN(STRUCT_BOOLEAN, earliestN, ignoreNulls);
   }
 
   @UdafFactory(description = "return the earliest value of a string column",
       aggregateSchema = "STRUCT<SEQ BIGINT, VAL STRING>")
   public static Udaf<String, Struct, String> earliestString() {
-    return earliest(STRUCT_STRING);
+    return earliestString(true);
   }
-  
+
+  @UdafFactory(description = "return the earliest value of a string column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL STRING>")
+  public static Udaf<String, Struct, String> earliestString(final boolean ignoreNulls) {
+    return earliest(STRUCT_STRING, ignoreNulls);
+  }
+
   @UdafFactory(description = "return the earliest N values of a string column",
       aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL STRING>>")
   public static Udaf<String, List<Struct>, List<String>> earliestStrings(final int earliestN) {
-    return earliestN(STRUCT_STRING, earliestN);
+    return earliestStrings(earliestN, true);
   }
-  
+
+  @UdafFactory(description = "return the earliest N values of a string column",
+      aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL STRING>>")
+  public static Udaf<String, List<Struct>, List<String>> earliestStrings(
+      final int earliestN,
+      final boolean ignoreNulls
+  ) {
+    return earliestN(STRUCT_STRING, earliestN, ignoreNulls);
+  }
+
+  @VisibleForTesting
   static <T> Struct createStruct(final Schema schema, final T val) {
-    final Struct struct = new Struct(schema);
-    struct.put(SEQ_FIELD, generateSequence());
-    struct.put(VAL_FIELD, val);
-    return struct;
+    return KudafByOffsetUtils.createStruct(schema, generateSequence(), val);
   }
 
   private static long generateSequence() {
     return sequence.getAndIncrement();
   }
 
-  static <T> Udaf<T, Struct, T> earliest(final Schema structSchema) {
+  @VisibleForTesting
+  static <T> Udaf<T, Struct, T> earliest(
+      final Schema structSchema,
+      final boolean ignoreNulls
+  ) {
     return new Udaf<T, Struct, T>() {
 
       @Override
       public Struct initialize() {
-        return createStruct(structSchema, null);
+        return null;
       }
 
       @Override
       public Struct aggregate(final T current, final Struct aggregate) {
-        if (current == null || aggregate.get(VAL_FIELD) != null) {
+        if (aggregate != null) {
           return aggregate;
-        } else {
-          return createStruct(structSchema, current);
         }
+
+        if (current == null && ignoreNulls) {
+          return null;
+        }
+
+        return createStruct(structSchema, current);
       }
 
       @Override
       public Struct merge(final Struct aggOne, final Struct aggTwo) {
+        if (aggOne == null) {
+          return aggTwo;
+        }
+
+        if (aggTwo == null) {
+          return aggOne;
+        }
+
         // When merging we need some way of evaluating the "earliest' one.
         // We do this by keeping track of the sequence of when it was originally processed
         if (INTERMEDIATE_STRUCT_COMPARATOR.compare(aggOne, aggTwo) < 0) {
@@ -153,29 +242,34 @@ public final class EarliestByOffset {
       @Override
       @SuppressWarnings("unchecked")
       public T map(final Struct agg) {
+        if (agg == null) {
+          return null;
+        }
+
         return (T) agg.get(VAL_FIELD);
       }
     };
   }
 
+  @VisibleForTesting
   static <T> Udaf<T, List<Struct>, List<T>> earliestN(
-      final Schema structSchema, 
-      final int earliestN
+      final Schema structSchema,
+      final int earliestN,
+      final boolean ignoreNulls
   ) {
-    
     if (earliestN <= 0) {
       throw new KsqlFunctionException("earliestN must be 1 or greater");
     }
-    
+
     return new Udaf<T, List<Struct>, List<T>>() {
       @Override
       public List<Struct> initialize() {
-        return new ArrayList<Struct>(earliestN);
+        return new ArrayList<>(earliestN);
       }
 
       @Override
       public List<Struct> aggregate(final T current, final List<Struct> aggregate) {
-        if (current == null) {
+        if (current == null && ignoreNulls) {
           return aggregate;
         }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/KudafByOffsetUtils.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/KudafByOffsetUtils.java
@@ -13,43 +13,44 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.function.udaf;
+package io.confluent.ksql.function.udaf.offset;
 
 import java.util.Comparator;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 
-public final class KudafByOffsetUtils {
-  public static final String SEQ_FIELD = "SEQ";
+final class KudafByOffsetUtils {
+
+  static final String SEQ_FIELD = "SEQ";
   public static final String VAL_FIELD = "VAL";
 
-  public static final Schema STRUCT_INTEGER = SchemaBuilder.struct().optional()
+  static final Schema STRUCT_INTEGER = SchemaBuilder.struct().optional()
       .field(SEQ_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
       .field(VAL_FIELD, Schema.OPTIONAL_INT32_SCHEMA)
       .build();
 
-  public static final Schema STRUCT_LONG = SchemaBuilder.struct().optional()
+  static final Schema STRUCT_LONG = SchemaBuilder.struct().optional()
       .field(SEQ_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
       .field(VAL_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
       .build();
 
-  public static final Schema STRUCT_DOUBLE = SchemaBuilder.struct().optional()
+  static final Schema STRUCT_DOUBLE = SchemaBuilder.struct().optional()
       .field(SEQ_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
       .field(VAL_FIELD, Schema.OPTIONAL_FLOAT64_SCHEMA)
       .build();
 
-  public static final Schema STRUCT_BOOLEAN = SchemaBuilder.struct().optional()
+  static final Schema STRUCT_BOOLEAN = SchemaBuilder.struct().optional()
       .field(SEQ_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
       .field(VAL_FIELD, Schema.OPTIONAL_BOOLEAN_SCHEMA)
       .build();
 
-  public static final Schema STRUCT_STRING = SchemaBuilder.struct().optional()
+  static final Schema STRUCT_STRING = SchemaBuilder.struct().optional()
       .field(SEQ_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
       .field(VAL_FIELD, Schema.OPTIONAL_STRING_SCHEMA)
       .build();
   
-  public static final Comparator<Struct> INTERMEDIATE_STRUCT_COMPARATOR = (struct1, struct2) -> {
+  static final Comparator<Struct> INTERMEDIATE_STRUCT_COMPARATOR = (struct1, struct2) -> {
     // Deal with overflow - we assume if one is positive and the other negative then the sequence
     // has overflowed - in which case the latest is the one with the smallest sequence
     final long sequence1 = struct1.getInt64(SEQ_FIELD);
@@ -63,7 +64,13 @@ public final class KudafByOffsetUtils {
     }
   };
 
-  private KudafByOffsetUtils() {
+  static <T> Struct createStruct(final Schema schema, final long sequence, final T val) {
+    final Struct struct = new Struct(schema);
+    struct.put(SEQ_FIELD, sequence);
+    struct.put(VAL_FIELD, val);
+    return struct;
+  }
 
+  private KudafByOffsetUtils() {
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/LatestByOffset.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/LatestByOffset.java
@@ -15,15 +15,15 @@
 
 package io.confluent.ksql.function.udaf.offset;
 
-import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.INTERMEDIATE_STRUCT_COMPARATOR;
-import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.SEQ_FIELD;
-import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.STRUCT_BOOLEAN;
-import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.STRUCT_DOUBLE;
-import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.STRUCT_INTEGER;
-import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.STRUCT_LONG;
-import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.STRUCT_STRING;
-import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.VAL_FIELD;
+import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.INTERMEDIATE_STRUCT_COMPARATOR;
+import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_BOOLEAN;
+import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_DOUBLE;
+import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_INTEGER;
+import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_LONG;
+import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_STRING;
+import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.VAL_FIELD;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udaf.Udaf;
 import io.confluent.ksql.function.udaf.UdafDescription;
@@ -54,75 +54,152 @@ public final class LatestByOffset {
   @UdafFactory(description = "return the latest value of an integer column",
       aggregateSchema = "STRUCT<SEQ BIGINT, VAL INT>")
   public static Udaf<Integer, Struct, Integer> latestInteger() {
-    return latest(STRUCT_INTEGER);
+    return latestInteger(true);
+  }
+
+  @UdafFactory(description = "return the latest value of an integer column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL INT>")
+  public static Udaf<Integer, Struct, Integer> latestInteger(final boolean ignoreNulls) {
+    return latest(STRUCT_INTEGER, ignoreNulls);
   }
 
   @UdafFactory(description = "return the latest N value of an integer column",
       aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL INT>>")
   public static Udaf<Integer, List<Struct>, List<Integer>> latestIntegers(final int latestN) {
-    return latestN(STRUCT_INTEGER, latestN);
+    return latestIntegers(latestN, true);
+  }
+
+  @UdafFactory(description = "return the latest N value of an integer column",
+      aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL INT>>")
+  public static Udaf<Integer, List<Struct>, List<Integer>> latestIntegers(
+      final int latestN,
+      final boolean ignoreNulls
+  ) {
+    return latestN(STRUCT_INTEGER, latestN, ignoreNulls);
   }
 
   @UdafFactory(description = "return the latest value of an big integer column",
       aggregateSchema = "STRUCT<SEQ BIGINT, VAL BIGINT>")
   public static Udaf<Long, Struct, Long> latestLong() {
-    return latest(STRUCT_LONG);
+    return latestLong(true);
   }
-  
+
+  @UdafFactory(description = "return the latest value of an big integer column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL BIGINT>")
+  public static Udaf<Long, Struct, Long> latestLong(final boolean ignoreNulls) {
+    return latest(STRUCT_LONG, ignoreNulls);
+  }
+
   @UdafFactory(description = "return the latest N value of an big integer column",
       aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL BIGINT>>")
-  public static Udaf<Long, List<Struct>, List<Long>> latestLong(final int latestN) {
-    return latestN(STRUCT_LONG, latestN);
+  public static Udaf<Long, List<Struct>, List<Long>> latestLongs(final int latestN) {
+    return latestLongs(latestN, true);
+  }
+
+  @UdafFactory(description = "return the latest N value of an big integer column",
+      aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL BIGINT>>")
+  public static Udaf<Long, List<Struct>, List<Long>> latestLongs(
+      final int latestN,
+      final boolean ignoreNulls
+  ) {
+    return latestN(STRUCT_LONG, latestN, ignoreNulls);
   }
 
   @UdafFactory(description = "return the latest value of a double column",
       aggregateSchema = "STRUCT<SEQ BIGINT, VAL DOUBLE>")
   public static Udaf<Double, Struct, Double> latestDouble() {
-    return latest(STRUCT_DOUBLE);
+    return latestDouble(true);
   }
-  
+
+  @UdafFactory(description = "return the latest value of a double column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL DOUBLE>")
+  public static Udaf<Double, Struct, Double> latestDouble(final boolean ignoreNulls) {
+    return latest(STRUCT_DOUBLE, ignoreNulls);
+  }
+
   @UdafFactory(description = "return the latest N values of a double column",
       aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL DOUBLE>>")
   public static Udaf<Double, List<Struct>, List<Double>> latestDoubles(final int latestN) {
-    return latestN(STRUCT_DOUBLE, latestN);
+    return latestDoubles(latestN, true);
+  }
+
+  @UdafFactory(description = "return the latest N values of a double column",
+      aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL DOUBLE>>")
+  public static Udaf<Double, List<Struct>, List<Double>> latestDoubles(
+      final int latestN,
+      final boolean ignoreNulls
+  ) {
+    return latestN(STRUCT_DOUBLE, latestN, ignoreNulls);
   }
 
   @UdafFactory(description = "return the latest value of a boolean column",
       aggregateSchema = "STRUCT<SEQ BIGINT, VAL BOOLEAN>")
   public static Udaf<Boolean, Struct, Boolean> latestBoolean() {
-    return latest(STRUCT_BOOLEAN);
+    return latestBoolean(true);
   }
-  
+
+  @UdafFactory(description = "return the latest value of a boolean column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL BOOLEAN>")
+  public static Udaf<Boolean, Struct, Boolean> latestBoolean(final boolean ignoreNulls) {
+    return latest(STRUCT_BOOLEAN, ignoreNulls);
+  }
+
   @UdafFactory(description = "return the latest N value of a boolean column",
       aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL BOOLEAN>>")
   public static Udaf<Boolean, List<Struct>, List<Boolean>> latestBooleans(final int latestN) {
-    return latestN(STRUCT_BOOLEAN, latestN);
+    return latestBooleans(latestN, true);
+  }
+
+  @UdafFactory(description = "return the latest N value of a boolean column",
+      aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL BOOLEAN>>")
+  public static Udaf<Boolean, List<Struct>, List<Boolean>> latestBooleans(
+      final int latestN,
+      final boolean ignoreNulls
+  ) {
+    return latestN(STRUCT_BOOLEAN, latestN, ignoreNulls);
   }
 
   @UdafFactory(description = "return the latest value of a string column",
       aggregateSchema = "STRUCT<SEQ BIGINT, VAL STRING>")
   public static Udaf<String, Struct, String> latestString() {
-    return latest(STRUCT_STRING);
+    return latestString(true);
   }
-  
+
+  @UdafFactory(description = "return the latest value of a string column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL STRING>")
+  public static Udaf<String, Struct, String> latestString(final boolean ignoreNulls) {
+    return latest(STRUCT_STRING, ignoreNulls);
+  }
+
   @UdafFactory(description = "return the latest N value of a string column",
       aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL STRING>>")
   public static Udaf<String, List<Struct>, List<String>> latestStrings(final int latestN) {
-    return latestN(STRUCT_STRING, latestN);
+    return latestStrings(latestN, true);
   }
-  
+
+  @UdafFactory(description = "return the latest N value of a string column",
+      aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL STRING>>")
+  public static Udaf<String, List<Struct>, List<String>> latestStrings(
+      final int latestN,
+      final boolean ignoreNulls
+  ) {
+    return latestN(STRUCT_STRING, latestN, ignoreNulls);
+  }
+
+  @VisibleForTesting
   static <T> Struct createStruct(final Schema schema, final T val) {
-    final Struct struct = new Struct(schema);
-    struct.put(SEQ_FIELD, generateSequence());
-    struct.put(VAL_FIELD, val);
-    return struct;
+    return KudafByOffsetUtils.createStruct(schema, generateSequence(), val);
   }
 
   private static long generateSequence() {
     return sequence.getAndIncrement();
   }
 
-  static <T> Udaf<T, Struct, T> latest(final Schema structSchema) {
+  @VisibleForTesting
+  static <T> Udaf<T, Struct, T> latest(
+      final Schema structSchema,
+      final boolean ignoreNulls
+  ) {
     return new Udaf<T, Struct, T>() {
 
       @Override
@@ -132,11 +209,11 @@ public final class LatestByOffset {
 
       @Override
       public Struct aggregate(final T current, final Struct aggregate) {
-        if (current == null) {
+        if (current == null && ignoreNulls) {
           return aggregate;
-        } else {
-          return createStruct(structSchema, current);
         }
+
+        return createStruct(structSchema, current);
       }
 
       @Override
@@ -158,24 +235,26 @@ public final class LatestByOffset {
     };
   }
 
+  @VisibleForTesting
   static <T> Udaf<T, List<Struct>, List<T>> latestN(
       final Schema structSchema,
-      final int latestN
+      final int latestN,
+      final boolean ignoreNulls
   ) {
-    
+
     if (latestN <= 0) {
       throw new KsqlFunctionException("earliestN must be 1 or greater");
     }
-    
+
     return new Udaf<T, List<Struct>, List<T>>() {
       @Override
       public List<Struct> initialize() {
-        return new ArrayList<Struct>(latestN);
+        return new ArrayList<>(latestN);
       }
 
       @Override
       public List<Struct> aggregate(final T current, final List<Struct> aggregate) {
-        if (current == null) {
+        if (current == null && ignoreNulls) {
           return aggregate;
         }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/offset/EarliestByOffsetTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/offset/EarliestByOffsetTest.java
@@ -15,18 +15,19 @@
 
 package io.confluent.ksql.function.udaf.offset;
 
-import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.SEQ_FIELD;
-import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.STRUCT_BOOLEAN;
-import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.STRUCT_DOUBLE;
-import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.STRUCT_INTEGER;
-import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.STRUCT_LONG;
-import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.STRUCT_STRING;
-import static io.confluent.ksql.function.udaf.KudafByOffsetUtils.VAL_FIELD;
+import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.SEQ_FIELD;
+import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_BOOLEAN;
+import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_DOUBLE;
+import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_INTEGER;
+import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_LONG;
+import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_STRING;
+import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.VAL_FIELD;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 import com.google.common.collect.Lists;
 import io.confluent.ksql.function.udaf.Udaf;
@@ -37,39 +38,38 @@ import org.apache.kafka.connect.data.Struct;
 import org.junit.Test;
 
 
-public class EarliestByOffsetUdafTest {
-  
+public class EarliestByOffsetTest {
+
   @Test
   public void shouldInitialize() {
     // Given:
-    final Udaf<Integer, Struct, Integer> udaf = EarliestByOffset.earliest(STRUCT_LONG);
+    final Udaf<Integer, Struct, Integer> udaf = EarliestByOffset
+        .earliest(STRUCT_LONG, true);
 
     // When:
-    Struct init = udaf.initialize();
+    final Struct init = udaf.initialize();
 
     // Then:
-    assertThat(init, is(notNullValue()));
+    assertThat(init, is(nullValue()));
   }
-  
+
   @Test
   public void shouldInitializeN() {
     // Given:
-    final Udaf<Integer, List<Struct>, List<Integer>> udaf = EarliestByOffset.earliestN(STRUCT_LONG, 2);
+    final Udaf<Integer, List<Struct>, List<Integer>> udaf = EarliestByOffset
+        .earliestN(STRUCT_LONG, 2, false);
 
     // When:
-    List<Struct> init = udaf.initialize();
+    final List<Struct> init = udaf.initialize();
 
     // Then:
-    assertThat(init, is(notNullValue()));
+    assertThat(init, is(empty()));
   }
   
   @Test
   public void shouldThrowExceptionForInvalidN() {
     try {
-      EarliestByOffset
-          // Given:
-          .earliestN(STRUCT_LONG, -1);
-
+      EarliestByOffset.earliestN(STRUCT_LONG, -1, true);
     } catch (KsqlException e) {
       assertThat(e.getMessage(), is("earliestN must be 1 or greater"));
     }
@@ -81,7 +81,7 @@ public class EarliestByOffsetUdafTest {
     final Udaf<Integer, Struct, Integer> udaf = EarliestByOffset.earliestInteger();
 
     // When:
-    Struct res = udaf.aggregate(123, EarliestByOffset.createStruct(STRUCT_INTEGER, 321));
+    final Struct res = udaf.aggregate(123, EarliestByOffset.createStruct(STRUCT_INTEGER, 321));
 
     // Then:
     assertThat(res.get(VAL_FIELD), is(321));
@@ -93,26 +93,29 @@ public class EarliestByOffsetUdafTest {
     final Udaf<Integer, List<Struct>, List<Integer>> udaf = EarliestByOffset.earliestIntegers(2);
 
     // When:
-    List<Struct> res = udaf
+    final List<Struct> res = udaf
         .aggregate(123, Lists.newArrayList(EarliestByOffset.createStruct(STRUCT_INTEGER, 321)));
-    
+
     // Then:
     assertThat(res.get(0).get(VAL_FIELD), is(321));
     assertThat(res.get(1).get(VAL_FIELD), is(123));
   }
-  
+
   @Test
   public void shouldCaptureValuesUpToN() {
     // Given:
     final Udaf<Integer, List<Struct>, List<Integer>> udaf = EarliestByOffset.earliestIntegers(2);
+
     // When:
-    List<Struct> res0 = udaf.aggregate(321, new ArrayList<>());
-    List<Struct> res1 = udaf.aggregate(123, res0);
+    final List<Struct> res0 = udaf.aggregate(321, new ArrayList<>());
+    final List<Struct> res1 = udaf.aggregate(123, res0);
+
+    // Then:
     assertThat(res1, hasSize(2));
     assertThat(res1.get(0).get(VAL_FIELD), is(321));
     assertThat(res1.get(1).get(VAL_FIELD), is(123));
   }
-  
+
   @Test
   public void shouldCaptureValuesPastN() {
     // Given:
@@ -121,8 +124,11 @@ public class EarliestByOffsetUdafTest {
         EarliestByOffset.createStruct(STRUCT_INTEGER, 10),
         EarliestByOffset.createStruct(STRUCT_INTEGER, 3)
     );
+
     // When:
     final List<Struct> result = udaf.aggregate(2, aggregate);
+
+    // Then:
     assertThat(result, hasSize(2));
     assertThat(result.get(0).get(VAL_FIELD), is(10));
     assertThat(result.get(1).get(VAL_FIELD), is(3));
@@ -133,18 +139,18 @@ public class EarliestByOffsetUdafTest {
     // Given:
     final Udaf<Integer, Struct, Integer> udaf = EarliestByOffset.earliestInteger();
 
-    Struct agg1 = EarliestByOffset.createStruct(STRUCT_INTEGER, 123);
-    Struct agg2 = EarliestByOffset.createStruct(STRUCT_INTEGER, 321);
+    final Struct agg1 = EarliestByOffset.createStruct(STRUCT_INTEGER, 123);
+    final Struct agg2 = EarliestByOffset.createStruct(STRUCT_INTEGER, 321);
 
     // When:
-    Struct merged1 = udaf.merge(agg1, agg2);
-    Struct merged2 = udaf.merge(agg2, agg1);
+    final Struct merged1 = udaf.merge(agg1, agg2);
+    final Struct merged2 = udaf.merge(agg2, agg1);
 
     // Then:
     assertThat(merged1, is(agg1));
     assertThat(merged2, is(agg1));
   }
-  
+
   @Test
   public void shouldMergeNIntegers() {
     // Given:
@@ -155,7 +161,7 @@ public class EarliestByOffsetUdafTest {
     final Struct struct4 = EarliestByOffset.createStruct(STRUCT_INTEGER, 654);
     final List<Struct> agg1 = new ArrayList<>(Lists.newArrayList(struct1, struct4));
     final List<Struct> agg2 = new ArrayList<>(Lists.newArrayList(struct2, struct3));
-    
+
     // When:
     final List<Struct> merged1 = udaf.merge(agg1, agg2);
     final List<Struct> merged2 = udaf.merge(agg2, agg1);
@@ -164,7 +170,7 @@ public class EarliestByOffsetUdafTest {
     assertThat(merged1, contains(struct1, struct2));
     assertThat(merged2, contains(struct1, struct2));
   }
-  
+
   @Test
   public void shouldMergeNIntegersSmallerThanN() {
     // Given:
@@ -175,7 +181,7 @@ public class EarliestByOffsetUdafTest {
     final Struct struct4 = EarliestByOffset.createStruct(STRUCT_INTEGER, 654);
     final List<Struct> agg1 = new ArrayList<>(Lists.newArrayList(struct1, struct4));
     final List<Struct> agg2 = new ArrayList<>(Lists.newArrayList(struct2, struct3));
-    
+
     // When:
     final List<Struct> merged1 = udaf.merge(agg1, agg2);
     final List<Struct> merged2 = udaf.merge(agg2, agg1);
@@ -185,7 +191,6 @@ public class EarliestByOffsetUdafTest {
     assertThat(merged1.size(), is(4));
     assertThat(merged2, contains(struct1, struct2, struct3, struct4));
     assertThat(merged2.size(), is(4));
-    
   }
 
   @Test
@@ -195,8 +200,8 @@ public class EarliestByOffsetUdafTest {
 
     EarliestByOffset.sequence.set(Long.MAX_VALUE);
 
-    Struct agg1 = EarliestByOffset.createStruct(STRUCT_INTEGER, 123);
-    Struct agg2 = EarliestByOffset.createStruct(STRUCT_INTEGER, 321);
+    final Struct agg1 = EarliestByOffset.createStruct(STRUCT_INTEGER, 123);
+    final Struct agg2 = EarliestByOffset.createStruct(STRUCT_INTEGER, 321);
 
     // When:
     final Struct merged1 = udaf.merge(agg1, agg2);
@@ -208,7 +213,7 @@ public class EarliestByOffsetUdafTest {
     assertThat(merged1, is(agg1));
     assertThat(merged2, is(agg1));
   }
-  
+
   @Test
   public void shouldMergeWithOverflowNIntegers() {
     // Given:
@@ -216,14 +221,14 @@ public class EarliestByOffsetUdafTest {
 
     EarliestByOffset.sequence.set(Long.MAX_VALUE - 1);
 
-    Struct struct1 = EarliestByOffset.createStruct(STRUCT_INTEGER, 123);
-    Struct struct2 = EarliestByOffset.createStruct(STRUCT_INTEGER, 321);
-    Struct struct3 = EarliestByOffset.createStruct(STRUCT_INTEGER, 543);
-    Struct struct4 = EarliestByOffset.createStruct(STRUCT_INTEGER, 654);
-    
-    List<Struct> agg1 = Lists.newArrayList(struct1, struct2);
-    List<Struct> agg2 = Lists.newArrayList(struct3, struct4);
-    
+    final Struct struct1 = EarliestByOffset.createStruct(STRUCT_INTEGER, 123);
+    final Struct struct2 = EarliestByOffset.createStruct(STRUCT_INTEGER, 321);
+    final Struct struct3 = EarliestByOffset.createStruct(STRUCT_INTEGER, 543);
+    final Struct struct4 = EarliestByOffset.createStruct(STRUCT_INTEGER, 654);
+
+    final List<Struct> agg1 = Lists.newArrayList(struct1, struct2);
+    final List<Struct> agg2 = Lists.newArrayList(struct3, struct4);
+
     // When:
     final List<Struct> merged1 = udaf.merge(agg1, agg2);
     final List<Struct> merged2 = udaf.merge(agg2, agg1);
@@ -241,29 +246,29 @@ public class EarliestByOffsetUdafTest {
     final Udaf<Long, Struct, Long> udaf = EarliestByOffset.earliestLong();
 
     // When:
-    Struct res = udaf.aggregate(123L, EarliestByOffset.createStruct(STRUCT_LONG, 321L));
+    final Struct res = udaf.aggregate(123L, EarliestByOffset.createStruct(STRUCT_LONG, 321L));
 
     // Then:
     assertThat(res.getInt64(VAL_FIELD), is(321L));
   }
-  
+
   @Test
   public void shouldComputeEarliestNLongs() {
     // Given:
     final Udaf<Long, List<Struct>, List<Long>> udaf = EarliestByOffset.earliestLongs(3);
 
     // When:
-    List<Struct> res = udaf
+    final List<Struct> res = udaf
         .aggregate(123L, Lists.newArrayList(EarliestByOffset.createStruct(STRUCT_LONG, 321L)));
-    
+
     List<Struct> res2 = udaf
         .aggregate(543L, res);
-    
+
     // Then:
     assertThat(res2.size(), is(3));
     assertThat(res2.get(0).get(VAL_FIELD), is(321L));
     assertThat(res2.get(1).get(VAL_FIELD), is(123L));
-    assertThat(res2.get(2).get(VAL_FIELD), is(543L));    
+    assertThat(res2.get(2).get(VAL_FIELD), is(543L));
   }
 
   @Test
@@ -272,20 +277,20 @@ public class EarliestByOffsetUdafTest {
     final Udaf<Double, Struct, Double> udaf = EarliestByOffset.earliestDouble();
 
     // When:
-    Struct res = udaf
+    final Struct res = udaf
         .aggregate(1.1d, EarliestByOffset.createStruct(STRUCT_DOUBLE, 2.2d));
 
     // Then:
     assertThat(res.getFloat64(VAL_FIELD), is(2.2d));
   }
-  
+
   @Test
   public void shouldComputeEarliestNDoubles() {
     // Given:
     final Udaf<Double, List<Struct>, List<Double>> udaf = EarliestByOffset.earliestDoubles(1);
 
     // When:
-    List<Struct> res = udaf
+    final List<Struct> res = udaf
         .aggregate(1.1d, Lists.newArrayList(EarliestByOffset.createStruct(STRUCT_DOUBLE, 2.2d)));
 
     // Then:
@@ -299,20 +304,20 @@ public class EarliestByOffsetUdafTest {
     final Udaf<Boolean, Struct, Boolean> udaf = EarliestByOffset.earliestBoolean();
 
     // When:
-    Struct res = udaf
+    final Struct res = udaf
         .aggregate(true, EarliestByOffset.createStruct(STRUCT_BOOLEAN, false));
 
     // Then:
     assertThat(res.getBoolean(VAL_FIELD), is(false));
   }
-  
+
   @Test
   public void shouldComputeEarliestNBooleans() {
     // Given:
     final Udaf<Boolean, List<Struct>, List<Boolean>> udaf = EarliestByOffset.earliestBooleans(2);
 
     // When:
-    List<Struct> res = udaf
+    final List<Struct> res = udaf
         .aggregate(true, Lists.newArrayList(EarliestByOffset.createStruct(STRUCT_BOOLEAN, false)));
 
     // Then:
@@ -327,19 +332,19 @@ public class EarliestByOffsetUdafTest {
     final Udaf<String, Struct, String> udaf = EarliestByOffset.earliestString();
 
     // When:
-    Struct res = udaf.aggregate("foo", EarliestByOffset.createStruct(STRUCT_STRING, "bar"));
+    final Struct res = udaf.aggregate("foo", EarliestByOffset.createStruct(STRUCT_STRING, "bar"));
 
     // Then:
     assertThat(res.getString(VAL_FIELD), is("bar"));
   }
-  
+
   @Test
   public void shouldComputeEarliestNStrings() {
     // Given:
     final Udaf<String, List<Struct>, List<String>> udaf = EarliestByOffset.earliestStrings(3);
 
     // When:
-    List<Struct> res = udaf.aggregate("boo",
+    final List<Struct> res = udaf.aggregate("boo",
         Lists.newArrayList(EarliestByOffset.createStruct(STRUCT_STRING, "foo"),
             EarliestByOffset.createStruct(STRUCT_STRING, "bar"),
             EarliestByOffset.createStruct(STRUCT_STRING, "baz")));
@@ -349,5 +354,134 @@ public class EarliestByOffsetUdafTest {
     assertThat(res.get(0).get(VAL_FIELD), is("foo"));
     assertThat(res.get(1).get(VAL_FIELD), is("bar"));
     assertThat(res.get(2).get(VAL_FIELD), is("baz"));
+  }
+
+  @Test
+  public void shouldNotAcceptNullAsEarliest() {
+    // Given:
+    final Udaf<String, Struct, String> udaf = EarliestByOffset.earliestString();
+
+    // When:
+    final Struct res = udaf
+        .aggregate(null, udaf.initialize());
+
+    // Then:
+    assertThat(res, is(nullValue()));
+
+    // When:
+    final Struct res2 = udaf
+        .aggregate("value", res);
+
+    // Then:
+    assertThat(res2.getString(VAL_FIELD), is("value"));
+  }
+
+  @Test
+  public void shouldAcceptNullAsEarliest() {
+    // Given:
+    final Udaf<String, Struct, String> udaf = EarliestByOffset.earliestString(false);
+
+    // When:
+    final Struct res = udaf
+        .aggregate(null, udaf.initialize());
+
+    // Then:
+    assertThat(res.getString(VAL_FIELD), is(nullValue()));
+
+    // When:
+    final Struct res2 = udaf
+        .aggregate("value", res);
+
+    // Then:
+    assertThat(res2.getString(VAL_FIELD), is(nullValue()));
+  }
+
+  @Test
+  public void shouldNotAcceptNullAsEarliestN() {
+    // Given:
+    final Udaf<String, List<Struct>, List<String>> udaf = EarliestByOffset
+        .earliestStrings(1);
+
+    // When:
+    final List<Struct> res = udaf
+        .aggregate(null, udaf.initialize());
+
+    // Then:
+    assertThat(res, is(empty()));
+  }
+
+  @Test
+  public void shouldAcceptNullAsEarliestN() {
+    // Given:
+    final Udaf<String, List<Struct>, List<String>> udaf = EarliestByOffset
+        .earliestStrings(1, false);
+
+    // When:
+    final List<Struct> res = udaf
+        .aggregate(null, udaf.initialize());
+
+    // Then:
+    assertThat(res, hasSize(1));
+    assertThat(res.get(0).getString(VAL_FIELD), is(nullValue()));
+  }
+
+  @Test
+  public void shouldMapInitialized() {
+    // Given:
+    final Udaf<String, Struct, String> udaf = EarliestByOffset.earliestString();
+
+    final Struct init = udaf.initialize();
+
+    // When:
+    final String result = udaf.map(init);
+
+    // Then:
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  public void shouldMergeAndMapInitialized() {
+    // Given:
+    final Udaf<String, Struct, String> udaf = EarliestByOffset.earliestString();
+
+    final Struct init1 = udaf.initialize();
+    final Struct init2 = udaf.initialize();
+
+    // When:
+    final Struct merged = udaf.merge(init1, init2);
+    final String result = udaf.map(merged);
+
+    // Then:
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  public void shouldMapInitializedN() {
+    // Given:
+    final Udaf<String, List<Struct>, List<String>> udaf = EarliestByOffset.earliestStrings(2);
+
+    final List<Struct> init = udaf.initialize();
+
+    // When:
+    final List<String> result = udaf.map(init);
+
+    // Then:
+    assertThat(result, is(empty()));
+  }
+
+  @Test
+  public void shouldMergeAndMapInitializedN() {
+    // Given:
+    final Udaf<String, List<Struct>, List<String>> udaf = EarliestByOffset.earliestStrings(2);
+
+    final List<Struct> init1 = udaf.initialize();
+    final List<Struct> init2 = udaf.initialize();
+
+    // When:
+    final List<Struct> merged = udaf.merge(init1, init2);
+    final List<String> result = udaf.map(merged);
+
+    // Then:
+    assertThat(result, is(empty()));
   }
 }

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows/6.1.0_1599660077543/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows/6.1.0_1599660077543/plan.json
@@ -1,0 +1,182 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  EARLIEST_BY_OFFSET(INPUT.F0) L0\nFROM INPUT INPUT\nWINDOW SESSION ( 1 SECONDS ) \nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "windowInfo" : {
+        "type" : "SESSION"
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamWindowedAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "EARLIEST_BY_OFFSET(F0)" ],
+            "windowExpression" : " SESSION ( 1 SECONDS ) "
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.streams.max.task.idle.ms" : "0",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.enable.metastore.backup" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows/6.1.0_1599660077543/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows/6.1.0_1599660077543/spec.json
@@ -1,0 +1,176 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1599660077543,
+  "path" : "query-validation-tests/earliest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_AGG_VARIABLE_0` STRUCT<`SEQ` BIGINT, `VAL` INTEGER>",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "serdeOptions" : [ ]
+    }
+  },
+  "testCase" : {
+    "name" : "merging session windows",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 1
+      },
+      "timestamp" : 0
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 3
+      },
+      "timestamp" : 1500
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 2
+      },
+      "timestamp" : 700
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 1
+      },
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 3
+      },
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 1500,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 1500,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 1
+      },
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 0,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0) AS L0 FROM INPUT WINDOW nWINDOW SESSION (1 SECONDS) GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "windowType" : "SESSION"
+        },
+        "serdeOptions" : [ ]
+      }, {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            },
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            },
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows/6.1.0_1599660077543/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows/6.1.0_1599660077543/topology
@@ -1,0 +1,28 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_all_nulls/6.1.0_1599660077739/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_all_nulls/6.1.0_1599660077739/plan.json
@@ -1,0 +1,182 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  EARLIEST_BY_OFFSET(INPUT.F0, false) L0\nFROM INPUT INPUT\nWINDOW SESSION ( 1 SECONDS ) \nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "windowInfo" : {
+        "type" : "SESSION"
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamWindowedAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0", "false AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "EARLIEST_BY_OFFSET(F0, false)" ],
+            "windowExpression" : " SESSION ( 1 SECONDS ) "
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.streams.max.task.idle.ms" : "0",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.enable.metastore.backup" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_all_nulls/6.1.0_1599660077739/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_all_nulls/6.1.0_1599660077739/spec.json
@@ -1,0 +1,176 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1599660077739,
+  "path" : "query-validation-tests/earliest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_INTERNAL_COL_2` BOOLEAN",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_AGG_VARIABLE_0` STRUCT<`SEQ` BIGINT, `VAL` INTEGER>",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "serdeOptions" : [ ]
+    }
+  },
+  "testCase" : {
+    "name" : "merging session windows - all nulls",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      },
+      "timestamp" : 0
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      },
+      "timestamp" : 1500
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      },
+      "timestamp" : 700
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : null
+      },
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : null
+      },
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 1500,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 1500,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : null
+      },
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 0,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0, false) AS L0 FROM INPUT WINDOW SESSION (1 SECONDS) GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "windowType" : "SESSION"
+        },
+        "serdeOptions" : [ ]
+      }, {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            },
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            },
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_all_nulls/6.1.0_1599660077739/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_all_nulls/6.1.0_1599660077739/topology
@@ -1,0 +1,28 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_all_nulls_-_N/6.1.0_1599660077889/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_all_nulls_-_N/6.1.0_1599660077889/plan.json
@@ -1,0 +1,182 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  EARLIEST_BY_OFFSET(INPUT.F0, 2, false) L0\nFROM INPUT INPUT\nWINDOW SESSION ( 1 SECONDS ) \nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "windowInfo" : {
+        "type" : "SESSION"
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamWindowedAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0", "2 AS KSQL_INTERNAL_COL_2", "false AS KSQL_INTERNAL_COL_3" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "EARLIEST_BY_OFFSET(F0, 2, false)" ],
+            "windowExpression" : " SESSION ( 1 SECONDS ) "
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.streams.max.task.idle.ms" : "0",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.enable.metastore.backup" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_all_nulls_-_N/6.1.0_1599660077889/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_all_nulls_-_N/6.1.0_1599660077889/spec.json
@@ -1,0 +1,176 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1599660077889,
+  "path" : "query-validation-tests/earliest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_INTERNAL_COL_2` INTEGER, `KSQL_INTERNAL_COL_3` BOOLEAN",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_AGG_VARIABLE_0` ARRAY<STRUCT<`SEQ` BIGINT, `VAL` INTEGER>>",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+      "serdeOptions" : [ ]
+    }
+  },
+  "testCase" : {
+    "name" : "merging session windows - all nulls - N",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      },
+      "timestamp" : 0
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      },
+      "timestamp" : 1500
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      },
+      "timestamp" : 700
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ null ]
+      },
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ null ]
+      },
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 1500,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 1500,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ null, null ]
+      },
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 0,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0, 2, false) AS L0 FROM INPUT WINDOW SESSION (1 SECONDS) GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "windowType" : "SESSION"
+        },
+        "serdeOptions" : [ ]
+      }, {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            },
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            },
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_all_nulls_-_N/6.1.0_1599660077889/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_all_nulls_-_N/6.1.0_1599660077889/topology
@@ -1,0 +1,28 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_with_nulls_ignored/6.1.0_1599660077622/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_with_nulls_ignored/6.1.0_1599660077622/plan.json
@@ -1,0 +1,182 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  EARLIEST_BY_OFFSET(INPUT.F0, true) L0\nFROM INPUT INPUT\nWINDOW SESSION ( 1 SECONDS ) \nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "windowInfo" : {
+        "type" : "SESSION"
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamWindowedAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0", "true AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "EARLIEST_BY_OFFSET(F0, true)" ],
+            "windowExpression" : " SESSION ( 1 SECONDS ) "
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.streams.max.task.idle.ms" : "0",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.enable.metastore.backup" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_with_nulls_ignored/6.1.0_1599660077622/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_with_nulls_ignored/6.1.0_1599660077622/spec.json
@@ -1,0 +1,176 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1599660077622,
+  "path" : "query-validation-tests/earliest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_INTERNAL_COL_2` BOOLEAN",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_AGG_VARIABLE_0` STRUCT<`SEQ` BIGINT, `VAL` INTEGER>",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "serdeOptions" : [ ]
+    }
+  },
+  "testCase" : {
+    "name" : "merging session windows - with nulls ignored",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      },
+      "timestamp" : 0
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 1
+      },
+      "timestamp" : 1500
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      },
+      "timestamp" : 700
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : null
+      },
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 1
+      },
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 1500,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 1500,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 1
+      },
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 0,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0, true) AS L0 FROM INPUT WINDOW SESSION (1 SECONDS) GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "windowType" : "SESSION"
+        },
+        "serdeOptions" : [ ]
+      }, {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            },
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            },
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_with_nulls_ignored/6.1.0_1599660077622/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_with_nulls_ignored/6.1.0_1599660077622/topology
@@ -1,0 +1,28 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_with_nulls_ignored_-_N/6.1.0_1599660077786/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_with_nulls_ignored_-_N/6.1.0_1599660077786/plan.json
@@ -1,0 +1,182 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  EARLIEST_BY_OFFSET(INPUT.F0, 2, true) L0\nFROM INPUT INPUT\nWINDOW SESSION ( 1 SECONDS ) \nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "windowInfo" : {
+        "type" : "SESSION"
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamWindowedAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0", "2 AS KSQL_INTERNAL_COL_2", "true AS KSQL_INTERNAL_COL_3" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "EARLIEST_BY_OFFSET(F0, 2, true)" ],
+            "windowExpression" : " SESSION ( 1 SECONDS ) "
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.streams.max.task.idle.ms" : "0",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.enable.metastore.backup" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_with_nulls_ignored_-_N/6.1.0_1599660077786/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_with_nulls_ignored_-_N/6.1.0_1599660077786/spec.json
@@ -1,0 +1,176 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1599660077786,
+  "path" : "query-validation-tests/earliest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_INTERNAL_COL_2` INTEGER, `KSQL_INTERNAL_COL_3` BOOLEAN",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_AGG_VARIABLE_0` ARRAY<STRUCT<`SEQ` BIGINT, `VAL` INTEGER>>",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+      "serdeOptions" : [ ]
+    }
+  },
+  "testCase" : {
+    "name" : "merging session windows - with nulls ignored - N",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      },
+      "timestamp" : 0
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 1
+      },
+      "timestamp" : 1500
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      },
+      "timestamp" : 700
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ ]
+      },
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ 1 ]
+      },
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 1500,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 1500,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ 1 ]
+      },
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 0,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0, 2, true) AS L0 FROM INPUT WINDOW SESSION (1 SECONDS) GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "windowType" : "SESSION"
+        },
+        "serdeOptions" : [ ]
+      }, {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            },
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            },
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_with_nulls_ignored_-_N/6.1.0_1599660077786/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_with_nulls_ignored_-_N/6.1.0_1599660077786/topology
@@ -1,0 +1,28 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_with_nulls_not_ignored/6.1.0_1599660077679/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_with_nulls_not_ignored/6.1.0_1599660077679/plan.json
@@ -1,0 +1,182 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  EARLIEST_BY_OFFSET(INPUT.F0, false) L0\nFROM INPUT INPUT\nWINDOW SESSION ( 1 SECONDS ) \nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "windowInfo" : {
+        "type" : "SESSION"
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamWindowedAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0", "false AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "EARLIEST_BY_OFFSET(F0, false)" ],
+            "windowExpression" : " SESSION ( 1 SECONDS ) "
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.streams.max.task.idle.ms" : "0",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.enable.metastore.backup" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_with_nulls_not_ignored/6.1.0_1599660077679/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_with_nulls_not_ignored/6.1.0_1599660077679/spec.json
@@ -1,0 +1,176 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1599660077679,
+  "path" : "query-validation-tests/earliest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_INTERNAL_COL_2` BOOLEAN",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_AGG_VARIABLE_0` STRUCT<`SEQ` BIGINT, `VAL` INTEGER>",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "serdeOptions" : [ ]
+    }
+  },
+  "testCase" : {
+    "name" : "merging session windows - with nulls not ignored",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      },
+      "timestamp" : 0
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 1
+      },
+      "timestamp" : 1500
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      },
+      "timestamp" : 700
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : null
+      },
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 1
+      },
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 1500,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 1500,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : null
+      },
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 0,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0, false) AS L0 FROM INPUT WINDOW SESSION (1 SECONDS) GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "windowType" : "SESSION"
+        },
+        "serdeOptions" : [ ]
+      }, {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            },
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            },
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_with_nulls_not_ignored/6.1.0_1599660077679/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_with_nulls_not_ignored/6.1.0_1599660077679/topology
@@ -1,0 +1,28 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_with_nulls_not_ignored_-_N/6.1.0_1599660077843/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_with_nulls_not_ignored_-_N/6.1.0_1599660077843/plan.json
@@ -1,0 +1,182 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  EARLIEST_BY_OFFSET(INPUT.F0, 2, false) L0\nFROM INPUT INPUT\nWINDOW SESSION ( 1 SECONDS ) \nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "windowInfo" : {
+        "type" : "SESSION"
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamWindowedAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0", "2 AS KSQL_INTERNAL_COL_2", "false AS KSQL_INTERNAL_COL_3" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "EARLIEST_BY_OFFSET(F0, 2, false)" ],
+            "windowExpression" : " SESSION ( 1 SECONDS ) "
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.streams.max.task.idle.ms" : "0",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.enable.metastore.backup" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_with_nulls_not_ignored_-_N/6.1.0_1599660077843/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_with_nulls_not_ignored_-_N/6.1.0_1599660077843/spec.json
@@ -1,0 +1,176 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1599660077843,
+  "path" : "query-validation-tests/earliest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_INTERNAL_COL_2` INTEGER, `KSQL_INTERNAL_COL_3` BOOLEAN",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_AGG_VARIABLE_0` ARRAY<STRUCT<`SEQ` BIGINT, `VAL` INTEGER>>",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+      "serdeOptions" : [ ]
+    }
+  },
+  "testCase" : {
+    "name" : "merging session windows - with nulls not ignored - N",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      },
+      "timestamp" : 0
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 1
+      },
+      "timestamp" : 1500
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      },
+      "timestamp" : 700
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ null ]
+      },
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ 1 ]
+      },
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 1500,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 1500,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ null, 1 ]
+      },
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 0,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0, 2, false) AS L0 FROM INPUT WINDOW SESSION (1 SECONDS) GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "windowType" : "SESSION"
+        },
+        "serdeOptions" : [ ]
+      }, {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            },
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            },
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_with_nulls_not_ignored_-_N/6.1.0_1599660077843/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_merging_session_windows_-_with_nulls_not_ignored_-_N/6.1.0_1599660077843/topology
@@ -1,0 +1,28 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_first_-_multiple_-_ignoring_nulls/6.1.0_1599660076728/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_first_-_multiple_-_ignoring_nulls/6.1.0_1599660076728/plan.json
@@ -1,0 +1,178 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  EARLIEST_BY_OFFSET(INPUT.F0, 2) L0\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0", "2 AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "EARLIEST_BY_OFFSET(F0, 2)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.streams.max.task.idle.ms" : "0",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.enable.metastore.backup" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_first_-_multiple_-_ignoring_nulls/6.1.0_1599660076728/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_first_-_multiple_-_ignoring_nulls/6.1.0_1599660076728/spec.json
@@ -1,0 +1,116 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1599660076728,
+  "path" : "query-validation-tests/earliest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_INTERNAL_COL_2` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_AGG_VARIABLE_0` ARRAY<STRUCT<`SEQ` BIGINT, `VAL` INTEGER>>",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+      "serdeOptions" : [ ]
+    }
+  },
+  "testCase" : {
+    "name" : "null first - multiple - ignoring nulls",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 13
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ 13 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0, 2) AS L0 FROM INPUT GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      }, {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_first_-_multiple_-_ignoring_nulls/6.1.0_1599660076728/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_first_-_multiple_-_ignoring_nulls/6.1.0_1599660076728/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_first_-_multiple_-_not_ignoring_nulls/6.1.0_1599660076886/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_first_-_multiple_-_not_ignoring_nulls/6.1.0_1599660076886/plan.json
@@ -1,0 +1,178 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  EARLIEST_BY_OFFSET(INPUT.F0, 2, false) L0\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0", "2 AS KSQL_INTERNAL_COL_2", "false AS KSQL_INTERNAL_COL_3" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "EARLIEST_BY_OFFSET(F0, 2, false)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.streams.max.task.idle.ms" : "0",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.enable.metastore.backup" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_first_-_multiple_-_not_ignoring_nulls/6.1.0_1599660076886/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_first_-_multiple_-_not_ignoring_nulls/6.1.0_1599660076886/spec.json
@@ -1,0 +1,116 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1599660076886,
+  "path" : "query-validation-tests/earliest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_INTERNAL_COL_2` INTEGER, `KSQL_INTERNAL_COL_3` BOOLEAN",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_AGG_VARIABLE_0` ARRAY<STRUCT<`SEQ` BIGINT, `VAL` INTEGER>>",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+      "serdeOptions" : [ ]
+    }
+  },
+  "testCase" : {
+    "name" : "null first - multiple - not ignoring nulls",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 13
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ null ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ null, 13 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0, 2, false) AS L0 FROM INPUT GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      }, {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_first_-_multiple_-_not_ignoring_nulls/6.1.0_1599660076886/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_first_-_multiple_-_not_ignoring_nulls/6.1.0_1599660076886/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_first_-_single_-_ignoring_nulls/6.1.0_1599660076648/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_first_-_single_-_ignoring_nulls/6.1.0_1599660076648/plan.json
@@ -1,0 +1,178 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  EARLIEST_BY_OFFSET(INPUT.F0, true) L0\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0", "true AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "EARLIEST_BY_OFFSET(F0, true)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.streams.max.task.idle.ms" : "0",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.enable.metastore.backup" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_first_-_single_-_ignoring_nulls/6.1.0_1599660076648/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_first_-_single_-_ignoring_nulls/6.1.0_1599660076648/spec.json
@@ -1,0 +1,116 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1599660076648,
+  "path" : "query-validation-tests/earliest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_INTERNAL_COL_2` BOOLEAN",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_AGG_VARIABLE_0` STRUCT<`SEQ` BIGINT, `VAL` INTEGER>",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "serdeOptions" : [ ]
+    }
+  },
+  "testCase" : {
+    "name" : "null first - single - ignoring nulls",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 13
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 13
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0, true) AS L0 FROM INPUT GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      }, {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_first_-_single_-_ignoring_nulls/6.1.0_1599660076648/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_first_-_single_-_ignoring_nulls/6.1.0_1599660076648/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_first_-_single_-_not_ignoring_nulls/6.1.0_1599660076818/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_first_-_single_-_not_ignoring_nulls/6.1.0_1599660076818/plan.json
@@ -1,0 +1,178 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  EARLIEST_BY_OFFSET(INPUT.F0, false) L0\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0", "false AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "EARLIEST_BY_OFFSET(F0, false)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.streams.max.task.idle.ms" : "0",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.enable.metastore.backup" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_first_-_single_-_not_ignoring_nulls/6.1.0_1599660076818/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_first_-_single_-_not_ignoring_nulls/6.1.0_1599660076818/spec.json
@@ -1,0 +1,116 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1599660076818,
+  "path" : "query-validation-tests/earliest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_INTERNAL_COL_2` BOOLEAN",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_AGG_VARIABLE_0` STRUCT<`SEQ` BIGINT, `VAL` INTEGER>",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "serdeOptions" : [ ]
+    }
+  },
+  "testCase" : {
+    "name" : "null first - single - not ignoring nulls",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 13
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : null
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0, false) AS L0 FROM INPUT GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      }, {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_first_-_single_-_not_ignoring_nulls/6.1.0_1599660076818/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_first_-_single_-_not_ignoring_nulls/6.1.0_1599660076818/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_later_-_multiple_-_nulls_not_ignored/6.1.0_1599660077148/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_later_-_multiple_-_nulls_not_ignored/6.1.0_1599660077148/plan.json
@@ -1,0 +1,178 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  EARLIEST_BY_OFFSET(INPUT.F0, 2, false) L0\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0", "2 AS KSQL_INTERNAL_COL_2", "false AS KSQL_INTERNAL_COL_3" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "EARLIEST_BY_OFFSET(F0, 2, false)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.streams.max.task.idle.ms" : "0",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.enable.metastore.backup" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_later_-_multiple_-_nulls_not_ignored/6.1.0_1599660077148/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_later_-_multiple_-_nulls_not_ignored/6.1.0_1599660077148/spec.json
@@ -1,0 +1,128 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1599660077148,
+  "path" : "query-validation-tests/earliest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_INTERNAL_COL_2` INTEGER, `KSQL_INTERNAL_COL_3` BOOLEAN",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_AGG_VARIABLE_0` ARRAY<STRUCT<`SEQ` BIGINT, `VAL` INTEGER>>",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+      "serdeOptions" : [ ]
+    }
+  },
+  "testCase" : {
+    "name" : "null later - multiple - nulls not ignored",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 12
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 13
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ 12 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ 12, null ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ 12, null ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0, 2, false) AS L0 FROM INPUT GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      }, {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_later_-_multiple_-_nulls_not_ignored/6.1.0_1599660077148/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_later_-_multiple_-_nulls_not_ignored/6.1.0_1599660077148/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_later_-_single_-_nulls_not_ignored/6.1.0_1599660077069/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_later_-_single_-_nulls_not_ignored/6.1.0_1599660077069/plan.json
@@ -1,0 +1,178 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  EARLIEST_BY_OFFSET(INPUT.F0, false) L0\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0", "false AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "EARLIEST_BY_OFFSET(F0, false)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.streams.max.task.idle.ms" : "0",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.enable.metastore.backup" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_later_-_single_-_nulls_not_ignored/6.1.0_1599660077069/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_later_-_single_-_nulls_not_ignored/6.1.0_1599660077069/spec.json
@@ -1,0 +1,128 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1599660077069,
+  "path" : "query-validation-tests/earliest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_INTERNAL_COL_2` BOOLEAN",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_AGG_VARIABLE_0` STRUCT<`SEQ` BIGINT, `VAL` INTEGER>",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "serdeOptions" : [ ]
+    }
+  },
+  "testCase" : {
+    "name" : "null later - single - nulls not ignored",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 12
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 13
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 12
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 12
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 12
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0, false) AS L0 FROM INPUT GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      }, {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_later_-_single_-_nulls_not_ignored/6.1.0_1599660077069/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_null_later_-_single_-_nulls_not_ignored/6.1.0_1599660077069/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_nulls_later_-_multiple_-_nulls_ignored/6.1.0_1599660076994/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_nulls_later_-_multiple_-_nulls_ignored/6.1.0_1599660076994/plan.json
@@ -1,0 +1,178 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  EARLIEST_BY_OFFSET(INPUT.F0, 2) L0\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0", "2 AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "EARLIEST_BY_OFFSET(F0, 2)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.streams.max.task.idle.ms" : "0",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.enable.metastore.backup" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_nulls_later_-_multiple_-_nulls_ignored/6.1.0_1599660076994/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_nulls_later_-_multiple_-_nulls_ignored/6.1.0_1599660076994/spec.json
@@ -1,0 +1,128 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1599660076994,
+  "path" : "query-validation-tests/earliest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_INTERNAL_COL_2` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_AGG_VARIABLE_0` ARRAY<STRUCT<`SEQ` BIGINT, `VAL` INTEGER>>",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+      "serdeOptions" : [ ]
+    }
+  },
+  "testCase" : {
+    "name" : "nulls later - multiple - nulls ignored",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 12
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 13
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ 12 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ 12 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ 12, 13 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0, 2) AS L0 FROM INPUT GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      }, {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_nulls_later_-_multiple_-_nulls_ignored/6.1.0_1599660076994/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_nulls_later_-_multiple_-_nulls_ignored/6.1.0_1599660076994/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_nulls_later_-_single_-_nulls_ignored/6.1.0_1599660076943/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_nulls_later_-_single_-_nulls_ignored/6.1.0_1599660076943/plan.json
@@ -1,0 +1,178 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  EARLIEST_BY_OFFSET(INPUT.F0) L0\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "EARLIEST_BY_OFFSET(F0)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.streams.max.task.idle.ms" : "0",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.enable.metastore.backup" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_nulls_later_-_single_-_nulls_ignored/6.1.0_1599660076943/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_nulls_later_-_single_-_nulls_ignored/6.1.0_1599660076943/spec.json
@@ -1,0 +1,128 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1599660076943,
+  "path" : "query-validation-tests/earliest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_AGG_VARIABLE_0` STRUCT<`SEQ` BIGINT, `VAL` INTEGER>",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "serdeOptions" : [ ]
+    }
+  },
+  "testCase" : {
+    "name" : "nulls later - single - nulls ignored",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 12
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 13
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 12
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 12
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 12
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0) AS L0 FROM INPUT GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      }, {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_nulls_later_-_single_-_nulls_ignored/6.1.0_1599660076943/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_nulls_later_-_single_-_nulls_ignored/6.1.0_1599660076943/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows/6.1.0_1599660120841/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows/6.1.0_1599660120841/plan.json
@@ -1,0 +1,182 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  LATEST_BY_OFFSET(INPUT.F0) L0\nFROM INPUT INPUT\nWINDOW SESSION ( 1 SECONDS ) \nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "windowInfo" : {
+        "type" : "SESSION"
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamWindowedAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "LATEST_BY_OFFSET(F0)" ],
+            "windowExpression" : " SESSION ( 1 SECONDS ) "
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.streams.max.task.idle.ms" : "0",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.enable.metastore.backup" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows/6.1.0_1599660120841/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows/6.1.0_1599660120841/spec.json
@@ -1,0 +1,176 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1599660120841,
+  "path" : "query-validation-tests/latest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_AGG_VARIABLE_0` STRUCT<`SEQ` BIGINT, `VAL` INTEGER>",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "serdeOptions" : [ ]
+    }
+  },
+  "testCase" : {
+    "name" : "merging session windows",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 1
+      },
+      "timestamp" : 0
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 3
+      },
+      "timestamp" : 1500
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 2
+      },
+      "timestamp" : 700
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 1
+      },
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 3
+      },
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 1500,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 1500,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 2
+      },
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 0,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0) AS L0 FROM INPUT WINDOW SESSION (1 SECONDS) GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "windowType" : "SESSION"
+        },
+        "serdeOptions" : [ ]
+      }, {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            },
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            },
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows/6.1.0_1599660120841/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows/6.1.0_1599660120841/topology
@@ -1,0 +1,28 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_all_nulls/6.1.0_1599660120983/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_all_nulls/6.1.0_1599660120983/plan.json
@@ -1,0 +1,182 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  LATEST_BY_OFFSET(INPUT.F0, false) L0\nFROM INPUT INPUT\nWINDOW SESSION ( 1 SECONDS ) \nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "windowInfo" : {
+        "type" : "SESSION"
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamWindowedAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0", "false AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "LATEST_BY_OFFSET(F0, false)" ],
+            "windowExpression" : " SESSION ( 1 SECONDS ) "
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.streams.max.task.idle.ms" : "0",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.enable.metastore.backup" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_all_nulls/6.1.0_1599660120983/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_all_nulls/6.1.0_1599660120983/spec.json
@@ -1,0 +1,176 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1599660120983,
+  "path" : "query-validation-tests/latest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_INTERNAL_COL_2` BOOLEAN",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_AGG_VARIABLE_0` STRUCT<`SEQ` BIGINT, `VAL` INTEGER>",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "serdeOptions" : [ ]
+    }
+  },
+  "testCase" : {
+    "name" : "merging session windows - all nulls",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      },
+      "timestamp" : 0
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      },
+      "timestamp" : 1500
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      },
+      "timestamp" : 700
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : null
+      },
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : null
+      },
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 1500,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 1500,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : null
+      },
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 0,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0, false) AS L0 FROM INPUT WINDOW SESSION (1 SECONDS) GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "windowType" : "SESSION"
+        },
+        "serdeOptions" : [ ]
+      }, {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            },
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            },
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_all_nulls/6.1.0_1599660120983/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_all_nulls/6.1.0_1599660120983/topology
@@ -1,0 +1,28 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_all_nulls_-_N/6.1.0_1599660121133/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_all_nulls_-_N/6.1.0_1599660121133/plan.json
@@ -1,0 +1,182 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  LATEST_BY_OFFSET(INPUT.F0, 2, false) L0\nFROM INPUT INPUT\nWINDOW SESSION ( 1 SECONDS ) \nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "windowInfo" : {
+        "type" : "SESSION"
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamWindowedAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0", "2 AS KSQL_INTERNAL_COL_2", "false AS KSQL_INTERNAL_COL_3" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "LATEST_BY_OFFSET(F0, 2, false)" ],
+            "windowExpression" : " SESSION ( 1 SECONDS ) "
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.streams.max.task.idle.ms" : "0",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.enable.metastore.backup" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_all_nulls_-_N/6.1.0_1599660121133/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_all_nulls_-_N/6.1.0_1599660121133/spec.json
@@ -1,0 +1,176 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1599660121133,
+  "path" : "query-validation-tests/latest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_INTERNAL_COL_2` INTEGER, `KSQL_INTERNAL_COL_3` BOOLEAN",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_AGG_VARIABLE_0` ARRAY<STRUCT<`SEQ` BIGINT, `VAL` INTEGER>>",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+      "serdeOptions" : [ ]
+    }
+  },
+  "testCase" : {
+    "name" : "merging session windows - all nulls - N",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      },
+      "timestamp" : 0
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      },
+      "timestamp" : 1500
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      },
+      "timestamp" : 700
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ null ]
+      },
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ null ]
+      },
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 1500,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 1500,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ null, null ]
+      },
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 0,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0, 2, false) AS L0 FROM INPUT WINDOW SESSION (1 SECONDS) GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "windowType" : "SESSION"
+        },
+        "serdeOptions" : [ ]
+      }, {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            },
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            },
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_all_nulls_-_N/6.1.0_1599660121133/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_all_nulls_-_N/6.1.0_1599660121133/topology
@@ -1,0 +1,28 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_ignored/6.1.0_1599660120887/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_ignored/6.1.0_1599660120887/plan.json
@@ -1,0 +1,182 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  LATEST_BY_OFFSET(INPUT.F0) L0\nFROM INPUT INPUT\nWINDOW SESSION ( 1 SECONDS ) \nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "windowInfo" : {
+        "type" : "SESSION"
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamWindowedAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "LATEST_BY_OFFSET(F0)" ],
+            "windowExpression" : " SESSION ( 1 SECONDS ) "
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.streams.max.task.idle.ms" : "0",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.enable.metastore.backup" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_ignored/6.1.0_1599660120887/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_ignored/6.1.0_1599660120887/spec.json
@@ -1,0 +1,176 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1599660120887,
+  "path" : "query-validation-tests/latest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_AGG_VARIABLE_0` STRUCT<`SEQ` BIGINT, `VAL` INTEGER>",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "serdeOptions" : [ ]
+    }
+  },
+  "testCase" : {
+    "name" : "merging session windows - with nulls ignored",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 1
+      },
+      "timestamp" : 0
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      },
+      "timestamp" : 1500
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 2
+      },
+      "timestamp" : 700
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 1
+      },
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : null
+      },
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 1500,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 1500,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 2
+      },
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 0,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0) AS L0 FROM INPUT WINDOW SESSION (1 SECONDS) GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "windowType" : "SESSION"
+        },
+        "serdeOptions" : [ ]
+      }, {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            },
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            },
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_ignored/6.1.0_1599660120887/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_ignored/6.1.0_1599660120887/topology
@@ -1,0 +1,28 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_ignored_-_N/6.1.0_1599660121033/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_ignored_-_N/6.1.0_1599660121033/plan.json
@@ -1,0 +1,182 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  LATEST_BY_OFFSET(INPUT.F0, 2, true) L0\nFROM INPUT INPUT\nWINDOW SESSION ( 1 SECONDS ) \nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "windowInfo" : {
+        "type" : "SESSION"
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamWindowedAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0", "2 AS KSQL_INTERNAL_COL_2", "true AS KSQL_INTERNAL_COL_3" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "LATEST_BY_OFFSET(F0, 2, true)" ],
+            "windowExpression" : " SESSION ( 1 SECONDS ) "
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.streams.max.task.idle.ms" : "0",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.enable.metastore.backup" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_ignored_-_N/6.1.0_1599660121033/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_ignored_-_N/6.1.0_1599660121033/spec.json
@@ -1,0 +1,176 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1599660121033,
+  "path" : "query-validation-tests/latest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_INTERNAL_COL_2` INTEGER, `KSQL_INTERNAL_COL_3` BOOLEAN",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_AGG_VARIABLE_0` ARRAY<STRUCT<`SEQ` BIGINT, `VAL` INTEGER>>",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+      "serdeOptions" : [ ]
+    }
+  },
+  "testCase" : {
+    "name" : "merging session windows - with nulls ignored - N",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 1
+      },
+      "timestamp" : 0
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      },
+      "timestamp" : 1500
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 2
+      },
+      "timestamp" : 700
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ 1 ]
+      },
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ ]
+      },
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 1500,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 1500,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ 1, 2 ]
+      },
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 0,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0, 2, true) AS L0 FROM INPUT WINDOW SESSION (1 SECONDS) GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "windowType" : "SESSION"
+        },
+        "serdeOptions" : [ ]
+      }, {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            },
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            },
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_ignored_-_N/6.1.0_1599660121033/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_ignored_-_N/6.1.0_1599660121033/topology
@@ -1,0 +1,28 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_not_ignored/6.1.0_1599660120941/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_not_ignored/6.1.0_1599660120941/plan.json
@@ -1,0 +1,182 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  LATEST_BY_OFFSET(INPUT.F0, false) L0\nFROM INPUT INPUT\nWINDOW SESSION ( 1 SECONDS ) \nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "windowInfo" : {
+        "type" : "SESSION"
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamWindowedAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0", "false AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "LATEST_BY_OFFSET(F0, false)" ],
+            "windowExpression" : " SESSION ( 1 SECONDS ) "
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.streams.max.task.idle.ms" : "0",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.enable.metastore.backup" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_not_ignored/6.1.0_1599660120941/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_not_ignored/6.1.0_1599660120941/spec.json
@@ -1,0 +1,176 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1599660120941,
+  "path" : "query-validation-tests/latest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_INTERNAL_COL_2` BOOLEAN",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_AGG_VARIABLE_0` STRUCT<`SEQ` BIGINT, `VAL` INTEGER>",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "serdeOptions" : [ ]
+    }
+  },
+  "testCase" : {
+    "name" : "merging session windows - with nulls not ignored",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 1
+      },
+      "timestamp" : 0
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      },
+      "timestamp" : 1500
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 2
+      },
+      "timestamp" : 700
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 1
+      },
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : null
+      },
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 1500,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 1500,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 2
+      },
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 0,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0, false) AS L0 FROM INPUT WINDOW SESSION (1 SECONDS) GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "windowType" : "SESSION"
+        },
+        "serdeOptions" : [ ]
+      }, {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            },
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            },
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_not_ignored/6.1.0_1599660120941/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_not_ignored/6.1.0_1599660120941/topology
@@ -1,0 +1,28 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_not_ignored_-_N/6.1.0_1599660121084/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_not_ignored_-_N/6.1.0_1599660121084/plan.json
@@ -1,0 +1,182 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  LATEST_BY_OFFSET(INPUT.F0, 2, false) L0\nFROM INPUT INPUT\nWINDOW SESSION ( 1 SECONDS ) \nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "windowInfo" : {
+        "type" : "SESSION"
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamWindowedAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0", "2 AS KSQL_INTERNAL_COL_2", "false AS KSQL_INTERNAL_COL_3" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "LATEST_BY_OFFSET(F0, 2, false)" ],
+            "windowExpression" : " SESSION ( 1 SECONDS ) "
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.streams.max.task.idle.ms" : "0",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.enable.metastore.backup" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_not_ignored_-_N/6.1.0_1599660121084/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_not_ignored_-_N/6.1.0_1599660121084/spec.json
@@ -1,0 +1,176 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1599660121084,
+  "path" : "query-validation-tests/latest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_INTERNAL_COL_2` INTEGER, `KSQL_INTERNAL_COL_3` BOOLEAN",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_AGG_VARIABLE_0` ARRAY<STRUCT<`SEQ` BIGINT, `VAL` INTEGER>>",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+      "serdeOptions" : [ ]
+    }
+  },
+  "testCase" : {
+    "name" : "merging session windows - with nulls not ignored - N",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 1
+      },
+      "timestamp" : 0
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      },
+      "timestamp" : 1500
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 2
+      },
+      "timestamp" : 700
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ 1 ]
+      },
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ null ]
+      },
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 1500,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 1500,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ null, 2 ]
+      },
+      "timestamp" : 1500,
+      "window" : {
+        "start" : 0,
+        "end" : 1500,
+        "type" : "SESSION"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0, 2, false) AS L0 FROM INPUT WINDOW SESSION (1 SECONDS) GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "windowType" : "SESSION"
+        },
+        "serdeOptions" : [ ]
+      }, {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            },
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            },
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_not_ignored_-_N/6.1.0_1599660121084/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_not_ignored_-_N/6.1.0_1599660121084/topology
@@ -1,0 +1,28 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_nulls_ignored_-_multiple/6.1.0_1599660120399/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_nulls_ignored_-_multiple/6.1.0_1599660120399/plan.json
@@ -1,0 +1,178 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  LATEST_BY_OFFSET(INPUT.F0, 2, true) L0\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0", "2 AS KSQL_INTERNAL_COL_2", "true AS KSQL_INTERNAL_COL_3" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "LATEST_BY_OFFSET(F0, 2, true)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.streams.max.task.idle.ms" : "0",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.enable.metastore.backup" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_nulls_ignored_-_multiple/6.1.0_1599660120399/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_nulls_ignored_-_multiple/6.1.0_1599660120399/spec.json
@@ -1,0 +1,128 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1599660120399,
+  "path" : "query-validation-tests/latest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_INTERNAL_COL_2` INTEGER, `KSQL_INTERNAL_COL_3` BOOLEAN",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_AGG_VARIABLE_0` ARRAY<STRUCT<`SEQ` BIGINT, `VAL` INTEGER>>",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+      "serdeOptions" : [ ]
+    }
+  },
+  "testCase" : {
+    "name" : "nulls ignored - multiple",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 12
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 13
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ 12 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ 12 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ 12, 13 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0, 2, true) AS L0 FROM INPUT GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      }, {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_nulls_ignored_-_multiple/6.1.0_1599660120399/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_nulls_ignored_-_multiple/6.1.0_1599660120399/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_nulls_ignored_-_single/6.1.0_1599660120349/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_nulls_ignored_-_single/6.1.0_1599660120349/plan.json
@@ -1,0 +1,178 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  LATEST_BY_OFFSET(INPUT.F0, true) L0\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0", "true AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "LATEST_BY_OFFSET(F0, true)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.streams.max.task.idle.ms" : "0",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.enable.metastore.backup" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_nulls_ignored_-_single/6.1.0_1599660120349/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_nulls_ignored_-_single/6.1.0_1599660120349/spec.json
@@ -1,0 +1,128 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1599660120349,
+  "path" : "query-validation-tests/latest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_INTERNAL_COL_2` BOOLEAN",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_AGG_VARIABLE_0` STRUCT<`SEQ` BIGINT, `VAL` INTEGER>",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "serdeOptions" : [ ]
+    }
+  },
+  "testCase" : {
+    "name" : "nulls ignored - single",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 12
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 13
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 12
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 12
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 13
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0, true) AS L0 FROM INPUT GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      }, {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_nulls_ignored_-_single/6.1.0_1599660120349/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_nulls_ignored_-_single/6.1.0_1599660120349/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_nulls_not_ignored_-_multiple/6.1.0_1599660120547/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_nulls_not_ignored_-_multiple/6.1.0_1599660120547/plan.json
@@ -1,0 +1,178 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  LATEST_BY_OFFSET(INPUT.F0, 2, false) L0\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0", "2 AS KSQL_INTERNAL_COL_2", "false AS KSQL_INTERNAL_COL_3" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "LATEST_BY_OFFSET(F0, 2, false)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.streams.max.task.idle.ms" : "0",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.enable.metastore.backup" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_nulls_not_ignored_-_multiple/6.1.0_1599660120547/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_nulls_not_ignored_-_multiple/6.1.0_1599660120547/spec.json
@@ -1,0 +1,128 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1599660120547,
+  "path" : "query-validation-tests/latest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_INTERNAL_COL_2` INTEGER, `KSQL_INTERNAL_COL_3` BOOLEAN",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_AGG_VARIABLE_0` ARRAY<STRUCT<`SEQ` BIGINT, `VAL` INTEGER>>",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+      "serdeOptions" : [ ]
+    }
+  },
+  "testCase" : {
+    "name" : "nulls not ignored - multiple",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 12
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 13
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ 12 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ 12, null ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : [ null, 13 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0, 2, false) AS L0 FROM INPUT GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `L0` ARRAY<INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      }, {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_nulls_not_ignored_-_multiple/6.1.0_1599660120547/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_nulls_not_ignored_-_multiple/6.1.0_1599660120547/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_nulls_not_ignored_-_single/6.1.0_1599660120482/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_nulls_not_ignored_-_single/6.1.0_1599660120482/plan.json
@@ -1,0 +1,178 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  LATEST_BY_OFFSET(INPUT.F0, false) L0\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0", "false AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "LATEST_BY_OFFSET(F0, false)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.streams.max.task.idle.ms" : "0",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.enable.metastore.backup" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_nulls_not_ignored_-_single/6.1.0_1599660120482/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_nulls_not_ignored_-_single/6.1.0_1599660120482/spec.json
@@ -1,0 +1,128 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1599660120482,
+  "path" : "query-validation-tests/latest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_INTERNAL_COL_2` BOOLEAN",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_AGG_VARIABLE_0` STRUCT<`SEQ` BIGINT, `VAL` INTEGER>",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "serdeOptions" : [ ]
+    }
+  },
+  "testCase" : {
+    "name" : "nulls not ignored - single",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 12
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 13
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 12
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 13
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0, false) AS L0 FROM INPUT GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      }, {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_nulls_not_ignored_-_single/6.1.0_1599660120482/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_nulls_not_ignored_-_single/6.1.0_1599660120482/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/udaf_-_support_more_than_one_literal_param/6.1.0_1599765849560/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/udaf_-_support_more_than_one_literal_param/6.1.0_1599765849560/plan.json
@@ -1,0 +1,178 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  EARLIEST_BY_OFFSET(INPUT.F0, 2, true) KSQL_COL_0\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `KSQL_COL_0` ARRAY<INTEGER>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0", "2 AS KSQL_INTERNAL_COL_2", "true AS KSQL_INTERNAL_COL_3" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "EARLIEST_BY_OFFSET(F0, 2, true)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS KSQL_COL_0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.streams.max.task.idle.ms" : "0",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.enable.metastore.backup" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/udaf_-_support_more_than_one_literal_param/6.1.0_1599765849560/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/udaf_-_support_more_than_one_literal_param/6.1.0_1599765849560/spec.json
@@ -1,0 +1,106 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1599765849560,
+  "path" : "query-validation-tests/udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_INTERNAL_COL_2` INTEGER, `KSQL_INTERNAL_COL_3` BOOLEAN",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_AGG_VARIABLE_0` ARRAY<STRUCT<`SEQ` BIGINT, `VAL` INTEGER>>",
+      "serdeOptions" : [ ]
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `KSQL_COL_0` ARRAY<INTEGER>",
+      "serdeOptions" : [ ]
+    }
+  },
+  "testCase" : {
+    "name" : "support more than one literal param",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 1
+      },
+      "timestamp" : 0
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "KSQL_COL_0" : [ 1 ]
+      },
+      "timestamp" : 0
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0, 2, true) FROM INPUT GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `KSQL_COL_0` ARRAY<INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      }, {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/udaf_-_support_more_than_one_literal_param/6.1.0_1599765849560/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/udaf_-_support_more_than_one_literal_param/6.1.0_1599765849560/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/earliest-offset-udaf.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/earliest-offset-udaf.json
@@ -24,18 +24,131 @@
       ]
     },
     {
-      "name": "earliest by offset with nulls",
+      "name": "null first - single - ignoring nulls",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0, true) AS L0 FROM INPUT GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"F0": null}},
+        {"topic": "test_topic", "key": 0, "value": {"F0": 13}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": null}},
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": 13}}
+      ]
+    },
+    {
+      "name": "null first - multiple - ignoring nulls",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0, 2) AS L0 FROM INPUT GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"F0": null}},
+        {"topic": "test_topic", "key": 0, "value": {"F0": 13}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": []}},
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": [13]}}
+      ]
+    },
+    {
+      "name": "null first - single - not ignoring nulls",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0, false) AS L0 FROM INPUT GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"F0": null}},
+        {"topic": "test_topic", "key": 0, "value": {"F0": 13}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": null}},
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": null}}
+      ]
+    },
+    {
+      "name": "null first - multiple - not ignoring nulls",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0, 2, false) AS L0 FROM INPUT GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"F0": null}},
+        {"topic": "test_topic", "key": 0, "value": {"F0": 13}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": [null]}},
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": [null,13]}}
+      ]
+    },
+    {
+      "name": "nulls later - single - nulls ignored",
       "statements": [
         "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0) AS L0 FROM INPUT GROUP BY ID;"
       ],
       "inputs": [
         {"topic": "test_topic", "key": 0, "value": {"F0": 12}},
-        {"topic": "test_topic", "key": 0, "value": {"F0": null}}
+        {"topic": "test_topic", "key": 0, "value": {"F0": null}},
+        {"topic": "test_topic", "key": 0, "value": {"F0": 13}}
       ],
       "outputs": [
         {"topic": "OUTPUT", "key": 0, "value": {"L0": 12}},
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": 12}},
         {"topic": "OUTPUT", "key": 0, "value": {"L0": 12}}
+      ]
+    },
+    {
+      "name": "nulls later - multiple - nulls ignored",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0, 2) AS L0 FROM INPUT GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"F0": 12}},
+        {"topic": "test_topic", "key": 0, "value": {"F0": null}},
+        {"topic": "test_topic", "key": 0, "value": {"F0": 13}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": [12]}},
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": [12]}},
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": [12,13]}}
+      ]
+    },
+    {
+      "name": "null later - single - nulls not ignored",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0, false) AS L0 FROM INPUT GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"F0": 12}},
+        {"topic": "test_topic", "key": 0, "value": {"F0": null}},
+        {"topic": "test_topic", "key": 0, "value": {"F0": 13}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": 12}},
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": 12}},
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": 12}}
+      ]
+    },
+    {
+      "name": "null later - multiple - nulls not ignored",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0, 2, false) AS L0 FROM INPUT GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"F0": 12}},
+        {"topic": "test_topic", "key": 0, "value": {"F0": null}},
+        {"topic": "test_topic", "key": 0, "value": {"F0": 13}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": [12]}},
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": [12,null]}},
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": [12,null]}}
       ]
     },
     {
@@ -102,6 +215,139 @@
       "outputs": [
         {"topic": "OUTPUT", "key": 0, "value": {"L0": []}},
         {"topic": "OUTPUT", "key": 0, "value": {"L0": []}}
+      ]
+    },
+    {
+      "name": "merging session windows",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0) AS L0 FROM INPUT WINDOW nWINDOW SESSION (1 SECONDS) GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 0, "key": 0, "value": {"F0": 1}},
+        {"topic": "test_topic", "timestamp": 1500, "key": 0, "value": {"F0": 3}},
+        {"topic": "test_topic", "timestamp": 700, "key": 0, "value": {"F0": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": {"L0": 1}},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 1500, "end": 1500, "type": "session"}, "value": {"L0": 3}},
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": null},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 1500, "end": 1500, "type": "session"}, "value": null},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 0, "end": 1500, "type": "session"}, "value": {"L0": 1}}
+      ]
+    },
+    {
+      "name": "merging session windows - with nulls ignored",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0, true) AS L0 FROM INPUT WINDOW SESSION (1 SECONDS) GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 0, "key": 0, "value": {"F0": null}},
+        {"topic": "test_topic", "timestamp": 1500, "key": 0, "value": {"F0": 1}},
+        {"topic": "test_topic", "timestamp": 700, "key": 0, "value": {"F0": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": {"L0": null}},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 1500, "end": 1500, "type": "session"}, "value": {"L0": 1}},
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": null},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 1500, "end": 1500, "type": "session"}, "value": null},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 0, "end": 1500, "type": "session"}, "value": {"L0": 1}}
+      ]
+    },
+    {
+      "name": "merging session windows - with nulls not ignored",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0, false) AS L0 FROM INPUT WINDOW SESSION (1 SECONDS) GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 0, "key": 0, "value": {"F0": null}},
+        {"topic": "test_topic", "timestamp": 1500, "key": 0, "value": {"F0": 1}},
+        {"topic": "test_topic", "timestamp": 700, "key": 0, "value": {"F0": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": {"L0": null}},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 1500, "end": 1500, "type": "session"}, "value": {"L0": 1}},
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": null},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 1500, "end": 1500, "type": "session"}, "value": null},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 0, "end": 1500, "type": "session"}, "value": {"L0": null}}
+      ]
+    },
+    {
+      "name": "merging session windows - all nulls",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0, false) AS L0 FROM INPUT WINDOW SESSION (1 SECONDS) GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 0, "key": 0, "value": {"F0": null}},
+        {"topic": "test_topic", "timestamp": 1500, "key": 0, "value": {"F0": null}},
+        {"topic": "test_topic", "timestamp": 700, "key": 0, "value": {"F0": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": {"L0": null}},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 1500, "end": 1500, "type": "session"}, "value": {"L0": null}},
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": null},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 1500, "end": 1500, "type": "session"}, "value": null},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 0, "end": 1500, "type": "session"}, "value": {"L0": null}}
+      ]
+    },
+    {
+      "name": "merging session windows - with nulls ignored - N",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0, 2, true) AS L0 FROM INPUT WINDOW SESSION (1 SECONDS) GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 0, "key": 0, "value": {"F0": null}},
+        {"topic": "test_topic", "timestamp": 1500, "key": 0, "value": {"F0": 1}},
+        {"topic": "test_topic", "timestamp": 700, "key": 0, "value": {"F0": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": {"L0": []}},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 1500, "end": 1500, "type": "session"}, "value": {"L0": [1]}},
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": null},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 1500, "end": 1500, "type": "session"}, "value": null},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 0, "end": 1500, "type": "session"}, "value": {"L0": [1]}}
+      ]
+    },
+    {
+      "name": "merging session windows - with nulls not ignored - N",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0, 2, false) AS L0 FROM INPUT WINDOW SESSION (1 SECONDS) GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 0, "key": 0, "value": {"F0": null}},
+        {"topic": "test_topic", "timestamp": 1500, "key": 0, "value": {"F0": 1}},
+        {"topic": "test_topic", "timestamp": 700, "key": 0, "value": {"F0": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": {"L0": [null]}},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 1500, "end": 1500, "type": "session"}, "value": {"L0": [1]}},
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": null},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 1500, "end": 1500, "type": "session"}, "value": null},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 0, "end": 1500, "type": "session"}, "value": {"L0": [null,1]}}
+      ]
+    },
+    {
+      "name": "merging session windows - all nulls - N",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0, 2, false) AS L0 FROM INPUT WINDOW SESSION (1 SECONDS) GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 0, "key": 0, "value": {"F0": null}},
+        {"topic": "test_topic", "timestamp": 1500, "key": 0, "value": {"F0": null}},
+        {"topic": "test_topic", "timestamp": 700, "key": 0, "value": {"F0": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": {"L0": [null]}},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 1500, "end": 1500, "type": "session"}, "value": {"L0": [null]}},
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": null},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 1500, "end": 1500, "type": "session"}, "value": null},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 0, "end": 1500, "type": "session"}, "value": {"L0": [null,null]}}
       ]
     }
   ]

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/latest-offset-udaf.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/latest-offset-udaf.json
@@ -23,18 +23,71 @@
       ]
     },
     {
-      "name": "latest by offset with nulls",
+      "name": "nulls ignored - single",
       "statements": [
         "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0) AS L0 FROM INPUT GROUP BY ID;"
+        "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0, true) AS L0 FROM INPUT GROUP BY ID;"
       ],
       "inputs": [
         {"topic": "test_topic", "key": 0, "value": {"F0": 12}},
-        {"topic": "test_topic", "key": 0, "value": {"F0": null}}
+        {"topic": "test_topic", "key": 0, "value": {"F0": null}},
+        {"topic": "test_topic", "key": 0, "value": {"F0": 13}}
       ],
       "outputs": [
         {"topic": "OUTPUT", "key": 0, "value": {"L0": 12}},
-        {"topic": "OUTPUT", "key": 0, "value": {"L0": 12}}
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": 12}},
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": 13}}
+      ]
+    },
+    {
+      "name": "nulls ignored - multiple",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0, 2, true) AS L0 FROM INPUT GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"F0": 12}},
+        {"topic": "test_topic", "key": 0, "value": {"F0": null}},
+        {"topic": "test_topic", "key": 0, "value": {"F0": 13}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": [12]}},
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": [12]}},
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": [12,13]}}
+      ]
+    },
+    {
+      "name": "nulls not ignored - single",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0, false) AS L0 FROM INPUT GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"F0": 12}},
+        {"topic": "test_topic", "key": 0, "value": {"F0": null}},
+        {"topic": "test_topic", "key": 0, "value": {"F0": 13}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": 12}},
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": null}},
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": 13}}
+      ]
+    },
+    {
+      "name": "nulls not ignored - multiple",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0, 2, false) AS L0 FROM INPUT GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"F0": 12}},
+        {"topic": "test_topic", "key": 0, "value": {"F0": null}},
+        {"topic": "test_topic", "key": 0, "value": {"F0": 13}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": [12]}},
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": [12, null]}},
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": [null, 13]}}
       ]
     },
     {
@@ -99,6 +152,139 @@
       "outputs": [
         {"topic": "OUTPUT", "key": 0, "value": {"L0": []}},
         {"topic": "OUTPUT", "key": 0, "value": {"L0": []}}
+      ]
+    },
+    {
+      "name": "merging session windows",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0) AS L0 FROM INPUT WINDOW SESSION (1 SECONDS) GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 0, "key": 0, "value": {"F0": 1}},
+        {"topic": "test_topic", "timestamp": 1500, "key": 0, "value": {"F0": 3}},
+        {"topic": "test_topic", "timestamp": 700, "key": 0, "value": {"F0": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": {"L0": 1}},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 1500, "end": 1500, "type": "session"}, "value": {"L0": 3}},
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": null},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 1500, "end": 1500, "type": "session"}, "value": null},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 0, "end": 1500, "type": "session"}, "value": {"L0": 2}}
+      ]
+    },
+    {
+      "name": "merging session windows - with nulls ignored",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0) AS L0 FROM INPUT WINDOW SESSION (1 SECONDS) GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 0, "key": 0, "value": {"F0": 1}},
+        {"topic": "test_topic", "timestamp": 1500, "key": 0, "value": {"F0": null}},
+        {"topic": "test_topic", "timestamp": 700, "key": 0, "value": {"F0": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": {"L0": 1}},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 1500, "end": 1500, "type": "session"}, "value": {"L0": null}},
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": null},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 1500, "end": 1500, "type": "session"}, "value": null},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 0, "end": 1500, "type": "session"}, "value": {"L0": 2}}
+      ]
+    },
+    {
+      "name": "merging session windows - with nulls not ignored",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0, false) AS L0 FROM INPUT WINDOW SESSION (1 SECONDS) GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 0, "key": 0, "value": {"F0": 1}},
+        {"topic": "test_topic", "timestamp": 1500, "key": 0, "value": {"F0": null}},
+        {"topic": "test_topic", "timestamp": 700, "key": 0, "value": {"F0": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": {"L0": 1}},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 1500, "end": 1500, "type": "session"}, "value": {"L0": null}},
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": null},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 1500, "end": 1500, "type": "session"}, "value": null},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 0, "end": 1500, "type": "session"}, "value": {"L0": 2}}
+      ]
+    },
+    {
+      "name": "merging session windows - all nulls",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0, false) AS L0 FROM INPUT WINDOW SESSION (1 SECONDS) GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 0, "key": 0, "value": {"F0": null}},
+        {"topic": "test_topic", "timestamp": 1500, "key": 0, "value": {"F0": null}},
+        {"topic": "test_topic", "timestamp": 700, "key": 0, "value": {"F0": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": {"L0": null}},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 1500, "end": 1500, "type": "session"}, "value": {"L0": null}},
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": null},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 1500, "end": 1500, "type": "session"}, "value": null},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 0, "end": 1500, "type": "session"}, "value": {"L0": null}}
+      ]
+    },
+    {
+      "name": "merging session windows - with nulls ignored - N",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0, 2, true) AS L0 FROM INPUT WINDOW SESSION (1 SECONDS) GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 0, "key": 0, "value": {"F0": 1}},
+        {"topic": "test_topic", "timestamp": 1500, "key": 0, "value": {"F0": null}},
+        {"topic": "test_topic", "timestamp": 700, "key": 0, "value": {"F0": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": {"L0": [1]}},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 1500, "end": 1500, "type": "session"}, "value": {"L0": []}},
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": null},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 1500, "end": 1500, "type": "session"}, "value": null},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 0, "end": 1500, "type": "session"}, "value": {"L0": [1,2]}}
+      ]
+    },
+    {
+      "name": "merging session windows - with nulls not ignored - N",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0, 2, false) AS L0 FROM INPUT WINDOW SESSION (1 SECONDS) GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 0, "key": 0, "value": {"F0": 1}},
+        {"topic": "test_topic", "timestamp": 1500, "key": 0, "value": {"F0": null}},
+        {"topic": "test_topic", "timestamp": 700, "key": 0, "value": {"F0": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": {"L0": [1]}},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 1500, "end": 1500, "type": "session"}, "value": {"L0": [null]}},
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": null},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 1500, "end": 1500, "type": "session"}, "value": null},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 0, "end": 1500, "type": "session"}, "value": {"L0": [null,2]}}
+      ]
+    },
+    {
+      "name": "merging session windows - all nulls - N",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0, 2, false) AS L0 FROM INPUT WINDOW SESSION (1 SECONDS) GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 0, "key": 0, "value": {"F0": null}},
+        {"topic": "test_topic", "timestamp": 1500, "key": 0, "value": {"F0": null}},
+        {"topic": "test_topic", "timestamp": 700, "key": 0, "value": {"F0": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": {"L0": [null]}},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 1500, "end": 1500, "type": "session"}, "value": {"L0": [null]}},
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": null},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 1500, "end": 1500, "type": "session"}, "value": null},
+        {"topic": "OUTPUT", "timestamp": 1500, "key": 0, "window": {"start": 0, "end": 1500, "type": "session"}, "value": {"L0": [null,null]}}
       ]
     }
   ]

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/udaf.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/udaf.json
@@ -1,0 +1,43 @@
+
+{
+  "comments": [
+    "Tests covering generic UDAFs"
+  ],
+  "tests": [
+    {
+      "name": "throw on signature mismatch",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0, false, 2) FROM INPUT GROUP BY ID;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Function 'EARLIEST_BY_OFFSET' does not accept parameters (INTEGER, BOOLEAN, INTEGER).\nValid alternatives are:\nEARLIEST_BY_OFFSET(INT val, INT earliestN, BOOLEAN ignoreNulls)"
+      }
+    },
+    {
+      "name": "throw on no literal expressions pass for literal params",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0, F0) FROM INPUT GROUP BY ID;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Parameter 2 passed to function EARLIEST_BY_OFFSET must be a literal constant, but was expression: 'F0'"
+      }
+    },
+    {
+      "name": "support more than one literal param",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0, 2, true) FROM INPUT GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 0, "key": 0, "value": {"F0": 1}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "value": {"KSQL_COL_0": [1]}}
+      ]
+    }
+  ]
+}

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/udaf.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/udaf.json
@@ -12,7 +12,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Function 'EARLIEST_BY_OFFSET' does not accept parameters (INTEGER, BOOLEAN, INTEGER).\nValid alternatives are:\nEARLIEST_BY_OFFSET(INT val, INT earliestN, BOOLEAN ignoreNulls)"
+        "message": "Function 'EARLIEST_BY_OFFSET' does not accept parameters (INTEGER, BOOLEAN, INTEGER).\nValid alternatives are:"
       }
     },
     {


### PR DESCRIPTION
### Description 

fixes: https://github.com/confluentinc/ksql/issues/5727

Adds additional, optional, `ignoreNulls` parameter to the `EARLIEST_BY_OFFSET` and `LATEST_BY_OFFSET` UDAFs, that controls null handling.  The default is to ignore nulls, which is inline with previous behaviour.  If the user passes `ignoreNulls` as `false` then the methods will treat `null` as a valid value and use it as the first/last value.

To achieve this, I've removed the limit on UDAFs that said you could only have one constant parameter.  UDAFs now support any number of constant parameters, (a.k.a. literals).  Though they can still only have one non-constant param.

### Testing done 

Usual. Including adding tests around session window merging.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

