### PR TITLE
feat: add service to restart failed persistent queries

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/PropertiesUtil.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/PropertiesUtil.java
@@ -59,7 +59,7 @@ public final class PropertiesUtil {
    * @param mapProps the map props to convert
    * @return {@code Properties} instance.
    */
-  public static Properties asProperties(final Map<String, String> mapProps) {
+  public static Properties asProperties(final Map<String, ?> mapProps) {
     final Properties properties = new Properties();
     properties.putAll(mapProps);
     return properties;

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -316,8 +316,14 @@ public class KsqlConfig extends AbstractConfig {
       .put(KSQL_STREAMS_PREFIX + StreamsConfig.MAX_TASK_IDLE_MS_CONFIG, 500L)
       .build();
 
+  public static final String KSQL_QUERY_RETRY_BACKOFF_INITIAL_MS
+      = "ksql.query.retry.backoff.initial.ms";
+  public static final Long KSQL_QUERY_RETRY_BACKOFF_INITIAL_MS_DEFAULT = 60000L;
+  public static final String KSQL_QUERY_RETRY_BACKOFF_INITIAL_MS_DOC = "The initial amount of time "
+      + "to wait before attempting to retry a persistent query in ERROR state.";
+
   public static final String KSQL_QUERY_RETRY_BACKOFF_MAX_MS = "ksql.query.retry.backoff.max.ms";
-  public static final Long KSQL_QUERY_RETRY_BACKOFF_MAX_MS_DEFAULT = 120000L;
+  public static final Long KSQL_QUERY_RETRY_BACKOFF_MAX_MS_DEFAULT = 900000L;
   public static final String KSQL_QUERY_RETRY_BACKOFF_MAX_MS_DOC = "The maximum amount of time "
       + "to wait before attempting to retry a persistent query in ERROR state.";
 
@@ -728,6 +734,13 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_SUPPRESS_ENABLED_DEFAULT,
             Importance.LOW,
             KSQL_SUPPRESS_ENABLED_DOC
+        )
+        .define(
+            KSQL_QUERY_RETRY_BACKOFF_INITIAL_MS,
+            Type.LONG,
+            KSQL_QUERY_RETRY_BACKOFF_INITIAL_MS_DEFAULT,
+            Importance.LOW,
+            KSQL_QUERY_RETRY_BACKOFF_INITIAL_MS_DOC
         )
         .define(
             KSQL_QUERY_RETRY_BACKOFF_MAX_MS,

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -316,6 +316,11 @@ public class KsqlConfig extends AbstractConfig {
       .put(KSQL_STREAMS_PREFIX + StreamsConfig.MAX_TASK_IDLE_MS_CONFIG, 500L)
       .build();
 
+  public static final String KSQL_QUERY_RETRY_BACKOFF_MAX_MS = "ksql.query.retry.backoff.max.ms";
+  public static final Long KSQL_QUERY_RETRY_BACKOFF_MAX_MS_DEFAULT = 120000L;
+  public static final String KSQL_QUERY_RETRY_BACKOFF_MAX_MS_DOC = "The maximum amount of time "
+      + "to wait before attempting to retry a persistent query in ERROR state.";
+
   private enum ConfigGeneration {
     LEGACY,
     CURRENT
@@ -723,6 +728,13 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_SUPPRESS_ENABLED_DEFAULT,
             Importance.LOW,
             KSQL_SUPPRESS_ENABLED_DOC
+        )
+        .define(
+            KSQL_QUERY_RETRY_BACKOFF_MAX_MS,
+            Type.LONG,
+            KSQL_QUERY_RETRY_BACKOFF_MAX_MS_DEFAULT,
+            Importance.LOW,
+            KSQL_QUERY_RETRY_BACKOFF_MAX_MS_DOC
         )
         .withClientSslSupport();
 

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -318,7 +318,7 @@ public class KsqlConfig extends AbstractConfig {
 
   public static final String KSQL_QUERY_RETRY_BACKOFF_INITIAL_MS
       = "ksql.query.retry.backoff.initial.ms";
-  public static final Long KSQL_QUERY_RETRY_BACKOFF_INITIAL_MS_DEFAULT = 60000L;
+  public static final Long KSQL_QUERY_RETRY_BACKOFF_INITIAL_MS_DEFAULT = 15000L;
   public static final String KSQL_QUERY_RETRY_BACKOFF_INITIAL_MS_DOC = "The initial amount of time "
       + "to wait before attempting to retry a persistent query in ERROR state.";
 
@@ -326,6 +326,12 @@ public class KsqlConfig extends AbstractConfig {
   public static final Long KSQL_QUERY_RETRY_BACKOFF_MAX_MS_DEFAULT = 900000L;
   public static final String KSQL_QUERY_RETRY_BACKOFF_MAX_MS_DOC = "The maximum amount of time "
       + "to wait before attempting to retry a persistent query in ERROR state.";
+
+  public static final String KSQL_QUERY_ERROR_MAX_QUEUE_SIZE = "ksql.query.error.max.queue.size";
+  public static final Integer KSQL_QUERY_ERROR_MAX_QUEUE_SIZE_DEFAULT = 10;
+  public static final String KSQL_QUERY_ERROR_MAX_QUEUE_SIZE_DOC = "The maximum number of "
+      + "error messages (per query) to hold in the internal query errors queue and display"
+      + "in the query description when executing the `EXPLAIN <query>` command.";
 
   private enum ConfigGeneration {
     LEGACY,
@@ -748,6 +754,13 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_QUERY_RETRY_BACKOFF_MAX_MS_DEFAULT,
             Importance.LOW,
             KSQL_QUERY_RETRY_BACKOFF_MAX_MS_DOC
+        )
+        .define(
+            KSQL_QUERY_ERROR_MAX_QUEUE_SIZE,
+            Type.INT,
+            KSQL_QUERY_ERROR_MAX_QUEUE_SIZE_DEFAULT,
+            Importance.LOW,
+            KSQL_QUERY_ERROR_MAX_QUEUE_SIZE_DOC
         )
         .withClientSslSupport();
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
@@ -229,7 +229,7 @@ final class EngineContext {
     }
   }
 
-  void unregisterQuery(final QueryMetadata query) {
+  private void unregisterQuery(final QueryMetadata query) {
     if (query instanceof PersistentQueryMetadata) {
       final PersistentQueryMetadata persistentQuery = (PersistentQueryMetadata) query;
       persistentQueries.remove(persistentQuery.getQueryId());

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
@@ -229,7 +229,7 @@ final class EngineContext {
     }
   }
 
-  private void unregisterQuery(final QueryMetadata query) {
+  void unregisterQuery(final QueryMetadata query) {
     if (query instanceof PersistentQueryMetadata) {
       final PersistentQueryMetadata persistentQuery = (PersistentQueryMetadata) query;
       persistentQueries.remove(persistentQuery.getQueryId());

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -373,7 +373,7 @@ final class EngineExecutor {
         serviceContext
     );
 
-    final PersistentQueryMetadata queryMetadata = executor.buildQuery(
+    final PersistentQueryMetadata queryMetadata = executor.buildPersistentQuery(
         statementText,
         queryPlan.getQueryId(),
         engineContext.getMetaStore().getSource(queryPlan.getSink()),

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -32,7 +32,6 @@ import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.QueryContainer;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.planner.plan.ConfiguredKsqlPlan;
-import io.confluent.ksql.properties.PropertiesUtil;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.query.id.QueryIdGenerator;
 import io.confluent.ksql.schema.registry.SchemaRegistryUtil;
@@ -47,7 +46,6 @@ import java.io.Closeable;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -55,10 +53,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
-import org.apache.kafka.streams.KafkaClientSupplier;
-import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
-import org.apache.kafka.streams.Topology;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -256,39 +251,6 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
     return statement instanceof ExecutableDdlStatement
         || statement instanceof QueryContainer
         || statement instanceof Query;
-  }
-
-  /**
-   * Resets a query internal KafkaStreams so it can be restarted.
-   * </p>
-   * When a KafkaStreams has been stopped, it cannot be started again. To allow a restart,
-   * the rest creates a new new KafkaStreams with the same topology and configs.
-   *
-   * @param queryId the queryId to reset.
-   */
-  public void resetQuery(final QueryId queryId) {
-    if (primaryContext.getPersistentQueries().containsKey(queryId)) {
-      final PersistentQueryMetadata query = primaryContext.getPersistentQueries().get(queryId);
-      if (query.getState() != State.NOT_RUNNING) {
-        throw new IllegalStateException(
-            String.format("Cannot reset query with application id: %s because is in %s state",
-                query.getQueryApplicationId(), query.getState()));
-      }
-
-      // Unregister the query to replace it with a new PersistentQueryMetadata
-      primaryContext.unregisterQuery(query);
-      // this.unregisterQuery() is called from withing primaryContext.unregisterQuery()
-
-      final Topology topology = query.getTopology();
-      final Properties props = PropertiesUtil.asProperties(query.getStreamsProperties());
-      final KafkaClientSupplier clientSupplier = getServiceContext().getKafkaClientSupplier();
-      final KafkaStreams kafkaStreams = new KafkaStreams(topology, props, clientSupplier);
-      final PersistentQueryMetadata newQuery = query.copyWith(kafkaStreams);
-
-      // Registers the  new PersistentQueryMetadata that has a new KafkaStreams
-      primaryContext.registerQuery(newQuery);
-      this.registerQuery(newQuery);
-    }
   }
 
   private void registerQuery(final QueryMetadata query) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryMonitor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryMonitor.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.engine;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Ticker;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.util.KsqlConfig;
+import java.io.Closeable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.streams.KafkaStreams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Monitor and manages the restart of persistent failed queries.
+ */
+public class QueryMonitor implements Closeable {
+  private static final Logger LOG = LoggerFactory.getLogger(QueryMonitor.class);
+
+  private static final Random random = new Random();
+  private static final Ticker CURRENT_TIME_MILLIS_TICKER = new Ticker() {
+    @Override
+    public long read() {
+      return System.currentTimeMillis();
+    }
+  };
+
+  private static final long BASE_WAITING_TIME_MS = 10000;
+  private static final int SHUTDOWN_TIMEOUT_MS = 5000;
+
+  private final Ticker ticker;
+  private final long retryBackoffMaxMs;
+  private final KsqlEngine ksqlEngine;
+  private final ExecutorService executor;
+  private final Map<QueryId, RetryEvent> queriesRetries = new HashMap<>();
+
+  private volatile boolean closed = false;
+
+  public QueryMonitor(final KsqlConfig ksqlConfig, final KsqlEngine ksqlEngine) {
+    this(
+        ksqlConfig,
+        ksqlEngine,
+        Executors.newSingleThreadExecutor(r -> new Thread(r, "QueryMonitor")),
+        CURRENT_TIME_MILLIS_TICKER
+    );
+  }
+
+  @VisibleForTesting
+  QueryMonitor(
+      final KsqlConfig ksqlConfig,
+      final KsqlEngine ksqlEngine,
+      final ExecutorService executor,
+      final Ticker ticker
+  ) {
+    this.retryBackoffMaxMs = ksqlConfig.getLong(KsqlConfig.KSQL_QUERY_RETRY_BACKOFF_MAX_MS);
+    this.ksqlEngine = ksqlEngine;
+    this.executor = executor;
+    this.ticker = ticker;
+  }
+
+  public void start() {
+    executor.execute(new Runner());
+    executor.shutdown();
+  }
+
+  @Override
+  public void close() {
+    closed = true;
+
+    try {
+      executor.awaitTermination(SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  boolean isClosed() {
+    return closed;
+  }
+
+  void restartFailedQueries() {
+    ksqlEngine.getPersistentQueries().stream()
+        .forEach(query -> {
+          final QueryId queryId = query.getQueryId();
+          final KafkaStreams.State queryState = query.getState();
+
+          // If the query was restarted previously, check if it needs another restart; or if the
+          // query is now up and running, then remove it from the restart list.
+          if (queriesRetries.containsKey(queryId)) {
+            final RetryEvent retryEvent = queriesRetries.get(queryId);
+            if (ticker.read() > retryEvent.nextRestartTimeMs()) {
+              if (queryState == KafkaStreams.State.ERROR) {
+                // Retry again if it's still in ERROR state
+                retryEvent.restart();
+              } else {
+                // Query is not in ERROR state anymore.
+                queriesRetries.remove(queryId);
+              }
+            }
+          } else if (queryState == KafkaStreams.State.ERROR) {
+            // Restart new query in ERROR state, and add it to the list of retries.
+            final RetryEvent retryEvent = new RetryEvent(
+                ksqlEngine, queryId, BASE_WAITING_TIME_MS, retryBackoffMaxMs, ticker);
+
+            queriesRetries.put(queryId, retryEvent);
+            retryEvent.restart();
+          }
+        });
+  }
+
+  private class Runner implements Runnable {
+    @Override
+    public void run() {
+      LOG.info("KSQL query monitor started.");
+
+      while (!closed) {
+        try {
+          restartFailedQueries();
+        } catch (final Exception e) {
+          LOG.warn("KSQL query monitor found an error attempting to restart failed queries.", e);
+        }
+      }
+    }
+  }
+
+  static class RetryEvent {
+    private final KsqlEngine ksqlEngine;
+    private final QueryId queryId;
+    private final Ticker ticker;
+
+    private int numRetries = 0;
+    private long waitingTimeMs;
+    private long expiryTimeMs;
+    private long retryBackoffMaxMs;
+    private long baseWaitingTimeMs;
+
+    RetryEvent(
+        final KsqlEngine ksqlEngine,
+        final QueryId queryId,
+        final long baseWaitingTimeMs,
+        final long retryBackoffMaxMs,
+        final Ticker ticker
+    ) {
+      this.ksqlEngine = ksqlEngine;
+      this.queryId = queryId;
+      this.ticker = ticker;
+
+      this.baseWaitingTimeMs = baseWaitingTimeMs;
+      this.waitingTimeMs = baseWaitingTimeMs;
+      this.expiryTimeMs = ticker.read() + baseWaitingTimeMs;
+      this.retryBackoffMaxMs = retryBackoffMaxMs;
+    }
+
+    public long nextRestartTimeMs() {
+      return expiryTimeMs;
+    }
+
+    public int getNumRetries() {
+      return numRetries;
+    }
+
+    public void restart() {
+      numRetries++;
+
+      LOG.info("Restarting query {} (attempt #{})", queryId, numRetries);
+
+      // Stop the queryId using the current QueryMetadata
+      ksqlEngine.getPersistentQuery(queryId).ifPresent(q -> q.stop());
+
+      // Reset the internal KafkaStreams query. This creates a new QueryMetadata.
+      ksqlEngine.resetQuery(queryId);
+
+      // Start the queryId using the new QueryMetadata created during the reset.
+      ksqlEngine.getPersistentQuery(queryId).ifPresent(q -> q.start());
+
+      this.waitingTimeMs = getWaitingTimeMs();
+      this.expiryTimeMs = ticker.read() + waitingTimeMs;
+
+      LOG.info(
+          "Query {} restarted. If the error persists, the query will be restarted again in {} ms",
+          queryId, waitingTimeMs);
+    }
+
+    private long getWaitingTimeMs() {
+      if ((waitingTimeMs * 2) < retryBackoffMaxMs) {
+        return waitingTimeMs * 2;
+      } else {
+        // Add some fuzz amount to the retryBackoffMaxMs to avoid several queries hitting
+        // the max. amount are not restarted at the same time
+        final int fuzz = random.nextInt((int) baseWaitingTimeMs / 2);
+        return retryBackoffMaxMs + fuzz;
+      }
+    }
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryMonitor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryMonitor.java
@@ -158,8 +158,10 @@ public class QueryMonitor implements Closeable {
 
         try {
           Thread.sleep(500);
-        } catch (final Exception e) {
-          // ignore.
+        } catch (final InterruptedException e) {
+          LOG.info("QueryMonitor sleep thread interrupted. Terminating QueryMonitor. Error = {}",
+              e.getMessage());
+          break;
         }
       }
     }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
@@ -150,7 +150,7 @@ public class KsqlEngineMetrics implements Closeable {
         query.getQueryApplicationId()
     );
 
-    query.registerQueryStateListener(listener);
+    query.setQueryStateListener(listener);
   }
 
   private void recordMessageConsumptionByQueryStats(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsBuilder.java
@@ -15,27 +15,10 @@
 
 package io.confluent.ksql.query;
 
-import static java.util.Objects.requireNonNull;
-
 import java.util.Map;
 import org.apache.kafka.streams.KafkaStreams;
-import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
 
 public interface KafkaStreamsBuilder {
-  BuildResult buildKafkaStreams(StreamsBuilder builder, Map<String, Object> conf);
-
-  class BuildResult {
-
-    final Topology topology;
-    final KafkaStreams kafkaStreams;
-
-    public BuildResult(
-        final Topology topology,
-        final KafkaStreams kafkaStreams
-    ) {
-      this.topology = requireNonNull(topology, "topology");
-      this.kafkaStreams = requireNonNull(kafkaStreams, "kafkaStreams");
-    }
-  }
+  KafkaStreams build(Topology topology, Map<String, Object> conf);
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsBuilderImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsBuilderImpl.java
@@ -15,16 +15,16 @@
 
 package io.confluent.ksql.query;
 
+import io.confluent.ksql.properties.PropertiesUtil;
+
 import java.util.Map;
 import java.util.Objects;
-import java.util.Properties;
+
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.KafkaStreams;
-import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
 
 public class KafkaStreamsBuilderImpl implements KafkaStreamsBuilder {
-
   private final KafkaClientSupplier clientSupplier;
 
   KafkaStreamsBuilderImpl(final KafkaClientSupplier clientSupplier) {
@@ -32,14 +32,7 @@ public class KafkaStreamsBuilderImpl implements KafkaStreamsBuilder {
   }
 
   @Override
-  public BuildResult buildKafkaStreams(
-      final StreamsBuilder builder,
-      final Map<String, Object> conf
-  ) {
-    final Properties props = new Properties();
-    props.putAll(conf);
-    final Topology topology = builder.build(props);
-    final KafkaStreams kafkaStreams = new KafkaStreams(topology, props, clientSupplier);
-    return new BuildResult(topology, kafkaStreams);
+  public KafkaStreams build(final Topology topology, final Map<String, Object> conf) {
+    return new KafkaStreams(topology, PropertiesUtil.asProperties(conf), clientSupplier);
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/MaterializationProviderBuilderFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/MaterializationProviderBuilderFactory.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.query;
+
+import static java.util.Objects.requireNonNull;
+
+import io.confluent.ksql.execution.materialization.MaterializationInfo;
+import io.confluent.ksql.execution.streams.materialization.KsqlMaterializationFactory;
+import io.confluent.ksql.execution.streams.materialization.MaterializationProvider;
+import io.confluent.ksql.execution.streams.materialization.ks.KsMaterialization;
+import io.confluent.ksql.execution.streams.materialization.ks.KsMaterializationFactory;
+import io.confluent.ksql.logging.processing.NoopProcessingLogContext;
+import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.serde.GenericKeySerDe;
+import io.confluent.ksql.serde.KeyFormat;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.util.KsqlConfig;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.streams.KafkaStreams;
+
+public final class MaterializationProviderBuilderFactory {
+  // Interface used for Function alias
+  public interface MaterializationProviderBuilder
+      extends Function<KafkaStreams, Optional<MaterializationProvider>> {
+  }
+
+  private final KsqlConfig ksqlConfig;
+  private final ServiceContext serviceContext;
+  private final KsMaterializationFactory ksMaterializationFactory;
+  private final KsqlMaterializationFactory ksqlMaterializationFactory;
+
+  public MaterializationProviderBuilderFactory(
+      final KsqlConfig ksqlConfig,
+      final ServiceContext serviceContext,
+      final KsMaterializationFactory ksMaterializationFactory,
+      final KsqlMaterializationFactory ksqlMaterializationFactory
+  ) {
+    this.ksqlConfig = requireNonNull(ksqlConfig, "ksqlConfig");
+    this.serviceContext = requireNonNull(serviceContext, "serviceContext");
+    this.ksMaterializationFactory =
+        requireNonNull(ksMaterializationFactory, "ksMaterializationFactory");
+    this.ksqlMaterializationFactory =
+        requireNonNull(ksqlMaterializationFactory, "ksqlMaterializationFactory");
+  }
+
+  public MaterializationProviderBuilder materializationProviderBuilder(
+      final MaterializationInfo materializationInfo,
+      final PhysicalSchema querySchema,
+      final KeyFormat keyFormat,
+      final Map<String, Object> streamsProperties,
+      final String applicationId
+  ) {
+    return (kafkaStreams) -> buildMaterializationProvider(
+        kafkaStreams,
+        materializationInfo,
+        querySchema,
+        keyFormat,
+        streamsProperties,
+        applicationId
+    );
+  }
+
+  private Optional<MaterializationProvider> buildMaterializationProvider(
+      final KafkaStreams kafkaStreams,
+      final MaterializationInfo materializationInfo,
+      final PhysicalSchema schema,
+      final KeyFormat keyFormat,
+      final Map<String, Object> streamsProperties,
+      final String applicationId
+  ) {
+    final Serializer<Struct> keySerializer = new GenericKeySerDe().create(
+        keyFormat.getFormatInfo(),
+        schema.keySchema(),
+        ksqlConfig,
+        serviceContext.getSchemaRegistryClientFactory(),
+        "",
+        NoopProcessingLogContext.INSTANCE
+    ).serializer();
+
+    final Optional<KsMaterialization> ksMaterialization = ksMaterializationFactory
+        .create(
+            materializationInfo.stateStoreName(),
+            kafkaStreams,
+            materializationInfo.getStateStoreSchema(),
+            keySerializer,
+            keyFormat.getWindowInfo(),
+            streamsProperties,
+            ksqlConfig,
+            applicationId
+        );
+
+    return ksMaterialization.map(ksMat -> (queryId, contextStacker) -> ksqlMaterializationFactory
+        .create(
+            ksMat,
+            materializationInfo,
+            queryId,
+            contextStacker
+        ));
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -196,7 +196,7 @@ public final class QueryExecutor {
     return Optional.empty();
   }
 
-  public PersistentQueryMetadata buildQuery(
+  public PersistentQueryMetadata buildPersistentQuery(
       final String statementText,
       final QueryId queryId,
       final DataSource sinkDataSource,
@@ -245,13 +245,11 @@ public final class QueryExecutor {
         built.kafkaStreams,
         querySchema,
         sources,
-        sinkDataSource.getName(),
+        sinkDataSource,
         planSummary,
         queryId,
-        sinkDataSource.getDataSourceType(),
         materializationBuilder,
         applicationId,
-        sinkDataSource.getKsqlTopic(),
         built.topology,
         ksqlQueryBuilder.getSchemas(),
         streamsProperties,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -174,7 +174,8 @@ public final class QueryExecutor {
         streamsProperties,
         overrides,
         queryCloseCallback,
-        ksqlConfig.getLong(KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG)
+        ksqlConfig.getLong(KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG),
+        ksqlConfig.getInt(KsqlConfig.KSQL_QUERY_ERROR_MAX_QUEUE_SIZE)
     );
   }
 
@@ -246,7 +247,8 @@ public final class QueryExecutor {
         queryCloseCallback,
         ksqlConfig.getLong(KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG),
         classifier,
-        physicalPlan
+        physicalPlan,
+        ksqlConfig.getInt(KsqlConfig.KSQL_QUERY_ERROR_MAX_QUEUE_SIZE)
     );
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -31,22 +31,17 @@ import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.PlanBuilder;
 import io.confluent.ksql.execution.streams.KSPlanBuilder;
 import io.confluent.ksql.execution.streams.materialization.KsqlMaterializationFactory;
-import io.confluent.ksql.execution.streams.materialization.MaterializationProvider;
-import io.confluent.ksql.execution.streams.materialization.ks.KsMaterialization;
 import io.confluent.ksql.execution.streams.materialization.ks.KsMaterializationFactory;
 import io.confluent.ksql.function.FunctionRegistry;
-import io.confluent.ksql.logging.processing.NoopProcessingLogContext;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metrics.ConsumerCollector;
 import io.confluent.ksql.metrics.ProducerCollector;
 import io.confluent.ksql.name.SourceName;
-import io.confluent.ksql.query.KafkaStreamsBuilder.BuildResult;
+import io.confluent.ksql.properties.PropertiesUtil;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
-import io.confluent.ksql.serde.GenericKeySerDe;
-import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
@@ -67,9 +62,6 @@ import java.util.Set;
 import java.util.function.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.serialization.Serializer;
-import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
@@ -90,9 +82,8 @@ public final class QueryExecutor {
   private final FunctionRegistry functionRegistry;
   private final KafkaStreamsBuilder kafkaStreamsBuilder;
   private final Consumer<QueryMetadata> queryCloseCallback;
-  private final KsMaterializationFactory ksMaterializationFactory;
-  private final KsqlMaterializationFactory ksqlMaterializationFactory;
   private final StreamsBuilder streamsBuilder;
+  private final MaterializationProviderBuilderFactory materializationProviderBuilderFactory;
 
   public QueryExecutor(
       final KsqlConfig ksqlConfig,
@@ -111,8 +102,12 @@ public final class QueryExecutor {
         new KafkaStreamsBuilderImpl(
             Objects.requireNonNull(serviceContext, "serviceContext").getKafkaClientSupplier()),
         new StreamsBuilder(),
-        new KsqlMaterializationFactory(processingLogContext),
-        new KsMaterializationFactory()
+        new MaterializationProviderBuilderFactory(
+            ksqlConfig,
+            serviceContext,
+            new KsMaterializationFactory(),
+            new KsqlMaterializationFactory(processingLogContext)
+        )
     );
   }
 
@@ -125,8 +120,8 @@ public final class QueryExecutor {
       final Consumer<QueryMetadata> queryCloseCallback,
       final KafkaStreamsBuilder kafkaStreamsBuilder,
       final StreamsBuilder streamsBuilder,
-      final KsqlMaterializationFactory ksqlMaterializationFactory,
-      final KsMaterializationFactory ksMaterializationFactory) {
+      final MaterializationProviderBuilderFactory materializationProviderBuilderFactory
+  ) {
     this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig");
     this.overrides = Objects.requireNonNull(overrides, "overrides");
     this.processingLogContext = Objects.requireNonNull(
@@ -139,16 +134,12 @@ public final class QueryExecutor {
         queryCloseCallback,
         "queryCloseCallback"
     );
-    this.ksMaterializationFactory = Objects.requireNonNull(
-        ksMaterializationFactory,
-        "ksMaterializationFactory"
+    this.kafkaStreamsBuilder = Objects.requireNonNull(kafkaStreamsBuilder, "kafkaStreamsBuilder");
+    this.streamsBuilder = Objects.requireNonNull(streamsBuilder, "streamsBuilder");
+    this.materializationProviderBuilderFactory = Objects.requireNonNull(
+        materializationProviderBuilderFactory,
+        "materializationProviderBuilderFactory"
     );
-    this.ksqlMaterializationFactory = Objects.requireNonNull(
-        ksqlMaterializationFactory,
-        "ksqlMaterializationFactory"
-    );
-    this.kafkaStreamsBuilder = Objects.requireNonNull(kafkaStreamsBuilder);
-    this.streamsBuilder = Objects.requireNonNull(streamsBuilder, "builder");
   }
 
   public TransientQueryMetadata buildTransientQuery(
@@ -169,19 +160,17 @@ public final class QueryExecutor {
     ));
 
     final Map<String, Object> streamsProperties = buildStreamsProperties(applicationId, queryId);
-
-    final BuildResult built =
-        kafkaStreamsBuilder.buildKafkaStreams(streamsBuilder, streamsProperties);
+    final Topology topology = streamsBuilder.build(PropertiesUtil.asProperties(streamsProperties));
 
     return new TransientQueryMetadata(
         statementText,
-        built.kafkaStreams,
         schema,
         sources,
         planSummary,
         queue,
         applicationId,
-        built.topology,
+        topology,
+        kafkaStreamsBuilder,
         streamsProperties,
         overrides,
         queryCloseCallback,
@@ -215,26 +204,26 @@ public final class QueryExecutor {
         queryId
     );
     final Map<String, Object> streamsProperties = buildStreamsProperties(applicationId, queryId);
-    final BuildResult built =
-        kafkaStreamsBuilder.buildKafkaStreams(streamsBuilder, streamsProperties);
+    final Topology topology = streamsBuilder.build(PropertiesUtil.asProperties(streamsProperties));
 
     final PhysicalSchema querySchema = PhysicalSchema.from(
         sinkDataSource.getSchema(),
         sinkDataSource.getSerdeOptions()
     );
-    final Optional<MaterializationProvider> materializationBuilder = getMaterializationInfo(result)
-        .flatMap(info -> buildMaterializationProvider(
-            info,
-            built.kafkaStreams,
-            querySchema,
-            sinkDataSource.getKsqlTopic().getKeyFormat(),
-            streamsProperties,
-            applicationId
-        ));
+
+    final Optional<MaterializationProviderBuilderFactory.MaterializationProviderBuilder>
+        materializationProviderBuilder = getMaterializationInfo(result).map(info ->
+            materializationProviderBuilderFactory.materializationProviderBuilder(
+                info,
+                querySchema,
+                sinkDataSource.getKsqlTopic().getKeyFormat(),
+                streamsProperties,
+                applicationId
+            ));
 
     final QueryErrorClassifier topicClassifier = new MissingTopicClassifier(
         applicationId,
-        extractTopics(built.topology),
+        extractTopics(topology),
         serviceContext.getTopicClient());
     final QueryErrorClassifier classifier = buildConfiguredClassifiers(ksqlConfig, applicationId)
         .map(topicClassifier::and)
@@ -242,15 +231,15 @@ public final class QueryExecutor {
 
     return new PersistentQueryMetadata(
         statementText,
-        built.kafkaStreams,
         querySchema,
         sources,
         sinkDataSource,
         planSummary,
         queryId,
-        materializationBuilder,
+        materializationProviderBuilder,
         applicationId,
-        built.topology,
+        topology,
+        kafkaStreamsBuilder,
         ksqlQueryBuilder.getSchemas(),
         streamsProperties,
         overrides,
@@ -398,43 +387,5 @@ public final class QueryExecutor {
 
   private static String addTimeSuffix(final String original) {
     return String.format("%s_%d", original, System.currentTimeMillis());
-  }
-
-  private Optional<MaterializationProvider> buildMaterializationProvider(
-      final MaterializationInfo info,
-      final KafkaStreams kafkaStreams,
-      final PhysicalSchema schema,
-      final KeyFormat keyFormat,
-      final Map<String, Object> streamsProperties,
-      final String applicationId
-  ) {
-    final Serializer<Struct> keySerializer = new GenericKeySerDe().create(
-        keyFormat.getFormatInfo(),
-        schema.keySchema(),
-        ksqlConfig,
-        serviceContext.getSchemaRegistryClientFactory(),
-        "",
-        NoopProcessingLogContext.INSTANCE
-    ).serializer();
-
-    final Optional<KsMaterialization> ksMaterialization = ksMaterializationFactory
-        .create(
-            info.stateStoreName(),
-            kafkaStreams,
-            info.getStateStoreSchema(),
-            keySerializer,
-            keyFormat.getWindowInfo(),
-            streamsProperties,
-            ksqlConfig,
-            applicationId
-        );
-
-    return ksMaterialization.map(ksMat -> (queryId, contextStacker) -> ksqlMaterializationFactory
-        .create(
-            ksMat,
-            info,
-            queryId,
-            contextStacker
-        ));
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -111,8 +111,25 @@ public class PersistentQueryMetadata extends QueryMetadata {
     this.physicalPlan = other.physicalPlan;
   }
 
+  private PersistentQueryMetadata(
+      final PersistentQueryMetadata other,
+      final KafkaStreams kafkaStreams
+  ) {
+    super(other, kafkaStreams);
+    this.resultTopic = other.resultTopic;
+    this.sinkName = other.sinkName;
+    this.schemas = other.schemas;
+    this.resultSchema = other.resultSchema;
+    this.materializationProvider = other.materializationProvider;
+    this.dataSourceType = other.dataSourceType;
+  }
+
   public PersistentQueryMetadata copyWith(final Consumer<QueryMetadata> closeCallback) {
     return new PersistentQueryMetadata(this, closeCallback);
+  }
+
+  public PersistentQueryMetadata copyWith(final KafkaStreams kafkaStreams) {
+    return new PersistentQueryMetadata(this, kafkaStreams);
   }
 
   public DataSourceType getDataSourceType() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -51,7 +51,7 @@ public class PersistentQueryMetadata extends QueryMetadata {
   private final Optional<MaterializationProviderBuilderFactory.MaterializationProviderBuilder>
       materializationProviderBuilder;
 
-  private Optional<MaterializationProvider> materializationProvider = Optional.empty();
+  private Optional<MaterializationProvider> materializationProvider;
 
   // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
   public PersistentQueryMetadata(
@@ -72,7 +72,8 @@ public class PersistentQueryMetadata extends QueryMetadata {
       final Consumer<QueryMetadata> closeCallback,
       final long closeTimeout,
       final QueryErrorClassifier errorClassifier,
-      final ExecutionStep<?> physicalPlan
+      final ExecutionStep<?> physicalPlan,
+      final int maxQueryErrorsQueueSize
   ) {
     // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     super(
@@ -88,7 +89,8 @@ public class PersistentQueryMetadata extends QueryMetadata {
         closeCallback,
         closeTimeout,
         id,
-        errorClassifier
+        errorClassifier,
+        maxQueryErrorsQueueSize
     );
 
     this.sinkDataSource = requireNonNull(sinkDataSource, "sinkDataSource");

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -61,7 +61,6 @@ public abstract class QueryMetadata {
   private final LogicalSchema logicalSchema;
   private final Long closeTimeout;
   private final QueryId queryId;
-  private final QueryError[] queryErrorRef = new QueryError[]{null};
   private final QueryErrorClassifier errorClassifier;
   private final Set<QueryError> queryErrors = new HashSet<>();
 
@@ -118,6 +117,22 @@ public abstract class QueryMetadata {
     this.sourceNames = other.sourceNames;
     this.logicalSchema = other.logicalSchema;
     this.closeCallback = Objects.requireNonNull(closeCallback, "closeCallback");
+    this.closeTimeout = other.closeTimeout;
+    this.queryId = other.queryId;
+    this.errorClassifier = other.errorClassifier;
+  }
+
+  protected QueryMetadata(final QueryMetadata other, final KafkaStreams kafkaStreams) {
+    this.statementString = other.statementString;
+    this.kafkaStreams = Objects.requireNonNull(kafkaStreams, "kafkaStreams");
+    this.executionPlan = other.executionPlan;
+    this.queryApplicationId = other.queryApplicationId;
+    this.topology = other.topology;
+    this.streamsProperties = other.streamsProperties;
+    this.overriddenProperties = other.overriddenProperties;
+    this.sourceNames = other.sourceNames;
+    this.logicalSchema = other.logicalSchema;
+    this.closeCallback = other.closeCallback;
     this.closeTimeout = other.closeTimeout;
     this.queryId = other.queryId;
     this.errorClassifier = other.errorClassifier;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -167,6 +167,10 @@ public abstract class QueryMetadata {
     return kafkaStreams.state();
   }
 
+  public boolean isError() {
+    return getState() == State.ERROR;
+  }
+
   public String getExecutionPlan() {
     return executionPlan;
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
@@ -51,7 +51,9 @@ public class TransientQueryMetadata extends QueryMetadata {
       final Map<String, Object> streamsProperties,
       final Map<String, Object> overriddenProperties,
       final Consumer<QueryMetadata> closeCallback,
-      final long closeTimeout) {
+      final long closeTimeout,
+      final int maxQueryErrorsQueueSize
+  ) {
     // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     super(
         statementString,
@@ -66,7 +68,9 @@ public class TransientQueryMetadata extends QueryMetadata {
         closeCallback,
         closeTimeout,
         new QueryId(queryApplicationId),
-        QueryErrorClassifier.DEFAULT_CLASSIFIER);
+        QueryErrorClassifier.DEFAULT_CLASSIFIER,
+        maxQueryErrorsQueueSize
+    );
     this.rowQueue = Objects.requireNonNull(rowQueue, "rowQueue");
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.util;
 
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.BlockingRowQueue;
+import io.confluent.ksql.query.KafkaStreamsBuilder;
 import io.confluent.ksql.query.LimitHandler;
 import io.confluent.ksql.query.QueryErrorClassifier;
 import io.confluent.ksql.query.QueryId;
@@ -27,7 +28,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
-import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.Topology;
 
 /**
@@ -41,13 +41,13 @@ public class TransientQueryMetadata extends QueryMetadata {
   // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
   public TransientQueryMetadata(
       final String statementString,
-      final KafkaStreams kafkaStreams,
       final LogicalSchema logicalSchema,
       final Set<SourceName> sourceNames,
       final String executionPlan,
       final BlockingRowQueue rowQueue,
       final String queryApplicationId,
       final Topology topology,
+      final KafkaStreamsBuilder kafkaStreamsBuilder,
       final Map<String, Object> streamsProperties,
       final Map<String, Object> overriddenProperties,
       final Consumer<QueryMetadata> closeCallback,
@@ -55,12 +55,12 @@ public class TransientQueryMetadata extends QueryMetadata {
     // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     super(
         statementString,
-        kafkaStreams,
         logicalSchema,
         sourceNames,
         executionPlan,
         queryApplicationId,
         topology,
+        kafkaStreamsBuilder,
         streamsProperties,
         overriddenProperties,
         closeCallback,

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -134,53 +134,6 @@ public class KsqlEngineTest {
   }
 
   @Test
-  public void shouldResetQueryInNotRunningState() {
-    // Given:
-    final QueryMetadata oldQuery = KsqlEngineTestUtil.execute(
-        serviceContext,
-        ksqlEngine,
-        "create table bar as select * from test2;",
-        KSQL_CONFIG,
-        Collections.emptyMap()
-    ).get(0);
-    oldQuery.stop();
-
-    // When:
-    ksqlEngine.resetQuery(oldQuery.getQueryId());
-    final QueryMetadata newQuery = ksqlEngine.getPersistentQueries().get(0);
-
-    // Then:
-    assertThat(oldQuery.getState(), is(KafkaStreams.State.NOT_RUNNING));
-    assertThat(newQuery.getQueryId(), is(oldQuery.getQueryId()));
-    assertThat(newQuery.getTopology(), is(oldQuery.getTopology()));
-    assertThat(newQuery.getState(), is(KafkaStreams.State.CREATED));
-    assertThat(newQuery.getStreamsProperties(), is(oldQuery.getStreamsProperties()));
-  }
-
-  @Test
-  public void shouldNotResetQueryNotInNotRunningState() {
-    // Given:
-    final QueryMetadata query = KsqlEngineTestUtil.execute(
-        serviceContext,
-        ksqlEngine,
-        "create table bar as select * from test2;",
-        KSQL_CONFIG,
-        Collections.emptyMap()
-    ).get(0);
-
-    // When:
-    final Exception e = assertThrows(
-        IllegalStateException.class,
-        () -> ksqlEngine.resetQuery(query.getQueryId())
-    );
-
-    // Then:
-    assertThat(e.getMessage(), containsString(
-        "Cannot reset query with application id: "
-            + "_confluent-ksql-default_query_CTAS_BAR_0 because is in CREATED state"));
-  }
-
-  @Test
   public void shouldCreatePersistentQueries() {
     // When:
     final List<QueryMetadata> queries

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/QueryMonitorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/QueryMonitorTest.java
@@ -1,9 +1,7 @@
 package io.confluent.ksql.engine;
 
 import com.google.common.base.Ticker;
-import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.query.QueryId;
-import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import org.apache.kafka.streams.KafkaStreams;
 import org.junit.Before;
@@ -46,11 +44,7 @@ public class QueryMonitorTest {
 
   @Before
   public void setup() {
-    final KsqlConfig ksqlConfig = new KsqlConfig(ImmutableMap.of(
-        KsqlConfig.KSQL_QUERY_RETRY_BACKOFF_MAX_MS, 1000
-    ));
-
-    queryMonitor = new QueryMonitor(ksqlConfig, ksqlEngine, executor, ticker);
+    queryMonitor = new QueryMonitor(ksqlEngine, executor, 1000, 1000, ticker);
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/QueryMonitorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/QueryMonitorTest.java
@@ -1,0 +1,240 @@
+package io.confluent.ksql.engine;
+
+import com.google.common.base.Ticker;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.PersistentQueryMetadata;
+import org.apache.kafka.streams.KafkaStreams;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+
+import static org.apache.kafka.streams.KafkaStreams.State.ERROR;
+import static org.apache.kafka.streams.KafkaStreams.State.RUNNING;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class QueryMonitorTest {
+  @Mock
+  private PersistentQueryMetadata queryMetadata;
+  @Mock
+  private KsqlEngine ksqlEngine;
+  @Mock
+  private ExecutorService executor;
+  @Mock
+  private Ticker ticker;
+
+  private QueryMonitor queryMonitor;
+
+  @Before
+  public void setup() {
+    final KsqlConfig ksqlConfig = new KsqlConfig(ImmutableMap.of(
+        KsqlConfig.KSQL_QUERY_RETRY_BACKOFF_MAX_MS, 1000
+    ));
+
+    queryMonitor = new QueryMonitor(ksqlConfig, ksqlEngine, executor, ticker);
+  }
+
+  @Test
+  public void shouldSubmitTaskOnStart() {
+    // When:
+    queryMonitor.start();
+
+    // Then:
+    final InOrder inOrder = inOrder(executor);
+    inOrder.verify(executor).execute(any(Runnable.class));
+    inOrder.verify(executor).shutdown();
+    assertThat(queryMonitor.isClosed(), is(false));
+  }
+
+  @Test
+  public void shouldCloseTheQueryMonitorCorrectly() throws Exception {
+    // Given:
+    queryMonitor.start();
+
+    // When:
+    queryMonitor.close();
+
+    // Then:
+    final InOrder inOrder = inOrder(executor);
+    inOrder.verify(executor).awaitTermination(anyLong(), any());
+    assertThat(queryMonitor.isClosed(), is(true));
+  }
+
+  @Test
+  public void shouldRetryEventStartWithInitialValues() {
+    // Given:
+    final long baseTime = 5;
+    final long currentTime = 20;
+    final QueryId queryId = new QueryId("id-1");
+    when(ticker.read()).thenReturn(currentTime);
+
+    // When:
+    final QueryMonitor.RetryEvent retryEvent =
+        new QueryMonitor.RetryEvent(ksqlEngine, queryId, baseTime, 100, ticker);
+
+    // Then:
+    assertThat(retryEvent.getNumRetries(), is(0));
+    assertThat(retryEvent.nextRestartTimeMs(), is(currentTime + baseTime));
+  }
+
+  @Test
+  public void shouldRetryEventRestartAndIncrementBackoffTime() {
+    // Given:
+    final long baseTime = 20;
+    final long currentTime = 20;
+    final QueryId queryId = new QueryId("id-1");
+    when(ticker.read()).thenReturn(currentTime);
+    when(ksqlEngine.getPersistentQuery(queryId)).thenReturn(Optional.of(queryMetadata));
+
+    // When:
+    final QueryMonitor.RetryEvent retryEvent =
+        new QueryMonitor.RetryEvent(ksqlEngine, queryId, baseTime, 50, ticker);
+    retryEvent.restart();
+
+    // Then:
+    assertThat(retryEvent.getNumRetries(), is(1));
+    assertThat(retryEvent.nextRestartTimeMs(), is(currentTime + baseTime * 2));
+    verify(queryMetadata).stop();
+    verify(ksqlEngine).resetQuery(queryId);
+    verify(queryMetadata).start();
+  }
+
+  @Test
+  public void shouldRetryEventRestartAndNotExceedBackoffMaxTime() {
+    // Given:
+    final long baseTime = 20;
+    final long currentTime = 20;
+    final long maxTime = 50;
+    final QueryId queryId = new QueryId("id-1");
+    when(ticker.read()).thenReturn(currentTime);
+    when(ksqlEngine.getPersistentQuery(queryId)).thenReturn(Optional.of(queryMetadata));
+
+    // When:
+    final QueryMonitor.RetryEvent retryEvent =
+        new QueryMonitor.RetryEvent(ksqlEngine, queryId, baseTime, maxTime, ticker);
+    retryEvent.restart();
+    retryEvent.restart();
+
+    // Then:
+    assertThat(retryEvent.getNumRetries(), is(2));
+    assertThat(retryEvent.nextRestartTimeMs(), greaterThanOrEqualTo(currentTime + maxTime));
+  }
+
+  @Test
+  public void shouldNotRestartRunningQueries() {
+    // Given:
+    final PersistentQueryMetadata query1 = mockPersistentQueryMetadata("id-1", RUNNING);
+    final PersistentQueryMetadata query2 = mockPersistentQueryMetadata("id-2", RUNNING);
+    when(ksqlEngine.getPersistentQueries()).thenReturn(Arrays.asList(query1, query2));
+
+    // When:
+    queryMonitor.restartFailedQueries();
+
+    // Then:
+    verify(query1, never()).stop();
+    verify(query1, never()).start();
+    verify(query2, never()).stop();
+    verify(query2, never()).start();
+  }
+
+  @Test
+  public void shouldRestartNewQueryInErrorState() {
+    // Given:
+    final PersistentQueryMetadata query = mockPersistentQueryMetadata("id-1", ERROR);
+    when(ksqlEngine.getPersistentQueries()).thenReturn(Arrays.asList(query));
+    when(ksqlEngine.getPersistentQuery(query.getQueryId())).thenReturn(Optional.of(query));
+
+    // When:
+    queryMonitor.restartFailedQueries();
+
+    // Then:
+    final InOrder inOrder = inOrder(query, ksqlEngine);
+    inOrder.verify(query, times(1)).stop();
+    inOrder.verify(ksqlEngine, times(1)).resetQuery(new QueryId("id-1"));
+    inOrder.verify(query, times(1)).start();
+  }
+
+  @Test
+  public void shouldRestartQueryInErrorStateAgainAfterBackoffTime() {
+    // Given:
+    final PersistentQueryMetadata query = mockPersistentQueryMetadata("id-1", ERROR);
+    when(ksqlEngine.getPersistentQueries()).thenReturn(Arrays.asList(query));
+    when(ksqlEngine.getPersistentQuery(query.getQueryId())).thenReturn(Optional.of(query));
+
+    // When:
+    queryMonitor.restartFailedQueries();
+    when(ticker.read()).thenReturn(10000L);
+    queryMonitor.restartFailedQueries();
+
+    // Then:
+    verify(query, times(2)).stop();
+    verify(ksqlEngine, times(2)).resetQuery(new QueryId("id-1"));
+    verify(query, times(2)).start();
+  }
+
+  @Test
+  public void shouldNotRestartQueryInErrorStateBeforeBackoffTime() {
+    // Given:
+    final PersistentQueryMetadata query = mockPersistentQueryMetadata("id-1", ERROR);
+    when(ksqlEngine.getPersistentQueries()).thenReturn(Arrays.asList(query));
+    when(ksqlEngine.getPersistentQuery(query.getQueryId())).thenReturn(Optional.of(query));
+    when(ticker.read()).thenReturn(0L);
+
+    // When:
+    queryMonitor.restartFailedQueries();
+    queryMonitor.restartFailedQueries(); // 2nd round should not restart before backoff time
+
+    // Then:
+    verify(query, times(1)).stop();
+    verify(ksqlEngine, times(1)).resetQuery(new QueryId("id-1"));
+    verify(query, times(1)).start();
+  }
+
+  @Test
+  public void shouldNotRestartQueryInErrorThenRunningAfterBackoffTime() {
+    // Given:
+    final PersistentQueryMetadata query = mockPersistentQueryMetadata("id-1", ERROR);
+    when(ksqlEngine.getPersistentQueries()).thenReturn(Arrays.asList(query));
+    when(ksqlEngine.getPersistentQuery(query.getQueryId())).thenReturn(Optional.of(query));
+
+    // When:
+    queryMonitor.restartFailedQueries();
+    when(ticker.read()).thenReturn(10000L);
+    when(query.getState()).thenReturn(RUNNING);
+    queryMonitor.restartFailedQueries(); // 2nd round should not restart before backoff time
+
+    // Then:
+    verify(query, times(1)).stop();
+    verify(ksqlEngine, times(1)).resetQuery(new QueryId("id-1"));
+    verify(query, times(1)).start();
+  }
+
+  private PersistentQueryMetadata mockPersistentQueryMetadata(
+      final String queryId,
+      final KafkaStreams.State queryState
+  ) {
+    final PersistentQueryMetadata query = mock(PersistentQueryMetadata.class);
+    when(query.getQueryId()).thenReturn(new QueryId(queryId));
+    when(query.getState()).thenReturn(queryState);
+    return query;
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/QueryMonitorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/QueryMonitorTest.java
@@ -182,7 +182,7 @@ public class QueryMonitorTest {
     queryMonitor.restartFailedQueries(); // 1st restart
 
     // Mock the query is in ERROR state, but then terminated manually
-    when(query.getState()).thenReturn(ERROR);
+    when(query.isError()).thenReturn(true);
     when(ksqlEngine.getPersistentQuery(query.getQueryId())).thenReturn(Optional.empty());
 
     // Internally, the query is found as ERROR because getPersistentQueries() returns it, but
@@ -250,7 +250,7 @@ public class QueryMonitorTest {
     // When:
     queryMonitor.restartFailedQueries();
     when(ticker.read()).thenReturn(10000L);
-    when(query.getState()).thenReturn(RUNNING);
+    when(query.isError()).thenReturn(false);
     queryMonitor.restartFailedQueries(); // 2nd round should not restart before backoff time
 
     // Then:
@@ -263,7 +263,7 @@ public class QueryMonitorTest {
   ) {
     final PersistentQueryMetadata query = mock(PersistentQueryMetadata.class);
     when(query.getQueryId()).thenReturn(new QueryId(queryId));
-    when(query.getState()).thenReturn(queryState);
+    when(query.isError()).thenReturn(queryState == ERROR);
     return query;
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/KsqlEngineMetricsTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/KsqlEngineMetricsTest.java
@@ -276,7 +276,7 @@ public class KsqlEngineMetricsTest {
     engineMetrics.registerQuery(query1);
 
     // Then:
-    verify(query1).registerQueryStateListener(any());
+    verify(query1).setQueryStateListener(any());
   }
 
   private double getMetricValue(final String metricName) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
@@ -242,7 +242,7 @@ public class QueryExecutorTest {
   @Test
   public void shouldBuildPersistentQueryCorrectly() {
     // When:
-    final PersistentQueryMetadata queryMetadata = queryBuilder.buildQuery(
+    final PersistentQueryMetadata queryMetadata = queryBuilder.buildPersistentQuery(
         STATEMENT_TEXT,
         QUERY_ID,
         sink,
@@ -268,7 +268,7 @@ public class QueryExecutorTest {
   @Test
   public void shouldBuildPersistentQueryWithCorrectStreamsApp() {
     // When:
-    final PersistentQueryMetadata queryMetadata = queryBuilder.buildQuery(
+    final PersistentQueryMetadata queryMetadata = queryBuilder.buildPersistentQuery(
         STATEMENT_TEXT,
         QUERY_ID,
         sink,
@@ -285,7 +285,7 @@ public class QueryExecutorTest {
   @Test
   public void shouldBuildPersistentQueryWithCorrectMaterializationProvider() {
     // Given:
-    final PersistentQueryMetadata queryMetadata = queryBuilder.buildQuery(
+    final PersistentQueryMetadata queryMetadata = queryBuilder.buildPersistentQuery(
         STATEMENT_TEXT,
         QUERY_ID,
         sink,
@@ -304,7 +304,7 @@ public class QueryExecutorTest {
   @Test
   public void shouldCreateKSMaterializationCorrectly() {
     // When:
-    queryBuilder.buildQuery(
+    queryBuilder.buildPersistentQuery(
         STATEMENT_TEXT,
         QUERY_ID,
         sink,
@@ -330,7 +330,7 @@ public class QueryExecutorTest {
   @Test
   public void shouldMaterializeCorrectly() {
     // Given:
-    final PersistentQueryMetadata queryMetadata = queryBuilder.buildQuery(
+    final PersistentQueryMetadata queryMetadata = queryBuilder.buildPersistentQuery(
         STATEMENT_TEXT,
         QUERY_ID,
         sink,
@@ -356,7 +356,7 @@ public class QueryExecutorTest {
     // Given:
     when(tableHolder.getMaterializationBuilder()).thenReturn(Optional.empty());
 
-    final PersistentQueryMetadata queryMetadata = queryBuilder.buildQuery(
+    final PersistentQueryMetadata queryMetadata = queryBuilder.buildPersistentQuery(
         STATEMENT_TEXT,
         QUERY_ID,
         sink,
@@ -375,7 +375,7 @@ public class QueryExecutorTest {
   @Test
   public void shouldCreateExpectedServiceId() {
     // When:
-    queryBuilder.buildQuery(
+    queryBuilder.buildPersistentQuery(
         STATEMENT_TEXT,
         QUERY_ID,
         sink,
@@ -395,7 +395,7 @@ public class QueryExecutorTest {
   @SuppressWarnings("unchecked")
   public void shouldAddMetricsInterceptorsToStreamsConfig() {
     // When:
-    queryBuilder.buildQuery(
+    queryBuilder.buildPersistentQuery(
         STATEMENT_TEXT,
         QUERY_ID,
         sink,
@@ -424,7 +424,7 @@ public class QueryExecutorTest {
     when(ksqlConfig.getKsqlStreamConfigProps(anyString())).thenReturn(properties);
 
     // When:
-    queryBuilder.buildQuery(
+    queryBuilder.buildPersistentQuery(
         STATEMENT_TEXT,
         QUERY_ID,
         sink,
@@ -482,7 +482,7 @@ public class QueryExecutorTest {
     ));
 
     // When:
-    queryBuilder.buildQuery(
+    queryBuilder.buildPersistentQuery(
         STATEMENT_TEXT,
         QUERY_ID,
         sink,
@@ -506,7 +506,7 @@ public class QueryExecutorTest {
     ));
 
     // When:
-    queryBuilder.buildQuery(
+    queryBuilder.buildPersistentQuery(
         STATEMENT_TEXT,
         QUERY_ID,
         sink,
@@ -531,7 +531,7 @@ public class QueryExecutorTest {
     ));
 
     // When:
-    queryBuilder.buildQuery(
+    queryBuilder.buildPersistentQuery(
         STATEMENT_TEXT,
         QUERY_ID,
         sink,
@@ -560,7 +560,7 @@ public class QueryExecutorTest {
     when(processingLoggerFactory.getLogger(QUERY_ID.toString())).thenReturn(logger);
 
     // When:
-    queryBuilder.buildQuery(
+    queryBuilder.buildPersistentQuery(
         STATEMENT_TEXT,
         QUERY_ID,
         sink,

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
@@ -37,7 +37,6 @@ import io.confluent.ksql.metrics.ConsumerCollector;
 import io.confluent.ksql.metrics.ProducerCollector;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
-import io.confluent.ksql.query.KafkaStreamsBuilder.BuildResult;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.SystemColumns;
@@ -180,8 +179,7 @@ public class QueryExecutorTest {
     when(sink.getName()).thenReturn(SINK_NAME);
     when(sink.getDataSourceType()).thenReturn(DataSourceType.KSTREAM);
     when(ksqlTopic.getKeyFormat()).thenReturn(KEY_FORMAT);
-    when(kafkaStreamsBuilder.buildKafkaStreams(any(), any()))
-        .thenReturn(new BuildResult(topology, kafkaStreams));
+    when(kafkaStreamsBuilder.build(any(), any())).thenReturn(kafkaStreams);
     when(tableHolder.getMaterializationBuilder()).thenReturn(Optional.of(materializationBuilder));
     when(materializationBuilder.build()).thenReturn(materializationInfo);
     when(materializationInfo.getStateStoreSchema()).thenReturn(aggregationSchema);
@@ -199,6 +197,7 @@ public class QueryExecutorTest {
     when(topology.describe()).thenReturn(topoDesc);
     when(topoDesc.subtopologies()).thenReturn(ImmutableSet.of());
     when(serviceContext.getTopicClient()).thenReturn(topicClient);
+    when(streamsBuilder.build(any())).thenReturn(topology);
     queryBuilder = new QueryExecutor(
         ksqlConfig,
         OVERRIDES,
@@ -208,8 +207,12 @@ public class QueryExecutorTest {
         closeCallback,
         kafkaStreamsBuilder,
         streamsBuilder,
-        ksqlMaterializationFactory,
-        ksMaterializationFactory
+        new MaterializationProviderBuilderFactory(
+            ksqlConfig,
+            serviceContext,
+            ksMaterializationFactory,
+            ksqlMaterializationFactory
+        )
     );
   }
 
@@ -235,7 +238,7 @@ public class QueryExecutorTest {
     assertThat(queryMetadata.getExecutionPlan(), equalTo(SUMMARY));
     assertThat(queryMetadata.getTopology(), is(topology));
     assertThat(queryMetadata.getOverriddenProperties(), equalTo(OVERRIDES));
-    verify(kafkaStreamsBuilder).buildKafkaStreams(any(), propertyCaptor.capture());
+    verify(kafkaStreamsBuilder).build(any(), propertyCaptor.capture());
     assertThat(queryMetadata.getStreamsProperties(), equalTo(propertyCaptor.getValue()));
   }
 
@@ -283,7 +286,7 @@ public class QueryExecutorTest {
   }
 
   @Test
-  public void shouldBuildPersistentQueryWithCorrectMaterializationProvider() {
+  public void shouldStartPersistentQueryWithCorrectMaterializationProvider() {
     // Given:
     final PersistentQueryMetadata queryMetadata = queryBuilder.buildPersistentQuery(
         STATEMENT_TEXT,
@@ -293,6 +296,7 @@ public class QueryExecutorTest {
         physicalPlan,
         SUMMARY
     );
+    queryMetadata.start();
 
     // When:
     final Optional<Materialization> result = queryMetadata.getMaterialization(QUERY_ID, stacker);
@@ -328,7 +332,7 @@ public class QueryExecutorTest {
   }
 
   @Test
-  public void shouldMaterializeCorrectly() {
+  public void shouldMaterializeCorrectlyOnStart() {
     // Given:
     final PersistentQueryMetadata queryMetadata = queryBuilder.buildPersistentQuery(
         STATEMENT_TEXT,
@@ -338,6 +342,7 @@ public class QueryExecutorTest {
         physicalPlan,
         SUMMARY
     );
+    queryMetadata.start();
 
     // When:
     queryMetadata.getMaterialization(QUERY_ID_2, stacker);
@@ -424,7 +429,7 @@ public class QueryExecutorTest {
     when(ksqlConfig.getKsqlStreamConfigProps(anyString())).thenReturn(properties);
 
     // When:
-    queryBuilder.buildPersistentQuery(
+    final PersistentQueryMetadata queryMetadata = queryBuilder.buildPersistentQuery(
         STATEMENT_TEXT,
         QUERY_ID,
         sink,
@@ -432,6 +437,7 @@ public class QueryExecutorTest {
         physicalPlan,
         SUMMARY
     );
+    queryMetadata.start();
 
     // Then:
     final Map<String, Object> captured = capturedStreamsProperties();
@@ -625,7 +631,7 @@ public class QueryExecutorTest {
   }
 
   private Map<String, Object> capturedStreamsProperties() {
-    verify(kafkaStreamsBuilder).buildKafkaStreams(any(), propertyCaptor.capture());
+    verify(kafkaStreamsBuilder).build(any(), propertyCaptor.capture());
     return propertyCaptor.getValue();
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/PersistentQueryMetadataTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/PersistentQueryMetadataTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+import io.confluent.ksql.execution.streams.materialization.MaterializationProvider;
+import io.confluent.ksql.metastore.model.DataSource;
+import io.confluent.ksql.query.KafkaStreamsBuilder;
+import io.confluent.ksql.query.MaterializationProviderBuilderFactory;
+import io.confluent.ksql.query.QueryErrorClassifier;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.Topology;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PersistentQueryMetadataTest {
+  private static final String SQL = "sql";
+  private static final String EXECUTION_PLAN = "execution plan";
+  private static final QueryId QUERY_ID = new QueryId("queryId");
+  private static final String APPLICATION_ID = "applicationId";
+  private static final long CLOSE_TIMEOUT = 10L;
+
+  @Mock
+  private KafkaStreamsBuilder kafkaStreamsBuilder;
+  @Mock
+  private KafkaStreams kafkaStreams;
+  @Mock
+  private PhysicalSchema physicalSchema;
+  @Mock
+  private DataSource sinkDataSource;
+  @Mock
+  private MaterializationProviderBuilderFactory.MaterializationProviderBuilder
+      materializationProviderBuilder;
+  @Mock
+  private MaterializationProvider materializationProvider;
+  @Mock
+  private Topology topology;
+  @Mock
+  private QuerySchemas schemas;
+  @Mock
+  private Map<String, Object> props;
+  @Mock
+  private Map<String, Object> overrides;
+  @Mock
+  private Consumer<QueryMetadata> closeCallback;
+  @Mock
+  private QueryErrorClassifier queryErrorClassifier;
+
+  private PersistentQueryMetadata query;
+
+  @Before
+  public void setUp()  {
+    when(kafkaStreamsBuilder.build(any(), any())).thenReturn(kafkaStreams);
+    when(physicalSchema.logicalSchema()).thenReturn(mock(LogicalSchema.class));
+    when(materializationProviderBuilder.apply(kafkaStreams))
+        .thenReturn(Optional.of(materializationProvider));
+
+    query = new PersistentQueryMetadata(
+        SQL,
+        physicalSchema,
+        Collections.emptySet(),
+        sinkDataSource,
+        EXECUTION_PLAN,
+        QUERY_ID,
+        Optional.of(materializationProviderBuilder),
+        APPLICATION_ID,
+        topology,
+        kafkaStreamsBuilder,
+        schemas,
+        props,
+        overrides,
+        closeCallback,
+        CLOSE_TIMEOUT,
+        queryErrorClassifier
+    );
+  }
+
+  @Test
+  public void shouldCloseKafkaStreamsOnStop() {
+    // When:
+    query.stop();
+
+    // Then:
+    final InOrder inOrder = inOrder(kafkaStreams);
+    inOrder.verify(kafkaStreams).close(any());
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldRestartKafkaStreams() {
+    final KafkaStreams newKafkaStreams = mock(KafkaStreams.class);
+    final MaterializationProvider newMaterializationProvider = mock(MaterializationProvider.class);
+
+    // Given:
+    when(kafkaStreamsBuilder.build(any(), any())).thenReturn(newKafkaStreams);
+    when(materializationProviderBuilder.apply(newKafkaStreams))
+        .thenReturn(Optional.of(newMaterializationProvider));
+
+    // When:
+    query.restart();
+
+    // Then:
+    final InOrder inOrder = inOrder(kafkaStreams, newKafkaStreams);
+    inOrder.verify(kafkaStreams).close(any());
+    inOrder.verify(newKafkaStreams).setUncaughtExceptionHandler(any());
+    inOrder.verify(newKafkaStreams).start();
+
+    assertThat(query.getKafkaStreams(), is(newKafkaStreams));
+    assertThat(query.getMaterializationProvider(), is(Optional.of(newMaterializationProvider)));
+  }
+
+  @Test
+  public void shouldNotRestartIfQueryIsClosed() {
+    // Given:
+    query.close();
+
+    // When:
+    final Exception e = assertThrows(Exception.class, () -> query.restart());
+
+    // Then:
+    assertThat(e.getMessage(), containsString("is already closed, cannot restart."));
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/PersistentQueryMetadataTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/PersistentQueryMetadataTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.util;
 
+import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.streams.materialization.MaterializationProvider;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.query.KafkaStreamsBuilder;
@@ -82,6 +83,8 @@ public class PersistentQueryMetadataTest {
   private Consumer<QueryMetadata> closeCallback;
   @Mock
   private QueryErrorClassifier queryErrorClassifier;
+  @Mock
+  private ExecutionStep<?> physicalPlan;
 
   private PersistentQueryMetadata query;
 
@@ -108,7 +111,9 @@ public class PersistentQueryMetadataTest {
         overrides,
         closeCallback,
         CLOSE_TIMEOUT,
-        queryErrorClassifier
+        queryErrorClassifier,
+        physicalPlan,
+        10
     );
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.internal.QueryStateListener;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.query.KafkaStreamsBuilder;
 import io.confluent.ksql.query.QueryErrorClassifier;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
@@ -61,6 +62,8 @@ public class QueryMetadataTest {
   private static final Long closeTimeout = KsqlConfig.KSQL_SHUTDOWN_TIMEOUT_MS_DEFAULT;
 
   @Mock
+  private KafkaStreamsBuilder kafkaStreamsBuilder;
+  @Mock
   private Topology topoplogy;
   @Mock
   private KafkaStreams kafkaStreams;
@@ -73,15 +76,17 @@ public class QueryMetadataTest {
 
   @Before
   public void setup() {
+    when(kafkaStreamsBuilder.build(topoplogy, Collections.emptyMap())).thenReturn(kafkaStreams);
+
     cleanUp = false;
     query = new QueryMetadata(
         "foo",
-        kafkaStreams,
         SOME_SCHEMA,
         SOME_SOURCES,
         "bar",
         QUERY_APPLICATION_ID,
         topoplogy,
+        kafkaStreamsBuilder,
         Collections.emptyMap(),
         Collections.emptyMap(),
         closeCallback,
@@ -100,7 +105,7 @@ public class QueryMetadataTest {
     when(kafkaStreams.state()).thenReturn(State.CREATED);
 
     // When:
-    query.registerQueryStateListener(listener);
+    query.setQueryStateListener(listener);
 
     // Then:
     verify(listener).onChange(State.CREATED, State.CREATED);
@@ -109,7 +114,7 @@ public class QueryMetadataTest {
   @Test
   public void shouldConnectAnyListenerToStreamAppOnStart() {
     // Given:
-    query.registerQueryStateListener(listener);
+    query.setQueryStateListener(listener);
 
     // When:
     query.start();
@@ -121,7 +126,7 @@ public class QueryMetadataTest {
   @Test
   public void shouldCloseAnyListenerOnClose() {
     // Given:
-    query.registerQueryStateListener(listener);
+    query.setQueryStateListener(listener);
 
     // When:
     query.close();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
@@ -91,7 +91,8 @@ public class QueryMetadataTest {
         Collections.emptyMap(),
         closeCallback,
         closeTimeout,
-        QUERY_ID, QueryErrorClassifier.DEFAULT_CLASSIFIER) {
+        QUERY_ID, QueryErrorClassifier.DEFAULT_CLASSIFIER,
+        10) {
       @Override
       public void stop() {
         doClose(cleanUp);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/TransientQueryMetadataTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/TransientQueryMetadataTest.java
@@ -18,10 +18,13 @@ package io.confluent.ksql.util;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.when;
 
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.BlockingRowQueue;
+import io.confluent.ksql.query.KafkaStreamsBuilder;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.util.KsqlConstants.KsqlQueryType;
 import java.util.Map;
@@ -45,6 +48,8 @@ public class TransientQueryMetadataTest {
   private static final long CLOSE_TIMEOUT = 10L;
 
   @Mock
+  private KafkaStreamsBuilder kafkaStreamsBuilder;
+  @Mock
   private KafkaStreams kafkaStreams;
   @Mock
   private LogicalSchema logicalSchema;
@@ -64,15 +69,17 @@ public class TransientQueryMetadataTest {
 
   @Before
   public void setUp()  {
+    when(kafkaStreamsBuilder.build(any(), any())).thenReturn(kafkaStreams);
+
     query = new TransientQueryMetadata(
         SQL,
-        kafkaStreams,
         logicalSchema,
         sourceNames,
         EXECUTION_PLAN,
         rowQueue,
         QUERY_ID,
         topology,
+        kafkaStreamsBuilder,
         props,
         overrides,
         closeCallback,
@@ -82,6 +89,9 @@ public class TransientQueryMetadataTest {
 
   @Test
   public void shouldCloseQueueBeforeTopologyToAvoidDeadLock() {
+    // Given:
+    query.start();
+
     // When:
     query.close();
 
@@ -93,6 +103,9 @@ public class TransientQueryMetadataTest {
 
   @Test
   public void shouldCallCloseOnStop() {
+    // Given:
+    query.start();
+
     // When:
     query.stop();
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/TransientQueryMetadataTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/TransientQueryMetadataTest.java
@@ -83,7 +83,8 @@ public class TransientQueryMetadataTest {
         props,
         overrides,
         closeCallback,
-        CLOSE_TIMEOUT
+        CLOSE_TIMEOUT,
+        10
     );
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
@@ -133,7 +133,8 @@ public class QueryDescriptionFactoryTest {
         STREAMS_PROPS,
         PROP_OVERRIDES,
         queryCloseCallback,
-        closeTimeout);
+        closeTimeout,
+        10);
 
     transientQueryDescription = QueryDescriptionFactory.forQueryMetadata(transientQuery, Collections.emptyMap());
 
@@ -154,7 +155,8 @@ public class QueryDescriptionFactoryTest {
         queryCloseCallback,
         closeTimeout,
         QueryErrorClassifier.DEFAULT_CLASSIFIER,
-        physicalPlan
+        physicalPlan,
+        10
     );
 
     persistentQueryDescription = QueryDescriptionFactory.forQueryMetadata(persistentQuery, STATUS_MAP);
@@ -262,7 +264,8 @@ public class QueryDescriptionFactoryTest {
         STREAMS_PROPS,
         PROP_OVERRIDES,
         queryCloseCallback,
-        closeTimeout);
+        closeTimeout,
+        10);
 
     // When:
     transientQueryDescription = QueryDescriptionFactory.forQueryMetadata(transientQuery, Collections.emptyMap());
@@ -295,7 +298,8 @@ public class QueryDescriptionFactoryTest {
         STREAMS_PROPS,
         PROP_OVERRIDES,
         queryCloseCallback,
-        closeTimeout);
+        closeTimeout,
+        10);
 
     // When:
     transientQueryDescription = QueryDescriptionFactory.forQueryMetadata(transientQuery, Collections.emptyMap());

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.execution.plan.ExecutionStep;
-import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
+import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.BlockingRowQueue;
@@ -100,6 +100,8 @@ public class QueryDescriptionFactoryTest {
   private KsqlTopic sinkTopic;
   @Mock
   private ExecutionStep<?> physicalPlan;
+  @Mock
+  private DataSource sinkDataSource;
 
   private QueryMetadata transientQuery;
   private PersistentQueryMetadata persistentQuery;
@@ -111,6 +113,8 @@ public class QueryDescriptionFactoryTest {
     when(topology.describe()).thenReturn(topologyDescription);
 
     when(sinkTopic.getKeyFormat()).thenReturn(KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())));
+    when(sinkDataSource.getKsqlTopic()).thenReturn(sinkTopic);
+    when(sinkDataSource.getName()).thenReturn(SourceName.of("sink name"));
 
     transientQuery = new TransientQueryMetadata(
         SQL_TEXT,
@@ -133,13 +137,11 @@ public class QueryDescriptionFactoryTest {
         queryStreams,
         PhysicalSchema.from(PERSISTENT_SCHEMA, SerdeOption.none()),
         SOURCE_NAMES,
-        SourceName.of("sink Name"),
+        sinkDataSource,
         "execution plan",
         QUERY_ID,
-        DataSourceType.KSTREAM,
         Optional.empty(),
         APPLICATION_ID,
-        sinkTopic,
         topology,
         QuerySchemas.of(new LinkedHashMap<>()),
         STREAMS_PROPS,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.rest.entity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableSet;
@@ -27,6 +28,7 @@ import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.BlockingRowQueue;
+import io.confluent.ksql.query.KafkaStreamsBuilder;
 import io.confluent.ksql.query.QueryErrorClassifier;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.entity.FieldInfo.FieldType;
@@ -89,6 +91,8 @@ public class QueryDescriptionFactoryTest {
   @Mock
   private Consumer<QueryMetadata> queryCloseCallback;
   @Mock
+  private KafkaStreamsBuilder kafkaStreamsBuilder;
+  @Mock
   private KafkaStreams queryStreams;
   @Mock
   private Topology topology;
@@ -111,6 +115,7 @@ public class QueryDescriptionFactoryTest {
   @Before
   public void setUp() {
     when(topology.describe()).thenReturn(topologyDescription);
+    when(kafkaStreamsBuilder.build(any(), any())).thenReturn(queryStreams);
 
     when(sinkTopic.getKeyFormat()).thenReturn(KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name())));
     when(sinkDataSource.getKsqlTopic()).thenReturn(sinkTopic);
@@ -118,13 +123,13 @@ public class QueryDescriptionFactoryTest {
 
     transientQuery = new TransientQueryMetadata(
         SQL_TEXT,
-        queryStreams,
         TRANSIENT_SCHEMA,
         SOURCE_NAMES,
         "execution plan",
         queryQueue,
         APPLICATION_ID,
         topology,
+        kafkaStreamsBuilder,
         STREAMS_PROPS,
         PROP_OVERRIDES,
         queryCloseCallback,
@@ -134,7 +139,6 @@ public class QueryDescriptionFactoryTest {
 
     persistentQuery = new PersistentQueryMetadata(
         SQL_TEXT,
-        queryStreams,
         PhysicalSchema.from(PERSISTENT_SCHEMA, SerdeOption.none()),
         SOURCE_NAMES,
         sinkDataSource,
@@ -143,6 +147,7 @@ public class QueryDescriptionFactoryTest {
         Optional.empty(),
         APPLICATION_ID,
         topology,
+        kafkaStreamsBuilder,
         QuerySchemas.of(new LinkedHashMap<>()),
         STREAMS_PROPS,
         PROP_OVERRIDES,
@@ -247,13 +252,13 @@ public class QueryDescriptionFactoryTest {
 
     transientQuery = new TransientQueryMetadata(
         SQL_TEXT,
-        queryStreams,
         schema,
         SOURCE_NAMES,
         "execution plan",
         queryQueue,
         "app id",
         topology,
+        kafkaStreamsBuilder,
         STREAMS_PROPS,
         PROP_OVERRIDES,
         queryCloseCallback,
@@ -280,13 +285,13 @@ public class QueryDescriptionFactoryTest {
 
     transientQuery = new TransientQueryMetadata(
         SQL_TEXT,
-        queryStreams,
         schema,
         SOURCE_NAMES,
         "execution plan",
         queryQueue,
         "app id",
         topology,
+        kafkaStreamsBuilder,
         STREAMS_PROPS,
         PROP_OVERRIDES,
         queryCloseCallback,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -223,7 +223,7 @@ public class KsqlRestApplicationTest {
   @Test
   public void shouldCloseQueryMonitorOnClose() {
     // When:
-    app.triggerShutdown();
+    app.shutdown();
 
     // then:
     verify(queryMonitor).close();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -55,6 +55,7 @@ import io.confluent.ksql.parser.tree.PrintTopic;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.query.BlockingRowQueue;
+import io.confluent.ksql.query.KafkaStreamsBuilder;
 import io.confluent.ksql.query.LimitHandler;
 import io.confluent.ksql.rest.ApiJsonMapper;
 import io.confluent.ksql.rest.EndpointResponse;
@@ -391,17 +392,19 @@ public class StreamedQueryResourceTest {
         .thenReturn(query);
 
     final Map<String, Object> requestStreamsProperties = Collections.emptyMap();
+    final KafkaStreamsBuilder kafkaStreamsBuilder = mock(KafkaStreamsBuilder.class);
+    when(kafkaStreamsBuilder.build(any(), any())).thenReturn(mockKafkaStreams);
 
     final TransientQueryMetadata transientQueryMetadata =
         new TransientQueryMetadata(
             queryString,
-            mockKafkaStreams,
             SOME_SCHEMA,
             Collections.emptySet(),
             "",
             new TestRowQueue(rowQueue),
             "",
             mock(Topology.class),
+            kafkaStreamsBuilder,
             Collections.emptyMap(),
             Collections.emptyMap(),
             queryCloseCallback,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -408,7 +408,8 @@ public class StreamedQueryResourceTest {
             Collections.emptyMap(),
             Collections.emptyMap(),
             queryCloseCallback,
-            closeTimeout);
+            closeTimeout,
+            10);
 
     when(mockKsqlEngine.executeQuery(serviceContext,
         ConfiguredStatement.of(query, requestStreamsProperties, VALID_CONFIG)))


### PR DESCRIPTION
### Description 

Fixes https://github.com/confluentinc/ksql/issues/5897

This PR adds a new global thread, `CommandMonitor`, that monitors all persistent queries registered in the system and restarts those that have failed for any reason (system, user,  unknown reasons). Restarting queries automatically in the background helps reduce the effort of users to terminate the queries and re-create the stream/table/insert manually.

The query restart uses an exponential backoff time (in milliseconds) to wait before retrying another restart. For now, the initial backoff time is hard-coded to 10 seconds, and it is being incremented exponentially on every restart (10s, 20s, 40s, ...) up to the maximum backoff time. The maximum backoff time may be configured using `ksql.query.retry.backoff.max.ms` and is set to 2 minutes by default (see `KsqlConfig`).

A new KafkaStream is required to be able to restart a query. When a query is stopped, manually or due to an error, the KafkaStream cannot be started anymore. To allow a restart, the `CommandMonitor` closes the KafkaStream and resets the internal KafkaStream with a new KafkaStream object that contains a copy of the topology and stream configurations. It is important not to close the KafkaStream completely (cleanUp= true) to avoid deleting the local state directory.

Resetting the query is done in the `KsqlEngine` because it has access to two registerQuery() methods (one in the EngineContext and another in the KsqlEngine). A query reset creates a new `QueryMetadata` that must be registered (the old is unregistered). Resetting the internal KafkaStream is not done inside the `QueryMetadata` because it violates the immutability of the initial KafkaStream passed in the constructor. **Note:**There should be better ways to handle these resets, but it needs some important code refactors. 

When restarting a new failed query, the `QueryMonitor` keeps a list of queries that have been restarted. Each of these retry events, or `RetryEvent`, have information about the QueryId, a number of retry attempts, and the time for the next restart to help the monitor know when to restart the query again.

### Testing done 
- I added unit tests.
- Run some manual tests to verify the queries are restarted when they failed. It is difficult to test this, though, because it's not easy to cause a query failure locally. I had to throw an exception from the `TimestampTransformer` in the `SinkBuilder` and also set the `ksql.streams.num.stream.threads=1` so KafkaStreams detect the exception quickly. 

The manual test causes an error when inserting 1 row. It then checks the query was restarting immediately, and during the backoff time period, I caused another error with another inserting row and checked the query was not restarted until the backoff time period expired and restarted the query. 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

