### PR TITLE
fix: make sure old query stream doesn't block on close

### DIFF
--- a/config/ksql-server.properties
+++ b/config/ksql-server.properties
@@ -64,11 +64,8 @@ bootstrap.servers=localhost:9092
 compression.type=snappy
 
 #------ Connect -------
-
 # uncomment the below to start an embedded Connect worker
 # ksql.connect.worker.config=config/connect.properties
-
 #------ Schema Registry -------
-
 # Uncomment and complete the following to enable KSQL's integration to the Confluent Schema Registry:
 # ksql.schema.registry.url=http://localhost:8081

--- a/config/ksql-server.properties
+++ b/config/ksql-server.properties
@@ -64,8 +64,11 @@ bootstrap.servers=localhost:9092
 compression.type=snappy
 
 #------ Connect -------
+
 # uncomment the below to start an embedded Connect worker
 # ksql.connect.worker.config=config/connect.properties
+
 #------ Schema Registry -------
+
 # Uncomment and complete the following to enable KSQL's integration to the Confluent Schema Registry:
 # ksql.schema.registry.url=http://localhost:8081

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ResponseOutputStream.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ResponseOutputStream.java
@@ -35,7 +35,7 @@ This is only used by legacy streaming endpoints from the old API which work with
  */
 public class ResponseOutputStream extends OutputStream {
 
-  private static final int WRITE_TIMEOUT_MS = 5 * 60000;
+  private static final int WRITE_TIMEOUT_MS = 10 * 60000;
   private static final int BLOCK_TIME_MS = 100;
 
   private final HttpServerResponse response;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ResponseOutputStream.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ResponseOutputStream.java
@@ -19,10 +19,13 @@ import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.VertxUtils;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServerResponse;
+import java.io.EOFException;
+import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.jetbrains.annotations.NotNull;
 
 /*
@@ -32,7 +35,11 @@ This is only used by legacy streaming endpoints from the old API which work with
  */
 public class ResponseOutputStream extends OutputStream {
 
+  private static final int WRITE_TIMEOUT_MS = 5 * 60000;
+  private static final int BLOCK_TIME_MS = 100;
+
   private final HttpServerResponse response;
+  private volatile boolean closed;
 
   public ResponseOutputStream(final HttpServerResponse response) {
     this.response = response;
@@ -45,7 +52,11 @@ public class ResponseOutputStream extends OutputStream {
   }
 
   @Override
-  public synchronized void write(final @NotNull byte[] bytes, final int offset, final int length) {
+  public synchronized void write(final @NotNull byte[] bytes, final int offset, final int length)
+      throws IOException {
+    if (closed) {
+      throw new EOFException("ResponseOutputStream is closed");
+    }
     Objects.requireNonNull(bytes);
     if ((offset < 0) || (offset > bytes.length)) {
       throw new IndexOutOfBoundsException();
@@ -65,21 +76,39 @@ public class ResponseOutputStream extends OutputStream {
 
   @Override
   public void close() {
+    if (closed) {
+      return;
+    }
+    closed = true;
     response.end();
   }
 
-  private void blockIfWriteQueueFull() {
+  private void blockIfWriteQueueFull() throws IOException {
     VertxUtils.checkIsWorker();
     if (response.writeQueueFull()) {
       final CompletableFuture<Void> cf = new CompletableFuture<>();
       response.drainHandler(v -> cf.complete(null));
+      blockOnWrite(cf);
+    }
+  }
+
+  private void blockOnWrite(final CompletableFuture<Void> cf) throws IOException {
+    final long start = System.currentTimeMillis();
+    do {
+      if (closed) {
+        throw new EOFException("ResponseOutputStream is closed");
+      }
       try {
-        cf.get(60, TimeUnit.SECONDS);
+        // We block for a small amount of time so we can check if the stream has been closed
+        cf.get(BLOCK_TIME_MS, TimeUnit.MILLISECONDS);
+        return;
+      } catch (TimeoutException e) {
+        // continue loop
       } catch (Exception e) {
-        // Very slow consumers will result in a timeout, this will cause the push query to be closed
         throw new KsqlException(e);
       }
-    }
+    } while (System.currentTimeMillis() - start < WRITE_TIMEOUT_MS);
+    throw new KsqlException("Timed out waiting to write to client");
   }
 
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/Server.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/Server.java
@@ -282,7 +282,7 @@ public class Server {
         .setPort(port)
         .setReuseAddress(true)
         .setReusePort(true)
-        .setIdleTimeout(60).setIdleTimeoutUnit(TimeUnit.SECONDS)
+        .setIdleTimeout(10 * 60).setIdleTimeoutUnit(TimeUnit.SECONDS)
         .setPerMessageWebSocketCompressionSupported(true)
         .setPerFrameWebSocketCompressionSupported(true);
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -227,8 +227,6 @@ public class ServerVerticle extends AbstractVerticle {
     final CompletableFuture<Void> connectionClosedFuture = new CompletableFuture<>();
     routingContext.request().connection().closeHandler(v -> connectionClosedFuture.complete(null));
 
-    routingContext.response().setWriteQueueMaxSize(200 * 1024);
-
     handleOldApiRequest(server, routingContext, KsqlRequest.class,
         (request, apiSecurityContext) ->
             endpoints


### PR DESCRIPTION
### Description 

Fixes https://github.com/confluentinc/ksql/issues/5724

The ksqlDB CLI currently uses the old query streaming API at /query.

When terminating a query from the CLI, the connection is closed. The close is detected in the QueryStreamWriter poll loop which causes it to flush the OutputStream. This causes a write to be called on the underlying ResponseOutputStream, but because the channel isn't available for writing writeQueueFull() returns true and the thread is blocked until it times out (previously 60 seconds). This means that, previously, if you start and terminate queries quite rapidly, it takes 60 seconds for each ones state to be cleared up on the server. 

This PR changes the blocking in ResponseOutputStream so it can return more quickly if the stream is closed. It also changes the blocking timeout to 10 minutes, and it changes the server idle timeout to 10 minutes.

The old query endpoint had been migrated as is from Jetty to Vert.x. The old code is somewhat complex and this bug arose in the mapping from the synchronous approach taken in the old implementation and the Vert.x asynchronous APIs.

I'd recommend that the ksqlDB is refactored to use the new query streaming API (e.g. via the new Java client) which does not have these issues, and the old /query API is deprecated.

### Testing done 

Non functional change.

Manually verified.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

