### PR TITLE
feat: expose query ID in CommandStatusEntity (MINOR)

### DIFF
--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -232,7 +232,11 @@ public class ConsoleTest {
         new CommandStatusEntity(
             "e",
             CommandId.fromString("topic/1/create"),
-            new CommandStatus(CommandStatus.Status.SUCCESS, "Success Message"),
+            new CommandStatus(
+                CommandStatus.Status.SUCCESS,
+                "Success Message",
+                Optional.of(new QueryId("CSAS_0"))
+            ),
             0L)
     ));
 
@@ -248,7 +252,8 @@ public class ConsoleTest {
           + "  \"commandId\" : \"topic/1/create\"," + NEWLINE
           + "  \"commandStatus\" : {" + NEWLINE
           + "    \"status\" : \"SUCCESS\"," + NEWLINE
-          + "    \"message\" : \"Success Message\"" + NEWLINE
+          + "    \"message\" : \"Success Message\"," + NEWLINE
+          + "    \"queryId\" : \"CSAS_0\"" + NEWLINE
           + "  }," + NEWLINE
           + "  \"commandSequenceNumber\" : 0," + NEWLINE
           + "  \"warnings\" : [ ]" + NEWLINE

--- a/ksqldb-common/src/main/java/io/confluent/ksql/query/QueryId.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/query/QueryId.java
@@ -26,7 +26,7 @@ import java.util.Objects;
  * A query id.
  *
  * <p>For backwards compatibility reasons query ids must preserve their case, as their text
- * representation is used, amoung other things, for internal topic naming.
+ * representation is used, among other things, for internal topic naming.
  *
  * <p>However, two ids with the same text, with different case, should compare equal. This is needed
  * so that look ups against query ids are not case-sensitive.

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutorTest.java
@@ -43,7 +43,6 @@ import io.confluent.ksql.engine.KsqlPlan;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.integration.Retry;
 import io.confluent.ksql.internal.KsqlEngineMetrics;
-import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.MetaStoreImpl;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
@@ -94,7 +93,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class InteractiveStatementExecutorTest {
-  private static final String CREATE_STREAM_FOO_STATMENT = "CREATE STREAM foo ("
+  private static final String CREATE_STREAM_FOO_STATEMENT = "CREATE STREAM foo ("
       + "biz bigint,"
       + " baz varchar) "
       + "WITH (kafka_topic = 'foo', "
@@ -114,8 +113,6 @@ public class InteractiveStatementExecutorTest {
   private SpecificQueryIdGenerator mockQueryIdGenerator;
   @Mock
   private KsqlEngine mockEngine;
-  @Mock
-  private MetaStore mockMetaStore;
   @Mock
   private PersistentQueryMetadata mockQueryMetadata;
   @Mock
@@ -166,7 +163,7 @@ public class InteractiveStatementExecutorTest {
     statementExecutorWithMocks.configure(ksqlConfig);
 
     plannedCommand = new Command(
-        CREATE_STREAM_FOO_STATMENT,
+        CREATE_STREAM_FOO_STATEMENT,
         emptyMap(),
         ksqlConfig.getAllConfigPropsWithSecretsObfuscated(),
         Optional.of(plan)
@@ -307,7 +304,7 @@ public class InteractiveStatementExecutorTest {
   public void shouldCompleteFutureOnSuccess() {
     // Given:
     final Command command = new Command(
-        CREATE_STREAM_FOO_STATMENT,
+        CREATE_STREAM_FOO_STATEMENT,
         emptyMap(),
         ksqlConfig.getAllConfigPropsWithSecretsObfuscated(),
         Optional.empty()
@@ -373,7 +370,7 @@ public class InteractiveStatementExecutorTest {
         new CommandStatus(Status.EXECUTING, "Executing statement"));
     inOrder.verify(mockEngine).execute(any(), any(ConfiguredKsqlPlan.class));
     inOrder.verify(status).setFinalStatus(
-        new CommandStatus(Status.SUCCESS, "Created query with ID qid"));
+        new CommandStatus(Status.SUCCESS, "Created query with ID qid", Optional.of(QUERY_ID)));
   }
 
   @Test
@@ -413,7 +410,7 @@ public class InteractiveStatementExecutorTest {
     // Given:
     final Map<String, String> savedConfigs = ImmutableMap.of("biz", "baz");
     plannedCommand = new Command(
-        CREATE_STREAM_FOO_STATMENT,
+        CREATE_STREAM_FOO_STATEMENT,
         emptyMap(),
         savedConfigs,
         Optional.of(plan)
@@ -440,7 +437,7 @@ public class InteractiveStatementExecutorTest {
     shouldCompleteFutureOnSuccess();
 
     final Command command = new Command(
-        CREATE_STREAM_FOO_STATMENT,
+        CREATE_STREAM_FOO_STATEMENT,
         emptyMap(),
         ksqlConfig.getAllConfigPropsWithSecretsObfuscated(),
         Optional.empty()
@@ -453,7 +450,7 @@ public class InteractiveStatementExecutorTest {
     } catch (final KsqlStatementException e) {
       // Then:
       assertEquals("Cannot add stream 'FOO': A stream with the same name already exists\n" +
-              "Statement: " + CREATE_STREAM_FOO_STATMENT,
+              "Statement: " + CREATE_STREAM_FOO_STATEMENT,
           e.getMessage());
     }
     final InOrder inOrder = Mockito.inOrder(status);

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/CommandStatus.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/CommandStatus.java
@@ -20,7 +20,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.confluent.ksql.query.QueryId;
 import java.util.Objects;
+import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeName("commandStatus")
@@ -30,13 +32,20 @@ public class CommandStatus {
 
   private final Status status;
   private final String message;
+  private final Optional<QueryId> queryId;
+
+  public CommandStatus(final Status status, final String message) {
+    this(status, message, Optional.empty());
+  }
 
   @JsonCreator
   public CommandStatus(
       @JsonProperty("status") final Status status,
-      @JsonProperty("message") final String message) {
+      @JsonProperty("message") final String message,
+      @JsonProperty("queryId") final Optional<QueryId> queryId) {
     this.status = status;
     this.message = message;
+    this.queryId = queryId;
   }
 
   public Status getStatus() {
@@ -45,6 +54,10 @@ public class CommandStatus {
 
   public String getMessage() {
     return message;
+  }
+
+  public Optional<QueryId> getQueryId() {
+    return queryId;
   }
 
   @Override
@@ -57,16 +70,18 @@ public class CommandStatus {
     }
     final CommandStatus that = (CommandStatus) o;
     return getStatus() == that.getStatus()
-        && Objects.equals(getMessage(), that.getMessage());
+        && Objects.equals(getMessage(), that.getMessage())
+        && Objects.equals(getQueryId(), that.getQueryId());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getStatus(), getMessage());
+    return Objects.hash(getStatus(), getMessage(), getQueryId());
   }
 
   @Override
   public String toString() {
-    return status.name() + ": " + message;
+    return status.name() + ": " + message + ". "
+        + "Query ID: " + (queryId.isPresent() ? queryId.toString() : "<empty>");
   }
 }


### PR DESCRIPTION
### Description 

This PR adds QueryId into CommandStatus in order to expose QueryId from CommandStatusEntity.

Motivation is as follows: When a CSAS/CTAS/INSERT INTO command is executed from the CLI, the user sees a message containing the ID of the newly created query:
```
ksql> create stream log_copy as select * from ksql_processing_log;

 Message
---------------------------------------
 Created query with ID CSAS_LOG_COPY_0
---------------------------------------
```
We'd like to also return the query ID from the Java client. However, the server response doesn't directly expose the query ID at the moment. Instead, the way the CLI prints that message is by directly printing the status message returned from the server, which happens to contain the query ID if the command status is `EXECUTED`. We could have the Java client parse the query ID out of the status message string but that feels brittle. It makes more sense to have the server response expose the query ID directly, as in this PR.

### Testing done 

Added tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

