### PR TITLE
Keyless udtf

### DIFF
--- a/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceFactoryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceFactoryTest.java
@@ -125,7 +125,7 @@ public class CreateSourceFactoryTest {
 
   private static final String TOPIC_NAME = "some topic";
 
-  private static final Map<String, Literal> MINIMIM_PROPS = ImmutableMap.of(
+  private static final Map<String, Literal> MINIMUM_PROPS = ImmutableMap.of(
       CommonCreateConfigs.VALUE_FORMAT_PROPERTY, new StringLiteral("JSON"),
       CommonCreateConfigs.KAFKA_TOPIC_NAME_PROPERTY, new StringLiteral(TOPIC_NAME)
   );
@@ -151,7 +151,7 @@ public class CreateSourceFactoryTest {
   private CreateSourceFactory createSourceFactory;
   private KsqlConfig ksqlConfig = new KsqlConfig(ImmutableMap.of());
   private CreateSourceProperties withProperties =
-      CreateSourceProperties.from(MINIMIM_PROPS);
+      CreateSourceProperties.from(MINIMUM_PROPS);
 
   @Before
   public void before() {
@@ -679,7 +679,7 @@ public class CreateSourceFactoryTest {
   public void shouldHandleSessionWindowedKeyForStream() {
     // Given:
     givenProperty("window_type", new StringLiteral("session"));
-    final CreateStream statement = new CreateStream(SOME_NAME, ONE_ELEMENT, true, withProperties);
+    final CreateStream statement = new CreateStream(SOME_NAME, STREAM_ELEMENTS, true, withProperties);
 
     // When:
     final CreateStreamCommand cmd = createSourceFactory.createStreamCommand(
@@ -699,7 +699,7 @@ public class CreateSourceFactoryTest {
         "window_type", new StringLiteral("tumbling"),
         "window_size", new StringLiteral("1 MINUTE")
     ));
-    final CreateStream statement = new CreateStream(SOME_NAME, ONE_ELEMENT, true, withProperties);
+    final CreateStream statement = new CreateStream(SOME_NAME, STREAM_ELEMENTS, true, withProperties);
 
     // When:
     final CreateStreamCommand cmd = createSourceFactory.createStreamCommand(
@@ -722,7 +722,7 @@ public class CreateSourceFactoryTest {
         "window_type", new StringLiteral("Hopping"),
         "window_size", new StringLiteral("2 SECONDS")
     ));
-    final CreateStream statement = new CreateStream(SOME_NAME, ONE_ELEMENT, true, withProperties);
+    final CreateStream statement = new CreateStream(SOME_NAME, STREAM_ELEMENTS, true, withProperties);
 
     // When:
     final CreateStreamCommand cmd = createSourceFactory.createStreamCommand(

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/ddl/commands/CreateSourceCommandTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/ddl/commands/CreateSourceCommandTest.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.execution.ddl.commands;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 
@@ -28,6 +29,7 @@ import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SystemColumns;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.WindowInfo;
+import io.confluent.ksql.util.KsqlException;
 import java.util.Optional;
 import org.junit.Test;
 
@@ -59,6 +61,30 @@ public class CreateSourceCommandTest {
         FORAMTS,
         Optional.empty()
     );
+  }
+
+  @Test
+  public void shouldThrowOnWindowedWithoutKeyColumn() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueColumn(ColumnName.of("V0"), SqlTypes.STRING)
+        .build();
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> new TestCommand(
+            SOURCE_NAME,
+            schema,
+            Optional.empty(),
+            TOPIC_NAME,
+            FORAMTS,
+            Optional.of(mock(WindowInfo.class))
+        )
+    );
+
+    // Then:
+    assertThat(e.getMessage(), is(("Windowed sources require a key column.")));
   }
 
   @Test

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/table-functions_-_stream_without_key/6.1.0_1593781702978/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/table-functions_-_stream_without_key/6.1.0_1593781702978/plan.json
@@ -1,0 +1,132 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT, MY_ARR ARRAY<BIGINT>) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT, `MY_ARR` ARRAY<BIGINT>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  TEST.ID ID,\n  EXPLODE(TEST.MY_ARR) VAL,\n  TEST.ID ID2\nFROM TEST TEST\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT, `VAL` BIGINT, `ID2` BIGINT",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      }
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamFlatMapV1",
+            "properties" : {
+              "queryContext" : "FlatMap"
+            },
+            "source" : {
+              "@type" : "streamSourceV1",
+              "properties" : {
+                "queryContext" : "KsqlTopic/Source"
+              },
+              "topicName" : "test_topic",
+              "formats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              },
+              "sourceSchema" : "`ID` BIGINT, `MY_ARR` ARRAY<BIGINT>"
+            },
+            "tableFunctions" : [ "EXPLODE(MY_ARR)" ]
+          },
+          "selectExpressions" : [ "ID AS ID", "KSQL_SYNTH_0 AS VAL", "ID AS ID2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.metric.reporters" : "",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.error.classifier.regex" : ""
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/table-functions_-_stream_without_key/6.1.0_1593781702978/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/table-functions_-_stream_without_key/6.1.0_1593781702978/spec.json
@@ -1,0 +1,97 @@
+{
+  "version" : "6.0.0",
+  "timestamp" : 1593781702978,
+  "path" : "query-validation-tests/table-functions.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<ID BIGINT, MY_ARR ARRAY<BIGINT>> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<ID BIGINT, VAL BIGINT, ID2 BIGINT> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "stream without key",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : {
+        "ID" : 0,
+        "MY_ARR" : [ 1, 2 ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "should be ignored",
+      "value" : {
+        "ID" : 1,
+        "MY_ARR" : [ 3, 4 ]
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "ID" : 0,
+        "VAL" : 1,
+        "ID2" : 0
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "ID" : 0,
+        "VAL" : 2,
+        "ID2" : 0
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "ID" : 1,
+        "VAL" : 3,
+        "ID2" : 1
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "ID" : 1,
+        "VAL" : 4,
+        "ID2" : 1
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID BIGINT, MY_ARR ARRAY<BIGINT>) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT ID, EXPLODE(MY_ARR) VAL, ID AS ID2 FROM TEST;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/table-functions_-_stream_without_key/6.1.0_1593781702978/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/table-functions_-_stream_without_key/6.1.0_1593781702978/topology
@@ -1,0 +1,16 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> FlatMap
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: FlatMap (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- FlatMap
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/elements.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/elements.json
@@ -907,6 +907,16 @@
           {"name": "OUTPUT", "type": "stream", "schema": "ID INT, F0 INT"}
         ]
       }
+    },
+    {
+      "name": "import windowed stream with no key",
+      "statements": [
+        "CREATE STREAM INPUT (F0 INT) WITH (kafka_topic='input', value_format='JSON', window_type='SESSION');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Windowed sources require a key column."
+      }
     }
   ]
 }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/table-functions.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/table-functions.json
@@ -349,6 +349,23 @@
         {"topic": "OUTPUT", "key": "a", "value": {"SHOULDTHROW": false, "KSQL_COL_0": 0}},
         {"topic": "OUTPUT", "key": "c", "value": {"SHOULDTHROW": false, "KSQL_COL_0": 0}}
       ]
+    },
+    {
+      "name": "stream without key",
+      "statements": [
+        "CREATE STREAM TEST (ID BIGINT, MY_ARR ARRAY<BIGINT>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT ID, EXPLODE(MY_ARR) VAL, ID AS ID2 FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": null, "value": {"ID": 0, "MY_ARR": [1, 2]}},
+        {"topic": "test_topic", "key": "should be ignored", "value": {"ID": 1, "MY_ARR": [3, 4]}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": null, "value": {"ID": 0, "VAL": 1, "ID2": 0}},
+        {"topic": "OUTPUT", "key": null, "value": {"ID": 0, "VAL": 2, "ID2": 0}},
+        {"topic": "OUTPUT", "key": null, "value": {"ID": 1, "VAL": 3, "ID2": 1}},
+        {"topic": "OUTPUT", "key": null, "value": {"ID": 1, "VAL": 4, "ID2": 1}}
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Description 

fixes: #5723

UDTFs didn't work with new keyless streams. This change fixes this.

Plus, adds an error message if you try and create a windowed stream without a key. This previously resulted in an NPE during processing.

### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

