### PR TITLE
feat: support CREATE OR REPLACE w/ config guard but w/o restrictions

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -284,6 +284,11 @@ public class KsqlConfig extends AbstractConfig {
       + " and the regex pattern will be matched against the error class name and message of any "
       + "uncaught error and subsequent error causes in the Kafka Streams applications.";
 
+  public static final String KSQL_CREATE_OR_REPLACE_ENABLED = "ksql.create.or.replace.enabled";
+  public static final Boolean KSQL_CREATE_OR_REPLACE_ENABLED_DEFAULT = false;
+  public static final String KSQL_CREATE_OR_REPLACE_ENABLED_DOC =
+      "Feature flag for CREATE OR REPLACE";
+
   private enum ConfigGeneration {
     LEGACY,
     CURRENT
@@ -652,6 +657,13 @@ public class KsqlConfig extends AbstractConfig {
             "",
             Importance.LOW,
             KSQL_ERROR_CLASSIFIER_REGEX_PREFIX_DOC
+        )
+        .define(
+            KSQL_CREATE_OR_REPLACE_ENABLED,
+            Type.BOOLEAN,
+            KSQL_CREATE_OR_REPLACE_ENABLED_DEFAULT,
+            Importance.LOW,
+            KSQL_CREATE_OR_REPLACE_ENABLED_DOC
         )
         .withClientSslSupport();
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
@@ -107,7 +107,7 @@ public final class CreateSourceFactory {
         io.confluent.ksql.execution.plan.Formats
             .of(topic.getKeyFormat(), topic.getValueFormat(), serdeOptions),
         topic.getKeyFormat().getWindowInfo(),
-        statement.isOrReplace()
+        Optional.of(statement.isOrReplace())
     );
   }
 
@@ -156,7 +156,7 @@ public final class CreateSourceFactory {
         io.confluent.ksql.execution.plan.Formats
             .of(topic.getKeyFormat(), topic.getValueFormat(), serdeOptions),
         topic.getKeyFormat().getWindowInfo(),
-        statement.isOrReplace()
+        Optional.of(statement.isOrReplace())
     );
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
@@ -106,7 +106,8 @@ public final class CreateSourceFactory {
         topic.getKafkaTopicName(),
         io.confluent.ksql.execution.plan.Formats
             .of(topic.getKeyFormat(), topic.getValueFormat(), serdeOptions),
-        topic.getKeyFormat().getWindowInfo()
+        topic.getKeyFormat().getWindowInfo(),
+        statement.isOrReplace()
     );
   }
 
@@ -154,7 +155,8 @@ public final class CreateSourceFactory {
         topic.getKafkaTopicName(),
         io.confluent.ksql.execution.plan.Formats
             .of(topic.getKeyFormat(), topic.getValueFormat(), serdeOptions),
-        topic.getKeyFormat().getWindowInfo()
+        topic.getKeyFormat().getWindowInfo(),
+        statement.isOrReplace()
     );
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/DdlCommandExec.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/DdlCommandExec.java
@@ -75,7 +75,7 @@ public class DdlCommandExec {
           withQuery,
           getKsqlTopic(createStream)
       );
-      metaStore.putSource(ksqlStream);
+      metaStore.putSource(ksqlStream, createStream.isOrReplace());
       return new DdlCommandResult(true, "Stream created");
     }
 
@@ -90,7 +90,7 @@ public class DdlCommandExec {
           withQuery,
           getKsqlTopic(createTable)
       );
