### PR TITLE
fix: Allow backported ALPN to be used and warn if no OpenSSL

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/Server.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/Server.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.rest.util.KeystoreUtil;
 import io.confluent.ksql.security.KsqlSecurityExtension;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.VertxCompletableFuture;
+import io.netty.handler.ssl.OpenSsl;
 import io.vertx.core.Vertx;
 import io.vertx.core.WorkerExecutor;
 import io.vertx.core.http.ClientAuth;
@@ -92,6 +93,10 @@ public class Server {
     this.authenticationPlugin = Objects.requireNonNull(authenticationPlugin);
     this.serverState = Objects.requireNonNull(serverState);
     this.maxPushQueryCount = config.getInt(KsqlRestConfig.MAX_PUSH_QUERIES);
+    if (!OpenSsl.isAvailable()) {
+      log.warn("OpenSSL does not appear to be installed. ksqlDB will fall back to using the JDK "
+          + "TLS implementation. OpenSSL is recommended for better performance.");
+    }
   }
 
   public synchronized void start() {

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
         <wiremock.version>2.24.0</wiremock.version>
         <clearspring-analytics.version>2.9.5</clearspring-analytics.version>
         <icu.version>67.1</icu.version>
-        <vertx.version>3.9.0</vertx.version>
+        <vertx.version>3.9.1</vertx.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <skip.docker.build>true</skip.docker.build>
         <skip.docker.test>true</skip.docker.test>


### PR DESCRIPTION
### Description 

Fixes: https://github.com/confluentinc/ksql/issues/5799

This PR:

1. Upgrades to Vert.x 3.9.1. This depends on Netty 4.1.49.Final which includes code which allows the backported ALPN implementation that is present in JDK 1.8.0_252 to be used. This means that if the user has configured ksqlDB for TLS and does not have OpenSSL installed and is using an up to date version of Java 8 then ksqlDB will successfully fall back to using the JDK TLS implementation and the ALPN implementation that was backported to Open JDK 1.8.0_252 from OpenJDK 9. Users with older versions of Java 8 should update their Java 8 version.

2. Logs a warning if OpenSSL is not installed. It's preferable to use OpenSSL for performance reasons. Most systems will have this pre-installed, but if not a warning will be logged so the user is aware of this and can install it.


### Testing done 

Manually tested.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

