### PR TITLE
feat: organize UDFs by category

### DIFF
--- a/docs/concepts/functions.md
+++ b/docs/concepts/functions.md
@@ -258,6 +258,7 @@ commands.
 |-------------|----------------------------------------------------------------------|----------|
 | name        | The case-insensitive name of the UDF(s) represented by this class.   | Yes      |
 | description | A string describing generally what the function(s) in this class do. | Yes      |
+| catgory     | For grouping similar functions in the output of SHOW FUNCTIONS.      | No       |
 | author      | The author of the UDF.                                               | No       |
 | version     | The version of the UDF.                                              | No       |
 

--- a/docs/concepts/functions.md
+++ b/docs/concepts/functions.md
@@ -258,7 +258,7 @@ commands.
 |-------------|----------------------------------------------------------------------|----------|
 | name        | The case-insensitive name of the UDF(s) represented by this class.   | Yes      |
 | description | A string describing generally what the function(s) in this class do. | Yes      |
-| catgory     | For grouping similar functions in the output of SHOW FUNCTIONS.      | No       |
+| category    | For grouping similar functions in the output of SHOW FUNCTIONS.      | No       |
 | author      | The author of the UDF.                                               | No       |
 | version     | The version of the UDF.                                              | No       |
 

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/FunctionNameListTableBuilder.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/FunctionNameListTableBuilder.java
@@ -1,16 +1,15 @@
 /*
  * Copyright 2018 Confluent Inc.
  *
- * Licensed under the Confluent Community License (the "License"); you may not use
- * this file except in compliance with the License.  You may obtain a copy of the
- * License at
+ * Licensed under the Confluent Community License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
  * http://www.confluent.io/confluent-community-license
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
  */
 
 package io.confluent.ksql.cli.console.table.builder;
@@ -19,24 +18,47 @@ import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.cli.console.table.Table;
 import io.confluent.ksql.cli.console.table.Table.Builder;
 import io.confluent.ksql.rest.entity.FunctionNameList;