-      metaStore.putSource(ksqlTable);
+      metaStore.putSource(ksqlTable, createTable.isOrReplace());
       return new DdlCommandResult(true, "Table created");
     }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -259,7 +259,8 @@ final class EngineExecutor {
           outputNode.getKsqlTopic().getKafkaTopicName(),
           formats,
           outputNode.getKsqlTopic().getKeyFormat().getWindowInfo(),
-          statement instanceof CreateAsSelect && ((CreateAsSelect) statement).isOrReplace()
+          Optional.of(
+              statement instanceof CreateAsSelect && ((CreateAsSelect) statement).isOrReplace())
       );
     } else {
       ddl = new CreateTableCommand(
@@ -269,7 +270,8 @@ final class EngineExecutor {
           outputNode.getKsqlTopic().getKafkaTopicName(),
           formats,
           outputNode.getKsqlTopic().getKeyFormat().getWindowInfo(),
-          statement instanceof CreateAsSelect && ((CreateAsSelect) statement).isOrReplace()
+          Optional.of(
+              statement instanceof CreateAsSelect && ((CreateAsSelect) statement).isOrReplace())
       );
     }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -206,7 +206,8 @@ final class EngineExecutor {
     final QueryId queryId = QueryIdUtil.buildId(
         engineContext.getMetaStore(),
         engineContext.idGenerator(),
-        outputNode
+        outputNode,
+        ksqlConfig.getBoolean(KsqlConfig.KSQL_CREATE_OR_REPLACE_ENABLED)
     );
     final PhysicalPlan physicalPlan = queryEngine.buildPhysicalPlan(
         logicalPlan,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryIdUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryIdUtil.java
@@ -42,13 +42,14 @@ final class QueryIdUtil {
    * @param metaStore   the meta store representing the current state of the engine
    * @param idGenerator generates query ids
    * @param outputNode  the logical plan
+   * @param createOrReplaceEnabled whether or not the queryID can replace an existing one
    * @return the {@link QueryId} to be used
    */
   static QueryId buildId(
       final MetaStore metaStore,
       final QueryIdGenerator idGenerator,
-      final OutputNode outputNode
-  ) {
+      final OutputNode outputNode,
+      final boolean createOrReplaceEnabled) {
     if (!outputNode.getSinkName().isPresent()) {
       return new QueryId(String.valueOf(Math.abs(ThreadLocalRandom.current().nextLong())));
     }
@@ -64,6 +65,9 @@ final class QueryIdUtil {
       throw new KsqlException("REPLACE for sink " + sink + " is not supported because there are "
           + "multiple queries writing into it: " + queriesForSink);
     } else if (!queriesForSink.isEmpty()) {
+      if (!createOrReplaceEnabled) {
+        throw new UnsupportedOperationException("CREATE OR REPLACE is not yet supported");
+      }
       return new QueryId(Iterables.getOnlyElement(queriesForSink));
     }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryIdUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryIdUtil.java
@@ -66,7 +66,13 @@ final class QueryIdUtil {
           + "multiple queries writing into it: " + queriesForSink);
     } else if (!queriesForSink.isEmpty()) {
       if (!createOrReplaceEnabled) {
-        throw new UnsupportedOperationException("CREATE OR REPLACE is not yet supported");
+        final String type = outputNode.getNodeOutputType().getKsqlType().toLowerCase();
+        throw new UnsupportedOperationException(
+            String.format(
+                "Cannot add %s '%s': A %s with the same name already exists",
+                type,
+                sink.text(),
+                type));
       }
       return new QueryId(Iterables.getOnlyElement(queriesForSink));
     }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerFunctionalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerFunctionalTest.java
@@ -179,7 +179,7 @@ public class AnalyzerFunctionalTest {
         ksqlTopic
     );
 
-    newAvroMetaStore.putSource(ksqlStream);
+    newAvroMetaStore.putSource(ksqlStream, false);
 
     final List<Statement> statements = parse(simpleQuery, newAvroMetaStore);
     final CreateStreamAsSelect createStreamAsSelect = (CreateStreamAsSelect) statements.get(0);
@@ -392,7 +392,7 @@ public class AnalyzerFunctionalTest {
         topic
     );
 
-    jsonMetaStore.putSource(stream);
+    jsonMetaStore.putSource(stream, false);
   }
 
   private static List<Statement> parse(final String simpleQuery, final MetaStore metaStore) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/DdlCommandExecTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/DdlCommandExecTest.java
@@ -302,7 +302,7 @@ public class DdlCommandExecTest {
             VALUE_FORMAT,
             SERDE_OPTIONS),
         Optional.empty(),
-        allowReplace
+        Optional.of(allowReplace)
     );
   }
 
@@ -317,7 +317,7 @@ public class DdlCommandExecTest {
             VALUE_FORMAT,
             SERDE_OPTIONS),
         Optional.of(windowInfo),
-        false
+        Optional.of(false)
     );
   }
 
@@ -333,7 +333,7 @@ public class DdlCommandExecTest {
             SERDE_OPTIONS
         ),
         Optional.of(windowInfo),
-        false
+        Optional.of(false)
     );
   }
 
@@ -349,7 +349,7 @@ public class DdlCommandExecTest {
             SERDE_OPTIONS
         ),
         Optional.empty(),
-        false
+        Optional.of(false)
     );
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/DdlCommandExecTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/DdlCommandExecTest.java
@@ -1,8 +1,10 @@
 package io.confluent.ksql.ddl.commands;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
 
 import io.confluent.ksql.execution.ddl.commands.CreateStreamCommand;
@@ -18,6 +20,7 @@ import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.parser.tree.CreateAsSelect;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.FormatFactory;
@@ -26,6 +29,7 @@ import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.serde.WindowInfo;
+import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.MetaStoreFixture;
 import java.util.Optional;
 import java.util.Set;
@@ -45,6 +49,12 @@ public class DdlCommandExecTest {
       .keyColumn(ColumnName.of("K0"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("F1"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("F2"), SqlTypes.STRING)
+      .build();
+  private static final LogicalSchema SCHEMA2 = LogicalSchema.builder()
+      .keyColumn(ColumnName.of("K0"), SqlTypes.BIGINT)
+      .valueColumn(ColumnName.of("F1"), SqlTypes.BIGINT)
+      .valueColumn(ColumnName.of("F2"), SqlTypes.STRING)
+      .valueColumn(ColumnName.of("F3"), SqlTypes.STRING)
       .build();
   private static final ValueFormat VALUE_FORMAT = ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name()));
   private static final KeyFormat KEY_FORMAT = KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name()));
@@ -90,6 +100,20 @@ public class DdlCommandExecTest {
 
     // Then:
     assertThat(metaStore.getSource(STREAM_NAME).getSqlExpression(), is(SQL_TEXT));
+  }
+
+  @Test
+  public void shouldAddStreamWithReplace() {
+    // Given:
+    givenCreateStream();
+    cmdExec.execute(SQL_TEXT, createStream, false);
+
+    // When:
+    givenCreateStream(SCHEMA2, true);
+    cmdExec.execute(SQL_TEXT, createStream, false);
+
+    // Then:
+    assertThat(metaStore.getSource(STREAM_NAME).getSchema(), is(SCHEMA2));
   }
 
   @Test
