### PR TITLE
fix: windowed tables now have cleanup policy compact+delete

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -240,17 +240,17 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
   @Override
   public TopicCleanupPolicy getTopicCleanupPolicy(final String topicName) {
     final String policy = getTopicConfig(topicName)
-        .getOrDefault(TopicConfig.CLEANUP_POLICY_CONFIG, "");
+        .getOrDefault(TopicConfig.CLEANUP_POLICY_CONFIG, "")
+        .toLowerCase();
 
-    switch (policy) {
-      case "compact":
-        return TopicCleanupPolicy.COMPACT;
-      case "delete":
-        return TopicCleanupPolicy.DELETE;
-      case "compact+delete":
-        return TopicCleanupPolicy.COMPACT_DELETE;
-      default:
-        throw new KsqlException("Could not get the topic configs for : " + topicName);
+    if (policy.equals("compact")) {
+      return TopicCleanupPolicy.COMPACT;
+    } else if (policy.equals("delete")) {
+      return TopicCleanupPolicy.DELETE;
+    } else if (policy.contains("compact") && policy.contains("delete")) {
+      return TopicCleanupPolicy.COMPACT_DELETE;
+    } else {
+      throw new KsqlException("Could not get the topic configs for : " + topicName);
     }
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -240,8 +240,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
   @Override
   public TopicCleanupPolicy getTopicCleanupPolicy(final String topicName) {
     final String policy = getTopicConfig(topicName)
-        .getOrDefault(TopicConfig.CLEANUP_POLICY_CONFIG, "")
-        .toLowerCase();
+        .getOrDefault(TopicConfig.CLEANUP_POLICY_CONFIG, "");
 
     if (policy.equals("compact")) {
       return TopicCleanupPolicy.COMPACT;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -240,7 +240,8 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
   @Override
   public TopicCleanupPolicy getTopicCleanupPolicy(final String topicName) {
     final String policy = getTopicConfig(topicName)
-        .getOrDefault(TopicConfig.CLEANUP_POLICY_CONFIG, "");
+        .getOrDefault(TopicConfig.CLEANUP_POLICY_CONFIG, "")
+        .toLowerCase();
 
     if (policy.equals("compact")) {
       return TopicCleanupPolicy.COMPACT;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
@@ -156,7 +156,7 @@ public class WindowingIntTest {
 
     // Then:
     assertOutputOf(resultStream0, expected, is(expected));
-    assertTopicsCleanedUp(TopicCleanupPolicy.DELETE, 3, resultStream0);
+    assertTopicsCleanedUp(TopicCleanupPolicy.COMPACT_DELETE, 3, resultStream0);
   }
 
   @Test
@@ -179,7 +179,7 @@ public class WindowingIntTest {
 
     // Then:
     assertOutputOf(resultStream0, expected, is(expected));
-    assertTopicsCleanedUp(TopicCleanupPolicy.DELETE, 3, resultStream0);
+    assertTopicsCleanedUp(TopicCleanupPolicy.COMPACT_DELETE, 3, resultStream0);
   }
 
   @Test
@@ -210,7 +210,7 @@ public class WindowingIntTest {
 
     // Then:
     assertOutputOf(resultStream0, expected, mapHasItems(expected));
-    assertTopicsCleanedUp(TopicCleanupPolicy.DELETE, 2, resultStream0);
+    assertTopicsCleanedUp(TopicCleanupPolicy.COMPACT_DELETE, 2, resultStream0);
   }
 
   private void givenTable(final String sql) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
@@ -54,6 +54,7 @@ import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -345,7 +346,7 @@ public class TopicCreateInjectorTest {
         "expectedName",
         10,
         (short) 10,
-        ImmutableMap.of(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE));
+        Collections.emptyMap());
   }
 
   @Test
@@ -362,7 +363,7 @@ public class TopicCreateInjectorTest {
         "expectedName",
         10,
         (short) 10,
-        ImmutableMap.of(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE));
+        Collections.emptyMap());
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
@@ -345,7 +345,7 @@ public class TopicCreateInjectorTest {
         "expectedName",
         10,
         (short) 10,
-        ImmutableMap.of());
+        ImmutableMap.of(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE));
   }
 
   @Test
@@ -362,7 +362,7 @@ public class TopicCreateInjectorTest {
         "expectedName",
         10,
         (short) 10,
-        ImmutableMap.of());
+        ImmutableMap.of(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE));
   }
 
   @Test
@@ -401,7 +401,7 @@ public class TopicCreateInjectorTest {
   }
 
   @Test
-  public void shouldCreateMissingTopicWithDefaultCleanupPolicyForWindowedTables() {
+  public void shouldCreateMissingTopicWithCompactAndDeleteCleanupPolicyForWindowedTables() {
     // Given:
     givenStatement("CREATE TABLE x WITH (kafka_topic='topic') "
         + "AS SELECT * FROM SOURCE WINDOW TUMBLING (SIZE 10 SECONDS);");
@@ -415,7 +415,8 @@ public class TopicCreateInjectorTest {
         "expectedName",
         10,
         (short) 10,
-        ImmutableMap.of());
+        ImmutableMap.of(TopicConfig.CLEANUP_POLICY_CONFIG,
+            TopicConfig.CLEANUP_POLICY_COMPACT + "," + TopicConfig.CLEANUP_POLICY_DELETE));
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
@@ -54,7 +54,6 @@ import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -346,7 +345,7 @@ public class TopicCreateInjectorTest {
         "expectedName",
         10,
         (short) 10,
-        Collections.emptyMap());
+        ImmutableMap.of(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE));
   }
 
   @Test
@@ -363,7 +362,7 @@ public class TopicCreateInjectorTest {
         "expectedName",
         10,
         (short) 10,
-        Collections.emptyMap());
+        ImmutableMap.of(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE));
   }
 
   @Test


### PR DESCRIPTION
### Description 

Fixes https://github.com/confluentinc/ksql/issues/5554

BREAKING CHANGE: ksqlDB now creates windowed tables with cleanup policy "compact,delete", rather than "compact". Also, topics that back streams are always created with cleanup policy "delete", rather than the broker default (by default, "delete").

### Testing done 

Unit tests + manual.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

