### PR TITLE
chore: ErrorMessageUtil dedups error messages properly

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/ErrorMessageUtil.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/ErrorMessageUtil.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.util;
 
 import java.net.ConnectException;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.text.WordUtils;
@@ -41,8 +42,7 @@ public final class ErrorMessageUtil {
       return "";
     }
 
-    final List<String> messages = getErrorMessages(throwable);
-    dedup(messages);
+    final List<String> messages = dedup(getErrorMessages(throwable));
 
     final String msg = messages.remove(0);
 
@@ -68,7 +68,8 @@ public final class ErrorMessageUtil {
 
   private static String getErrorMessage(final Throwable e) {
     if (e instanceof ConnectException) {
-      return "Could not connect to the server.";
+      return "Could not connect to the server. "
+          + "Please check the server details are correct and that the server is running.";
     } else {
       return e.getMessage() == null ? e.toString() : e.getMessage();
     }
@@ -84,13 +85,7 @@ public final class ErrorMessageUtil {
     return list;
   }
 
-  private static void dedup(final List<String> messages) {
-    while (messages.size() > 1) {
-      if (!messages.get(0).equals(messages.get(1))) {
-        return;
-      }
-
-      messages.remove(0);
-    }
+  private static List<String> dedup(final List<String> messages) {
+    return new ArrayList<>(new LinkedHashSet<>(messages));
   }
 }

--- a/ksqldb-common/src/test/java/io/confluent/ksql/util/ErrorMessageUtilTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/util/ErrorMessageUtilTest.java
@@ -40,7 +40,7 @@ public class ErrorMessageUtilTest {
   public void shouldUseCustomMsgForConnectException() {
     assertThat(
         buildErrorMessage(new ConnectException("asdf")),
-        is("Could not connect to the server.")
+        is("Could not connect to the server. Please check the server details are correct and that the server is running.")
     );
   }
 
@@ -71,7 +71,8 @@ public class ErrorMessageUtilTest {
   @Test
   public void shouldDeduplicateMessage() {
     final Throwable cause = new TestException("Something went wrong");
-    final Throwable subLevel2 = new TestException("Msg that matches", cause);
+    final Throwable subLevel3 = new TestException("Something went wrong", cause);
+    final Throwable subLevel2 = new TestException("Msg that matches", subLevel3);
     final Throwable subLevel1 = new TestException("Msg that matches", subLevel2);
     final Throwable e = new TestException("Msg that matches", subLevel1);
 


### PR DESCRIPTION
### Description
Addresses: https://github.com/confluentinc/ksql/issues/5599
Error message is now
```
ksql> show topics;
Error issuing POST to KSQL server. path:/ksql
Caused by: io.netty.channel.AbstractChannel$AnnotatedConnectException:
	Connection refused: localhost/127.0.0.1:8088
Caused by: Could not connect to the server. Please check the server details are
	correct and that the server is running.
```
I don't think the dedup function was working as intended so I updated it. 

### Testing done 
Manual verification
Updated unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