@@ -204,7 +228,7 @@ public class DdlCommandExecTest {
   @Test
   public void shouldDropSource() {
     // Given:
-    metaStore.putSource(source);
+    metaStore.putSource(source, false);
     givenDropSourceCommand(STREAM_NAME);
 
     // When:
@@ -245,21 +269,40 @@ public class DdlCommandExecTest {
     assertThat(result.getMessage(), is("Type 'type' does not exist"));
   }
 
+  @Test
+  public void shouldFailAddDuplicateStreamWithoutReplace() {
+    // Given:
+    givenCreateStream();
+    cmdExec.execute(SQL_TEXT, createStream, false);
+
+    // When:
+    givenCreateStream(SCHEMA2, false);
+    final KsqlException e = assertThrows(KsqlException.class, () -> cmdExec.execute(SQL_TEXT, createStream, false));
+
+    // Then:
+    assertThat(e.getMessage(), containsString("A stream with the same name already exists"));
+  }
+
   private void givenDropSourceCommand(final SourceName name) {
     dropSource = new DropSourceCommand(name);
   }
 
   private void givenCreateStream() {
+    givenCreateStream(SCHEMA, false);
+  }
+
+  private void givenCreateStream(final LogicalSchema schema, final boolean allowReplace) {
     createStream = new CreateStreamCommand(
         STREAM_NAME,
-        SCHEMA,
+        schema,
         Optional.of(timestampColumn),
         "topic",
         io.confluent.ksql.execution.plan.Formats.of(
             KEY_FORMAT,
             VALUE_FORMAT,
             SERDE_OPTIONS),
-        Optional.empty()
+        Optional.empty(),
+        allowReplace
     );
   }
 
@@ -273,7 +316,8 @@ public class DdlCommandExecTest {
             KEY_FORMAT,
             VALUE_FORMAT,
             SERDE_OPTIONS),
-        Optional.of(windowInfo)
+        Optional.of(windowInfo),
+        false
     );
   }
 
@@ -288,7 +332,8 @@ public class DdlCommandExecTest {
             VALUE_FORMAT,
             SERDE_OPTIONS
         ),
-        Optional.of(windowInfo)
+        Optional.of(windowInfo),
+        false
     );
   }
 
@@ -303,7 +348,8 @@ public class DdlCommandExecTest {
             VALUE_FORMAT,
             SERDE_OPTIONS
         ),
-        Optional.empty()
+        Optional.empty(),
+        false
     );
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
@@ -927,7 +927,7 @@ public class InsertValuesExecutorTest {
     }
 
     final MetaStoreImpl metaStore = new MetaStoreImpl(TestFunctionRegistry.INSTANCE.get());
