### PR TITLE
chore: add kafka.version as property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,7 @@
         <jetty.version>9.4.28.v20200408</jetty.version>
         <git-commit-id-plugin.version>2.2.6</git-commit-id-plugin.version>
         <scala.version>2.13.2</scala.version>
+        <kafka.version>6.0.0-ccs-beta200608020919-hf-1</kafka.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
### Description 
Running:
`mvn --batch-mode versions:set-property -Dproperty=kafka.version -DnewVersion=<version> -DgenerateBackupPoms=false`
does nothing currently since the property doesn't exist. Adding the property so we can override it manually when needed.

### Testing done 
Ran the command above and verified the kafka version was set to what was specified

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

