### PR TITLE
chore: force register changelog topic schemas

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedSchemaRegistryClient.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedSchemaRegistryClient.java
@@ -40,6 +40,9 @@ final class SandboxedSchemaRegistryClient {
     return LimitedProxyBuilder.forClass(SchemaRegistryClient.class)
         .swallow("register", anyParams(), 123)
         .forward("getAllSubjects", methodParams(), delegate)
+        .forward("getAllVersions", methodParams(String.class), delegate)
+        .forward("getByVersion", methodParams(String.class, int.class, boolean.class), delegate)
+        .forward("getSchemaById", methodParams(int.class), delegate)
         .forward("getLatestSchemaMetadata", methodParams(String.class), delegate)
         .forward("getSchemaBySubjectAndId", methodParams(String.class, int.class), delegate)
         .forward("testCompatibility",

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedSchemaRegistryClientTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedSchemaRegistryClientTest.java
@@ -63,6 +63,9 @@ public final class SandboxedSchemaRegistryClientTest {
           .ignore("testCompatibility", String.class, ParsedSchema.class)
           .ignore("deleteSubject", String.class)
           .ignore("getAllSubjects")
+          .ignore("getAllVersions", String.class)
+          .ignore("getByVersion", String.class, int.class, boolean.class)
+          .ignore("getSchemaById", int.class)
           .build();
     }
 

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/SourceBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/SourceBuilderTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
@@ -713,7 +714,20 @@ public class SourceBuilderTest {
   }
 
   @Test
-  public void shouldNotRegisterSourceSchemaOnChangelogTopicWhenChangelogIsNotForcedButChangelogSubjectExists()
+  public void shouldNotRegisterSourceSchemaOnChangelogTopicWhenSchemaRegistryIsDisabled() throws IOException, RestClientException {
+    // Given:
+    when(queryBuilder.getQueryId()).thenReturn(new QueryId("ID"));
+    givenUnwindowedSourceTable(false);
+
+    // When:
+    tableSource.build(planBuilder);
+
+    // Then:
+    verifyZeroInteractions(srClient);
+  }
+
+  @Test
+  public void shouldNotRegisterSourceSchemaOnChangelogTopicWhenChangelogTopicExists()
       throws IOException, RestClientException
   {
     // Given:


### PR DESCRIPTION
### Description 

fixes #5673 

This commit will always register the original topic schema into the changelog topic for old (existing, pre #5781 queries) so that we don't run into the issue described in #5673 during recovery. Note that this means we will register this schema even if the table is never materialized (e.g. it is possible that this subject will exist when we never need it).

This commit also safeguards from registering the schema unnecessarily to the subject if the topic already exists (e.g. the changelog optimization was not realized). We can be sure that the topic exists before running the SourceBuilder in this case because this change only applies for _existing_ queries. There is a small edge case where the query was enqueued onto the command topic before #5781 but wasn't executed until this commit goes through - in that case we will register the schema unnecessarily, but that is acceptable.

### Testing done 

- unit tests
- manual testing based on the description in #5673 after reverting #5781 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

