### PR TITLE
feat(client): return query ID when persistent query started via Java client

### DIFF
--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/Client.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/Client.java
@@ -128,9 +128,10 @@ public interface Client {
    * failed.
    *
    * @param sql the request to be executed
-   * @return a future that completes once the server response is received
+   * @return a future that completes once the server response is received, and contains the query ID
+   *         for statements that start new persistent queries
    */
-  CompletableFuture<Void> executeStatement(String sql);
+  CompletableFuture<ExecuteStatementResult> executeStatement(String sql);
 
   /**
    * Sends a SQL request with the specified properties to the ksqlDB server. This method supports
@@ -150,9 +151,11 @@ public interface Client {
    *
    * @param sql the request to be executed
    * @param properties properties associated with the request
-   * @return a future that completes once the server response is received
+   * @return a future that completes once the server response is received, and contains the query ID
+   *         for statements that start new persistent queries
    */
-  CompletableFuture<Void> executeStatement(String sql, Map<String, Object> properties);
+  CompletableFuture<ExecuteStatementResult>
+      executeStatement(String sql, Map<String, Object> properties);
 
   /**
    * Returns the list of ksqlDB streams from the ksqlDB server's metastore.

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/ExecuteStatementResult.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/ExecuteStatementResult.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.client;
+
+import java.util.Optional;
+
+/**
+ * The result of executing a 'CREATE', 'CREATE ... AS * SELECT', 'DROP', 'TERMINATE', or 'INSERT
+ * INTO ... AS SELECT' statement on the ksqlDB server.
+ */
+public interface ExecuteStatementResult {
+
+  /**
+   * Returns the ID of a newly started persistent query, if applicable. The return value is empty
+   * for all statements other than 'CREATE ... AS * SELECT' and 'INSERT * INTO ... AS SELECT'
+   * statements, as only these statements start persistent queries. For statements that start
+   * persistent queries, the return value may still be empty if either:
+   *
+   * <p><ul>
+   *   <li> The statement was not executed on the server by the time the server response was sent.
+   *   This typically does not happen under normal server operation, but may happen if the ksqlDB
+   *   server's command runner thread is stuck, or if the configured value for
+   *   {@code ksql.server.command.response.timeout.ms} is too low
+   *   <li> The ksqlDB server version is lower than 0.11.0.
+   * </ul>
+   *
+   * @return the query ID, if applicable
+   */
+  Optional<String> queryId();
+
+}

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientImpl.java
@@ -23,6 +23,7 @@ import io.confluent.ksql.api.client.AcksPublisher;
 import io.confluent.ksql.api.client.BatchedQueryResult;
 import io.confluent.ksql.api.client.Client;
 import io.confluent.ksql.api.client.ClientOptions;
+import io.confluent.ksql.api.client.ExecuteStatementResult;
 import io.confluent.ksql.api.client.KsqlObject;
 import io.confluent.ksql.api.client.QueryInfo;
 import io.confluent.ksql.api.client.StreamInfo;
@@ -193,14 +194,14 @@ public class ClientImpl implements Client {
   }
 
   @Override
-  public CompletableFuture<Void> executeStatement(final String sql) {
+  public CompletableFuture<ExecuteStatementResult> executeStatement(final String sql) {
     return executeStatement(sql, Collections.emptyMap());
   }
 
   @Override
-  public CompletableFuture<Void> executeStatement(
+  public CompletableFuture<ExecuteStatementResult> executeStatement(
       final String sql, final Map<String, Object> properties) {
-    final CompletableFuture<Void> cf = new CompletableFuture<>();
+    final CompletableFuture<ExecuteStatementResult> cf = new CompletableFuture<>();
 
     if (!validateExecuteStatementRequest(sql, cf)) {
       return cf;

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/DdlDmlRequestValidators.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/DdlDmlRequestValidators.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.api.client.impl;
 
+import io.confluent.ksql.api.client.ExecuteStatementResult;
 import io.confluent.ksql.api.client.exception.KsqlClientException;
 import java.util.concurrent.CompletableFuture;
 
@@ -25,7 +26,7 @@ final class DdlDmlRequestValidators {
 
   static boolean validateExecuteStatementRequest(
       final String sql,
-      final CompletableFuture<Void> cf
+      final CompletableFuture<ExecuteStatementResult> cf
   ) {
     if (!sql.contains(";")) {
       cf.completeExceptionally(new KsqlClientException(

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/DdlDmlResponseHandlers.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/DdlDmlResponseHandlers.java
@@ -43,10 +43,8 @@ final class DdlDmlResponseHandlers {
     }
 
     try {
-      final JsonObject commandStatus = ksqlEntity.getJsonObject("commandStatus");
-      final Optional<String> queryId = commandStatus.getString("queryId") != null
-          ? Optional.of(commandStatus.getString("queryId"))
-          : Optional.empty();
+      final Optional<String> queryId = Optional.ofNullable(
+          ksqlEntity.getJsonObject("commandStatus").getString("queryId"));
       cf.complete(new ExecuteStatementResultImpl(queryId));
     } catch (Exception e) {
       cf.completeExceptionally(new IllegalStateException(

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ExecuteStatementResultImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ExecuteStatementResultImpl.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.client.impl;
+
+import io.confluent.ksql.api.client.ExecuteStatementResult;
+import java.util.Objects;
+import java.util.Optional;
+
+public class ExecuteStatementResultImpl implements ExecuteStatementResult {
+
+  private final Optional<String> queryId;
+
+  ExecuteStatementResultImpl(final Optional<String> queryId) {
+    this.queryId = Objects.requireNonNull(queryId);
+  }
+
+  @Override
+  public Optional<String> queryId() {
+    return queryId;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ExecuteStatementResultImpl that = (ExecuteStatementResultImpl) o;
+    return queryId.equals(that.queryId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(queryId);
+  }
+
+  @Override
+  public String toString() {
+    return "ExecuteStatementResult{"
+        + "queryId=" + queryId
+        + '}';
+  }
+}

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/ExecuteStatementResultImplTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/ExecuteStatementResultImplTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.client.impl;
+
+import com.google.common.testing.EqualsTester;
+import java.util.Optional;
+import org.junit.Test;
+
+public class ExecuteStatementResultImplTest {
+
+  @Test
+  public void shouldImplementHashCodeAndEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            new ExecuteStatementResultImpl(Optional.of("CSAS_0")),
+            new ExecuteStatementResultImpl(Optional.of("CSAS_0"))
+        )
+        .addEqualityGroup(
+            new ExecuteStatementResultImpl(Optional.empty()),
+            new ExecuteStatementResultImpl(Optional.empty())
+        )
+        .addEqualityGroup(
+            new ExecuteStatementResultImpl(Optional.of("CSAS_1"))
+        )
+        .testEquals();
+  }
+
+}


### PR DESCRIPTION
### Description 

This PR is stacked on https://github.com/confluentinc/ksql/pull/5775 and https://github.com/confluentinc/ksql/pull/5814 -- only the [latest commit (`feat(client): return query ID when persistent query started via Java client`)](https://github.com/confluentinc/ksql/pull/5816/commits/c2a032ec529494ee99a8673d62e3cfddf1088a85) needs to be reviewed.

This PR uses the new query ID field added to CommandStatusEntity in https://github.com/confluentinc/ksql/pull/5814 to return the query ID for persistent queries started with the `executeStatement()` method of the Java client. This is useful so client apps can easily terminate new persistent queries. The javadocs on the new `ExecuteStatementResult` interface explain the new behavior in more detail.

### Testing done 

Added unit and integration tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