+import io.confluent.ksql.rest.entity.SimpleFunctionInfo;
+import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class FunctionNameListTableBuilder implements TableBuilder<FunctionNameList> {
 
-  private static final List<String> HEADERS =
-      ImmutableList.of("Function Name", "Type");
+  private static final List<String> HEADERS = ImmutableList.of("Function Name", "Category");
+  private static final List<String> EMPTY_ROW = ImmutableList.of(" ", " ");
 
   @Override
   public Table buildTable(final FunctionNameList functionNameList) {
-    final Stream<List<String>> rows = functionNameList.getFunctions()
-        .stream()
-        .sorted()
-        .map(func -> ImmutableList.of(func.getName(), func.getType().name().toUpperCase()));
 
-    return new Builder()
-        .withColumnHeaders(HEADERS)
-        .withRows(rows)
-        .build();
+    Builder builder = new Builder().withColumnHeaders(HEADERS);
+
+    // poor mans version check for the case we are running against an older ksqlDB server
+    Iterator<SimpleFunctionInfo> funcs = functionNameList.getFunctions().iterator();
+    if (!funcs.hasNext() || funcs.next().getCategory().isEmpty()) {
+      final Stream<List<String>> rows = functionNameList.getFunctions()
+          .stream()
+          .sorted(Comparator.comparing(SimpleFunctionInfo::getName))
+          .map(func -> ImmutableList.of(func.getName(), func.getType().name().toUpperCase()));
+      builder.withRows(rows);
+    } else { // category info present, use new display layout
+      final List<SimpleFunctionInfo> sortedFunctions = functionNameList.getFunctions().stream()
+          .sorted(Comparator.comparing(SimpleFunctionInfo::getCategory)
+              .thenComparing(SimpleFunctionInfo::getName))
+          .collect(Collectors.toList());
+      String prevCategory = sortedFunctions.get(0).getCategory();
+      for (SimpleFunctionInfo fn : sortedFunctions) {
+        if (!fn.getCategory().equals(prevCategory)) {
+          builder.withRow(EMPTY_ROW);
+        }
+        builder.withRow(fn.getName(), fn.getCategory());
+        prevCategory = fn.getCategory();
+      }
+    }
+    builder.withFooterLine(
+        "For detailed information about a function, run: DESCRIBE FUNCTION <Function Name>;");
+    return builder.build();
   }
 }

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/FunctionNameListTableBuilder.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/FunctionNameListTableBuilder.java
@@ -33,10 +33,10 @@ public class FunctionNameListTableBuilder implements TableBuilder<FunctionNameLi
   @Override
   public Table buildTable(final FunctionNameList functionNameList) {
 
-    Builder builder = new Builder().withColumnHeaders(HEADERS);
+    final Builder builder = new Builder().withColumnHeaders(HEADERS);
 
     // poor mans version check for the case we are running against an older ksqlDB server
-    Iterator<SimpleFunctionInfo> funcs = functionNameList.getFunctions().iterator();
+    final Iterator<SimpleFunctionInfo> funcs = functionNameList.getFunctions().iterator();
     if (!funcs.hasNext() || funcs.next().getCategory().isEmpty()) {
       final Stream<List<String>> rows = functionNameList.getFunctions()
           .stream()

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -784,8 +784,8 @@ public class CliTest {
   @Test
   public void shouldListFunctions() {
     assertRunListCommand("functions", hasRows(
-        row("TIMESTAMPTOSTRING", "SCALAR"),
-        row("EXTRACTJSONFIELD", "SCALAR"),
+        row("TIMESTAMPTOSTRING", "DATE_TIME"),
+        row("EXTRACTJSONFIELD", "JSON"),
         row("TOPK", "AGGREGATE")
     ));
   }

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -784,7 +784,7 @@ public class CliTest {
   @Test
   public void shouldListFunctions() {
     assertRunListCommand("functions", hasRows(
-        row("TIMESTAMPTOSTRING", "DATE_TIME"),
+        row("TIMESTAMPTOSTRING", "DATE / TIME"),
         row("EXTRACTJSONFIELD", "JSON"),
         row("TOPK", "AGGREGATE")
     ));

--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/AggregateFunctionFactory.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/AggregateFunctionFactory.java
@@ -49,6 +49,7 @@ public abstract class AggregateFunctionFactory {
         "",
         KsqlConstants.CONFLUENT_AUTHOR,
         "",
+        FunctionCategory.AGGREGATE,
         KsqlScalarFunction.INTERNAL_PATH
     ));
   }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/udf/UdfMetadata.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/udf/UdfMetadata.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf;
 
+import io.confluent.ksql.function.FunctionCategory;
 import java.util.Objects;
 
 public class UdfMetadata {
@@ -23,17 +24,20 @@ public class UdfMetadata {
   private final String author;
   private final String version;
   private final String path;
+  private final FunctionCategory category;
 
   public UdfMetadata(final String name,
                      final String description,
                      final String author,
                      final String version,
+                     final FunctionCategory category,
                      final String path
   ) {
     this.name = Objects.requireNonNull(name, "name cant be null");
     this.description = Objects.requireNonNull(description, "description can't be null");
     this.author = Objects.requireNonNull(author, "author can't be null");
     this.version = Objects.requireNonNull(version, "version can't be null");
+    this.category = Objects.requireNonNull(category, "category can't be null");
     this.path = Objects.requireNonNull(path, "path can't be null");
   }
 
@@ -57,6 +61,10 @@ public class UdfMetadata {
     return path;
   }
 
+  public FunctionCategory getCategory() {
+    return category;
+  }
+
   @Override
   public String toString() {
     return "UdfMetadata{"
@@ -64,7 +72,8 @@ public class UdfMetadata {
         + ", description='" + description + '\''
         + ", author='" + author + '\''
         + ", version='" + version + '\''
-        + ", path='" + path + "'"
+        + ", path='" + path + '\''
+        + ", category='" + category.name() + "'"
         + '}';
   }
 
@@ -81,11 +90,12 @@ public class UdfMetadata {
         && Objects.equals(description, that.description)
         && Objects.equals(author, that.author)
         && Objects.equals(version, that.version)
-        && Objects.equals(path, that.path);
+        && Objects.equals(path, that.path)
+        && Objects.equals(category, that.category);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, description, author, version, path);
+    return Objects.hash(name, description, author, version, path, category);
   }
 }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/udf/UdfMetadata.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/udf/UdfMetadata.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.function.udf;
 
-import io.confluent.ksql.function.FunctionCategory;
 import java.util.Objects;
 
 public class UdfMetadata {
@@ -24,13 +23,13 @@ public class UdfMetadata {
   private final String author;
   private final String version;
   private final String path;
-  private final FunctionCategory category;
+  private final String category;
 
   public UdfMetadata(final String name,
                      final String description,
                      final String author,
                      final String version,
-                     final FunctionCategory category,
+      final String category,
                      final String path
   ) {
     this.name = Objects.requireNonNull(name, "name cant be null");
@@ -61,7 +60,7 @@ public class UdfMetadata {
     return path;
   }
 
-  public FunctionCategory getCategory() {
+  public String getCategory() {
     return category;
   }
 
@@ -73,7 +72,7 @@ public class UdfMetadata {
         + ", author='" + author + '\''
         + ", version='" + version + '\''
         + ", path='" + path + '\''
-        + ", category='" + category.name() + "'"
+        + ", category='" + category + "'"
         + '}';
   }
 

--- a/ksqldb-common/src/test/java/io/confluent/ksql/function/UdfFactoryTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/function/UdfFactoryTest.java
@@ -35,7 +35,7 @@ public class UdfFactoryTest {
 
   private static final String functionName = "TestFunc";
   private final UdfFactory factory = new UdfFactory(TestFunc.class,
-      new UdfMetadata(functionName, "", "", "", "internal"));
+      new UdfMetadata(functionName, "", "", "", FunctionCategory.OTHER, "internal"));
 
   @Test
   public void shouldThrowIfNoVariantFoundThatAcceptsSuppliedParamTypes() {

--- a/ksqldb-common/src/test/java/io/confluent/ksql/function/udf/UdfMetadataTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/function/udf/UdfMetadataTest.java
@@ -14,8 +14,8 @@
 
 package io.confluent.ksql.function.udf;
 
+import static io.confluent.ksql.function.FunctionCategory.MAP;
 import static io.confluent.ksql.function.FunctionCategory.OTHER;
-import static io.confluent.ksql.function.FunctionCategory.STRING;
 
 import com.google.common.testing.EqualsTester;
 import org.junit.Test;
@@ -32,7 +32,7 @@ public class UdfMetadataTest {
         .addEqualityGroup(new UdfMetadata("name", "DIF", "auth", "ver", OTHER, "path"))
         .addEqualityGroup(new UdfMetadata("name", "desc", "DIF", "ver", OTHER, "path"))
         .addEqualityGroup(new UdfMetadata("name", "desc", "auth", "DIF", OTHER, "path"))
-        .addEqualityGroup(new UdfMetadata("name", "desc", "auth", "ver", STRING, "path"))
+        .addEqualityGroup(new UdfMetadata("name", "desc", "auth", "ver", MAP, "path"))
         .addEqualityGroup(new UdfMetadata("name", "desc", "auth", "ver", OTHER, "DIF"))
         .testEquals();
   }

--- a/ksqldb-common/src/test/java/io/confluent/ksql/function/udf/UdfMetadataTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/function/udf/UdfMetadataTest.java
@@ -1,19 +1,21 @@
 /*
  * Copyright 2018 Confluent Inc.
  *
- * Licensed under the Confluent Community License (the "License"); you may not use
- * this file except in compliance with the License.  You may obtain a copy of the
- * License at
+ * Licensed under the Confluent Community License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
  * http://www.confluent.io/confluent-community-license
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
  */
 
 package io.confluent.ksql.function.udf;
+
+import static io.confluent.ksql.function.FunctionCategory.OTHER;
+import static io.confluent.ksql.function.FunctionCategory.STRING;
 
 import com.google.common.testing.EqualsTester;
 import org.junit.Test;
@@ -24,14 +26,14 @@ public class UdfMetadataTest {
   public void shouldImplementHashCodeAndEqualsProperly() {
     new EqualsTester()
         .addEqualityGroup(
-            new UdfMetadata("name", "desc", "auth", "ver", "path"),
-            new UdfMetadata("name", "desc", "auth", "ver", "path")
-        )
-        .addEqualityGroup(new UdfMetadata("DIF", "desc", "auth", "ver", "path"))
-        .addEqualityGroup(new UdfMetadata("name", "DIF", "auth", "ver", "path"))
-        .addEqualityGroup(new UdfMetadata("name", "desc", "DIF", "ver", "path"))
-        .addEqualityGroup(new UdfMetadata("name", "desc", "auth", "DIF", "path"))
-        .addEqualityGroup(new UdfMetadata("name", "desc", "auth", "ver", "DIF"))
+            new UdfMetadata("name", "desc", "auth", "ver", OTHER, "path"),
+            new UdfMetadata("name", "desc", "auth", "ver", OTHER, "path"))
+        .addEqualityGroup(new UdfMetadata("DIF", "desc", "auth", "ver", OTHER, "path"))
+        .addEqualityGroup(new UdfMetadata("name", "DIF", "auth", "ver", OTHER, "path"))
+        .addEqualityGroup(new UdfMetadata("name", "desc", "DIF", "ver", OTHER, "path"))
+        .addEqualityGroup(new UdfMetadata("name", "desc", "auth", "DIF", OTHER, "path"))
+        .addEqualityGroup(new UdfMetadata("name", "desc", "auth", "ver", STRING, "path"))
+        .addEqualityGroup(new UdfMetadata("name", "desc", "auth", "ver", OTHER, "DIF"))
         .testEquals();
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafLoader.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafLoader.java
@@ -102,6 +102,7 @@ class UdafLoader {
             udafAnnotation.description(),
             udafAnnotation.author(),
             udafAnnotation.version(),
+            udafAnnotation.category(),
             path
         ),
         invokers

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
@@ -93,6 +93,7 @@ public class UdfLoader {
             udfDescriptionAnnotation.description(),
             udfDescriptionAnnotation.author(),
             udfDescriptionAnnotation.version(),
+            udfDescriptionAnnotation.category(),
             path
         )
     );

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdfLoaderUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdfLoaderUtil.java
@@ -40,6 +40,7 @@ public final class UdfLoaderUtil {
         udf.getDescription(),
         "Test Author",
         "",
+        FunctionCategory.OTHER,
         KsqlScalarFunction.INTERNAL_PATH
     );
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdtfLoader.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdtfLoader.java
@@ -74,6 +74,7 @@ public class UdtfLoader {
         udtfDescriptionAnnotation.description(),
         udtfDescriptionAnnotation.author(),
         udtfDescriptionAnnotation.version(),
+        udtfDescriptionAnnotation.category(),
         path
     );
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/ArrayDistinct.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/ArrayDistinct.java
@@ -15,6 +15,7 @@
 package io.confluent.ksql.function.udf.array;
 
 import com.google.common.collect.Sets;
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -24,6 +25,7 @@ import java.util.Set;
 
 @UdfDescription(
     name = "array_distinct",
+    category = FunctionCategory.ARRAY,
     description = "Returns an array of all the distinct values, including NULL if present, from"
         + " the input array."
         + " The output array elements will be in order of their first occurrence in the input."

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/ArrayExcept.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/ArrayExcept.java
@@ -14,6 +14,7 @@
 
 package io.confluent.ksql.function.udf.array;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -25,6 +26,7 @@ import java.util.stream.Collectors;
 
 @UdfDescription(
     name = "array_except",
+    category = FunctionCategory.ARRAY,
     description = "Returns an array of all the elements in an array except for those also present"
         + " in a second array. The order of entries in the first array is preserved although any"
         + " duplicates are removed. Returns NULL if either input is NULL.")

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/ArrayIntersect.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/ArrayIntersect.java
@@ -16,6 +16,7 @@ package io.confluent.ksql.function.udf.array;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -24,6 +25,7 @@ import java.util.Set;
 
 @UdfDescription(
     name = "array_intersect",
+    category = FunctionCategory.ARRAY,
     description = "Returns an array of all the distinct elements from the intersection of both"
         + " input arrays, or NULL if either input array is NULL. The order of entries in the"
         + " output is the same as in the first input array.")

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/ArrayJoin.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/ArrayJoin.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.function.udf.array;
 
 import com.google.common.collect.ImmutableSet;
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
@@ -29,6 +30,7 @@ import java.util.StringJoiner;
 @SuppressWarnings("MethodMayBeStatic") // UDF methods can not be static.
 @UdfDescription(
     name = "ARRAY_JOIN",
+    category = FunctionCategory.ARRAY,
     description = "joins the array elements into a flat string representation",
     author = KsqlConstants.CONFLUENT_AUTHOR
 )

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/ArrayLength.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/ArrayLength.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.array;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -27,6 +28,7 @@ import java.util.List;
 @SuppressWarnings("MethodMayBeStatic") // UDF methods can not be static.
 @UdfDescription(
     name = "ARRAY_LENGTH",
+    category = FunctionCategory.ARRAY,
     description = "Returns the length on an array",
     author = KsqlConstants.CONFLUENT_AUTHOR
 )

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/ArrayMax.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/ArrayMax.java
@@ -14,6 +14,7 @@
 
 package io.confluent.ksql.function.udf.array;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -24,6 +25,7 @@ import java.util.List;
  */
 @UdfDescription(
     name = "array_max",
+    category = FunctionCategory.ARRAY,
     description = "Return the maximum value from within an array of primitive values, according to"
         + " their natural sort order. If the array is NULL, or contains only NULLs, return NULL.")
 public class ArrayMax {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/ArrayMin.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/ArrayMin.java
@@ -14,6 +14,7 @@
 
 package io.confluent.ksql.function.udf.array;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -24,6 +25,7 @@ import java.util.List;
  */
 @UdfDescription(
     name = "array_min",
+    category = FunctionCategory.ARRAY,
     description = "Return the minimum value from within an array of primitive values, according to"
         + " their natural sort order. If the array is NULL, or contains only NULLs, return NULL.")
 public class ArrayMin {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/ArraySort.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/ArraySort.java
@@ -18,6 +18,7 @@ import static java.util.Comparator.naturalOrder;
 import static java.util.Comparator.nullsLast;
 
 import com.google.common.collect.Lists;
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -29,6 +30,7 @@ import java.util.List;
  */
 @UdfDescription(
     name = "array_sort",
+    category = FunctionCategory.ARRAY,
     description = "Sort an array of primitive values, according to their natural sort order. Any "
         + "NULLs in the array will be placed at the end.")
 public class ArraySort {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/ArrayUnion.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/ArrayUnion.java
@@ -15,6 +15,7 @@
 package io.confluent.ksql.function.udf.array;
 
 import com.google.common.collect.Sets;
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -24,6 +25,7 @@ import java.util.Set;
 
 @UdfDescription(
     name = "array_union",
+    category = FunctionCategory.ARRAY,
     description = "Returns an array of all the distinct elements from both input arrays, "
         + "or NULL if either array is NULL.")
 public class ArrayUnion {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/Entries.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/Entries.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.array;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -36,6 +37,7 @@ import org.apache.kafka.connect.data.Struct;
  */
 @UdfDescription(
     name = "ENTRIES",
+    category = FunctionCategory.MAP,
     description =
         "Construct an array from the entries in a map."
             + "The array can be optionally sorted on the keys.",

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/GenerateSeries.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/GenerateSeries.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.array;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
@@ -28,6 +29,7 @@ import java.util.List;
  */
 @UdfDescription(
     name = "GENERATE_SERIES",
+    category = FunctionCategory.ARRAY,
     description = "Construct an array of a range of values",
     author = KsqlConstants.CONFLUENT_AUTHOR
 )

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/datetime/DateToString.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/datetime/DateToString.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.function.udf.datetime;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
@@ -29,6 +30,7 @@ import java.util.concurrent.ExecutionException;
 
 @UdfDescription(
     name = "datetostring",
+    category = FunctionCategory.DATE_TIME,
     author = KsqlConstants.CONFLUENT_AUTHOR,
     description = "Converts an integer representing days since epoch to a date string"
         + " using the given format pattern. Note this is the format Kafka Connect uses"

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/datetime/StringToDate.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/datetime/StringToDate.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.function.udf.datetime;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
@@ -29,6 +30,7 @@ import java.util.concurrent.ExecutionException;
 
 @UdfDescription(
     name = "stringtodate",
+    category = FunctionCategory.DATE_TIME,
     author = KsqlConstants.CONFLUENT_AUTHOR,
     description = "Converts a string representation of a date into an integer representing"
         + " days since epoch using the given format pattern."

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/datetime/StringToTimestamp.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/datetime/StringToTimestamp.java
@@ -18,18 +18,19 @@ package io.confluent.ksql.function.udf.datetime;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.timestamp.StringToTimestampParser;
-
 import java.time.ZoneId;
 import java.util.concurrent.ExecutionException;
 
 @UdfDescription(
     name = "stringtotimestamp",
+    category = FunctionCategory.DATE_TIME,
     author = KsqlConstants.CONFLUENT_AUTHOR,
     description = "Converts a string representation of a date in the given format"
         + " into the BIGINT value that represents the millisecond timestamp."

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/datetime/TimestampToString.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/datetime/TimestampToString.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.function.udf.datetime;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
@@ -30,6 +31,7 @@ import java.util.concurrent.ExecutionException;
 
 @UdfDescription(
     name = "timestamptostring",
+    category = FunctionCategory.DATE_TIME,
     author = KsqlConstants.CONFLUENT_AUTHOR,
     description = "Converts a BIGINT millisecond timestamp value into"
         + " the string representation of the timestamp in the given format."

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/datetime/UnixDate.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/datetime/UnixDate.java
@@ -14,6 +14,7 @@
 
 package io.confluent.ksql.function.udf.datetime;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.util.KsqlConstants;
@@ -21,6 +22,7 @@ import java.time.LocalDate;
 
 @UdfDescription(
     name = "unix_date",
+    category = FunctionCategory.DATE_TIME,
     description = "Gets an integer representing days since epoch.",
     author = KsqlConstants.CONFLUENT_AUTHOR
 )

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/datetime/UnixTimestamp.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/datetime/UnixTimestamp.java
@@ -14,12 +14,14 @@
 
 package io.confluent.ksql.function.udf.datetime;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.util.KsqlConstants;
 
 @UdfDescription(
     name = "unix_timestamp",
+    category = FunctionCategory.DATE_TIME,
     description = "Gets the Unix timestamp in milliseconds, represented as a BIGINT.",
     author = KsqlConstants.CONFLUENT_AUTHOR
 )

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonArrayContains.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonArrayContains.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonFactoryBuilder;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -40,6 +41,7 @@ import java.util.function.Predicate;
 
 @UdfDescription(
     name = "JSON_ARRAY_CONTAINS",
+    category = FunctionCategory.JSON,
     description = JsonArrayContains.DESCRIPTION,
     author = KsqlConstants.CONFLUENT_AUTHOR
 )

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonExtractString.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonExtractString.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
@@ -29,6 +30,7 @@ import java.util.List;
 
 @UdfDescription(
     name = "extractjsonfield",
+    category = FunctionCategory.JSON,
     description = "Given a STRING that contains JSON data, extract the value at the specified "
         + " JSONPath or NULL if the specified path does not exist.")
 public class JsonExtractString {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/list/ArrayContains.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/list/ArrayContains.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.list;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -23,6 +24,7 @@ import java.util.List;
 
 @UdfDescription(
     name = "ARRAY_CONTAINS",
+    category = FunctionCategory.ARRAY,
     description = ArrayContains.DESCRIPTION,
     author = KsqlConstants.CONFLUENT_AUTHOR
 )

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/list/Slice.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/list/Slice.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.list;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -23,6 +24,7 @@ import java.util.List;
 
 @UdfDescription(
     name = "slice",
+    category = FunctionCategory.ARRAY,
     description = "slice of an ARRAY",
     author = KsqlConstants.CONFLUENT_AUTHOR
 )

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/map/AsMap.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/map/AsMap.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.map;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -25,6 +26,7 @@ import java.util.Map;
 
 @UdfDescription(
     name = "AS_MAP",
+    category = FunctionCategory.MAP,
     description = "Construct a list based on some inputs",
     author = KsqlConstants.CONFLUENT_AUTHOR
 )

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/map/MapKeys.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/map/MapKeys.java
@@ -15,6 +15,7 @@
 package io.confluent.ksql.function.udf.map;
 
 import com.google.common.collect.Lists;
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import java.util.List;
@@ -22,6 +23,7 @@ import java.util.Map;
 
 @UdfDescription(
     name = "map_keys",
+    category = FunctionCategory.MAP,
     description = "Returns an array of all the keys from the specified map, "
         + "or NULL if the input map is NULL.")
 public class MapKeys {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/map/MapUnion.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/map/MapUnion.java
@@ -14,6 +14,7 @@
 
 package io.confluent.ksql.function.udf.map;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -26,6 +27,7 @@ import java.util.stream.Stream;
 
 @UdfDescription(
     name = "map_union",
+    category = FunctionCategory.MAP,
     description = "Returns a new map containing the union of all entries from both input maps. "
         + "If a key is present in both input maps then the value from map2 is the one which "
         + "appears in the result. Returns NULL if all of the input maps are NULL.")

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/map/MapValues.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/map/MapValues.java
@@ -15,6 +15,7 @@
 package io.confluent.ksql.function.udf.map;
 
 import com.google.common.collect.Lists;
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import java.util.List;
@@ -22,6 +23,7 @@ import java.util.Map;
 
 @UdfDescription(
     name = "map_values",
+    category = FunctionCategory.MAP,
     description = "Returns an array of all the values from the specified map, "
         + "or NULL if the input map is NULL.")
 public class MapValues {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Abs.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Abs.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.math;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -28,6 +29,7 @@ import java.util.List;
 
 @UdfDescription(
     name = "Abs",
+    category = FunctionCategory.MATHEMATICAL,
     description = Abs.DESCRIPTION,
     author = KsqlConstants.CONFLUENT_AUTHOR
 )

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Ceil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Ceil.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.math;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -29,6 +30,7 @@ import java.util.List;
 
 @UdfDescription(
     name = "Ceil",
+    category = FunctionCategory.MATHEMATICAL,
     description = Ceil.DESCRIPTION,
     author = KsqlConstants.CONFLUENT_AUTHOR
 )

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Exp.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Exp.java
@@ -14,6 +14,7 @@
 
 package io.confluent.ksql.function.udf.math;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -22,6 +23,7 @@ import io.confluent.ksql.util.KsqlConstants;
 @SuppressWarnings("WeakerAccess") // Invoked via reflection
 @UdfDescription(
     name = "exp",
+    category = FunctionCategory.MATHEMATICAL,
     author = KsqlConstants.CONFLUENT_AUTHOR,
     description = "The exponential of a value."
 )

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Floor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Floor.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.math;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -29,6 +30,7 @@ import java.util.List;
 
 @UdfDescription(
     name = "Floor",
+    category = FunctionCategory.MATHEMATICAL,
     description = Floor.DESCRIPTION,
     author = KsqlConstants.CONFLUENT_AUTHOR
 )

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Ln.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Ln.java
@@ -14,6 +14,7 @@
 
 package io.confluent.ksql.function.udf.math;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -21,6 +22,7 @@ import io.confluent.ksql.util.KsqlConstants;
 
 @UdfDescription(
     name = "ln",
+    category = FunctionCategory.MATHEMATICAL,
     author = KsqlConstants.CONFLUENT_AUTHOR,
     description = "The natural logarithm of a value."
 )

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Random.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Random.java
@@ -15,11 +15,13 @@
 
 package io.confluent.ksql.function.udf.math;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 
 @UdfDescription(
     name = "random",
+    category = FunctionCategory.MATHEMATICAL,
     description = "Returns a random number greater than or equal to 0.0 and less than 1.0.")
 public class Random {
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Round.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Round.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.math;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -63,6 +64,7 @@ is +ve or -ve to get consistent behaviour.
 */
 @UdfDescription(
     name = "Round",
+    category = FunctionCategory.MATHEMATICAL,
     description = Round.DESCRIPTION,
     author = KsqlConstants.CONFLUENT_AUTHOR
 )

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Sign.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Sign.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.math;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -23,6 +24,7 @@ import io.confluent.ksql.util.KsqlConstants;
 @SuppressWarnings("WeakerAccess") // Invoked via reflection
 @UdfDescription(
     name = "sign",
+    category = FunctionCategory.MATHEMATICAL,
     author = KsqlConstants.CONFLUENT_AUTHOR,
     description = "The sign of a value."
 )

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Sqrt.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Sqrt.java
@@ -14,6 +14,7 @@
 
 package io.confluent.ksql.function.udf.math;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -22,6 +23,7 @@ import io.confluent.ksql.util.KsqlConstants;
 @SuppressWarnings("WeakerAccess") // Invoked via reflection
 @UdfDescription(
     name = "sqrt",
+    category = FunctionCategory.MATHEMATICAL,
     author = KsqlConstants.CONFLUENT_AUTHOR,
     description = "The square root of a value."
 )

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/nulls/Coalesce.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/nulls/Coalesce.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.nulls;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.name.FunctionName;
@@ -28,6 +29,7 @@ import java.util.Objects;
 @SuppressWarnings("MethodMayBeStatic") // UDF methods can not be static.
 @UdfDescription(
     name = Coalesce.NAME_TEXT,
+    category = FunctionCategory.CONDITIONAL,
     description = "Returns first non-null element",
     author = KsqlConstants.CONFLUENT_AUTHOR
 )

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/nulls/IfNull.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/nulls/IfNull.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.nulls;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -23,6 +24,7 @@ import io.confluent.ksql.util.KsqlConstants;
 @SuppressWarnings({"MethodMayBeStatic", "unused"}) // UDF methods can not be static.
 @UdfDescription(
     name = "IFNULL",
+    category = FunctionCategory.CONDITIONAL,
     description = "Returns expression if NOT NULL, otherwise the alternative value",
     author = KsqlConstants.CONFLUENT_AUTHOR
 )

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Chr.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Chr.java
@@ -14,6 +14,7 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -21,6 +22,7 @@ import org.apache.commons.lang3.StringEscapeUtils;
 
 @UdfDescription(
     name = "Chr",
+    category = FunctionCategory.STRING,
     description = "Returns a single-character string corresponding to the input character code.")
 public class Chr {
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Concat.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Concat.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -24,6 +25,7 @@ import java.util.stream.Collectors;
 
 @UdfDescription(
     name = "concat",
+    category = FunctionCategory.STRING,
     description = "Concatenate an arbitrary number of string fields together")
 public class Concat {
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/ConcatWS.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/ConcatWS.java
@@ -14,6 +14,7 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
@@ -24,6 +25,7 @@ import java.util.stream.Collectors;
 
 @UdfDescription(
     name = "concat_ws",
+    category = FunctionCategory.STRING,
     description = "Concatenate several strings, inserting a separator string passed as the "
         + "first argument between each one.")
 public class ConcatWS {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Elt.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Elt.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -22,6 +23,7 @@ import io.confluent.ksql.util.KsqlConstants;
 
 @UdfDescription(
     name = "elt",
+    category = FunctionCategory.STRING,
     description = Elt.DESCRIPTION,
     author = KsqlConstants.CONFLUENT_AUTHOR
 )

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Encode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Encode.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.function.udf.string;
 
 import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
@@ -29,6 +30,7 @@ import org.apache.commons.codec.binary.Hex;
 @SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
 @UdfDescription(name = "encode",
     author = KsqlConstants.CONFLUENT_AUTHOR,
+    category = FunctionCategory.STRING,
     description = "Takes an input string s, which is encoded as input_encoding, "
         + "and encodes it as output_encoding. The accepted input and output encodings are: "
         + "hex, utf8, ascii and base64. Throws exception if provided encodings are not supported.")

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Field.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Field.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -22,6 +23,7 @@ import io.confluent.ksql.util.KsqlConstants;
 
 @UdfDescription(
     name = "field",
+    category = FunctionCategory.STRING,
     description = Field.DESCRIPTION,
     author = KsqlConstants.CONFLUENT_AUTHOR
 )

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/InitCap.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/InitCap.java
@@ -15,17 +15,18 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.util.KsqlConstants;
-
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @SuppressWarnings("unused") // Invoked via reflection.
 @UdfDescription(
     name = "initcap",
+    category = FunctionCategory.STRING,
     author = KsqlConstants.CONFLUENT_AUTHOR,
     description = "Capitalizes the first letter of each word in a string and the rest lowercased."
         + " Words are delimited by whitespace."

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Instr.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Instr.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.function.udf.string;
 import static org.apache.commons.lang3.StringUtils.ordinalIndexOf;
 import static org.apache.commons.lang3.StringUtils.substring;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.util.KsqlConstants;
@@ -25,6 +26,7 @@ import org.apache.commons.lang3.StringUtils;
 
 @UdfDescription(
     name = "instr",
+    category = FunctionCategory.STRING,
     author = KsqlConstants.CONFLUENT_AUTHOR,
     description = "Returns the position of substring in the provided string"
 )

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/LCase.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/LCase.java
@@ -15,12 +15,14 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
 
 @UdfDescription(
     name = "lcase",
+    category = FunctionCategory.STRING,
     description = "Returns a lower-case version of the input string.")
 public class LCase {
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/LPad.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/LPad.java
@@ -14,12 +14,14 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
 
 @UdfDescription(
     name = "LPad",
+    category = FunctionCategory.STRING,
     description = "Pads the input string, beginning from the left, with the specified padding"
         + " string until the target length is reached. If the input string is longer than the"
         + " specified target length it will be truncated. If the padding string is empty or"

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Len.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Len.java
@@ -14,12 +14,14 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
 
 @UdfDescription(
     name = "len",
+    category = FunctionCategory.STRING,
     description = "Returns the length of the input string.")
 public class Len {
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Mask.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Mask.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -22,6 +23,7 @@ import io.confluent.ksql.util.KsqlConstants;
 
 @UdfDescription(
     name = "mask",
+    category = FunctionCategory.STRING,
     author = KsqlConstants.CONFLUENT_AUTHOR,
     description = "Returns a version of the input string with every character replaced by a mask."
         + " Default masking rules will replace all upper-case characters with 'X', all lower-case"

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKeepLeft.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKeepLeft.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -22,6 +23,7 @@ import io.confluent.ksql.util.KsqlConstants;
 
 @UdfDescription(
     name = MaskKeepLeft.NAME,
+    category = FunctionCategory.STRING,
     author = KsqlConstants.CONFLUENT_AUTHOR,
     description = "Returns a version of the input string with all but the"
         + " specified number of left-most characters masked out."

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKeepRight.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKeepRight.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -22,6 +23,7 @@ import io.confluent.ksql.util.KsqlConstants;
 
 @UdfDescription(
     name = MaskKeepRight.NAME,
+    category = FunctionCategory.STRING,
     author = KsqlConstants.CONFLUENT_AUTHOR,
     description = "Returns a version of the input string with all but the"
         + " specified number of right-most characters masked out."

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskLeft.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskLeft.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -22,6 +23,7 @@ import io.confluent.ksql.util.KsqlConstants;
 
 @UdfDescription(
     name = MaskLeft.NAME,
+    category = FunctionCategory.STRING,
     author = KsqlConstants.CONFLUENT_AUTHOR,
     description = "Returns a version of the input string with the"
         + " specified number of characters, starting from the beginning of the string, masked out."

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskRight.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskRight.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -22,6 +23,7 @@ import io.confluent.ksql.util.KsqlConstants;
 
 @UdfDescription(
     name = MaskRight.NAME,
+    category = FunctionCategory.STRING,
     author = KsqlConstants.CONFLUENT_AUTHOR,
     description = "Returns a version of the input string with the"
         + " specified number of characters, counting back from the end of the string, masked out."

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/RPad.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/RPad.java
@@ -14,12 +14,14 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
 
 @UdfDescription(
     name = "RPad",
+    category = FunctionCategory.STRING,
     description = "Pads the input string, starting from the end, with the specified padding"
         + " string until the target length is reached. If the input string is longer than the"
         + " specified target length it will be truncated. If the padding string is empty or"

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/RegexpExtract.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/RegexpExtract.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -24,6 +25,7 @@ import java.util.regex.Pattern;
 
 @UdfDescription(
     name = "regexp_extract",
+    category = FunctionCategory.REGULAR_EXPRESSION,
     author = KsqlConstants.CONFLUENT_AUTHOR,
     description = "extract the first subtring matched by a regex pattern"
 )

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/RegexpExtractAll.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/RegexpExtractAll.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
@@ -28,6 +29,7 @@ import java.util.regex.PatternSyntaxException;
 
 @UdfDescription(
     name = "regexp_extract_all",
+    category = FunctionCategory.REGULAR_EXPRESSION,
     author = KsqlConstants.CONFLUENT_AUTHOR,
     description = "Extracts the all subtrings matched by a regex pattern")
 public class RegexpExtractAll {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/RegexpReplace.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/RegexpReplace.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
@@ -24,6 +25,7 @@ import java.util.regex.PatternSyntaxException;
 
 @UdfDescription(name = "regexp_replace",
     author = KsqlConstants.CONFLUENT_AUTHOR,
+    category = FunctionCategory.REGULAR_EXPRESSION,
     description = "Replaces all matches of a regexp in a string with a new substring.")
 public class RegexpReplace {
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/RegexpSplitToArray.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/RegexpSplitToArray.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.function.udf.string;
 
 import com.google.common.base.Splitter;
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
@@ -28,6 +29,7 @@ import java.util.regex.PatternSyntaxException;
 
 @UdfDescription(name = "regexp_split_to_array",
     author = KsqlConstants.CONFLUENT_AUTHOR,
+    category = FunctionCategory.REGULAR_EXPRESSION,
     description = "Splits a string into an array of substrings based on a regexp. "
         + "If the regexp is found at the beginning of the string, end of the string, or there "
         + "are contiguous matches in the string, then empty strings are added to the array. "

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Replace.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Replace.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -23,6 +24,7 @@ import io.confluent.ksql.util.KsqlConstants;
 @SuppressWarnings("unused") // Invoked via reflection.
 @UdfDescription(
     name = "replace",
+    category = FunctionCategory.STRING,
     author = KsqlConstants.CONFLUENT_AUTHOR,
     description = "Replaces all occurances of a substring in a string with a new substring."
 )

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Split.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Split.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.function.udf.string;
 
 import com.google.common.base.Splitter;
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
@@ -27,6 +28,7 @@ import java.util.regex.Pattern;
 
 @UdfDescription(
     name = Split.NAME,
+    category = FunctionCategory.STRING,
     author = KsqlConstants.CONFLUENT_AUTHOR,
     description = "Splits a string into an array of substrings based on a delimiter. "
         + "If the delimiter is found at the beginning of the string, end of the string, or there "

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/SplitToMap.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/SplitToMap.java
@@ -15,6 +15,7 @@
 package io.confluent.ksql.function.udf.string;
 
 import com.google.common.base.Splitter;
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -24,10 +25,11 @@ import java.util.stream.StreamSupport;
 
 @UdfDescription(
     name = "split_to_map",
+    category = FunctionCategory.STRING,
     description = "Splits a string into key-value pairs and creates a map from them. The "
         + "'entryDelimiter' splits the string into key-value pairs which are then split by "
         + "'kvDelimiter'. If the same key is present multiple times in the input, the latest "
-        + "value for that key is returned. Returns NULL f the input text or either of the "
+        + "value for that key is returned. Returns NULL if the input text or either of the "
         + "delimiters is NULL.")
 public class SplitToMap {
   @Udf

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Substring.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Substring.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -23,6 +24,7 @@ import io.confluent.ksql.util.KsqlConstants;
 @SuppressWarnings("unused") // Invoked via reflection.
 @UdfDescription(
     name = "substring",
+    category = FunctionCategory.STRING,
     author = KsqlConstants.CONFLUENT_AUTHOR,
     description = "Returns a substring of the passed in value."
 )

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Trim.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Trim.java
@@ -14,12 +14,14 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
 
 @UdfDescription(
     name = "trim",
+    category = FunctionCategory.STRING,
     description = "Remove whitespace from the beginning and end of a string.")
 public class Trim {
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/UCase.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/UCase.java
@@ -14,12 +14,14 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
 
 @UdfDescription(
     name = "ucase",
+    category = FunctionCategory.STRING,
     description = "Returns an upper-case version of the input string.")
 public class UCase {
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Uuid.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Uuid.java
@@ -14,11 +14,13 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 
 @UdfDescription(
     name = "UUID",
+    category = FunctionCategory.STRING,
     description = "Create a Universally Unique Identifier (UUID) generated according to RFC 4122. "
         + "A call to UUID() returns a value conforming to UUID version 4, sometimes called "
         + "\"random UUID\", as described in RFC 4122. The value is a 128-bit number represented "

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlDecodeParam.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlDecodeParam.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.function.udf.url;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
@@ -28,6 +29,7 @@ import java.net.URLDecoder;
 
 @UdfDescription(
     name = "url_decode_param",
+    category = FunctionCategory.URL,
     description = "Decodes a previously encoded application/x-www-form-urlencoded String",
     author = KsqlConstants.CONFLUENT_AUTHOR
 )

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlEncodeParam.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlEncodeParam.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.function.udf.url;
 
 import com.google.common.escape.Escaper;
 import com.google.common.net.UrlEscapers;
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -24,6 +25,7 @@ import io.confluent.ksql.util.KsqlConstants;
 
 @UdfDescription(
     name = "url_encode_param",
+    category = FunctionCategory.URL,
     description = "Returns a version of the input with all URL sensitive characters encoded "
         + "using the application/x-www-form-urlencoded standard.",
     author = KsqlConstants.CONFLUENT_AUTHOR

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractFragment.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractFragment.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.url;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -23,6 +24,7 @@ import java.net.URI;
 
 @UdfDescription(
     name = "url_extract_fragment",
+    category = FunctionCategory.URL,
     description = "Extracts the fragment of an application/x-www-form-urlencoded String input",
     author = KsqlConstants.CONFLUENT_AUTHOR
 )

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractHost.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractHost.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.url;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -23,6 +24,7 @@ import java.net.URI;
 
 @UdfDescription(
     name = "url_extract_host",
+    category = FunctionCategory.URL,
     description = "Extracts the Host Name of an application/x-www-form-urlencoded String input",
     author = KsqlConstants.CONFLUENT_AUTHOR
 )

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractParameter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractParameter.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.function.udf.url;
 
 import com.google.common.base.Splitter;
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -25,6 +26,7 @@ import java.util.List;
 
 @UdfDescription(
     name = "url_extract_parameter",
+    category = FunctionCategory.URL,
     description = "Extracts a parameter with a specified name encoded inside an "
         + "application/x-www-form-urlencoded String.",
     author = KsqlConstants.CONFLUENT_AUTHOR

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractPath.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractPath.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.url;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -23,6 +24,7 @@ import java.net.URI;
 
 @UdfDescription(
     name = "url_extract_path",
+    category = FunctionCategory.URL,
     description = "Extracts the path of an application/x-www-form-urlencoded encoded String input",
     author = KsqlConstants.CONFLUENT_AUTHOR
 )

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractPort.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractPort.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.url;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -23,6 +24,7 @@ import java.net.URI;
 
 @UdfDescription(
     name = "url_extract_port",
+    category = FunctionCategory.URL,
     description = "Extracts the port from an application/x-www-form-urlencoded encoded String."
         + " If there is no port or the string is invalid, this will return null.",
     author = KsqlConstants.CONFLUENT_AUTHOR

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractProtocol.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractProtocol.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.url;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -23,6 +24,7 @@ import java.net.URI;
 
 @UdfDescription(
     name = "url_extract_protocol",
+    category = FunctionCategory.URL,
     description = "Extracts the Scheme Component (protocol) of an "
         + "application/x-www-form-urlencoded encoded String input",
     author = KsqlConstants.CONFLUENT_AUTHOR

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractQuery.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractQuery.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf.url;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
@@ -23,6 +24,7 @@ import java.net.URI;
 
 @UdfDescription(
     name = "url_extract_query",
+    category = FunctionCategory.URL,
     description = "Extracts the query parameters of an "
         + "application/x-www-form-urlencoded encoded String input, if it exists.",
     author = KsqlConstants.CONFLUENT_AUTHOR

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udtf/Cube.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udtf/Cube.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udtf;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.util.KsqlConstants;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -22,6 +23,7 @@ import java.util.List;
 
 @UdtfDescription(
     name = "cube_explode",
+    category = FunctionCategory.TABLE,
     author = KsqlConstants.CONFLUENT_AUTHOR,
     description =
         "Takes as argument a list of columns and outputs all possible combinations of them. "

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udtf/array/Explode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udtf/array/Explode.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udtf.array;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.UdfSchemaProvider;
 import io.confluent.ksql.function.udtf.Udtf;
 import io.confluent.ksql.function.udtf.UdtfDescription;
@@ -32,6 +33,7 @@ import java.util.List;
  */
 @UdtfDescription(
     name = "explode",
+    category = FunctionCategory.TABLE,
     author = KsqlConstants.CONFLUENT_AUTHOR,
     description =
         "Explodes an array. This function outputs one value for each element of the array."

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/InternalFunctionRegistryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/InternalFunctionRegistryTest.java
@@ -388,7 +388,7 @@ public class InternalFunctionRegistryTest {
 
   private TableFunctionFactory createTableFunctionFactory() {
     return new TableFunctionFactory(new UdfMetadata("my_tablefunction",
-        "", "", "", "")) {
+        "", "", "", FunctionCategory.OTHER, "")) {
       @Override
       public KsqlTableFunction createTableFunction(final List<SqlType> argTypeList) {
         return tableFunction;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListFunctionsExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListFunctionsExecutor.java
@@ -45,7 +45,7 @@ public final class ListFunctionsExecutor {
         .map(factory -> new SimpleFunctionInfo(
             factory.getName().toUpperCase(),
             FunctionType.SCALAR, 
-            factory.getMetadata().getCategory().toString()
+            factory.getMetadata().getCategory()
         ))
         .collect(Collectors.toList());
 
@@ -53,7 +53,7 @@ public final class ListFunctionsExecutor {
         .map(factory -> new SimpleFunctionInfo(
             factory.getName().toUpperCase(),
             FunctionType.TABLE, 
-            factory.getMetadata().getCategory().toString()
+            factory.getMetadata().getCategory()
         ))
         .forEach(all::add);
 
@@ -61,7 +61,7 @@ public final class ListFunctionsExecutor {
         .map(factory -> new SimpleFunctionInfo(
             factory.getName().toUpperCase(),
             FunctionType.AGGREGATE, 
-            factory.getMetadata().getCategory().toString()
+            factory.getMetadata().getCategory()
         ))
         .forEach(all::add);
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListFunctionsExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListFunctionsExecutor.java
@@ -44,21 +44,24 @@ public final class ListFunctionsExecutor {
     final List<SimpleFunctionInfo> all = functionRegistry.listFunctions().stream()
         .map(factory -> new SimpleFunctionInfo(
             factory.getName().toUpperCase(),
-            FunctionType.SCALAR
+            FunctionType.SCALAR, 
+            factory.getMetadata().getCategory().toString()
         ))
         .collect(Collectors.toList());
 
     functionRegistry.listTableFunctions().stream()
         .map(factory -> new SimpleFunctionInfo(
             factory.getName().toUpperCase(),
-            FunctionType.TABLE
+            FunctionType.TABLE, 
+            factory.getMetadata().getCategory().toString()
         ))
         .forEach(all::add);
 
     functionRegistry.listAggregateFunctions().stream()
         .map(factory -> new SimpleFunctionInfo(
             factory.getName().toUpperCase(),
-            FunctionType.AGGREGATE
+            FunctionType.AGGREGATE, 
+            factory.getMetadata().getCategory().toString()
         ))
         .forEach(all::add);
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListFunctionsExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListFunctionsExecutorTest.java
@@ -51,15 +51,15 @@ public class ListFunctionsExecutorTest {
     final Collection<SimpleFunctionInfo> functions = functionList.getFunctions();
     assertThat(functions, hasItems(
         new SimpleFunctionInfo("TEST_UDF_1", FunctionType.SCALAR,
-            FunctionCategory.OTHER.toString()),
+            FunctionCategory.OTHER),
         new SimpleFunctionInfo("TOPK", FunctionType.AGGREGATE,
-            FunctionCategory.AGGREGATE.toString()),
+            FunctionCategory.AGGREGATE),
         new SimpleFunctionInfo("MAX", FunctionType.AGGREGATE,
-            FunctionCategory.AGGREGATE.toString()),
+            FunctionCategory.AGGREGATE),
         new SimpleFunctionInfo("TEST_UDTF1", FunctionType.TABLE, 
-            FunctionCategory.TABLE.toString()),
+            FunctionCategory.TABLE),
         new SimpleFunctionInfo("TEST_UDTF2", FunctionType.TABLE,
-            FunctionCategory.TABLE.toString())
+            FunctionCategory.TABLE)
     ));
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListFunctionsExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListFunctionsExecutorTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.FunctionNameList;
 import io.confluent.ksql.rest.entity.FunctionType;
@@ -49,11 +50,16 @@ public class ListFunctionsExecutorTest {
     // Then:
     final Collection<SimpleFunctionInfo> functions = functionList.getFunctions();
     assertThat(functions, hasItems(
-        new SimpleFunctionInfo("TEST_UDF_1", FunctionType.SCALAR),
-        new SimpleFunctionInfo("TOPK", FunctionType.AGGREGATE),
-        new SimpleFunctionInfo("MAX", FunctionType.AGGREGATE),
-        new SimpleFunctionInfo("TEST_UDTF1", FunctionType.TABLE),
-        new SimpleFunctionInfo("TEST_UDTF2", FunctionType.TABLE)
+        new SimpleFunctionInfo("TEST_UDF_1", FunctionType.SCALAR,
+            FunctionCategory.OTHER.toString()),
+        new SimpleFunctionInfo("TOPK", FunctionType.AGGREGATE,
+            FunctionCategory.AGGREGATE.toString()),
+        new SimpleFunctionInfo("MAX", FunctionType.AGGREGATE,
+            FunctionCategory.AGGREGATE.toString()),
+        new SimpleFunctionInfo("TEST_UDTF1", FunctionType.TABLE, 
+            FunctionCategory.TABLE.toString()),
+        new SimpleFunctionInfo("TEST_UDTF2", FunctionType.TABLE,
+            FunctionCategory.TABLE.toString())
     ));
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -464,11 +464,11 @@ public class KsqlResourceTest {
     // Then:
     assertThat(functionList.getFunctions(), hasItems(
         new SimpleFunctionInfo("TRIM", FunctionType.SCALAR, 
-            FunctionCategory.STRING.toString()),
+            FunctionCategory.STRING),
         new SimpleFunctionInfo("TOPK", FunctionType.AGGREGATE,
-            FunctionCategory.AGGREGATE.toString()),
+            FunctionCategory.AGGREGATE),
         new SimpleFunctionInfo("MAX", FunctionType.AGGREGATE,
-            FunctionCategory.AGGREGATE.toString())
+            FunctionCategory.AGGREGATE)
     ));
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -80,6 +80,7 @@ import io.confluent.ksql.exception.KsqlTopicAuthorizationException;
 import io.confluent.ksql.execution.ddl.commands.DropSourceCommand;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.function.MutableFunctionRegistry;
 import io.confluent.ksql.function.UserFunctionLoader;
@@ -462,9 +463,12 @@ public class KsqlResourceTest {
 
     // Then:
     assertThat(functionList.getFunctions(), hasItems(
-        new SimpleFunctionInfo("TRIM", FunctionType.SCALAR),
-        new SimpleFunctionInfo("TOPK", FunctionType.AGGREGATE),
-        new SimpleFunctionInfo("MAX", FunctionType.AGGREGATE)
+        new SimpleFunctionInfo("TRIM", FunctionType.SCALAR, 
+            FunctionCategory.STRING.toString()),
+        new SimpleFunctionInfo("TOPK", FunctionType.AGGREGATE,
+            FunctionCategory.AGGREGATE.toString()),
+        new SimpleFunctionInfo("MAX", FunctionType.AGGREGATE,
+            FunctionCategory.AGGREGATE.toString())
     ));
   }
 

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/SimpleFunctionInfo.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/SimpleFunctionInfo.java
@@ -61,7 +61,7 @@ public class SimpleFunctionInfo implements Comparable<SimpleFunctionInfo> {
     final SimpleFunctionInfo that = (SimpleFunctionInfo) o;
     return Objects.equals(name, that.name)
         && type == that.type
-        && category == that.category;
+        && Objects.equals(category, that.category);
   }
 
   @Override

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/SimpleFunctionInfo.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/SimpleFunctionInfo.java
@@ -25,14 +25,17 @@ public class SimpleFunctionInfo implements Comparable<SimpleFunctionInfo> {
 
   private final String name;
   private final FunctionType type;
+  private final String category;
 
   @JsonCreator
   public SimpleFunctionInfo(
       @JsonProperty("name") final String name,
-      @JsonProperty("type") final FunctionType type
+      @JsonProperty("type") final FunctionType type,
+      @JsonProperty("category") final String category
   ) {
     this.name = Objects.requireNonNull(name, "name can't be null");
     this.type = Objects.requireNonNull(type, "type can't be null");
+    this.category = Objects.isNull(category) ? "" : category;
   }
 
   public String getName() {
@@ -41,6 +44,10 @@ public class SimpleFunctionInfo implements Comparable<SimpleFunctionInfo> {
 
   public FunctionType getType() {
     return type;
+  }
+
+  public String getCategory() {
+    return category;
   }
 
   @Override
@@ -53,19 +60,21 @@ public class SimpleFunctionInfo implements Comparable<SimpleFunctionInfo> {
     }
     final SimpleFunctionInfo that = (SimpleFunctionInfo) o;
     return Objects.equals(name, that.name)
-        && type == that.type;
+        && type == that.type
+        && category == that.category;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, type);
+    return Objects.hash(name, type, category);
   }
 
   @Override
   public String toString() {
     return "SimpleFunctionInfo{"
         + "name='" + name + '\''
-        + ", type=" + type
+        + ", type='" + type + '\''
+        + ", category=" + category
         + '}';
   }
 

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/function/FunctionCategory.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/function/FunctionCategory.java
@@ -14,7 +14,7 @@
 
 package io.confluent.ksql.function;
 
-public class FunctionCategory {
+public final class FunctionCategory {
 
   private FunctionCategory() {
     // extra code for style adherence

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/function/FunctionCategory.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/function/FunctionCategory.java
@@ -14,17 +14,17 @@
 
 package io.confluent.ksql.function;
 
-public enum FunctionCategory {
-  CONDITIONAL,
-  MATHEMATICAL,
-  STRING, 
-  REGULAR_EXPRESSION,
-  JSON,
-  DATE_TIME,
-  ARRAY,
-  MAP,
-  URL,
-  OTHER, 
-  AGGREGATE,
-  TABLE;
+public class FunctionCategory {
+  public static final String CONDITIONAL = "CONDITIONAL";
+  public static final String MATHEMATICAL = "OTHER";
+  public static final String STRING = "OTHER";
+  public static final String REGULAR_EXPRESSION = "OTHER";
+  public static final String JSON = "OTHER";
+  public static final String DATE_TIME = "OTHER";
+  public static final String ARRAY = "ARRAY";
+  public static final String MAP = "MAP";
+  public static final String URL = "URL";
+  public static final String OTHER = "OTHER";
+  public static final String AGGREGATE = "AGGREGATE";
+  public static final String TABLE = "TABLE";
 }

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/function/FunctionCategory.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/function/FunctionCategory.java
@@ -15,6 +15,11 @@
 package io.confluent.ksql.function;
 
 public class FunctionCategory {
+
+  private FunctionCategory() {
+    // extra code for style adherence
+  }
+
   public static final String CONDITIONAL = "CONDITIONAL";
   public static final String MATHEMATICAL = "OTHER";
   public static final String STRING = "OTHER";

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/function/FunctionCategory.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/function/FunctionCategory.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package io.confluent.ksql.function;
+
+public enum FunctionCategory {
+  CONDITIONAL,
+  MATHEMATICAL,
+  STRING, 
+  REGULAR_EXPRESSION,
+  JSON,
+  DATE_TIME,
+  ARRAY,
+  MAP,
+  URL,
+  OTHER, 
+  AGGREGATE,
+  TABLE;
+}

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/function/FunctionCategory.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/function/FunctionCategory.java
@@ -21,11 +21,11 @@ public final class FunctionCategory {
   }
 
   public static final String CONDITIONAL = "CONDITIONAL";
-  public static final String MATHEMATICAL = "OTHER";
-  public static final String STRING = "OTHER";
-  public static final String REGULAR_EXPRESSION = "OTHER";
-  public static final String JSON = "OTHER";
-  public static final String DATE_TIME = "OTHER";
+  public static final String MATHEMATICAL = "MATHEMATICAL";
+  public static final String STRING = "STRING";
+  public static final String REGULAR_EXPRESSION = "REGULAR EXPRESSION";
+  public static final String JSON = "JSON";
+  public static final String DATE_TIME = "DATE / TIME";
   public static final String ARRAY = "ARRAY";
   public static final String MAP = "MAP";
   public static final String URL = "URL";

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/function/udaf/UdafDescription.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/function/udaf/UdafDescription.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udaf;
 
+import io.confluent.ksql.function.FunctionCategory;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -31,6 +32,8 @@ public @interface UdafDescription {
   String name();
 
   String description();
+
+  FunctionCategory category() default FunctionCategory.AGGREGATE;
 
   String author() default "";
 

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/function/udaf/UdafDescription.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/function/udaf/UdafDescription.java
@@ -33,7 +33,7 @@ public @interface UdafDescription {
 
   String description();
 
-  FunctionCategory category() default FunctionCategory.AGGREGATE;
+  String category() default FunctionCategory.AGGREGATE;
 
   String author() default "";
 

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/function/udf/UdfDescription.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/function/udf/UdfDescription.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf;
 
+import io.confluent.ksql.function.FunctionCategory;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -54,9 +55,20 @@ public @interface UdfDescription {
   String description();
 
   /**
+   * The category or type of the function.
+   *
+   * <p>
+   * This text is used to group functions displayed when the user calls {@code SHOW FUNCTIONS ...}.
+   *
+   * @return function category.
+   */
+  FunctionCategory category() default FunctionCategory.OTHER;
+
+  /**
    * The author of the function.
    *
-   * <p>This text is displayed when the user calls {@code DESCRIBE FUNCTION ...}.
+   * <p>
+   * This text is displayed when the user calls {@code DESCRIBE FUNCTION ...}.
    *
    * @return function author.
    */

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/function/udf/UdfDescription.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/function/udf/UdfDescription.java
@@ -57,8 +57,7 @@ public @interface UdfDescription {
   /**
    * The category or type of the function.
    *
-   * <p>
-   * This text is used to group functions displayed when the user calls {@code SHOW FUNCTIONS ...}.
+   * <p>This text is used to group functions displayed when invoking {@code SHOW FUNCTIONS ...}.
    *
    * @return function category.
    */
@@ -67,8 +66,7 @@ public @interface UdfDescription {
   /**
    * The author of the function.
    *
-   * <p>
-   * This text is displayed when the user calls {@code DESCRIBE FUNCTION ...}.
+   * <p>This text is displayed when the user calls {@code DESCRIBE FUNCTION ...}.
    *
    * @return function author.
    */

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/function/udf/UdfDescription.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/function/udf/UdfDescription.java
@@ -61,7 +61,7 @@ public @interface UdfDescription {
    *
    * @return function category.
    */
-  FunctionCategory category() default FunctionCategory.OTHER;
+  String category() default FunctionCategory.OTHER;
 
   /**
    * The author of the function.

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/function/udtf/UdtfDescription.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/function/udtf/UdtfDescription.java
@@ -58,8 +58,7 @@ public @interface UdtfDescription {
   /**
    * The category or type of the table function.
    *
-   * <p>
-   * This text is used to group functions displayed when the user calls {@code SHOW FUNCTIONS ...}.
+   * <p>This text is used to group functions displayed when invoking {@code SHOW FUNCTIONS ...}.
    *
    * @return function category.
    */
@@ -68,8 +67,7 @@ public @interface UdtfDescription {
   /**
    * The author of the table function.
    *
-   * <p>
-   * This text is displayed when the user calls {@code DESCRIBE FUNCTION ...}.
+   * <p>This text is displayed when the user calls {@code DESCRIBE FUNCTION ...}.
    *
    * @return function author.
    */

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/function/udtf/UdtfDescription.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/function/udtf/UdtfDescription.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udtf;
 
+import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -55,9 +56,20 @@ public @interface UdtfDescription {
   String description();
 
   /**
+   * The category or type of the table function.
+   *
+   * <p>
+   * This text is used to group functions displayed when the user calls {@code SHOW FUNCTIONS ...}.
+   *
+   * @return function category.
+   */
+  FunctionCategory category() default FunctionCategory.TABLE;
+
+  /**
    * The author of the table function.
    *
-   * <p>This text is displayed when the user calls {@code DESCRIBE FUNCTION ...}.
+   * <p>
+   * This text is displayed when the user calls {@code DESCRIBE FUNCTION ...}.
    *
    * @return function author.
    */

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/function/udtf/UdtfDescription.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/function/udtf/UdtfDescription.java
@@ -62,7 +62,7 @@ public @interface UdtfDescription {
    *
    * @return function category.
    */
-  FunctionCategory category() default FunctionCategory.TABLE;
+  String category() default FunctionCategory.TABLE;
 
   /**
    * The author of the table function.


### PR DESCRIPTION
A little friday afternoon, quality-of-life-improvement: i noticed that we now have quite some UDFs, which is cool, but the list you get when executing `show functions` is quite long and hard to navigate unless you really know what you are looking for. Hence this PR adds a new categorization of UDFs into STRING|AGGREGATE|ARRAY|... etc.

Also a small message at the end of the listing detailing how to get further information about a function of interest.

Looks like quite a lot of changes but most of it is just inserting the appropriate category into the source file of each individual UDF.