### PR TITLE
fix: do not overwrite schemas from a CREATE STREAM/TABLE

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjector.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.schema.ksql.inference;
 
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.KsqlExecutionContext.ExecuteResult;
@@ -73,7 +75,8 @@ public class SchemaRegisterInjector implements Injector {
         cs.getStatement().getProperties().getKafkaTopic(),
         cs.getStatement().getProperties().getFormatInfo(),
         cs.getConfig(),
-        cs.getStatementText()
+        cs.getStatementText(),
+        false
     );
   }
 
@@ -96,7 +99,8 @@ public class SchemaRegisterInjector implements Injector {
         queryMetadata.getResultTopic().getKafkaTopicName(),
         queryMetadata.getResultTopic().getValueFormat().getFormatInfo(),
         cas.getConfig(),
-        cas.getStatementText()
+        cas.getStatementText(),
+        true
     );
   }
 
@@ -105,7 +109,8 @@ public class SchemaRegisterInjector implements Injector {
       final String topic,
       final FormatInfo formatInfo,
       final KsqlConfig config,
-      final String statementText
+      final String statementText,
+      final boolean overwriteExisting
   ) {
     final Format format = FormatFactory.of(formatInfo);
     if (!format.supportsSchemaInference()) {
@@ -115,10 +120,23 @@ public class SchemaRegisterInjector implements Injector {
     if (config.getString(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY) != null
         && !config.getString(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY).isEmpty()) {
       try {
-        serviceContext.getSchemaRegistryClient().register(
-            topic + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX,
-            format.toParsedSchema(schema.withoutPseudoAndKeyColsInValue().value(), formatInfo)
-        );
+        final SchemaRegistryClient srClient = serviceContext.getSchemaRegistryClient();
+        final String subject = topic + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX;
+        final ParsedSchema parsedSchema =
+            format.toParsedSchema(schema.withoutPseudoAndKeyColsInValue().value(), formatInfo);
+
+        if (!overwriteExisting && srClient.getAllSubjects().contains(subject)) {
+          if (!srClient.testCompatibility(subject, parsedSchema)) {
+            throw new KsqlStatementException(
+                String.format(
+                    "Could not register schema for subject "
+                        + "'%s' because it is incompatible with existing schema.",
+                    subject),
+                statementText);
+          }
+        } else {
+          srClient.register(subject, parsedSchema);
+        }
       } catch (IOException | RestClientException e) {
         throw new KsqlStatementException("Could not register schema for topic.", statementText, e);
       }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedSchemaRegistryClient.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedSchemaRegistryClient.java
@@ -39,6 +39,7 @@ final class SandboxedSchemaRegistryClient {
 
     return LimitedProxyBuilder.forClass(SchemaRegistryClient.class)
         .swallow("register", anyParams(), 123)
+        .forward("getAllSubjects", methodParams(), delegate)
         .forward("getLatestSchemaMetadata", methodParams(String.class), delegate)
         .forward("getSchemaBySubjectAndId", methodParams(String.class, int.class), delegate)
         .forward("testCompatibility",

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjectorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjectorTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
@@ -176,6 +177,38 @@ public class SchemaRegisterInjectorTest {
 
     // Then:
     verify(schemaRegistryClient).register("expectedName-value", AVRO_SCHEMA);
+  }
+
+  @Test
+  public void shouldNotReplaceExistingSchemaForSchemaRegistryEnabledFormatCreateSource()
+      throws IOException, RestClientException {
+    // Given:
+    givenStatement("CREATE STREAM sink (f1 VARCHAR) WITH (kafka_topic='expectedName', value_format='AVRO', partitions=1);");
+    when(schemaRegistryClient.getAllSubjects()).thenReturn(ImmutableSet.of("expectedName-value"));
+    when(schemaRegistryClient.testCompatibility(eq("expectedName-value"), any(ParsedSchema.class))).thenReturn(true);
+
+    // When:
+    injector.inject(statement);
+
+    // Then:
+    verify(schemaRegistryClient).getAllSubjects();
+    verify(schemaRegistryClient).testCompatibility(eq("expectedName-value"), any(ParsedSchema.class));
+    verifyNoMoreInteractions(schemaRegistryClient);
+  }
+
+  @Test
+  public void shouldThrowOnExistingSchemaForSchemaRegistryEnabledFormatCreateSourceIncompatible()
+      throws IOException, RestClientException {
+    // Given:
+    givenStatement("CREATE STREAM sink (f1 VARCHAR) WITH (kafka_topic='expectedName', value_format='AVRO', partitions=1);");
+    when(schemaRegistryClient.getAllSubjects()).thenReturn(ImmutableSet.of("expectedName-value"));
+    when(schemaRegistryClient.testCompatibility(eq("expectedName-value"), any(ParsedSchema.class))).thenReturn(false);
+
+    // When:
+    final KsqlStatementException e = assertThrows(KsqlStatementException.class, () -> injector.inject(statement));
+
+    // Then:
+    assertThat(e.getMessage(), containsString("Could not register schema for subject 'expectedName-value' because it is incompatible with existing schema."));
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedSchemaRegistryClientTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedSchemaRegistryClientTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableSet;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
@@ -61,6 +62,7 @@ public final class SandboxedSchemaRegistryClientTest {
           .ignore("testCompatibility", String.class, Schema.class)
           .ignore("testCompatibility", String.class, ParsedSchema.class)
           .ignore("deleteSubject", String.class)
+          .ignore("getAllSubjects")
           .build();
     }
 
@@ -125,6 +127,18 @@ public final class SandboxedSchemaRegistryClientTest {
       // Then:
       assertThat(first, is(true));
       assertThat(second, is(false));
+    }
+
+    @Test
+    public void shouldGetAllSubjects() throws Exception {
+      // Given:
+      when(delegate.getAllSubjects()).thenReturn(ImmutableSet.of("foo"));
+
+      // When:
+      final Collection<String> subjects = sandboxedClient.getAllSubjects();
+
+      // Then:
+      assertThat(subjects, is(ImmutableSet.of("foo")));
     }
 
     @Test


### PR DESCRIPTION
### Description 

fixes #5553 

This commit makes sure that `C*` statements do not overwrite existing schemas in schema registry and instead only check compatibility with a declared schema, if a declared schema is present.

**NOTE**: if you `INSERT INTO` a stream, all bets are off (i.e. another schema will be registered under the schema value, but that is not a regression as this is a serializer-specific behavior) 

### Testing done 

Unit tests, and manual testing (registered the same source with a subset schema and confirmed there's only one version in schema registry)

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

