### PR TITLE
 fix: better error on DECIMAL type with PROTOBUF format

### DIFF
--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/decimal.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/decimal.json
@@ -45,6 +45,40 @@
       ]
     },
     {
+      "name": "PROTOBUF does not yet support DECIMAL",
+      "comment": "Adding support covered by https://github.com/confluentinc/ksql/issues/5762",
+      "statements": [
+        "CREATE STREAM INPUT (ID STRING KEY, dec DECIMAL(6,4)) WITH (kafka_topic='test', value_format='PROTOBUF');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The 'PROTOBUF' format does not support type 'DECIMAL'. See https://github.com/confluentinc/ksql/issues/5762."
+      }
+    },
+    {
+      "enabled": false,
+      "name": "PROTOBUF should not trim trailing zeros",
+      "comment": "Enable once https://github.com/confluentinc/ksql/issues/5762 fixed",
+      "statements": [
+        "CREATE STREAM INPUT (ID STRING KEY, dec DECIMAL(6,4)) WITH (kafka_topic='test', value_format='PROTOBUF');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "test", "value": {"DEC": 10.0}},
+        {"topic": "test", "value": {"DEC": 1.0000}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"DEC": 10.0}},
+        {"topic": "OUTPUT", "value": {"DEC": 1.0000}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "INPUT", "type": "stream", "schema": "ID STRING KEY, DEC DECIMAL(6,4)"},
+          {"name": "OUTPUT", "type": "stream", "schema": "ID STRING KEY, DEC DECIMAL(6,4)"}
+        ]
+      }
+    },
+    {
       "name": "negation",
       "statements": [
         "CREATE STREAM TEST (dec DECIMAL(7,5)) WITH (kafka_topic='test', value_format='AVRO');",

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/decimal.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/decimal.json
@@ -48,7 +48,7 @@
       "name": "PROTOBUF does not yet support DECIMAL",
       "comment": "Adding support covered by https://github.com/confluentinc/ksql/issues/5762",
       "statements": [
-        "CREATE STREAM INPUT (ID STRING KEY, dec DECIMAL(6,4)) WITH (kafka_topic='test', value_format='PROTOBUF');"
+        "CREATE STREAM INPUT (ROWKEY STRING KEY, dec DECIMAL(6,4)) WITH (kafka_topic='test', value_format='PROTOBUF');"
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
@@ -60,7 +60,7 @@
       "name": "PROTOBUF should not trim trailing zeros",
       "comment": "Enable once https://github.com/confluentinc/ksql/issues/5762 fixed",
       "statements": [
-        "CREATE STREAM INPUT (ID STRING KEY, dec DECIMAL(6,4)) WITH (kafka_topic='test', value_format='PROTOBUF');",
+        "CREATE STREAM INPUT (ROWKEY STRING KEY, dec DECIMAL(6,4)) WITH (kafka_topic='test', value_format='PROTOBUF');",
         "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
       ],
       "inputs": [

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufSerdeFactory.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufSerdeFactory.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.serde.protobuf;
 import io.confluent.connect.protobuf.ProtobufConverter;
 import io.confluent.connect.protobuf.ProtobufConverterConfig;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.ksql.schema.connect.SchemaWalker;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.serde.KsqlSerdeFactory;
 import io.confluent.ksql.serde.connect.ConnectDataTranslator;
@@ -25,19 +26,22 @@ import io.confluent.ksql.serde.connect.KsqlConnectDeserializer;
 import io.confluent.ksql.serde.connect.KsqlConnectSerializer;
 import io.confluent.ksql.serde.tls.ThreadLocalDeserializer;
 import io.confluent.ksql.serde.tls.ThreadLocalSerializer;
+import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.connect.data.Schema;
 
 public class ProtobufSerdeFactory implements KsqlSerdeFactory {
 
   @Override
   public void validate(final PersistenceSchema schema) {
-    // Supports all types
+    SchemaWalker.visit(schema.serializedSchema(), new SchemaValidator());
   }
 
   @Override
@@ -67,7 +71,7 @@ public class ProtobufSerdeFactory implements KsqlSerdeFactory {
     );
   }
 
-  private KsqlConnectSerializer createSerializer(
+  private static KsqlConnectSerializer createSerializer(
       final PersistenceSchema schema,
       final KsqlConfig ksqlConfig,
       final Supplier<SchemaRegistryClient> schemaRegistryClientFactory
@@ -81,7 +85,7 @@ public class ProtobufSerdeFactory implements KsqlSerdeFactory {
     );
   }
 
-  private KsqlConnectDeserializer createDeserializer(
+  private static KsqlConnectDeserializer createDeserializer(
       final PersistenceSchema schema,
       final KsqlConfig ksqlConfig,
       final Supplier<SchemaRegistryClient> schemaRegistryClientFactory
@@ -94,7 +98,7 @@ public class ProtobufSerdeFactory implements KsqlSerdeFactory {
     );
   }
 
-  private ProtobufConverter getConverter(
+  private static ProtobufConverter getConverter(
       final SchemaRegistryClient schemaRegistryClient,
       final KsqlConfig ksqlConfig
   ) {
@@ -112,4 +116,14 @@ public class ProtobufSerdeFactory implements KsqlSerdeFactory {
     return converter;
   }
 
+  private static class SchemaValidator implements SchemaWalker.Visitor<Void, Void> {
+
+    public Void visitBytes(final Schema schema) {
+      if (DecimalUtil.isDecimal(schema)) {
+        throw new KsqlException("The '" + ProtobufFormat.NAME + "' format does not support type "
+            + "'DECIMAL'. See https://github.com/confluentinc/ksql/issues/5762.");
+      }
+      return null;
+    }
+  }
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufSerdeFactory.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufSerdeFactory.java
@@ -125,5 +125,10 @@ public class ProtobufSerdeFactory implements KsqlSerdeFactory {
       }
       return null;
     }
+
+    @Override
+    public Void visitSchema(final Schema schema) {
+      return null;
+    }
   }
 }

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/ProtobufSerdeFactoryTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/ProtobufSerdeFactoryTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.serde.protobuf;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.when;
+
+import io.confluent.ksql.schema.ksql.PersistenceSchema;
+import io.confluent.ksql.util.DecimalUtil;
+import io.confluent.ksql.util.KsqlException;
+import org.apache.kafka.connect.data.ConnectSchema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProtobufSerdeFactoryTest {
+
+  @Mock
+  private PersistenceSchema schema;
+
+  private ProtobufSerdeFactory factory;
+
+  @Before
+  public void setUp() {
+    factory = new ProtobufSerdeFactory();
+  }
+
+  @Test
+  public void shouldThrowOnDecimal() {
+    // Given:
+    final ConnectSchema schemaWithNestedDecimal = (ConnectSchema) SchemaBuilder.struct()
+        .field("f0", SchemaBuilder.array(DecimalUtil.builder(10, 2)))
+        .build();
+
+    when(schema.serializedSchema())
+        .thenReturn(schemaWithNestedDecimal);
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> factory.validate(schema)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), is("The 'PROTOBUF' format does not support type 'DECIMAL'. "
+        + "See https://github.com/confluentinc/ksql/issues/5762."));
+  }
+
+  @Test
+  public void shouldNotThrowOnNonDecimal() {
+    // Given:
+    final ConnectSchema schemaWithOutDecimal = (ConnectSchema) SchemaBuilder.struct()
+        .field("f0", SchemaBuilder.array(SchemaBuilder.OPTIONAL_STRING_SCHEMA))
+        .build();
+
+    when(schema.serializedSchema())
+        .thenReturn(schemaWithOutDecimal);
+
+    // When:
+    factory.validate(schema);
+
+    // Then (did not throw)
+  }
+}


### PR DESCRIPTION
### Description 

fixes: #5784

Error message is no longer:

```
Caused by: java.lang.RuntimeException: Unexpected BYTES type null
```

It is now:

```
The 'PROTOBUF' format does not support type 'DECIMAL'. See #5762.
```

### Testing done 

usual


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