-    metaStore.putSource(dataSource);
+    metaStore.putSource(dataSource, false);
 
     when(engine.getMetaStore()).thenReturn(metaStore);
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/QueryIdUtilTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/QueryIdUtilTest.java
@@ -133,6 +133,7 @@ public class QueryIdUtilTest {
     // Given:
     when(plan.getSinkName()).thenReturn(Optional.of(SINK));
     when(plan.createInto()).thenReturn(true);
+    when(plan.getNodeOutputType()).thenReturn(DataSourceType.KSTREAM);
     when(metaStore.getQueriesWithSink(SINK)).thenReturn(ImmutableSet.of("CTAS_FOO_10"));
 
     // When:

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/ReplaceIntTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/ReplaceIntTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.integration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Multimap;
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.metastore.model.DataSource;
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.schema.ksql.Column;
+import io.confluent.ksql.schema.ksql.Column.Namespace;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.serde.FormatFactory;
+import io.confluent.ksql.serde.SerdeOption;
+import io.confluent.ksql.test.util.TopicTestUtil;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.TestDataProvider;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ReplaceIntTest {
+
+  @ClassRule
+  public static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
+
+  @Rule
+  public final TestKsqlContext ksqlContext = TEST_HARNESS.ksqlContextBuilder()
+      .withAdditionalConfig(KsqlConfig.KSQL_CREATE_OR_REPLACE_ENABLED, true)
+      .build();
+
+  private String inputTopic;
+
+  @Before
+  public void before() {
+    inputTopic = TopicTestUtil.uniqueTopicName("Orders");
+
+    TEST_HARNESS.ensureTopics(inputTopic);
+
+    ksqlContext.sql(
+        String.format(
+            "CREATE STREAM source (%s) WITH (kafka_topic='%s', value_format='JSON');",
+            Provider.SQL,
+            inputTopic
+        )
+    );
+  }
+
+  @Test
+  public void shouldReplaceDDL() throws InterruptedException {
+    // When:
+    ksqlContext.sql(
+        String.format(
+            "CREATE OR REPLACE STREAM source (%s) WITH (kafka_topic='%s', value_format='JSON');",
+            Provider.SQL + ", col3 BIGINT",
+            inputTopic
+        )
+    );
+
+    // Then:
+    DataSource source = ksqlContext.getMetaStore().getSource(SourceName.of("SOURCE"));
+    assertThat(source.getSchema().value().size(), is(3));
+    assertThat(source.getSchema().value().get(2), is(Column.of(ColumnName.of("COL3"), SqlTypes.BIGINT, Namespace.VALUE, 2)));
+  }
+
+  @Test
+  public void shouldReplaceSimpleProject() {
+    // Given:
+    final String outputTopic = TopicTestUtil.uniqueTopicName("");
+    ksqlContext.sql(
+        String.format(
+            "CREATE STREAM project WITH(kafka_topic='%s') AS SELECT k, col1 FROM source;",
+            outputTopic));
+
+    TEST_HARNESS.produceRows(inputTopic, new Provider("1", "A", 1), FormatFactory.JSON);
+    assertForSource("PROJECT", outputTopic, ImmutableMap.of("1", GenericRow.genericRow("A")));
+
+    // When:
+    ksqlContext.sql(
+        String.format(
+            "CREATE OR REPLACE STREAM project WITH(kafka_topic='%s') AS SELECT k, col1, col2 FROM source;",
+            outputTopic));
+    TEST_HARNESS.produceRows(inputTopic, new Provider("2", "B", 2), FormatFactory.JSON);
+
+    // Then:
+    final Map<String, GenericRow> expected = ImmutableMap.of(
+        "1", GenericRow.genericRow("A", null),  // this row is leftover from the original query
+        "2", GenericRow.genericRow("B", 2)      // this row is an artifact from the new query
+    );
+    assertForSource("PROJECT", outputTopic, expected);
+  }
+
+  @Test
+  public void shouldReplaceSimpleFilter() {
+    // Given:
+    final String outputTopic = TopicTestUtil.uniqueTopicName("");
+    ksqlContext.sql(
+        String.format(
+            "CREATE STREAM project WITH(kafka_topic='%s') AS SELECT k, col1 FROM source;",
+            outputTopic));
+
+    TEST_HARNESS.produceRows(inputTopic, new Provider("1", "A", 1), FormatFactory.JSON);
+    assertForSource("PROJECT", outputTopic, ImmutableMap.of("1", GenericRow.genericRow("A")));
+
+    // When:
+    ksqlContext.sql(
+        String.format(
+            "CREATE OR REPLACE STREAM project WITH(kafka_topic='%s') AS SELECT k, col1 FROM source WHERE col1 <> 'A';", outputTopic));
+    TEST_HARNESS.produceRows(inputTopic, new Provider("2", "A", 2), FormatFactory.JSON); // this row should be filtered out
+    TEST_HARNESS.produceRows(inputTopic, new Provider("3", "C", 3), FormatFactory.JSON);
+
+    // Then:
+    final Map<String, GenericRow> expected = ImmutableMap.of(
+        "1", GenericRow.genericRow("A"),  // this row is leftover from the original query
+        "3", GenericRow.genericRow("C")   // this row is an artifact from the new query
+    );
+    assertForSource("PROJECT", outputTopic, expected);
+  }
+
+  private void assertForSource(
+      final String sourceName,
+      final String topic,
+      final Map<String, GenericRow> expected
+  ) {
+    DataSource source = ksqlContext.getMetaStore().getSource(SourceName.of(sourceName));
+    PhysicalSchema resultSchema = PhysicalSchema.from(source.getSchema(), source.getSerdeOptions());
+
+    assertThat(
+        TEST_HARNESS.verifyAvailableUniqueRows(topic, expected.size(), FormatFactory.JSON, resultSchema),
+        is(expected)
+    );
+  }
+
+  private static class Provider extends TestDataProvider<String> {
+
+    private static final String SQL = "k VARCHAR KEY, col1 VARCHAR, col2 INT";
+    private static final LogicalSchema LOGICAL_SCHEMA = LogicalSchema.builder()
+        .keyColumn(ColumnName.of("K"), SqlTypes.STRING)
+        .valueColumn(ColumnName.of("COL1"), SqlTypes.STRING)
+        .valueColumn(ColumnName.of("COL2"), SqlTypes.INTEGER)
+        .build();
+
+    public Provider(final String k, final String col1, final int col2) {
+      super("SOURCE", PhysicalSchema.from(LOGICAL_SCHEMA, SerdeOption.none()), rows(k, col1, col2));
+    }
+
+    private static Multimap<String, GenericRow> rows(
+        final String key,
+        final String col1,
+        final Integer col2
+    ) {
+      return ImmutableListMultimap.of(key, GenericRow.genericRow(col1, col2));
+    }
+  }
+
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjectorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjectorTest.java
@@ -138,7 +138,7 @@ public class SchemaRegisterInjectorTest {
         false,
         sourceTopic
     );
-    metaStore.putSource(source);
+    metaStore.putSource(source, false);
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/security/KsqlAuthorizationValidatorImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/security/KsqlAuthorizationValidatorImplTest.java
@@ -391,6 +391,6 @@ public class KsqlAuthorizationValidatorImplTest {
         sourceTopic
     );
 
-    metaStore.putSource(streamSource);
+    metaStore.putSource(streamSource, false);
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/topic/SourceTopicsExtractorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/topic/SourceTopicsExtractorTest.java
@@ -174,7 +174,7 @@ public class SourceTopicsExtractorTest {
         sourceTopic
     );
 
-    metaStore.putSource(streamSource);
+    metaStore.putSource(streamSource, false);
   }
 
   private static void givenTopic(final String topicName, final TopicDescription topicDescription) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
@@ -114,7 +114,7 @@ public class TopicCreateInjectorTest {
         false,
         sourceTopic
     );
-    metaStore.putSource(source);
+    metaStore.putSource(source, false);
 
     final KsqlTopic joinTopic = new KsqlTopic(
         "jSource",
@@ -131,7 +131,7 @@ public class TopicCreateInjectorTest {
         false,
         joinTopic
     );
-    metaStore.putSource(joinSource);
+    metaStore.putSource(joinSource, false);
 
     when(topicClient.describeTopic("source")).thenReturn(sourceDescription);
     when(topicClient.isTopicExists("source")).thenReturn(true);

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateSourceCommand.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateSourceCommand.java
@@ -36,6 +36,7 @@ public abstract class CreateSourceCommand implements DdlCommand {
   private final String topicName;
   private final Formats formats;
   private final Optional<WindowInfo> windowInfo;
+  private final boolean orReplace;
 
   CreateSourceCommand(
       final SourceName sourceName,
@@ -43,7 +44,8 @@ public abstract class CreateSourceCommand implements DdlCommand {
       final Optional<TimestampColumn> timestampColumn,
       final String topicName,
       final Formats formats,
-      final Optional<WindowInfo> windowInfo
+      final Optional<WindowInfo> windowInfo,
+      final boolean orReplace
   ) {
     this.sourceName = Objects.requireNonNull(sourceName, "sourceName");
     this.schema = Objects.requireNonNull(schema, "schema");
@@ -52,6 +54,7 @@ public abstract class CreateSourceCommand implements DdlCommand {
     this.topicName = Objects.requireNonNull(topicName, "topicName");
     this.formats = Objects.requireNonNull(formats, "formats");
     this.windowInfo = Objects.requireNonNull(windowInfo, "windowInfo");
+    this.orReplace = orReplace;
 
     validate(schema, windowInfo.isPresent());
   }
@@ -78,6 +81,10 @@ public abstract class CreateSourceCommand implements DdlCommand {
 
   public Optional<WindowInfo> getWindowInfo() {
     return windowInfo;
+  }
+
+  public boolean isOrReplace() {
+    return orReplace;
   }
 
   private static void validate(final LogicalSchema schema, final boolean windowed) {

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateSourceCommand.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateSourceCommand.java
@@ -36,7 +36,7 @@ public abstract class CreateSourceCommand implements DdlCommand {
   private final String topicName;
   private final Formats formats;
   private final Optional<WindowInfo> windowInfo;
-  private final boolean orReplace;
+  private final Boolean orReplace;
 
   CreateSourceCommand(
       final SourceName sourceName,
@@ -45,7 +45,7 @@ public abstract class CreateSourceCommand implements DdlCommand {
       final String topicName,
       final Formats formats,
       final Optional<WindowInfo> windowInfo,
-      final boolean orReplace
+      final Boolean orReplace
   ) {
     this.sourceName = Objects.requireNonNull(sourceName, "sourceName");
     this.schema = Objects.requireNonNull(schema, "schema");
@@ -83,7 +83,7 @@ public abstract class CreateSourceCommand implements DdlCommand {
     return windowInfo;
   }
 
-  public boolean isOrReplace() {
+  public Boolean isOrReplace() {
     return orReplace;
   }
 

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateStreamCommand.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateStreamCommand.java
@@ -36,7 +36,8 @@ public class CreateStreamCommand extends CreateSourceCommand {
       Optional<TimestampColumn> timestampColumn,
       @JsonProperty(value = "topicName", required = true) final String topicName,
       @JsonProperty(value = "formats", required = true) final Formats formats,
-      @JsonProperty(value = "windowInfo") final Optional<WindowInfo> windowInfo
+      @JsonProperty(value = "windowInfo") final Optional<WindowInfo> windowInfo,
+      @JsonProperty(value = "orReplace") final boolean orReplace
   ) {
     super(
         sourceName,
@@ -44,7 +45,8 @@ public class CreateStreamCommand extends CreateSourceCommand {
         timestampColumn,
         topicName,
         formats,
-        windowInfo
+        windowInfo,
+        orReplace
     );
   }
 

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateStreamCommand.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateStreamCommand.java
@@ -37,7 +37,7 @@ public class CreateStreamCommand extends CreateSourceCommand {
       @JsonProperty(value = "topicName", required = true) final String topicName,
       @JsonProperty(value = "formats", required = true) final Formats formats,
       @JsonProperty(value = "windowInfo") final Optional<WindowInfo> windowInfo,
-      @JsonProperty(value = "orReplace") final boolean orReplace
+      @JsonProperty(value = "orReplace", defaultValue = "false") final Optional<Boolean> orReplace
   ) {
     super(
         sourceName,
@@ -46,7 +46,7 @@ public class CreateStreamCommand extends CreateSourceCommand {
         topicName,
         formats,
         windowInfo,
-        orReplace
+        orReplace.orElse(false)
     );
   }
 

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateTableCommand.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateTableCommand.java
@@ -35,7 +35,8 @@ public class CreateTableCommand extends CreateSourceCommand {
       @JsonProperty("timestampColumn") final Optional<TimestampColumn> timestampColumn,
       @JsonProperty(value = "topicName", required = true) final String topicName,
       @JsonProperty(value = "formats", required = true) final Formats formats,
-      @JsonProperty(value = "windowInfo") final Optional<WindowInfo> windowInfo
+      @JsonProperty(value = "windowInfo") final Optional<WindowInfo> windowInfo,
+      @JsonProperty(value = "orReplace") final boolean orReplace
   ) {
     super(
         sourceName,
@@ -43,7 +44,8 @@ public class CreateTableCommand extends CreateSourceCommand {
         timestampColumn,
         topicName,
         formats,
-        windowInfo
+        windowInfo,
+        orReplace
     );
 
     if (schema.key().isEmpty()) {

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateTableCommand.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateTableCommand.java
@@ -36,7 +36,7 @@ public class CreateTableCommand extends CreateSourceCommand {
       @JsonProperty(value = "topicName", required = true) final String topicName,
       @JsonProperty(value = "formats", required = true) final Formats formats,
       @JsonProperty(value = "windowInfo") final Optional<WindowInfo> windowInfo,
-      @JsonProperty(value = "orReplace") final boolean orReplace
+      @JsonProperty(value = "orReplace", defaultValue = "false") final Optional<Boolean> orReplace
   ) {
     super(
         sourceName,
@@ -45,7 +45,7 @@ public class CreateTableCommand extends CreateSourceCommand {
         topicName,
         formats,
         windowInfo,
-        orReplace
+        orReplace.orElse(false)
     );
 
     if (schema.key().isEmpty()) {

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/ddl/commands/CreateSourceCommandTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/ddl/commands/CreateSourceCommandTest.java
@@ -149,7 +149,7 @@ public class CreateSourceCommandTest {
         final Formats formats,
         final Optional<WindowInfo> windowInfo
     ) {
-      super(sourceName, schema, timestampColumn, topicName, formats, windowInfo);
+      super(sourceName, schema, timestampColumn, topicName, formats, windowInfo, false);
     }
 
     @Override

--- a/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/MetaStoreImpl.java
+++ b/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/MetaStoreImpl.java
@@ -77,11 +77,9 @@ public final class MetaStoreImpl implements MutableMetaStore {
   }
 
   @Override
-  public void putSource(final DataSource dataSource) {
-    final SourceInfo existing = dataSources
-        .putIfAbsent(dataSource.getName(), new SourceInfo(dataSource));
-
-    if (existing != null) {
+  public void putSource(final DataSource dataSource, final boolean allowReplace) {
+    final SourceInfo existing = dataSources.get(dataSource.getName());
+    if (existing != null && !allowReplace) {
       final SourceName name = dataSource.getName();
       final String newType = dataSource.getDataSourceType().getKsqlType().toLowerCase();
       final String existingType = existing.source.getDataSourceType().getKsqlType().toLowerCase();
@@ -90,6 +88,8 @@ public final class MetaStoreImpl implements MutableMetaStore {
           "Cannot add %s '%s': A %s with the same name already exists",
           newType, name.text(), existingType));
     }
+
+    dataSources.put(dataSource.getName(), new SourceInfo(dataSource));
   }
 
   @Override

--- a/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/MutableMetaStore.java
+++ b/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/MutableMetaStore.java
@@ -21,7 +21,7 @@ import java.util.Set;
 
 public interface MutableMetaStore extends MetaStore {
 
-  void putSource(DataSource dataSource);
+  void putSource(DataSource dataSource, boolean allowReplace);
 
   void deleteSource(SourceName sourceName);
 

--- a/ksqldb-metastore/src/test/java/io/confluent/ksql/metastore/MetaStoreImplTest.java
+++ b/ksqldb-metastore/src/test/java/io/confluent/ksql/metastore/MetaStoreImplTest.java
@@ -90,7 +90,7 @@ public class MetaStoreImplTest {
   @Test
   public void shouldDeepCopySourcesOnCopy() {
     // Given:
-    metaStore.putSource(dataSource);
+    metaStore.putSource(dataSource, false);
 
     // When:
     final MetaStore copy = metaStore.copy();
@@ -118,7 +118,7 @@ public class MetaStoreImplTest {
   @Test
   public void shouldDeepCopySourceReferentialIntegrityDataOnCopy() {
     // Given:
-    metaStore.putSource(dataSource);
+    metaStore.putSource(dataSource, false);
 
     metaStore.updateForPersistentQuery(
         "source query",
@@ -145,7 +145,7 @@ public class MetaStoreImplTest {
   @Test
   public void shouldNotAllowModificationViaGetAllDataSources() {
     // Given:
-    metaStore.putSource(dataSource);
+    metaStore.putSource(dataSource, false);
 
     final Map<SourceName, DataSource> dataSources = metaStore
         .getAllDataSources();
@@ -160,12 +160,12 @@ public class MetaStoreImplTest {
   @Test
   public void shouldThrowOnDuplicateSource() {
     // Given:
-    metaStore.putSource(dataSource);
+    metaStore.putSource(dataSource, false);
 
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> metaStore.putSource(dataSource)
+        () -> metaStore.putSource(dataSource, false)
     );
 
     // Then:
@@ -188,7 +188,7 @@ public class MetaStoreImplTest {
   @Test
   public void shouldThrowOnDropSourceIfUsedAsSourceOfQueries() {
     // Given:
-    metaStore.putSource(dataSource);
+    metaStore.putSource(dataSource, false);
     metaStore.updateForPersistentQuery(
         "source query",
         ImmutableSet.of(dataSource.getName()),
@@ -237,7 +237,7 @@ public class MetaStoreImplTest {
   @Test
   public void shouldThrowOnDropSourceIfUsedAsSinkOfQueries() {
     // Given:
-    metaStore.putSource(dataSource);
+    metaStore.putSource(dataSource, false);
     metaStore.updateForPersistentQuery(
         "sink query",
         ImmutableSet.of(),
@@ -300,7 +300,7 @@ public class MetaStoreImplTest {
   @Test
   public void shouldRegisterQuerySources() {
     // Given:
-    metaStore.putSource(dataSource);
+    metaStore.putSource(dataSource, false);
 
     // When:
     metaStore.updateForPersistentQuery(
@@ -315,7 +315,7 @@ public class MetaStoreImplTest {
   @Test
   public void shouldRegisterQuerySinks() {
     // Given:
-    metaStore.putSource(dataSource);
+    metaStore.putSource(dataSource, false);
 
     // When:
     metaStore.updateForPersistentQuery(
@@ -357,7 +357,7 @@ public class MetaStoreImplTest {
         .forEach(idx -> {
           final DataSource source = mock(DataSource.class);
           when(source.getName()).thenReturn(SourceName.of("source" + idx));
-          metaStore.putSource(source);
+          metaStore.putSource(source, false);
           metaStore.getSource(source.getName());
 
           metaStore.getAllDataSources();
@@ -387,11 +387,11 @@ public class MetaStoreImplTest {
     final AtomicInteger remaining = new AtomicInteger(iterations);
     final ImmutableSet<SourceName> sources = ImmutableSet.of(dataSource1.getName(), dataSource.getName());
 
-    metaStore.putSource(dataSource1);
+    metaStore.putSource(dataSource1, false);
 
     final Future<?> mainThread = executor.submit(() -> {
       while (remaining.get() > 0) {
-        metaStore.putSource(dataSource);
+        metaStore.putSource(dataSource, false);
 
         while (true) {
           try {

--- a/ksqldb-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
+++ b/ksqldb-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
@@ -75,7 +75,7 @@ public final class MetaStoreFixture {
         ksqlTopic0
     );
 
-    metaStore.putSource(ksqlStream0);
+    metaStore.putSource(ksqlStream0, false);
 
     final KsqlTopic ksqlTopic1 = new KsqlTopic(
         "test1",
@@ -93,7 +93,7 @@ public final class MetaStoreFixture {
         ksqlTopic1
     );
 
-    metaStore.putSource(ksqlStream1);
+    metaStore.putSource(ksqlStream1, false);
 
     final LogicalSchema test2Schema = LogicalSchema.builder()
         .keyColumn(ColumnName.of("COL0"), SqlTypes.BIGINT)
@@ -118,7 +118,7 @@ public final class MetaStoreFixture {
         ksqlTopic2
     );
 
-    metaStore.putSource(ksqlTable);
+    metaStore.putSource(ksqlTable, false);
 
     final SqlType addressSchema = SqlTypes.struct()
         .field("NUMBER", SqlTypes.BIGINT)
@@ -166,7 +166,7 @@ public final class MetaStoreFixture {
         ksqlTopicOrders
     );
 
-    metaStore.putSource(ksqlStreamOrders);
+    metaStore.putSource(ksqlStreamOrders, false);
 
     final LogicalSchema testTable3 = LogicalSchema.builder()
         .keyColumn(ColumnName.of("COL0"), SqlTypes.BIGINT)
@@ -191,7 +191,7 @@ public final class MetaStoreFixture {
         ksqlTopic3
     );
 
-    metaStore.putSource(ksqlTable3);
+    metaStore.putSource(ksqlTable3, false);
 
     final SqlType nestedOrdersSchema = SqlTypes.struct()
         .field("ORDERTIME", SqlTypes.BIGINT)
@@ -228,7 +228,7 @@ public final class MetaStoreFixture {
         nestedArrayStructMapTopic
     );
 
-    metaStore.putSource(nestedArrayStructMapOrders);
+    metaStore.putSource(nestedArrayStructMapOrders, false);
 
     final KsqlTopic ksqlTopic4 = new KsqlTopic(
         "test4",
@@ -246,7 +246,7 @@ public final class MetaStoreFixture {
         ksqlTopic4
     );
 
-    metaStore.putSource(ksqlStream4);
+    metaStore.putSource(ksqlStream4, false);
 
     final LogicalSchema sensorReadingsSchema = LogicalSchema.builder()
         .keyColumn(ColumnName.of("ID"), SqlTypes.BIGINT)
@@ -271,7 +271,7 @@ public final class MetaStoreFixture {
         ksqlTopicSensorReadings
     );
 
-    metaStore.putSource(ksqlStreamSensorReadings);
+    metaStore.putSource(ksqlStreamSensorReadings, false);
 
     return metaStore;
   }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -253,10 +253,6 @@ public class AstBuilder {
 
       final Map<String, Literal> properties = processTableProperties(context.tableProperties());
 
-      if (context.REPLACE() != null) {
-        throw new UnsupportedOperationException("CREATE OR REPLACE is not yet supported.");
-      }
-
       return new CreateTable(
           getLocation(context),
           ParserUtil.getSourceName(context.sourceName()),
@@ -275,10 +271,6 @@ public class AstBuilder {
 
       final Map<String, Literal> properties = processTableProperties(context.tableProperties());
 
-      if (context.REPLACE() != null) {
-        throw new UnsupportedOperationException("CREATE OR REPLACE is not yet supported.");
-      }
-
       return new CreateStream(
           getLocation(context),
           ParserUtil.getSourceName(context.sourceName()),
@@ -295,10 +287,6 @@ public class AstBuilder {
 
       final Query query = withinPersistentQuery(() -> visitQuery(context.query()));
 
-      if (context.REPLACE() != null) {
-        throw new UnsupportedOperationException("CREATE OR REPLACE is not yet supported.");
-      }
-
       return new CreateStreamAsSelect(
           getLocation(context),
           ParserUtil.getSourceName(context.sourceName()),
@@ -314,10 +302,6 @@ public class AstBuilder {
       final Map<String, Literal> properties = processTableProperties(context.tableProperties());
 
       final Query query = withinPersistentQuery(() -> visitQuery(context.query()));
-
-      if (context.REPLACE() != null) {
-        throw new UnsupportedOperationException("CREATE OR REPLACE is not yet supported.");
-      }
 
       return new CreateTableAsSelect(
           getLocation(context),

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -163,7 +163,7 @@ public class KsqlParserTest {
         ksqlTopicOrders
     );
 
-    metaStore.putSource(ksqlStreamOrders);
+    metaStore.putSource(ksqlStreamOrders, false);
 
     final KsqlTopic ksqlTopicItems = new KsqlTopic(
         "item_topic",
@@ -181,7 +181,7 @@ public class KsqlParserTest {
         ksqlTopicItems
     );
 
-    metaStore.putSource(ksqlTableOrders);
+    metaStore.putSource(ksqlTableOrders, false);
   }
 
   @Test

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
@@ -528,7 +528,7 @@ public class SqlFormatterTest {
         + "FROM ADDRESS A\nEMIT CHANGES"));
   }
 
-  @Test(expected = ParseFailedException.class)
+  @Test
   public void shouldFormatReplaceSelectQueryCorrectly() {
     final String statementString =
         "CREATE OR REPLACE STREAM S AS SELECT a.address->city FROM address a;";

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
@@ -189,7 +189,7 @@ public class SqlFormatterTest {
         ksqlTopicOrders
     );
 
-    metaStore.putSource(ksqlStreamOrders);
+    metaStore.putSource(ksqlStreamOrders, false);
 
     final KsqlTopic ksqlTopicItems = new KsqlTopic(
         "item_topic",
@@ -206,7 +206,7 @@ public class SqlFormatterTest {
         ksqlTopicItems
     );
 
-    metaStore.putSource(ksqlTableOrders);
+    metaStore.putSource(ksqlTableOrders, false);
 
     final KsqlTable<String> ksqlTableTable = new KsqlTable<>(
         "sqlexpression",
@@ -218,7 +218,7 @@ public class SqlFormatterTest {
         ksqlTopicItems
     );
 
-    metaStore.putSource(ksqlTableTable);
+    metaStore.putSource(ksqlTableTable, false);
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TlsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TlsTest.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.common.config.SslConfigs;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
@@ -159,7 +159,7 @@ public class TemporaryEngine extends ExternalResource {
       default:
         throw new IllegalArgumentException(type.toString());
     }
-    metaStore.putSource(source);
+    metaStore.putSource(source, false);
 
     return (T) source;
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -2228,7 +2228,7 @@ public class KsqlResourceTest {
               Optional.empty(),
               false,
               ksqlTopic
-          ));
+          ), false);
     }
     if (type == DataSourceType.KTABLE) {
       metaStore.putSource(
@@ -2240,7 +2240,7 @@ public class KsqlResourceTest {
               Optional.empty(),
               false,
               ksqlTopic
-          ));
+          ), false);
     }
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/RequestValidatorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/RequestValidatorTest.java
@@ -58,7 +58,6 @@ import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.Sandbox;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.junit.Before;
@@ -111,8 +110,8 @@ public class RequestValidatorTest {
     final KsqlStream<?> sink = mock(KsqlStream.class);
     when(sink.getName()).thenReturn(SourceName.of("SINK"));
 
-    metaStore.putSource(source);
-    metaStore.putSource(sink);
+    metaStore.putSource(source, false);
+    metaStore.putSource(sink, false);
 
     givenRequestValidator(ImmutableMap.of());
   }

--- a/ksqldb-rest-app/src/test/resources/ksql-plan-schema/schema.json
+++ b/ksqldb-rest-app/src/test/resources/ksql-plan-schema/schema.json
@@ -63,6 +63,10 @@
         },
         "windowInfo" : {
           "$ref" : "#/definitions/WindowInfo"
+        },
+        "orReplace" : {
+          "type" : "boolean",
+          "default" : false
         }
       },
       "title" : "createStreamV1",
@@ -157,6 +161,10 @@
         },
         "windowInfo" : {
           "$ref" : "#/definitions/WindowInfo"
+        },
+        "orReplace" : {
+          "type" : "boolean",
+          "default" : false
         }
       },
       "title" : "createTableV1",


### PR DESCRIPTION
### Description 

This PR does the work of allowing us to issue `CREATE OR REPLACE <source>` and it will replace the source with the new query. It does not do any type of validation, which may be extraordinarily dangerous, so it is disabled by default. Future PRs will introduce guardrails to ensure that the compatibility is validated.

The funcitonal change is only a few lines in `EngineContext` and `MetaStoreImpl`, most the hard work was done in the preivous pr (#5710) to reuse queryIds.

### Testing done 

The main test is `ReplaceIntTest`, the rest are just updated legacy tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

